### PR TITLE
Add permanent session tree deletion

### DIFF
--- a/.changeset/permanent-session-tree-deletion.md
+++ b/.changeset/permanent-session-tree-deletion.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": patch
+"@opengeni/sdk": minor
+"@opengeni/api-router": minor
+---
+
+Add an authorized, quiescence-fenced API and SDK operation for permanently deleting a root session tree.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -93,6 +93,7 @@ import {
   getRetainedProcess,
   getSandbox,
   getSession,
+  deleteSessionTreeIfQuiescent,
   getSessionEvent,
   getSessionForSubject,
   getSessionGoal,
@@ -1724,6 +1725,44 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       throw new HTTPException(404, { message: "session not found" });
     }
     return c.json(await withEffectivePolicy(deps, workspaceId, grant.subjectId, session));
+  });
+
+  app.delete("/v1/workspaces/:workspaceId/sessions/:sessionId", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const deleted = await deleteSessionTreeIfQuiescent(db, {
+      workspaceId,
+      subjectId: grant.subjectId,
+      sessionId: c.req.param("sessionId"),
+    });
+    switch (deleted.status) {
+      case "deleted":
+        return c.json({ deletedSessionCount: deleted.deletedSessionCount });
+      case "not_found":
+        throw new HTTPException(404, { message: "session not found" });
+      case "not_root":
+        throw new HTTPException(409, {
+          message: "delete the root session to remove the complete workstream",
+        });
+      case "active_sessions":
+        throw new HTTPException(409, {
+          message: "cancel the workstream and wait for active turns to finish before deleting it",
+        });
+      case "active_video_generations":
+        throw new HTTPException(409, {
+          message: "wait for active video generations to finish before deleting this workstream",
+        });
+      case "live_sandboxes":
+        throw new HTTPException(409, {
+          message:
+            "wait for the workstream's sandbox activity to finish draining before deleting it",
+        });
+      case "externally_referenced":
+        throw new HTTPException(409, {
+          message:
+            "this workstream has durable workspace outputs or independent forks; archive it instead",
+        });
+    }
   });
 
   app.patch(
@@ -3983,6 +4022,7 @@ export function sessionAuthorizationOperationForHttp(
   if (suffix === "") {
     if (verb === "GET") return "session.read";
     if (verb === "PATCH") return "session.title.write";
+    if (verb === "DELETE") return "session.delete";
     return null;
   }
   if (suffix === "/pin" && verb === "PUT") return "session.pin.write";

--- a/apps/api/test/session-authorization.test.ts
+++ b/apps/api/test/session-authorization.test.ts
@@ -15,6 +15,7 @@ const root = `/v1/workspaces/22222222-2222-4222-8222-222222222222/sessions/${ses
 const cases: Array<[string, string, SessionAuthorizationOperation]> = [
   ["GET", "", "session.read"],
   ["PATCH", "", "session.title.write"],
+  ["DELETE", "", "session.delete"],
   ["PUT", "/pin", "session.pin.write"],
   ["PUT", "/attention", "session.attention.write"],
   ["PUT", "/archive", "session.archive.write"],

--- a/apps/api/test/session-delete.test.ts
+++ b/apps/api/test/session-delete.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+import { Hono } from "hono";
+import {
+  createDb,
+  createSession,
+  createWorkspace,
+  getSession,
+  initializeSessionStartAtomically,
+  migrate,
+  type Database,
+  type DbClient,
+} from "@opengeni/db";
+import { signDelegatedAccessToken } from "@opengeni/contracts";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
+import { registerSessionRoutes } from "../src/routes/sessions";
+
+const DELEGATION_SECRET = "session-delete-test-secret";
+const explicitDatabaseUrl = process.env.OPENGENI_SESSION_DELETE_TEST_DATABASE_URL;
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+let app: Hono;
+
+const settings = testSettings({
+  productAccessMode: "managed",
+  delegationSecret: DELEGATION_SECRET,
+});
+
+function workflowClient(): SessionWorkflowClient {
+  const noop = async () => {};
+  return {
+    signalUserMessage: noop,
+    wakeSessionWorkflow: noop,
+    requestSessionWorkflowWakeDispatch: noop,
+    signalApprovalDecision: noop,
+    signalSessionControl: noop,
+    syncScheduledTask: noop,
+    deleteScheduledTaskSchedule: noop,
+    triggerScheduledTask: noop,
+  } as unknown as SessionWorkflowClient;
+}
+
+function deps(): ApiRouteDeps {
+  return {
+    settings,
+    db,
+    bus: new MemoryEventBus(),
+    workflowClient: workflowClient(),
+    githubStateSecret: "x",
+    objectStorage: null,
+    documentIndexer: { indexDocument: async () => {} },
+    getDocumentServices: () => ({}) as never,
+  } as unknown as ApiRouteDeps;
+}
+
+async function bearer(accountId: string, workspaceId: string, permissions: string[]) {
+  return `Bearer ${await signDelegatedAccessToken(DELEGATION_SECRET, {
+    accountId,
+    workspaceId,
+    subjectId: "session-deleter",
+    permissions,
+    principalKind: "human_session",
+    exp: Math.floor(Date.now() / 1000) + 3_600,
+  })}`;
+}
+
+async function fixture() {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('session delete account') returning id`;
+  const workspace = await createWorkspace(db, {
+    accountId: account!.id,
+    name: "session delete workspace",
+  });
+  const root = await createSession(db, {
+    accountId: account!.id,
+    workspaceId: workspace.id,
+    initialMessage: "delete root",
+    resources: [],
+    metadata: {},
+    model: "test-model",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  await initializeSessionStartAtomically(db, {
+    accountId: account!.id,
+    workspaceId: workspace.id,
+    sessionId: root.id,
+    reasoningEffortFallback: "low",
+    createdEventPayload: {},
+  });
+  const child = await createSession(db, {
+    accountId: account!.id,
+    workspaceId: workspace.id,
+    initialMessage: "delete child",
+    resources: [],
+    metadata: {},
+    model: "test-model",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+    parentSessionId: root.id,
+  });
+  await admin`
+    update sessions
+    set status = 'cancelled'
+    where id in (${root.id}, ${child.id})`;
+  return { accountId: account!.id, workspaceId: workspace.id, root, child };
+}
+
+beforeAll(async () => {
+  if (explicitDatabaseUrl) {
+    await migrate(explicitDatabaseUrl);
+    admin = postgres(explicitDatabaseUrl, { max: 4 });
+    client = createDb(explicitDatabaseUrl);
+  } else {
+    shared = await acquireSharedTestDatabase("session-delete");
+    if (!shared) {
+      if (requireRealDatabase) throw new Error("PostgreSQL is required for session delete tests");
+      available = false;
+      return;
+    }
+    admin = shared.admin;
+    client = createDb(shared.appUrl);
+  }
+  db = client.db;
+  app = new Hono();
+  registerSessionRoutes(app, deps());
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close().catch(() => undefined);
+  if (explicitDatabaseUrl) await admin?.end().catch(() => undefined);
+  await shared?.release();
+}, 180_000);
+
+describe("session tree deletion", () => {
+  test("requires control authority and deletes a quiescent root with its descendants", async () => {
+    if (!available) return;
+    const value = await fixture();
+    const url = `http://x/v1/workspaces/${value.workspaceId}/sessions/${value.root.id}`;
+
+    const denied = await app.request(url, {
+      method: "DELETE",
+      headers: {
+        authorization: await bearer(value.accountId, value.workspaceId, ["sessions:read"]),
+      },
+    });
+    expect(denied.status).toBe(403);
+
+    const childDelete = await app.request(
+      `http://x/v1/workspaces/${value.workspaceId}/sessions/${value.child.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          authorization: await bearer(value.accountId, value.workspaceId, [
+            "sessions:read",
+            "sessions:control",
+          ]),
+        },
+      },
+    );
+    expect(childDelete.status).toBe(409);
+
+    const deleted = await app.request(url, {
+      method: "DELETE",
+      headers: {
+        authorization: await bearer(value.accountId, value.workspaceId, [
+          "sessions:read",
+          "sessions:control",
+        ]),
+      },
+    });
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ deletedSessionCount: 2 });
+    expect(await getSession(db, value.workspaceId, value.root.id)).toBeNull();
+    expect(await getSession(db, value.workspaceId, value.child.id)).toBeNull();
+  }, 180_000);
+
+  test("refuses an active root without deleting it", async () => {
+    if (!available) return;
+    const value = await fixture();
+    await admin`update sessions set status = 'running' where id = ${value.root.id}`;
+    const response = await app.request(
+      `http://x/v1/workspaces/${value.workspaceId}/sessions/${value.root.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          authorization: await bearer(value.accountId, value.workspaceId, [
+            "sessions:read",
+            "sessions:control",
+          ]),
+        },
+      },
+    );
+    expect(response.status).toBe(409);
+    expect(await getSession(db, value.workspaceId, value.root.id)).not.toBeNull();
+  }, 180_000);
+});

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -9,7 +9,7 @@ import {
   OpenGeniSessionListCursorError,
   type SessionListResponse,
 } from "@opengeni/sdk";
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   ArchiveIcon,
   CalendarClockIcon,
@@ -175,6 +175,7 @@ type UpdateAttentionFn = (
   update: { unread?: boolean; activelyWorking?: boolean },
 ) => Promise<void>;
 type ArchiveFn = (session: Session, archived: boolean) => Promise<void>;
+type RequestDeleteFn = (session: Session) => void;
 type PinOverride = { session: Session; operation: number };
 type PendingPinFocus = {
   sessionId: string;
@@ -207,6 +208,7 @@ function findSessionTreeNode(
 export function SessionList() {
   const rail = useRail();
   const context = useAppContext();
+  const navigate = useNavigate();
   // Poll so running sessions surface and move to the top without a manual
   // refresh; the previous index relied on a one-shot load.
   const [searchDraft, setSearchDraft] = useState("");
@@ -269,6 +271,7 @@ export function SessionList() {
   const [channelDialogOpen, setChannelDialogOpen] = useState(false);
   const [channelNameDraft, setChannelNameDraft] = useState("");
   const [projectPendingDelete, setProjectPendingDelete] = useState<Channel | null>(null);
+  const [sessionPendingDelete, setSessionPendingDelete] = useState<Session | null>(null);
   const [draggedProjectId, setDraggedProjectId] = useState<string | null>(null);
   const [dragOverProjectId, setDragOverProjectId] = useState<string | null>(null);
   const { sessions, nextCursor, loading, error, refresh } = rootPage;
@@ -772,6 +775,33 @@ export function SessionList() {
     },
     [context, rail.workspaceId, refreshSessionPages],
   );
+  const onDeleteSession = useCallback(async (): Promise<boolean> => {
+    if (!sessionPendingDelete) return false;
+    try {
+      const result = await context.client.deleteSession(rail.workspaceId, sessionPendingDelete.id);
+      const viewingDeletedTree = context.session?.rootSessionId === sessionPendingDelete.id;
+      if (viewingDeletedTree) {
+        context.resetSessionView();
+        await navigate({
+          to: "/workspaces/$workspaceId/sessions",
+          params: { workspaceId: rail.workspaceId },
+          replace: true,
+        });
+      }
+      await refreshSessionPages();
+      toast.success(
+        result.deletedSessionCount === 1
+          ? "Session deleted"
+          : `${result.deletedSessionCount} sessions deleted`,
+      );
+      return true;
+    } catch (deleteError) {
+      toast.error("Couldn't delete the workstream.", {
+        description: deleteError instanceof Error ? deleteError.message : String(deleteError),
+      });
+      return false;
+    }
+  }, [context, navigate, rail.workspaceId, refreshSessionPages, sessionPendingDelete]);
   const nodesById = useMemo(() => {
     const result = new Map<string, SessionTreeNode>();
     const visit = (node: SessionTreeNode): void => {
@@ -1518,6 +1548,7 @@ export function SessionList() {
                   onMoveToChannel={onMoveToChannel}
                   onUpdateAttention={onUpdateAttention}
                   onArchive={onArchive}
+                  onRequestDelete={setSessionPendingDelete}
                 />
                 {pinnedTruncated ? (
                   <p className="px-2 pb-2 text-[11px] text-fg-subtle" role="status">
@@ -1571,6 +1602,7 @@ export function SessionList() {
                   onMoveToChannel={onMoveToChannel}
                   onUpdateAttention={onUpdateAttention}
                   onArchive={onArchive}
+                  onRequestDelete={setSessionPendingDelete}
                 />
               ))
             ) : (
@@ -1593,6 +1625,7 @@ export function SessionList() {
                     onMoveToChannel={onMoveToChannel}
                     onUpdateAttention={onUpdateAttention}
                     onArchive={onArchive}
+                    onRequestDelete={setSessionPendingDelete}
                   />
                 ) : null}
                 {forest.grouped.map((bucket) => (
@@ -1614,6 +1647,7 @@ export function SessionList() {
                     onMoveToChannel={onMoveToChannel}
                     onUpdateAttention={onUpdateAttention}
                     onArchive={onArchive}
+                    onRequestDelete={setSessionPendingDelete}
                   />
                 ))}
               </>
@@ -1642,6 +1676,7 @@ export function SessionList() {
                 onMoveToChannel={onMoveToChannel}
                 onUpdateAttention={onUpdateAttention}
                 onArchive={onArchive}
+                onRequestDelete={setSessionPendingDelete}
               />
             ) : null}
             {continuationCursor ? (
@@ -1678,6 +1713,21 @@ export function SessionList() {
           if (!open) setChannelNameDraft("");
         }}
         onSubmit={() => void submitCreateChannel()}
+      />
+      <ConfirmDialog
+        open={sessionPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setSessionPendingDelete(null);
+        }}
+        title={<>Delete “{sessionPendingDelete?.title?.trim() || "Untitled session"}”?</>}
+        description={
+          sessionPendingDelete?.treeStats?.totalDescendants
+            ? `This permanently deletes the complete workstream and its ${sessionPendingDelete.treeStats.totalDescendants} spawned sessions. This cannot be undone.`
+            : "This permanently deletes the session and its history. This cannot be undone."
+        }
+        confirmLabel="Delete workstream"
+        cancelAutoFocus
+        onConfirm={onDeleteSession}
       />
       <ConfirmDialog
         open={projectPendingDelete !== null}
@@ -1736,6 +1786,7 @@ function SessionGroup(props: {
   onMoveToChannel: MoveToChannelFn;
   onUpdateAttention: UpdateAttentionFn;
   onArchive: ArchiveFn;
+  onRequestDelete: RequestDeleteFn;
 }) {
   const sectionId = `session-group-${
     props.sectionId ?? props.label.toLowerCase().replace(/[^a-z0-9]+/g, "-")
@@ -1886,6 +1937,7 @@ function SessionGroup(props: {
               onMoveToChannel={props.onMoveToChannel}
               onUpdateAttention={props.onUpdateAttention}
               onArchive={props.onArchive}
+              onRequestDelete={props.onRequestDelete}
             />
           ))}
         </div>
@@ -1912,6 +1964,7 @@ function SessionTreeRow(props: {
   onMoveToChannel: MoveToChannelFn;
   onUpdateAttention: UpdateAttentionFn;
   onArchive: ArchiveFn;
+  onRequestDelete: RequestDeleteFn;
 }) {
   const { node } = props;
   const index = props.flat.indexOf(node.session);
@@ -1955,6 +2008,7 @@ function SessionTreeRow(props: {
         onMoveToChannel={props.onMoveToChannel}
         onUpdateAttention={props.onUpdateAttention}
         onArchive={props.onArchive}
+        onRequestDelete={props.onRequestDelete}
       />
       {hasVisibleChildRegion ? (
         <div role="list" aria-label={`Spawned sessions from ${title}`}>
@@ -1976,6 +2030,7 @@ function SessionTreeRow(props: {
               onMoveToChannel={props.onMoveToChannel}
               onUpdateAttention={props.onUpdateAttention}
               onArchive={props.onArchive}
+              onRequestDelete={props.onRequestDelete}
             />
           ) : null}
           {childCount > 0 && isExpanded
@@ -1998,6 +2053,7 @@ function SessionTreeRow(props: {
                   onMoveToChannel={props.onMoveToChannel}
                   onUpdateAttention={props.onUpdateAttention}
                   onArchive={props.onArchive}
+                  onRequestDelete={props.onRequestDelete}
                 />
               ))
             : null}
@@ -2079,6 +2135,7 @@ function SessionRow(props: {
   onMoveToChannel: MoveToChannelFn;
   onUpdateAttention: UpdateAttentionFn;
   onArchive: ArchiveFn;
+  onRequestDelete: RequestDeleteFn;
 }) {
   const rail = useRail();
   const title =
@@ -2233,6 +2290,7 @@ function SessionRow(props: {
             onMoveToChannel={props.onMoveToChannel}
             onUpdateAttention={props.onUpdateAttention}
             onArchive={props.onArchive}
+            onRequestDelete={props.onRequestDelete}
           />
         </div>
       </ContextMenuTrigger>
@@ -2298,6 +2356,15 @@ function SessionRow(props: {
             {props.session.archived ? "Restore" : "Archive"}
           </ContextMenuItem>
         ) : null}
+        {props.session.parentSessionId === null && props.session.archived ? (
+          <ContextMenuItem
+            className="pointer-coarse:min-h-11 text-status-failed"
+            onSelect={() => props.onRequestDelete(props.session)}
+          >
+            <Trash2Icon className="size-4" />
+            Delete workstream
+          </ContextMenuItem>
+        ) : null}
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -2341,6 +2408,7 @@ function RowActionsMenu({
   onMoveToChannel,
   onUpdateAttention,
   onArchive,
+  onRequestDelete,
 }: {
   session: Session;
   onRename: () => void;
@@ -2349,6 +2417,7 @@ function RowActionsMenu({
   onMoveToChannel: MoveToChannelFn;
   onUpdateAttention: UpdateAttentionFn;
   onArchive: ArchiveFn;
+  onRequestDelete: RequestDeleteFn;
 }) {
   const pinSelection = useRef(false);
   // Filing is a root-session concept: the rail groups a whole tree by its
@@ -2439,6 +2508,16 @@ function RowActionsMenu({
           >
             <ArchiveIcon className="size-4" />
             {session.archived ? "Restore" : "Archive"}
+          </DropdownMenuItem>
+        ) : null}
+        {session.parentSessionId === null && session.archived ? (
+          <DropdownMenuItem
+            variant="destructive"
+            onSelect={() => onRequestDelete(session)}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Trash2Icon className="size-4" />
+            Delete workstream
           </DropdownMenuItem>
         ) : null}
         {canMove ? (

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ It does **not** restate the run lifecycle, goal loop, deployment procedures, or 
 
 **The "managed agent service" framing.** OpenGeni is the _substrate_, not the agent. You bring a goal and a workspace; OpenGeni gives you:
 
-- **A session API** — create/list/get/rename sessions, Send/Steer human prompts, Pause/Resume recursive workstreams, terminally cancel session subtrees, approve tools, and read durable history.
+- **A session API** — create/list/get/rename sessions, Send/Steer human prompts, Pause/Resume recursive workstreams, terminally cancel session subtrees, permanently delete quiescent root trees, approve tools, and read durable history.
 - **An exactly-once live stream** — SSE anchored on a per-session monotonic `sequence`, with reconnect, replay, and gap backfill.
 - **Durable, recoverable runs** — runs survive worker death and provider hiccups, with no run-length limits by design.
 - **A dual compute model** — _provisioned sandboxes_ (disposable boxes OpenGeni creates, snapshots, and reaps across ten local/cloud backends) **and** _Connected Machines_ (a user's own always-on machine, enrolled via the `selfhosted` backend, as a **first-class, co-equal PRIMARY** compute target — a machine-targeted turn runs the agent **directly on the machine** with no cloud box created, leased, or billed).
@@ -958,6 +958,8 @@ The **relay** (`opengeni-relay`) is the data-plane edge that carries live pixel 
 ---
 
 ## 7. Component deep-dives
+
+Permanent session deletion is a distinct `sessions:control` boundary: only a complete root tree may be removed, every session and provider-side owner must be quiescent, tree-owned evidence cascades atomically, and independent forks or immutable workspace provenance keep their restrictive foreign keys and force the caller to archive instead.
 
 ### 7.1 `apps/api` — the public edge
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5887,6 +5887,7 @@ export const SessionAuthorizationOperation = z.enum([
   "session.pin.write",
   "session.attention.write",
   "session.archive.write",
+  "session.delete",
   "session.codex_account.write",
   "session.realtime.start",
   "session.realtime.control",

--- a/packages/db/drizzle/0312_quiescent_session_tree_deletion.sql
+++ b/packages/db/drizzle/0312_quiescent_session_tree_deletion.sql
@@ -1,0 +1,39 @@
+-- deployment-mode: rolling
+-- Allow the explicit quiescent session-tree deletion lifecycle to remove the
+-- rows that are owned exclusively by that tree. Cross-session and workspace
+-- provenance keeps its existing RESTRICT fence, so published artifacts,
+-- governed learning evidence, forks, and other durable external references
+-- fail closed instead of being silently orphaned.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+ALTER TABLE sessions
+  DROP CONSTRAINT sessions_workspace_parent_fk,
+  ADD CONSTRAINT sessions_workspace_parent_fk
+    FOREIGN KEY (workspace_id, parent_session_id)
+    REFERENCES sessions(workspace_id, id) ON DELETE CASCADE;
+
+ALTER TABLE session_turn_attempts
+  DROP CONSTRAINT session_turn_attempts_workspace_session_fk,
+  ADD CONSTRAINT session_turn_attempts_workspace_session_fk
+    FOREIGN KEY (workspace_id, session_id)
+    REFERENCES sessions(workspace_id, id) ON DELETE CASCADE;
+
+ALTER TABLE session_command_receipts
+  DROP CONSTRAINT session_command_receipts_target_session_fk,
+  ADD CONSTRAINT session_command_receipts_target_session_fk
+    FOREIGN KEY (workspace_id, target_session_id)
+    REFERENCES sessions(workspace_id, id) ON DELETE CASCADE;
+
+ALTER TABLE workspace_control_events
+  DROP CONSTRAINT workspace_control_events_root_session_fk,
+  ADD CONSTRAINT workspace_control_events_root_session_fk
+    FOREIGN KEY (workspace_id, root_session_id)
+    REFERENCES sessions(workspace_id, id) ON DELETE CASCADE;
+
+ALTER TABLE session_attempt_interruptions
+  DROP CONSTRAINT session_attempt_interruptions_workspace_session_fk,
+  ADD CONSTRAINT session_attempt_interruptions_workspace_session_fk
+    FOREIGN KEY (workspace_id, session_id)
+    REFERENCES sessions(workspace_id, id) ON DELETE CASCADE;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -26567,6 +26567,273 @@ export async function getSession(
   });
 }
 
+export type DeleteSessionTreeIfQuiescentResult =
+  | { status: "deleted"; deletedSessionCount: number }
+  | {
+      status:
+        | "not_found"
+        | "not_root"
+        | "active_sessions"
+        | "active_video_generations"
+        | "live_sandboxes"
+        | "externally_referenced";
+    };
+
+/**
+ * Permanently delete one complete root session tree after proving that no
+ * runtime or provider-side owner can still act on it.
+ *
+ * The workspace-control and tree row locks fence new sessions and concurrent
+ * lifecycle changes. Session-owned evidence follows the migration-owned
+ * cascade; immutable workspace-level provenance and independent forks
+ * deliberately retain RESTRICT and surface `externally_referenced` instead of
+ * being orphaned.
+ */
+export async function deleteSessionTreeIfQuiescent(
+  db: Database,
+  input: { workspaceId: string; subjectId: string; sessionId: string },
+): Promise<DeleteSessionTreeIfQuiescentResult> {
+  try {
+    return await withWorkspaceSubjectRls(
+      db,
+      input.workspaceId,
+      input.subjectId,
+      async (scopedDb) =>
+        await scopedDb.transaction(async (txRaw) => {
+          const tx = txRaw as unknown as Database;
+          // Match the canonical session-control lock prefix. Session creation
+          // takes this row FOR SHARE, so the update lock also fences a new
+          // descendant or shared-sandbox peer from appearing after our tree
+          // and group checks.
+          await lockWorkspaceInferenceControl(tx, input.workspaceId, "update");
+          const [root] = await tx
+            .select({
+              id: schema.sessions.id,
+              parentSessionId: schema.sessions.parentSessionId,
+            })
+            .from(schema.sessions)
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, input.sessionId),
+              ),
+            )
+            .for("update", { noWait: true })
+            .limit(1);
+          if (!root) return { status: "not_found" as const };
+          if (root.parentSessionId !== null) return { status: "not_root" as const };
+
+          const tree = await tx
+            .select({
+              id: schema.sessions.id,
+              status: schema.sessions.status,
+              sandboxGroupId: schema.sessions.sandboxGroupId,
+            })
+            .from(schema.sessions)
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.rootSessionId, input.sessionId),
+              ),
+            )
+            .for("update", { noWait: true });
+          const sessionIds = tree.map((session) => session.id);
+          const groupIds = [...new Set(tree.map((session) => session.sandboxGroupId))];
+          if (
+            tree.some((session) =>
+              ["queued", "running", "requires_action", "recovering", "waiting_capacity"].includes(
+                session.status,
+              ),
+            )
+          ) {
+            return { status: "active_sessions" as const };
+          }
+
+          const [liveAttempts, activeVideoGenerations, externalForks, sharedGroups] =
+            await Promise.all([
+              tx
+                .select({ id: schema.sessionTurnAttempts.id })
+                .from(schema.sessionTurnAttempts)
+                .where(
+                  and(
+                    eq(schema.sessionTurnAttempts.workspaceId, input.workspaceId),
+                    inArray(schema.sessionTurnAttempts.sessionId, sessionIds),
+                    inArray(schema.sessionTurnAttempts.state, ["claimed", "running"]),
+                  ),
+                )
+                .for("update", { noWait: true }),
+              tx
+                .select({ id: schema.videoGenerationOperations.id })
+                .from(schema.videoGenerationOperations)
+                .where(
+                  and(
+                    eq(schema.videoGenerationOperations.workspaceId, input.workspaceId),
+                    inArray(schema.videoGenerationOperations.sessionId, sessionIds),
+                    inArray(schema.videoGenerationOperations.status, [
+                      "preparing",
+                      "prepared",
+                      "accepted",
+                      "submission_uncertain",
+                      "provider_started",
+                      "retaining",
+                    ]),
+                  ),
+                )
+                .for("update", { noWait: true }),
+              tx
+                .select({ id: schema.sessions.id })
+                .from(schema.sessions)
+                .where(
+                  and(
+                    eq(schema.sessions.workspaceId, input.workspaceId),
+                    inArray(schema.sessions.forkedFromSessionId, sessionIds),
+                    notInArray(schema.sessions.id, sessionIds),
+                  ),
+                )
+                .limit(1),
+              tx
+                .select({ id: schema.sessions.id })
+                .from(schema.sessions)
+                .where(
+                  and(
+                    eq(schema.sessions.workspaceId, input.workspaceId),
+                    inArray(schema.sessions.sandboxGroupId, groupIds),
+                    notInArray(schema.sessions.id, sessionIds),
+                  ),
+                )
+                .limit(1),
+            ]);
+          if (liveAttempts.length > 0) return { status: "active_sessions" as const };
+          if (activeVideoGenerations.length > 0) {
+            return { status: "active_video_generations" as const };
+          }
+          if (externalForks.length > 0 || sharedGroups.length > 0) {
+            return { status: "externally_referenced" as const };
+          }
+
+          const leases = await tx
+            .select({
+              id: schema.sandboxLeases.id,
+              liveness: schema.sandboxLeases.liveness,
+              refcount: schema.sandboxLeases.refcount,
+              turnHolders: schema.sandboxLeases.turnHolders,
+              viewerHolders: schema.sandboxLeases.viewerHolders,
+              instanceId: schema.sandboxLeases.instanceId,
+              archiveCaptureId: schema.sandboxLeases.archiveCaptureId,
+              reaperHoldId: schema.sandboxLeases.reaperHoldId,
+              rotationRequestedAt: schema.sandboxLeases.rotationRequestedAt,
+              providerDeadlineAt: schema.sandboxLeases.providerDeadlineAt,
+            })
+            .from(schema.sandboxLeases)
+            .where(
+              and(
+                eq(schema.sandboxLeases.workspaceId, input.workspaceId),
+                inArray(schema.sandboxLeases.sandboxGroupId, groupIds),
+              ),
+            )
+            .for("update", { noWait: true });
+          if (
+            leases.some(
+              (lease) =>
+                lease.liveness !== "cold" ||
+                lease.refcount !== 0 ||
+                lease.turnHolders !== 0 ||
+                lease.viewerHolders !== 0 ||
+                lease.instanceId !== null ||
+                lease.archiveCaptureId !== null ||
+                lease.reaperHoldId !== null ||
+                lease.rotationRequestedAt !== null ||
+                lease.providerDeadlineAt !== null,
+            )
+          ) {
+            return { status: "live_sandboxes" as const };
+          }
+
+          const leaseIds = leases.map((lease) => lease.id);
+          if (leaseIds.length > 0) {
+            const [holders, unsettledAdmissions, activeProcesses, openPtys] = await Promise.all([
+              tx
+                .select({ id: schema.sandboxLeaseHolders.id })
+                .from(schema.sandboxLeaseHolders)
+                .where(inArray(schema.sandboxLeaseHolders.leaseId, leaseIds))
+                .for("update", { noWait: true }),
+              tx
+                .select({ id: schema.sandboxWorkspaceMutationAdmissions.id })
+                .from(schema.sandboxWorkspaceMutationAdmissions)
+                .where(
+                  and(
+                    inArray(schema.sandboxWorkspaceMutationAdmissions.leaseId, leaseIds),
+                    isNull(schema.sandboxWorkspaceMutationAdmissions.settledAt),
+                  ),
+                )
+                .for("update", { noWait: true }),
+              tx
+                .select({ id: schema.sandboxRetainedProcesses.id })
+                .from(schema.sandboxRetainedProcesses)
+                .where(
+                  and(
+                    inArray(schema.sandboxRetainedProcesses.leaseId, leaseIds),
+                    eq(schema.sandboxRetainedProcesses.state, "active"),
+                  ),
+                )
+                .for("update", { noWait: true }),
+              tx
+                .select({ id: schema.sandboxPtySessions.id })
+                .from(schema.sandboxPtySessions)
+                .where(
+                  and(
+                    inArray(schema.sandboxPtySessions.sessionId, sessionIds),
+                    eq(schema.sandboxPtySessions.status, "open"),
+                  ),
+                )
+                .for("update", { noWait: true }),
+            ]);
+            if (
+              holders.length > 0 ||
+              unsettledAdmissions.length > 0 ||
+              activeProcesses.length > 0 ||
+              openPtys.length > 0
+            ) {
+              return { status: "live_sandboxes" as const };
+            }
+            await tx.delete(schema.sandboxLeases).where(inArray(schema.sandboxLeases.id, leaseIds));
+          }
+
+          const deleted = await tx
+            .delete(schema.sessions)
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, input.sessionId),
+              ),
+            )
+            .returning({ id: schema.sessions.id });
+          if (deleted.length !== 1) return { status: "not_found" as const };
+          return { status: "deleted" as const, deletedSessionCount: sessionIds.length };
+        }),
+    );
+  } catch (error) {
+    let current: unknown = error;
+    const visited = new Set<unknown>();
+    for (let depth = 0; depth < 8 && current && !visited.has(current); depth += 1) {
+      visited.add(current);
+      const code =
+        typeof current === "object" && "code" in current
+          ? (current as { code?: unknown }).code
+          : undefined;
+      if (code === "55P03") return { status: "live_sandboxes" };
+      if (code === "23503" || code === "42501" || code === "55000") {
+        return { status: "externally_referenced" };
+      }
+      current =
+        typeof current === "object" && "cause" in current
+          ? (current as { cause?: unknown }).cause
+          : undefined;
+    }
+    throw error;
+  }
+}
+
 export type SessionAuthorityProjection = {
   sessionId: string;
   rootSessionId: string;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3190,8 +3190,8 @@ export const sessions = pgTable(
     // spawning a worker); null for direct API creates and scheduled-task runs.
     // When set, this worker's terminal-for-now transitions wake the parent so a
     // manager can orchestrate workers without busy-polling. The migration-owned
-    // self-reference uses ON DELETE RESTRICT so immutable hierarchy and
-    // authority lineage cannot be silently orphaned by a parent hard delete.
+    // self-reference uses ON DELETE CASCADE so the explicit quiescent root-tree
+    // deletion lifecycle removes the complete hierarchy atomically.
     parentSessionId: uuid("parent_session_id"),
     // Exact parent turn whose worker-signed attempt created this child. This is
     // private immutable authority lineage: child completion copies personal MCP
@@ -5561,7 +5561,7 @@ export const sessionTurnAttempts = pgTable(
       name: "session_turn_attempts_workspace_session_fk",
       columns: [table.workspaceId, table.sessionId],
       foreignColumns: [sessions.workspaceId, sessions.id],
-    }).onDelete("restrict"),
+    }).onDelete("cascade"),
     workspaceTurn: foreignKey({
       name: "session_turn_attempts_workspace_turn_fk",
       columns: [table.workspaceId, table.turnId],
@@ -6181,7 +6181,7 @@ export const sessionCommandReceipts = pgTable(
       name: "session_command_receipts_target_session_fk",
       columns: [table.workspaceId, table.targetSessionId],
       foreignColumns: [sessions.workspaceId, sessions.id],
-    }).onDelete("restrict"),
+    }).onDelete("cascade"),
     targetTurn: foreignKey({
       name: "session_command_receipts_target_turn_fk",
       columns: [table.workspaceId, table.targetTurnId],
@@ -6247,7 +6247,7 @@ export const workspaceControlEvents = pgTable(
       name: "workspace_control_events_root_session_fk",
       columns: [table.workspaceId, table.rootSessionId],
       foreignColumns: [sessions.workspaceId, sessions.id],
-    }).onDelete("restrict"),
+    }).onDelete("cascade"),
     workspaceRevision: uniqueIndex("workspace_control_events_workspace_revision_uq").on(
       table.workspaceId,
       table.revision,
@@ -6295,7 +6295,7 @@ export const sessionAttemptInterruptions = pgTable(
       name: "session_attempt_interruptions_workspace_session_fk",
       columns: [table.workspaceId, table.sessionId],
       foreignColumns: [sessions.workspaceId, sessions.id],
-    }).onDelete("restrict"),
+    }).onDelete("cascade"),
     operation: foreignKey({
       name: "session_attempt_interruptions_operation_fk",
       columns: [table.workspaceId, table.operationId],

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1121,6 +1121,17 @@ export class OpenGeniClient {
     );
   }
 
+  /** Permanently delete one quiescent root session and its full descendant tree. */
+  async deleteSession(
+    workspaceId: string,
+    sessionId: string,
+  ): Promise<{ deletedSessionCount: number }> {
+    return await this.requestJson<{ deletedSessionCount: number }>(
+      "DELETE",
+      `/v1/workspaces/${workspaceId}/sessions/${sessionId}`,
+    );
+  }
+
   async getSessionLineage(workspaceId: string, sessionId: string): Promise<SessionLineageResponse> {
     const path = `/v1/workspaces/${workspaceId}/sessions/${sessionId}/lineage`;
     return await this.singleFlightRead(path, () =>

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -147,6 +147,7 @@ describe("release schema contract", () => {
       "0305_personal_resource_grant_management.sql",
       "0306_atomic_personal_resource_attachments.sql",
       "0311_company_scope_and_private_session_create.sql",
+      "0312_quiescent_session_tree_deletion.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );


### PR DESCRIPTION
## Summary

- add a `sessions:control` DELETE API and SDK method for complete root session trees
- fence deletion on canonical workspace/session locks, live attempts, video work, sandbox ownership, and durable external references
- expose a destructive confirmation action for archived root workstreams
- add migration, architecture, authorization, and real PostgreSQL coverage

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun test apps/api/test/session-delete.test.ts apps/api/test/session-authorization.test.ts`
- `bun run check:migration-ordinals`
- `bun run check:docs-refs`
- API, SDK, and web production builds

Linear: OPE-286