### PR TITLE
fix(web): keep active session unread state accurate

### DIFF
--- a/.changeset/exact-session-read-frontier.md
+++ b/.changeset/exact-session-read-frontier.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/sdk": patch
+---
+
+Allow foreground session readers to acknowledge an exact rendered event sequence so later unseen events remain unread.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1493,9 +1493,10 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     }
   });
 
-  // Personal follow-up state. Viewing a session never acknowledges it; the
-  // member must explicitly mark it read/unread, and the actively-working label
-  // remains independent of that acknowledgment.
+  // Personal follow-up state. Session reads stay side-effect free; clients use
+  // this explicit mutation after a deliberate read/unread action. The managed
+  // web console treats an exact foreground chat view as that action, while the
+  // actively-working label remains independent of acknowledgment.
   app.put("/v1/workspaces/:workspaceId/sessions/:sessionId/attention", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:read");

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1495,8 +1495,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // Personal follow-up state. Session reads stay side-effect free; clients use
   // this explicit mutation after a deliberate read/unread action. The managed
-  // web console treats an exact foreground chat view as that action, while the
-  // actively-working label remains independent of acknowledgment.
+  // web console treats an exact foreground chat event frontier as that action,
+  // while the actively-working label remains independent of acknowledgment.
   app.put("/v1/workspaces/:workspaceId/sessions/:sessionId/attention", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:read");

--- a/apps/web/src/lib/session-attention.test.ts
+++ b/apps/web/src/lib/session-attention.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { sessionReadProjectionKey, shouldAcknowledgeActiveSession } from "./session-attention";
+
+const session = {
+  id: "session-a",
+  workspaceId: "workspace-a",
+  unread: true,
+  archived: false,
+};
+
+describe("active session read acknowledgement", () => {
+  test("a later event in the same open chat requires a new acknowledgement", () => {
+    const acknowledged = sessionReadProjectionKey(session.id, 12);
+    expect(sessionReadProjectionKey(session.id, 12)).toBe(acknowledged);
+    expect(sessionReadProjectionKey(session.id, 13)).not.toBe(acknowledged);
+  });
+
+  test("acknowledges the exact unread chat in the foreground", () => {
+    expect(
+      shouldAcknowledgeActiveSession({
+        activeSessionId: session.id,
+        workspaceId: session.workspaceId,
+        session,
+        documentVisible: true,
+        windowFocused: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not consume unread state for a background tab or window", () => {
+    for (const foreground of [
+      { documentVisible: false, windowFocused: true },
+      { documentVisible: true, windowFocused: false },
+    ]) {
+      expect(
+        shouldAcknowledgeActiveSession({
+          activeSessionId: session.id,
+          workspaceId: session.workspaceId,
+          session,
+          ...foreground,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("rejects stale route, workspace, read, and archived projections", () => {
+    const candidates = [
+      { activeSessionId: "session-b", workspaceId: "workspace-a", session },
+      { activeSessionId: "session-a", workspaceId: "workspace-b", session },
+      {
+        activeSessionId: "session-a",
+        workspaceId: "workspace-a",
+        session: { ...session, unread: false },
+      },
+      {
+        activeSessionId: "session-a",
+        workspaceId: "workspace-a",
+        session: { ...session, archived: true },
+      },
+      { activeSessionId: "session-a", workspaceId: "workspace-a", session: null },
+    ];
+    for (const candidate of candidates) {
+      expect(
+        shouldAcknowledgeActiveSession({
+          ...candidate,
+          documentVisible: true,
+          windowFocused: true,
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/session-attention.ts
+++ b/apps/web/src/lib/session-attention.ts
@@ -1,0 +1,35 @@
+import type { Session } from "@/types";
+
+export type ActiveSessionReadCandidate = Pick<
+  Session,
+  "id" | "workspaceId" | "unread" | "archived"
+>;
+
+/** One foreground-view receipt per exact session event frontier. */
+export function sessionReadProjectionKey(sessionId: string, latestEventSequence: number): string {
+  return `${sessionId}:${latestEventSequence}`;
+}
+
+/**
+ * A chat is read only while the exact route is genuinely in the foreground.
+ * Merely leaving a session route mounted in a background tab/window must not
+ * consume its unread signal.
+ */
+export function shouldAcknowledgeActiveSession(input: {
+  activeSessionId: string | null;
+  workspaceId: string;
+  session: ActiveSessionReadCandidate | null;
+  documentVisible: boolean;
+  windowFocused: boolean;
+}): boolean {
+  const { session } = input;
+  return Boolean(
+    input.documentVisible &&
+    input.windowFocused &&
+    session &&
+    !session.archived &&
+    session.unread &&
+    session.workspaceId === input.workspaceId &&
+    session.id === input.activeSessionId,
+  );
+}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -325,6 +325,7 @@ export function SessionRoute({
       void client
         .updateSessionAttention(workspaceId, targetSession.id, {
           unread: false,
+          acknowledgedThroughSequence: latestEventSequence,
         })
         .then(async (updated) => {
           if (cancelled || !ownsWorkspaceInvocation(workspaceId, acceptedTransition)) return;

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -89,6 +89,7 @@ import {
 } from "@/lib/model-policy";
 import { sessionTimelineEmptyStateCopy } from "@/lib/session-empty-state";
 import { mergeSessionContextProjection } from "@/lib/session-pins";
+import { sessionReadProjectionKey, shouldAcknowledgeActiveSession } from "@/lib/session-attention";
 import { createWorkspaceRetainedArtifactLoader } from "@/lib/retained-artifact-loader";
 import { downloadSandboxFileArtifact } from "@/lib/sandbox-artifact-download";
 import { createSessionRetainedScreenshotLoader } from "@/lib/retained-screenshot-loader";
@@ -255,46 +256,115 @@ export function SessionRoute({
 
   // Keep the workspace header (title, status badge, connection pill) in sync.
   const {
+    client,
+    captureWorkspaceInvocation,
+    ownsWorkspaceInvocation,
     setSession: setContextSession,
     setConnectionState: setContextConnectionState,
     sessionEventFeedStore,
   } = context;
-  const acknowledgedSessionRef = useRef<string | null>(null);
+  const acknowledgedProjectionRef = useRef<string | null>(null);
+  const [foreground, setForeground] = useState(() => ({
+    documentVisible: document.visibilityState === "visible",
+    windowFocused: document.hasFocus(),
+  }));
+  const latestEventSequence = useMemo(
+    () => events.reduce((latest, event) => Math.max(latest, event.sequence), 0),
+    [events],
+  );
   useEffect(() => {
     setContextSession((current) => mergeSessionContextProjection(current, session));
   }, [session, setContextSession]);
   useEffect(() => {
-    if (!session?.unread || acknowledgedSessionRef.current === session.id) return;
-    acknowledgedSessionRef.current = session.id;
-    void context.client
-      .updateSessionAttention(workspaceId, session.id, {
-        unread: false,
-        expectedVersion: session.attentionVersion ?? 0,
-      })
-      .then((updated) => {
-        setContextSession((current) =>
-          current?.id === updated.id
-            ? {
-                ...current,
-                unread: updated.unread,
-                activelyWorking: updated.activelyWorking,
-                attentionVersion: updated.attentionVersion,
-              }
-            : current,
-        );
-      })
-      .catch(() => {
-        // A later route load or the normal rail refresh can retry. Reading a
-        // chat should never interrupt the user with an acknowledgement error.
-        if (acknowledgedSessionRef.current === session.id) {
-          acknowledgedSessionRef.current = null;
-        }
+    const reconcileForeground = () => {
+      setForeground({
+        documentVisible: document.visibilityState === "visible",
+        windowFocused: document.hasFocus(),
       });
+    };
+    window.addEventListener("focus", reconcileForeground);
+    window.addEventListener("blur", reconcileForeground);
+    document.addEventListener("visibilitychange", reconcileForeground);
+    return () => {
+      window.removeEventListener("focus", reconcileForeground);
+      window.removeEventListener("blur", reconcileForeground);
+      document.removeEventListener("visibilitychange", reconcileForeground);
+    };
+  }, []);
+  useEffect(() => {
+    const projectionKey = session
+      ? sessionReadProjectionKey(session.id, latestEventSequence)
+      : null;
+    const unreadProjection = session
+      ? {
+          ...session,
+          unread:
+            (session.unread || latestEventSequence > 0) &&
+            projectionKey !== acknowledgedProjectionRef.current,
+        }
+      : null;
+    if (
+      !session ||
+      !projectionKey ||
+      !shouldAcknowledgeActiveSession({
+        activeSessionId: sessionId,
+        workspaceId,
+        session: unreadProjection,
+        ...foreground,
+      })
+    ) {
+      return;
+    }
+    const targetSession = session;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      if (document.visibilityState !== "visible" || !document.hasFocus()) return;
+      const acceptedTransition = captureWorkspaceInvocation(workspaceId);
+      if (!acceptedTransition) return;
+      acknowledgedProjectionRef.current = projectionKey;
+      void client
+        .updateSessionAttention(workspaceId, targetSession.id, {
+          unread: false,
+        })
+        .then(async (updated) => {
+          if (cancelled || !ownsWorkspaceInvocation(workspaceId, acceptedTransition)) return;
+          setContextSession((current) =>
+            current?.id === updated.id
+              ? {
+                  ...current,
+                  unread: updated.unread,
+                  activelyWorking: updated.activelyWorking,
+                  attentionVersion: updated.attentionVersion,
+                }
+              : current,
+          );
+          await refreshSession();
+        })
+        .catch(() => {
+          // A foreground/focus transition or the next durable event can retry.
+          // Reading a chat should never interrupt the user with an error.
+          if (
+            !cancelled &&
+            ownsWorkspaceInvocation(workspaceId, acceptedTransition) &&
+            acknowledgedProjectionRef.current === projectionKey
+          ) {
+            acknowledgedProjectionRef.current = null;
+          }
+        });
+    }, 750);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, [
-    context.client,
-    session?.attentionVersion,
-    session?.id,
-    session?.unread,
+    captureWorkspaceInvocation,
+    client,
+    foreground,
+    latestEventSequence,
+    ownsWorkspaceInvocation,
+    refreshSession,
+    session,
+    sessionId,
     setContextSession,
     workspaceId,
   ]);

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -271,6 +271,7 @@ export function SessionRoute({
     sessionEventFeedStore,
   } = context;
   const acknowledgedProjectionRef = useRef<string | null>(null);
+  const retriedProjectionRef = useRef<string | null>(null);
   const [foreground, setForeground] = useState(() => ({
     documentVisible: document.visibilityState === "visible",
     windowFocused: document.hasFocus(),
@@ -347,13 +348,16 @@ export function SessionRoute({
           );
         })
         .catch(() => {
-          // A foreground/focus transition or the next durable event can retry.
-          // Reading a chat should never interrupt the user with an error.
+          // Retry one transient failure for this exact frontier. Keeping the
+          // receipt after the second failure prevents a permanent 4xx/5xx from
+          // becoming an unbounded request and log loop.
           if (
             !cancelled &&
             ownsWorkspaceInvocation(workspaceId, acceptedTransition) &&
-            acknowledgedProjectionRef.current === projectionKey
+            acknowledgedProjectionRef.current === projectionKey &&
+            retriedProjectionRef.current !== projectionKey
           ) {
+            retriedProjectionRef.current = projectionKey;
             acknowledgedProjectionRef.current = null;
             setAttentionRetryRevision((revision) => revision + 1);
           }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5426,17 +5426,25 @@ export type UpdateSessionPinRequest = z.infer<typeof UpdateSessionPinRequest>;
 /**
  * A member's durable follow-up state for one session. Reading the session does
  * not acknowledge it: `unread` changes only through this explicit mutation.
+ * A foreground reader may provide `acknowledgedThroughSequence` with
+ * `unread: false` so later server events remain unread instead of being
+ * consumed by a delayed acknowledgement request.
  * `activelyWorking` is an independent personal label that survives read state.
  */
 export const UpdateSessionAttentionRequest = z
   .object({
     unread: z.boolean().optional(),
+    acknowledgedThroughSequence: z.number().int().nonnegative().optional(),
     activelyWorking: z.boolean().optional(),
     expectedVersion: z.number().int().nonnegative().optional(),
   })
   .strict()
   .refine((value) => value.unread !== undefined || value.activelyWorking !== undefined, {
     message: "unread or activelyWorking is required",
+  })
+  .refine((value) => value.acknowledgedThroughSequence === undefined || value.unread === false, {
+    message: "acknowledgedThroughSequence requires unread false",
+    path: ["acknowledgedThroughSequence"],
   });
 export type UpdateSessionAttentionRequest = z.infer<typeof UpdateSessionAttentionRequest>;
 

--- a/packages/contracts/test/session-attention.test.ts
+++ b/packages/contracts/test/session-attention.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { UpdateSessionAttentionRequest } from "../src/index";
+
+describe("session attention request", () => {
+  test("accepts an exact read-through event frontier", () => {
+    expect(
+      UpdateSessionAttentionRequest.parse({
+        unread: false,
+        acknowledgedThroughSequence: 42,
+      }),
+    ).toEqual({ unread: false, acknowledgedThroughSequence: 42 });
+  });
+
+  test("keeps read-through frontiers bounded to read acknowledgements", () => {
+    for (const request of [
+      { acknowledgedThroughSequence: 42 },
+      { unread: true, acknowledgedThroughSequence: 42 },
+      { unread: false, acknowledgedThroughSequence: -1 },
+      { unread: false, acknowledgedThroughSequence: 1.5 },
+    ]) {
+      expect(UpdateSessionAttentionRequest.safeParse(request).success).toBe(false);
+    }
+  });
+
+  test("preserves ordinary unread and actively-working mutations", () => {
+    expect(UpdateSessionAttentionRequest.safeParse({ unread: true }).success).toBe(true);
+    expect(UpdateSessionAttentionRequest.safeParse({ activelyWorking: true }).success).toBe(true);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -28304,6 +28304,7 @@ export async function setSessionAttention(
     subjectId: string;
     sessionId: string;
     unread?: boolean | undefined;
+    acknowledgedThroughSequence?: number | undefined;
     activelyWorking?: boolean | undefined;
     expectedVersion?: number | undefined;
   },
@@ -28351,10 +28352,24 @@ export async function setSessionAttention(
           )
           .limit(1);
         const current = mapSessionAttention(session, existing);
-        const desiredUnread = input.unread ?? current.unread;
+        const currentAcknowledgedSequence = existing?.acknowledgedSequence ?? 0;
+        const acknowledgedSequence =
+          input.unread === undefined
+            ? currentAcknowledgedSequence
+            : input.unread
+              ? current.unread
+                ? currentAcknowledgedSequence
+                : Math.max(-1, session.lastSequence - 1)
+              : Math.max(
+                  currentAcknowledgedSequence,
+                  Math.min(
+                    input.acknowledgedThroughSequence ?? session.lastSequence,
+                    session.lastSequence,
+                  ),
+                );
         const desiredActivelyWorking = input.activelyWorking ?? current.activelyWorking;
         if (
-          desiredUnread === current.unread &&
+          acknowledgedSequence === currentAcknowledgedSequence &&
           desiredActivelyWorking === current.activelyWorking
         ) {
           const mcpServers = await sessionMcpServerMetadataForSessions(tx, input.workspaceId, [
@@ -28375,12 +28390,6 @@ export async function setSessionAttention(
           throw new SessionAttentionVersionConflictError(current);
         }
 
-        const acknowledgedSequence =
-          input.unread === undefined
-            ? (existing?.acknowledgedSequence ?? 0)
-            : input.unread
-              ? Math.max(-1, session.lastSequence - 1)
-              : session.lastSequence;
         let state = existing ?? null;
         if (!existing) {
           const [inserted] = await tx

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -28293,9 +28293,9 @@ export async function setSessionPin(
 }
 
 /**
- * Idempotently update one member's explicit follow-up state. Opening a route is
- * intentionally absent from this protocol: acknowledgment is a deliberate
- * action, and the next durable session event makes the session unread again.
+ * Idempotently update one member's explicit follow-up state. Route reads remain
+ * side-effect free: a foreground client acknowledges its exact rendered event
+ * frontier through this mutation, and later durable events remain unread.
  */
 export async function setSessionAttention(
   db: Database,

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -1478,30 +1478,48 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       { unread: true, activelyWorking: false, attentionVersion: 2 },
     );
 
+    // The browser rendered through sequence 3, then sequence 5 arrived before
+    // its acknowledgement request reached the API. Only the rendered frontier
+    // is consumed; the unseen newer events remain unread.
+    const partialRead = await setSessionAttention(db, {
+      workspaceId: workspace.workspaceId,
+      subjectId: subject,
+      sessionId: target.id,
+      unread: false,
+      acknowledgedThroughSequence: 3,
+      expectedVersion: 2,
+    });
+    expect(partialRead).toMatchObject({
+      unread: true,
+      activelyWorking: false,
+      attentionVersion: 3,
+    });
+
     const read = await setSessionAttention(db, {
       workspaceId: workspace.workspaceId,
       subjectId: subject,
       sessionId: target.id,
       unread: false,
-      expectedVersion: 2,
+      acknowledgedThroughSequence: 5,
+      expectedVersion: 3,
     });
-    expect(read).toMatchObject({ unread: false, activelyWorking: false, attentionVersion: 3 });
+    expect(read).toMatchObject({ unread: false, activelyWorking: false, attentionVersion: 4 });
 
     const active = await setSessionAttention(db, {
       workspaceId: workspace.workspaceId,
       subjectId: subject,
       sessionId: target.id,
       activelyWorking: true,
-      expectedVersion: 3,
+      expectedVersion: 4,
     });
-    expect(active).toMatchObject({ unread: false, activelyWorking: true, attentionVersion: 4 });
+    expect(active).toMatchObject({ unread: false, activelyWorking: true, attentionVersion: 5 });
 
     await executeSessionActivity(
       workspace.workspaceId,
       sql`update sessions set last_sequence = 6 where id = ${target.id}`,
     );
     expect(await getSessionForSubject(db, workspace.workspaceId, target.id, subject)).toMatchObject(
-      { unread: true, activelyWorking: true, attentionVersion: 4 },
+      { unread: true, activelyWorking: true, attentionVersion: 5 },
     );
     expect(
       await getSessionForSubject(db, workspace.workspaceId, target.id, otherSubject),

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1283,6 +1283,7 @@ export type UpdateSessionPinRequest = {
 
 export type UpdateSessionAttentionRequest = {
   unread?: boolean;
+  acknowledgedThroughSequence?: number;
   activelyWorking?: boolean;
   expectedVersion?: number;
 };

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -64,7 +64,7 @@ const budgets = {
   // Foreground read reconciliation now follows each active chat's durable
   // event frontier and composes with the landed same-tab rail projection. The
   // exact configured production graph measures 1,499,526 initial raw bytes and
-  // 2,083,190 direct-session raw bytes on macOS/arm64; their next whole-KiB
+  // 2,083,239 direct-session raw bytes on macOS/arm64; their next whole-KiB
   // envelopes are 1,465 and 2,035 KiB. Every gzip, file, lazy, and CSS cap
   // remains unchanged.
   initialRaw: 1465 * kib,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -61,7 +61,13 @@ const budgets = {
   // 2,081,360 raw / 578,755 gzip bytes on a direct session load on
   // macOS/arm64. Only these three graph envelopes advance to the next whole
   // KiB; file, lazy, CSS, and all other caps remain unchanged.
-  initialRaw: 1464 * kib,
+  // Foreground read reconciliation now follows each active chat's durable
+  // event frontier and composes with the landed same-tab rail projection. The
+  // exact configured production graph measures 1,499,526 initial raw bytes and
+  // 2,083,190 direct-session raw bytes on macOS/arm64; their next whole-KiB
+  // envelopes are 1,465 and 2,035 KiB. Every gzip, file, lazy, and CSS cap
+  // remains unchanged.
+  initialRaw: 1465 * kib,
   // The managed personal-resource create/composer controls plus current main
   // measured 1,484,426 initial raw and 577,450 direct-session gzip bytes on
   // macOS/arm64. The final uncertain-Send reconciliation repair measured
@@ -69,18 +75,13 @@ const budgets = {
   // next full-KiB envelope is 2,030 KiB (2,078,720 bytes). The 1,450 KiB
   // initial-raw and 564 KiB direct-session-gzip envelopes, plus every unrelated
   // graph and per-file cap, stay fixed.
-  // Foreground read reconciliation now follows each active chat's durable
-  // event frontier instead of acknowledging only its first render. The exact
-  // configured production graph measures 2,082,545 raw bytes on macOS/arm64;
-  // its next whole-KiB envelope is 2,034 KiB. Every gzip, file, lazy, initial,
-  // and CSS cap remains unchanged.
   initialGzip: 400 * kib,
   // 77 KiB: the largest shared chunk sits 22 bytes over 76 KiB under CI's
   // bun chunking with the channels/For-you rail code; the graph totals above
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2034 * kib,
+  directSessionRaw: 2035 * kib,
   directSessionGzip: 566 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -69,13 +69,18 @@ const budgets = {
   // next full-KiB envelope is 2,030 KiB (2,078,720 bytes). The 1,450 KiB
   // initial-raw and 564 KiB direct-session-gzip envelopes, plus every unrelated
   // graph and per-file cap, stay fixed.
+  // Foreground read reconciliation now follows each active chat's durable
+  // event frontier instead of acknowledging only its first render. The exact
+  // configured production graph measures 2,082,545 raw bytes on macOS/arm64;
+  // its next whole-KiB envelope is 2,034 KiB. Every gzip, file, lazy, initial,
+  // and CSS cap remains unchanged.
   initialGzip: 400 * kib,
   // 77 KiB: the largest shared chunk sits 22 bytes over 76 KiB under CI's
   // bun chunking with the channels/For-you rail code; the graph totals above
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2033 * kib,
+  directSessionRaw: 2034 * kib,
   directSessionGzip: 566 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -130,6 +130,76 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await shared?.release();
   }, 60_000);
 
+  test("acknowledges later output without leaving and reopening the active chat", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const target = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Unread active chat",
+      );
+      const attentionPath = `/v1/workspaces/${workspaceId}/sessions/${target.id}/attention`;
+      const firstAcknowledgement = page.waitForResponse(
+        (response) =>
+          response.request().method() === "PUT" &&
+          new URL(response.url()).pathname === attentionPath,
+        { timeout: 10_000 },
+      );
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
+      expect((await firstAcknowledgement).status()).toBe(200);
+      // Let every initial tail/load projection settle so the next mutation can
+      // only be caused by the event appended below, not by a second initial
+      // render of the same chat.
+      await page.waitForTimeout(1_500);
+
+      const laterAcknowledgement = page.waitForResponse(
+        (response) =>
+          response.request().method() === "PUT" &&
+          new URL(response.url()).pathname === attentionPath,
+        { timeout: 10_000 },
+      );
+      const sendResponse = await page.evaluate(
+        async ({ browserApiBaseUrl, targetWorkspaceId, targetSessionId }) => {
+          const response = await fetch(
+            `${browserApiBaseUrl}/v1/workspaces/${targetWorkspaceId}/sessions/${targetSessionId}/events`,
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                type: "user.message",
+                clientEventId: crypto.randomUUID(),
+                payload: { text: "Later output arrived while the chat stayed open" },
+              }),
+            },
+          );
+          return { status: response.status, body: await response.text() };
+        },
+        {
+          browserApiBaseUrl: apiBaseUrl,
+          targetWorkspaceId: workspaceId,
+          targetSessionId: target.id,
+        },
+      );
+      expect(sendResponse).toEqual({ status: 202, body: expect.any(String) });
+      expect((await laterAcknowledgement).status()).toBe(200);
+      await page
+        .locator(`a[data-session-row="${target.id}"]`)
+        .waitFor({ state: "visible", timeout: 10_000 });
+      expect(
+        await page.locator(`a[data-session-row="${target.id}"]`).getAttribute("aria-label"),
+      ).not.toContain("unread");
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+
   test("pins through UI, reconciles another device, and stays above newer paged/search rows", async () => {
     const deviceA = await configuredContext(browser, {
       viewport: { width: 1280, height: 800 },

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -146,14 +146,33 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         "Unread active chat",
       );
       const attentionPath = `/v1/workspaces/${workspaceId}/sessions/${target.id}/attention`;
+      let acknowledgementAttempts = 0;
+      await page.route(`**${attentionPath}`, async (route) => {
+        acknowledgementAttempts += 1;
+        if (acknowledgementAttempts === 1) {
+          await route.fulfill({
+            status: 503,
+            contentType: "application/json",
+            body: JSON.stringify({ message: "transient acknowledgement failure" }),
+          });
+          return;
+        }
+        await route.continue();
+      });
       const firstAcknowledgement = page.waitForResponse(
         (response) =>
           response.request().method() === "PUT" &&
-          new URL(response.url()).pathname === attentionPath,
+          new URL(response.url()).pathname === attentionPath &&
+          response.status() === 200,
         { timeout: 10_000 },
       );
       await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
-      expect((await firstAcknowledgement).status()).toBe(200);
+      const firstAcknowledgementResponse = await firstAcknowledgement;
+      const firstReadThrough = Number(
+        firstAcknowledgementResponse.request().postDataJSON().acknowledgedThroughSequence,
+      );
+      expect(acknowledgementAttempts).toBeGreaterThanOrEqual(2);
+      expect(Number.isSafeInteger(firstReadThrough)).toBe(true);
       // Let every initial tail/load projection settle so the next mutation can
       // only be caused by the event appended below, not by a second initial
       // render of the same chat.
@@ -188,7 +207,11 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         },
       );
       expect(sendResponse).toEqual({ status: 202, body: expect.any(String) });
-      expect((await laterAcknowledgement).status()).toBe(200);
+      const laterAcknowledgementResponse = await laterAcknowledgement;
+      expect(laterAcknowledgementResponse.status()).toBe(200);
+      expect(
+        Number(laterAcknowledgementResponse.request().postDataJSON().acknowledgedThroughSequence),
+      ).toBeGreaterThan(firstReadThrough);
       await page
         .locator(`a[data-session-row="${target.id}"]`)
         .waitFor({ state: "visible", timeout: 10_000 });


### PR DESCRIPTION
## Summary
- acknowledge the active foreground chat again when later durable output arrives, without requiring navigation away and back
- bind each acknowledgement to the exact coalesced event frontier rendered by the browser so unseen newer events remain unread
- preserve same-tab rail reconciliation, live-tip/history/focus fencing, and retry one transient failure without looping on permanent errors
- add the public optional read-through sequence contract plus real-Postgres, contract, unit, and browser regressions

## Verification
- independent review: APPROVE exact `b6d3e36891d4e6feefcaae00f45a0fd140ea5aab`
- 33 real-Postgres/contract tests
- 847 web tests
- 9/9 session-pin Chromium E2E tests
- all 31 TypeScript projects
- production web build and bundle budgets
- lint, format, public hygiene, CI impact, changeset status, diff check

## Bundle
- initial raw: 1,499,526 / 1,500,160 bytes
- direct-session raw: 2,083,239 / 2,083,840 bytes
- direct-session gzip: 579,514 / 579,584 bytes
- all other caps unchanged and green
