### PR TITLE
feat(react): redesign session workspace chrome

### DIFF
--- a/.changeset/polite-workspaces-rest.md
+++ b/.changeset/polite-workspaces-rest.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": minor
+---
+
+Replace the horizontally scrolling workspace tabs with a responsive vertical
+activity rail, add a panel-local Hide workspace action, and distinguish managed
+sleeping compute from genuinely offline Connected Machines.

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -12,9 +12,11 @@ import { BrandMark } from "@/components/brand-mark";
 import {
   useCallback,
   useEffect,
+  lazy,
   useRef,
   useState,
   useSyncExternalStore,
+  Suspense,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
@@ -48,6 +50,12 @@ import { isCodexProductModel } from "@/lib/session-model";
 import { isIntelligenceEffort } from "@/lib/session-tools";
 import type { Session } from "@/types";
 import { cn } from "@/lib/utils";
+
+const LazySessionTenancyRouteControl = lazy(() =>
+  import("@/components/session/session-tenancy-control").then(({ SessionTenancyRouteControl }) => ({
+    default: SessionTenancyRouteControl,
+  })),
+);
 
 /** The rail body — shared between the fixed desktop column and the mobile drawer. */
 function RailBody() {
@@ -528,6 +536,13 @@ function SessionRouteHeader({
       billingClass={selectedRow?.billingClass}
       modelLabel={selectedRow?.label}
       policyLoading={policyLoading}
+      accessSlot={
+        session.tenancy ? (
+          <Suspense fallback={null}>
+            <LazySessionTenancyRouteControl session={session} events={events} />
+          </Suspense>
+        ) : null
+      }
       sandboxSlot={
         sessionSupportsFleetSwitching(session.sandboxBackend) ? (
           <SessionSandboxSwitcher

--- a/apps/web/src/components/rail/session-header.test.tsx
+++ b/apps/web/src/components/rail/session-header.test.tsx
@@ -73,4 +73,40 @@ describe("SessionHeader mobile touch targets", () => {
       container.remove();
     }
   });
+
+  test("renders access beside the title actions and names workspace open/hide state", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const render = (inspectorOpen: boolean) => (
+      <SessionHeader
+        session={session}
+        ancestors={[]}
+        connectionState="live"
+        status="idle"
+        keyAuthRequired={false}
+        onForgetAccessKey={() => undefined}
+        inspectorOpen={inspectorOpen}
+        onToggleInspector={() => undefined}
+        onRename={async () => null}
+        onPin={async () => null}
+        accessSlot={<span data-testid="session-access-slot">Private</span>}
+      />
+    );
+
+    try {
+      await act(async () => root.render(render(false)));
+      const access = container.querySelector('[data-testid="session-access-slot"]');
+      const title = container.querySelector('button[title$="· click to rename"]');
+      expect(access).not.toBeNull();
+      expect(title).not.toBeNull();
+      expect(access?.parentElement?.contains(title ?? null)).toBe(true);
+      expect(container.querySelector('[aria-label="Open workspace"]')).not.toBeNull();
+      await act(async () => root.render(render(true)));
+      expect(container.querySelector('[aria-label="Hide workspace"]')).not.toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
 });

--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -16,7 +16,8 @@ import type { SessionSummary } from "@opengeni/sdk";
 import {
   CalendarClockIcon,
   LockIcon,
-  PanelRightIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
   PauseIcon,
   PencilIcon,
   PinIcon,
@@ -55,6 +56,7 @@ export function SessionHeader({
   onPin,
   sandboxSlot,
   codexSlot,
+  accessSlot,
   leading,
   lastStartedModel,
   lastStartedReasoningEffort,
@@ -88,6 +90,8 @@ export function SessionHeader({
    * clickable for account status/switch. Absent for host-credit sessions.
    */
   codexSlot?: ReactNode;
+  /** Compact session access state/menu, lazy-mounted by the route shell. */
+  accessSlot?: ReactNode;
   /** Leading control (the mobile hamburger); absent on desktop. */
   leading?: ReactNode;
   /**
@@ -163,7 +167,10 @@ export function SessionHeader({
             </button>
           ) : null}
         </div>
-        <SessionTitleEditor session={session} onRename={onRename} />
+        <div className="flex min-w-0 items-center gap-1.5">
+          <SessionTitleEditor session={session} onRename={onRename} />
+          {accessSlot}
+        </div>
       </div>
       <div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center justify-end gap-1.5 sm:gap-2">
         {/* Provider + model · effort · speed stay one cluster on the action side. */}
@@ -228,10 +235,15 @@ export function SessionHeader({
           variant={inspectorOpen ? "secondary" : "ghost"}
           size="icon-sm"
           onClick={onToggleInspector}
-          aria-label={inspectorOpen ? "Hide session panel" : "Show session panel"}
+          aria-label={inspectorOpen ? "Hide workspace" : "Open workspace"}
+          title={inspectorOpen ? "Hide workspace" : "Open workspace"}
           className="pointer-coarse:size-11"
         >
-          <PanelRightIcon className="size-4" />
+          {inspectorOpen ? (
+            <PanelRightCloseIcon className="size-4" />
+          ) : (
+            <PanelRightOpenIcon className="size-4" />
+          )}
         </Button>
       </div>
     </header>

--- a/apps/web/src/components/rail/session-list-delivery-attention.test.tsx
+++ b/apps/web/src/components/rail/session-list-delivery-attention.test.tsx
@@ -8,7 +8,7 @@ import { registerDom, renderComponent } from "../../../../../packages/react/test
 registerDom();
 
 describe("production session rail delivery attention", () => {
-  test("uses the existing status slot without changing the metadata geometry", async () => {
+  test("uses the existing compact status position without changing metadata geometry", async () => {
     const failed: RailAggregateStatus = {
       kind: "failed",
       count: 1,
@@ -24,9 +24,7 @@ describe("production session rail delivery attention", () => {
     );
 
     const existingOuterClass = rendered.container.firstElementChild?.className;
-    const existingGridClass = rendered.container.firstElementChild?.firstElementChild?.className;
-    const existingSlotClass =
-      rendered.container.firstElementChild?.firstElementChild?.children.item(1)?.className;
+    const existingStatusClass = rendered.container.querySelector('[title="1 failed"]')?.className;
 
     const sendFailed: RailAggregateStatus = {
       kind: "send_failed",
@@ -43,13 +41,11 @@ describe("production session rail delivery attention", () => {
     );
 
     const outer = rendered.container.firstElementChild;
-    const geometry = outer?.firstElementChild;
-    const statusSlot = geometry?.children.item(1);
+    const statusSlot = rendered.container.querySelector('[title="1 message not sent"]');
     const icon = statusSlot?.querySelector("svg");
 
     expect(outer?.className).toBe(existingOuterClass);
-    expect(geometry?.className).toBe(existingGridClass);
-    expect(statusSlot?.className).toBe(existingSlotClass);
+    expect(statusSlot?.className).toBe(existingStatusClass);
     expect(statusSlot?.getAttribute("title")).toBe("1 message not sent");
     expect(icon?.classList.contains("text-status-failed")).toBe(true);
     expect(rendered.container.textContent).toBe("2m");

--- a/apps/web/src/components/rail/session-list-metadata.test.tsx
+++ b/apps/web/src/components/rail/session-list-metadata.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RailTrailingMetadata } from "./session-list";
+
+const neutral = { kind: "neutral", count: 1, total: 1, label: "Idle" } as const;
+const active = { kind: "active", count: 1, total: 1, label: "Running" } as const;
+
+describe("RailTrailingMetadata", () => {
+  test.each(["1 Aug", "12 Aug", "now", "30m", "3h"])(
+    "keeps %s on one stable metadata line",
+    (relativeTime) => {
+      const markup = renderToStaticMarkup(
+        <RailTrailingMetadata summary={neutral} relativeTime={relativeTime} />,
+      );
+
+      expect(markup).toContain("grid-cols-[0.875rem_0.75rem_2.25rem]");
+      expect(markup).toContain("shrink-0 whitespace-nowrap");
+      expect(markup).toContain(`>${relativeTime}</span>`);
+    },
+  );
+
+  test("keeps status and scheduled columns separate from the fixed date column", () => {
+    const markup = renderToStaticMarkup(
+      <RailTrailingMetadata summary={active} scheduled relativeTime="12 Aug" />,
+    );
+
+    expect(markup).toContain("Scheduled task");
+    expect(markup).toContain("Running");
+    expect(markup).toContain(">12 Aug</span>");
+  });
+});

--- a/apps/web/src/components/rail/session-list-metadata.test.tsx
+++ b/apps/web/src/components/rail/session-list-metadata.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { RailTrailingMetadata } from "./session-list";
+import { RailTrailingMetadata } from "./session-row-content";
 
 const neutral = { kind: "neutral", count: 1, total: 1, label: "Idle" } as const;
 const active = { kind: "active", count: 1, total: 1, label: "Running" } as const;
@@ -14,13 +14,14 @@ describe("RailTrailingMetadata", () => {
         <RailTrailingMetadata summary={neutral} relativeTime={relativeTime} />,
       );
 
-      expect(markup).toContain("grid-cols-[0.875rem_0.75rem_2.25rem]");
-      expect(markup).toContain("shrink-0 whitespace-nowrap");
+      expect(markup).toContain("data-session-row-metadata");
+      expect(markup).toContain("min-w-9 shrink-0 whitespace-nowrap");
       expect(markup).toContain(`>${relativeTime}</span>`);
+      expect(markup).not.toContain("w-[4.375rem]");
     },
   );
 
-  test("keeps status and scheduled columns separate from the fixed date column", () => {
+  test("renders only status, schedule, and date metadata that actually exists", () => {
     const markup = renderToStaticMarkup(
       <RailTrailingMetadata summary={active} scheduled relativeTime="12 Aug" />,
     );
@@ -28,5 +29,9 @@ describe("RailTrailingMetadata", () => {
     expect(markup).toContain("Scheduled task");
     expect(markup).toContain("Running");
     expect(markup).toContain(">12 Aug</span>");
+  });
+
+  test("reserves no trailing rail width when a row has no metadata", () => {
+    expect(renderToStaticMarkup(<RailTrailingMetadata summary={neutral} />)).toBe("");
   });
 });

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -12,7 +12,6 @@ import {
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   ArchiveIcon,
-  CalendarClockIcon,
   ChevronRightIcon,
   CircleDashedIcon,
   Clock3Icon,
@@ -21,7 +20,6 @@ import {
   FolderPlusIcon,
   FolderOpenIcon,
   ListFilterIcon,
-  Loader2Icon,
   MailIcon,
   MailOpenIcon,
   MessagesSquareIcon,
@@ -30,7 +28,6 @@ import {
   PlusIcon,
   SearchIcon,
   Trash2Icon,
-  TriangleAlertIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -46,6 +43,8 @@ import {
 } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
+import { RailTrailingMetadata, SessionRowContent } from "@/components/rail/session-row-content";
+export { RailTrailingMetadata } from "@/components/rail/session-row-content";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -2307,30 +2306,12 @@ function SessionRow(props: {
             }}
             className="flex h-full min-w-0 flex-1 items-center gap-1 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
           >
-            <span className="sr-only">{stateLabel}. </span>
-            {/* Let long titles run toward the metadata and dissolve under a
-                short edge mask. This preserves more of the useful title than
-                a hard ellipsis while keeping the icon columns untouched. */}
-            <span className="flex min-w-0 flex-1 flex-col leading-tight">
-              <span
-                className="block overflow-hidden whitespace-nowrap"
-                style={{
-                  maskImage: "linear-gradient(to right, black calc(100% - 0.75rem), transparent)",
-                  WebkitMaskImage:
-                    "linear-gradient(to right, black calc(100% - 0.75rem), transparent)",
-                }}
-              >
-                {title}
-              </span>
-              {rail.isMobile ? (
-                <span className="mt-0.5 truncate text-2xs font-normal text-fg-muted">
-                  {[stateLabel, depthLabel, descendantLabel, relativeTime]
-                    .filter(Boolean)
-                    .join(" · ")}
-                </span>
-              ) : null}
-            </span>
-            <RailTrailingMetadata
+            <SessionRowContent
+              title={title}
+              stateLabel={stateLabel}
+              depthLabel={depthLabel}
+              descendantLabel={descendantLabel}
+              mobile={rail.isMobile}
               summary={props.aggregateStatus}
               scheduled={Boolean(scheduledTaskIdOf(props.session))}
               relativeTime={rail.isMobile ? undefined : relativeTime}
@@ -2607,81 +2588,6 @@ function RowActionsMenu({
         ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-/** The one descendant-aware status marker shared by rows and section headers. */
-function RailAggregateDot({ summary }: { summary: RailAggregateStatus }) {
-  if (summary.kind === "neutral") return null;
-  if (summary.kind === "active") {
-    return (
-      <Loader2Icon
-        aria-hidden="true"
-        className="size-3 shrink-0 animate-spin text-fg-subtle motion-reduce:animate-none"
-      />
-    );
-  }
-  if (summary.kind === "active_work") {
-    return (
-      <span
-        aria-hidden="true"
-        className="inline-flex size-2.5 shrink-0 rounded-full border border-brand"
-        style={{
-          backgroundImage:
-            "repeating-linear-gradient(-12deg, var(--og-color-accent) 0 2px, transparent 2px 3.5px)",
-        }}
-      />
-    );
-  }
-  if (summary.kind === "send_failed") {
-    return (
-      <TriangleAlertIcon aria-hidden="true" className="size-3.5 shrink-0 text-status-failed" />
-    );
-  }
-  const tone =
-    summary.kind === "needs_attention"
-      ? "bg-status-waiting"
-      : summary.kind === "failed"
-        ? "bg-status-failed"
-        : "bg-brand";
-  return (
-    <span
-      aria-hidden="true"
-      className={cn("relative inline-flex size-2 shrink-0 rounded-full", tone)}
-    />
-  );
-}
-
-export function RailTrailingMetadata({
-  summary,
-  scheduled = false,
-  relativeTime,
-}: {
-  summary: RailAggregateStatus;
-  scheduled?: boolean;
-  relativeTime?: string | undefined;
-}) {
-  const hasStatusMarker = summary.kind !== "neutral";
-  return (
-    <span className="flex w-[4.375rem] shrink-0 items-center">
-      <span className="grid w-[4.375rem] shrink-0 grid-cols-[0.875rem_0.75rem_2.25rem] items-center gap-1">
-        <span className="flex size-3.5 items-center justify-center">
-          {scheduled && hasStatusMarker ? (
-            <CalendarClockIcon aria-label="Scheduled task" className="size-3.5 text-fg-subtle" />
-          ) : null}
-        </span>
-        <span className="flex size-3 items-center justify-center" title={summary.label}>
-          {hasStatusMarker ? (
-            <RailAggregateDot summary={summary} />
-          ) : scheduled ? (
-            <CalendarClockIcon aria-label="Scheduled task" className="size-3.5 text-fg-subtle" />
-          ) : null}
-        </span>
-        <span className="w-9 shrink-0 whitespace-nowrap text-right text-2xs tabular-nums text-fg group-hover:invisible group-focus-within:invisible pointer-coarse:group-hover:visible">
-          {relativeTime}
-        </span>
-      </span>
-    </span>
   );
 }
 

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -2663,8 +2663,8 @@ export function RailTrailingMetadata({
 }) {
   const hasStatusMarker = summary.kind !== "neutral";
   return (
-    <span className="flex w-[3.625rem] shrink-0 items-center">
-      <span className="grid w-[3.625rem] shrink-0 grid-cols-[0.875rem_0.75rem_1.5rem] items-center gap-1">
+    <span className="flex w-[4.375rem] shrink-0 items-center">
+      <span className="grid w-[4.375rem] shrink-0 grid-cols-[0.875rem_0.75rem_2.25rem] items-center gap-1">
         <span className="flex size-3.5 items-center justify-center">
           {scheduled && hasStatusMarker ? (
             <CalendarClockIcon aria-label="Scheduled task" className="size-3.5 text-fg-subtle" />
@@ -2677,7 +2677,7 @@ export function RailTrailingMetadata({
             <CalendarClockIcon aria-label="Scheduled task" className="size-3.5 text-fg-subtle" />
           ) : null}
         </span>
-        <span className="w-6 text-right text-2xs tabular-nums text-fg group-hover:invisible group-focus-within:invisible pointer-coarse:group-hover:visible">
+        <span className="w-9 shrink-0 whitespace-nowrap text-right text-2xs tabular-nums text-fg group-hover:invisible group-focus-within:invisible pointer-coarse:group-hover:visible">
           {relativeTime}
         </span>
       </span>

--- a/apps/web/src/components/rail/session-row-content.tsx
+++ b/apps/web/src/components/rail/session-row-content.tsx
@@ -1,0 +1,117 @@
+import { CalendarClockIcon, Loader2Icon, TriangleAlertIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { RailAggregateStatus } from "@/lib/sessions-group";
+
+/** The one descendant-aware status marker shared by rows and section headers. */
+function RailAggregateDot({ summary }: { summary: RailAggregateStatus }) {
+  if (summary.kind === "neutral") return null;
+  if (summary.kind === "active") {
+    return (
+      <Loader2Icon
+        aria-hidden="true"
+        className="size-3 shrink-0 animate-spin text-fg-subtle motion-reduce:animate-none"
+      />
+    );
+  }
+  if (summary.kind === "active_work") {
+    return (
+      <span
+        aria-hidden="true"
+        className="inline-flex size-2.5 shrink-0 rounded-full border border-brand"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(-12deg, var(--og-color-accent) 0 2px, transparent 2px 3.5px)",
+        }}
+      />
+    );
+  }
+  if (summary.kind === "send_failed") {
+    return (
+      <TriangleAlertIcon aria-hidden="true" className="size-3.5 shrink-0 text-status-failed" />
+    );
+  }
+  const tone =
+    summary.kind === "needs_attention"
+      ? "bg-status-waiting"
+      : summary.kind === "failed"
+        ? "bg-status-failed"
+        : "bg-brand";
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("relative inline-flex size-2 shrink-0 rounded-full", tone)}
+    />
+  );
+}
+
+export function RailTrailingMetadata({
+  summary,
+  scheduled = false,
+  relativeTime,
+}: {
+  summary: RailAggregateStatus;
+  scheduled?: boolean;
+  relativeTime?: string | undefined;
+}) {
+  const hasStatusMarker = summary.kind !== "neutral";
+  const hasRelativeTime = Boolean(relativeTime);
+  if (!scheduled && !hasStatusMarker && !hasRelativeTime) return null;
+  return (
+    <span data-session-row-metadata className="inline-flex shrink-0 items-center justify-end gap-1">
+      {scheduled ? (
+        <CalendarClockIcon
+          aria-label="Scheduled task"
+          className="size-3.5 shrink-0 text-fg-subtle"
+        />
+      ) : null}
+      {hasStatusMarker ? (
+        <span className="flex size-3 items-center justify-center" title={summary.label}>
+          <RailAggregateDot summary={summary} />
+        </span>
+      ) : null}
+      {hasRelativeTime ? (
+        <span className="min-w-9 shrink-0 whitespace-nowrap text-right text-2xs tabular-nums text-fg group-hover:invisible group-focus-within:invisible pointer-coarse:group-hover:visible">
+          {relativeTime}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export function SessionRowContent({
+  title,
+  stateLabel,
+  depthLabel,
+  descendantLabel,
+  mobile,
+  summary,
+  scheduled = false,
+  relativeTime,
+}: {
+  title: string;
+  stateLabel: string;
+  depthLabel?: string | null;
+  descendantLabel?: string | null;
+  mobile: boolean;
+  summary: RailAggregateStatus;
+  scheduled?: boolean;
+  relativeTime?: string;
+}) {
+  return (
+    <>
+      <span className="sr-only">{stateLabel}. </span>
+      <span className="flex min-w-0 flex-1 flex-col leading-tight">
+        <span data-session-row-title className="block min-w-0 truncate">
+          {title}
+        </span>
+        {mobile ? (
+          <span className="mt-0.5 truncate text-2xs font-normal text-fg-muted">
+            {[stateLabel, depthLabel, descendantLabel, relativeTime].filter(Boolean).join(" · ")}
+          </span>
+        ) : null}
+      </span>
+      <RailTrailingMetadata summary={summary} scheduled={scheduled} relativeTime={relativeTime} />
+    </>
+  );
+}

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -130,6 +130,7 @@ export function SessionWorkspace(props: {
       collapsed={effectiveCollapsed}
       onCollapsedChange={props.onCollapsedChange}
       {...(props.openFileRequest ? { openFileRequest: props.openFileRequest } : {})}
+      showCollapseControl
       {...(props.mobileLeadingControl ? { mobileLeadingControl: props.mobileLeadingControl } : {})}
       autoSaveId={layoutStorageId}
       browserExtensionSetupUrl="/browser-extension-setup.html"

--- a/apps/web/src/components/session/session-tenancy-control.test.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.test.tsx
@@ -51,6 +51,29 @@ mock.module("@/components/ui/confirm-dialog", () => ({
     ) : null,
 }));
 
+// Keep mutation/reconciliation tests independent of Radix portal geometry.
+// The production module remains Radix-backed; this semantic stand-in exposes
+// the same trigger/menuitem interaction in the test document.
+mock.module("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    "aria-label": ariaLabel,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+    "aria-label"?: string;
+  }) => (
+    <button type="button" role="menuitem" aria-label={ariaLabel} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
 const { SessionTenancyControl } = await import("./session-tenancy-control");
 
 const baseSession = {
@@ -138,6 +161,20 @@ function dialogButton(container: HTMLElement, label: string): HTMLButtonElement 
   return button(dialog, label);
 }
 
+async function chooseAccessAction(container: HTMLElement, label: string): Promise<void> {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    'button[aria-label$="Manage session access"]',
+  );
+  if (!trigger) throw new Error("Missing session access menu trigger");
+  await act(async () => trigger.click());
+  const item = Array.from(container.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+    (candidate) =>
+      candidate.getAttribute("aria-label") === label || candidate.textContent?.trim() === label,
+  );
+  if (!item) throw new Error(`Missing session access action: ${label}`);
+  await act(async () => item.click());
+}
+
 async function flush() {
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -196,8 +233,8 @@ describe("SessionTenancyControl", () => {
       );
     });
     expect(container.textContent).toContain("Workspace");
-    expect(container.textContent).not.toContain("Make private");
-    expect(container.textContent).not.toContain("Private copy");
+    expect(container.querySelector('[aria-label^="Workspace session access"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label$="Manage session access"]')).toBeNull();
 
     await act(async () => root.unmount());
     container.remove();
@@ -258,20 +295,20 @@ describe("SessionTenancyControl", () => {
       );
     });
 
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
     expect(container.textContent).toContain(
       "Close active Files, Terminal, Desktop, and viewer access first.",
     );
-    expect(container.textContent).toContain("Retry make private");
+    expect(container.textContent).toContain("Retry limit to me");
 
-    await act(async () => dialogButton(container, "Retry make private").click());
+    await act(async () => dialogButton(container, "Retry limit to me").click());
     await flush();
     expect(keys).toHaveLength(2);
     expect(keys[1]).toBe(keys[0]);
     expect(getSession).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain("Only me");
+    expect(container.textContent).toContain("Private");
 
     await act(async () => root.unmount());
     container.remove();
@@ -303,8 +340,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
 
     expect(getSession).toHaveBeenCalledTimes(1);
@@ -352,8 +389,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
 
     expect(container.textContent).toContain("Visible to people in Engineering.");
@@ -399,8 +436,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
 
     expect(container.textContent).toBe("");
@@ -461,16 +498,16 @@ describe("SessionTenancyControl", () => {
     document.body.append(container);
     let root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
     await act(async () => root.unmount());
 
     root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await act(async () => button(container, "Make private").click());
-    expect(container.textContent).toContain("Retry make private");
-    await act(async () => dialogButton(container, "Retry make private").click());
+    await chooseAccessAction(container, "Retry: Limit this session to me…");
+    expect(container.textContent).toContain("Retry limit to me");
+    await act(async () => dialogButton(container, "Retry limit to me").click());
     await flush();
 
     expect(keys).toHaveLength(2);
@@ -525,15 +562,15 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
     expect(container.textContent).toContain(
       "Session access changed in another tab. The latest state has been loaded.",
     );
 
-    await act(async () => button(container, "Make private").click());
-    await act(async () => dialogButton(container, "Make private").click());
+    await chooseAccessAction(container, "Limit this session to me…");
+    await act(async () => dialogButton(container, "Limit to me").click());
     await flush();
     expect(epochs).toEqual([4, 5]);
     expect(keys[1]).not.toBe(keys[0]);
@@ -590,9 +627,11 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private copy").click());
-    expect(container.textContent).toContain("independent private session in the same workspace");
-    await act(async () => button(container, "Create private copy").click());
+    await chooseAccessAction(container, "Fork session…");
+    expect(container.textContent).toContain("copies the session into a new session");
+    expect(container.textContent).toContain("current session stays unchanged");
+    expect(container.textContent).not.toContain("privately");
+    await act(async () => button(container, "Fork session").click());
     await flush();
 
     expect(keys).toHaveLength(2);
@@ -648,8 +687,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private copy").click());
-    await act(async () => button(container, "Create private copy").click());
+    await chooseAccessAction(container, "Fork session…");
+    await act(async () => button(container, "Fork session").click());
     await flush();
 
     expect(openSession).not.toHaveBeenCalled();
@@ -709,16 +748,15 @@ describe("SessionTenancyControl", () => {
     document.body.append(container);
     let root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await act(async () => button(container, "Private copy").click());
-    await act(async () => button(container, "Create private copy").click());
+    await chooseAccessAction(container, "Fork session…");
+    await act(async () => button(container, "Fork session").click());
     await flush();
     await act(async () => root.unmount());
 
     root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    expect(container.textContent).toContain("Retry private copy");
-    await act(async () => button(container, "Retry private copy").click());
-    await act(async () => dialogButton(container, "Retry private copy").click());
+    await chooseAccessAction(container, "Retry: Fork session…");
+    await act(async () => dialogButton(container, "Retry fork").click());
     await flush();
 
     expect(keys).toHaveLength(3);
@@ -752,8 +790,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private copy").click());
-    await act(async () => button(container, "Create private copy").click());
+    await chooseAccessAction(container, "Fork session…");
+    await act(async () => button(container, "Fork session").click());
     current = false;
     pending.reject(apiError({ status: 503, code: "upstream_unavailable", outcomeUnknown: true }));
     await flush();
@@ -799,8 +837,8 @@ describe("SessionTenancyControl", () => {
           />,
         );
       });
-      await act(async () => button(container, "Make private").click());
-      await act(async () => dialogButton(container, "Make private").click());
+      await chooseAccessAction(container, "Limit this session to me…");
+      await act(async () => dialogButton(container, "Limit to me").click());
       current = false;
       pending.resolve({
         operationId: crypto.randomUUID(),

--- a/apps/web/src/components/session/session-tenancy-control.test.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.test.tsx
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { OpenGeniApiError, type Session } from "@opengeni/sdk";
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
-import { act, type ReactNode } from "react";
+import { act, type ReactNode, type RefObject } from "react";
 import { createRoot } from "react-dom/client";
 import * as SonnerPackage from "sonner";
 
@@ -13,6 +13,7 @@ import {
 
 const toastSuccess = mock((_message: string) => undefined);
 const toastInfo = mock((_message: string) => undefined);
+let confirmRestoreFocusRef: RefObject<HTMLElement | null> | undefined;
 
 mock.module("sonner", () => ({
   ...SonnerPackage,
@@ -32,15 +33,18 @@ mock.module("@/components/ui/confirm-dialog", () => ({
     description,
     onConfirm,
     open,
+    restoreFocusRef,
     title,
   }: {
     confirmLabel: string;
     description?: ReactNode;
     onConfirm: () => unknown;
     open: boolean;
+    restoreFocusRef?: RefObject<HTMLElement | null>;
     title: ReactNode;
-  }) =>
-    open ? (
+  }) => {
+    confirmRestoreFocusRef = restoreFocusRef;
+    return open ? (
       <div role="dialog">
         <span>{title}</span>
         <span>{description}</span>
@@ -48,7 +52,8 @@ mock.module("@/components/ui/confirm-dialog", () => ({
           {confirmLabel}
         </button>
       </div>
-    ) : null,
+    ) : null;
+  },
 }));
 
 // Keep mutation/reconciliation tests independent of Radix portal geometry.
@@ -196,6 +201,7 @@ afterAll(() => {
 beforeEach(() => {
   toastInfo.mockClear();
   toastSuccess.mockClear();
+  confirmRestoreFocusRef = undefined;
 });
 
 describe("SessionTenancyControl", () => {
@@ -235,6 +241,43 @@ describe("SessionTenancyControl", () => {
     expect(container.textContent).toContain("Workspace");
     expect(container.querySelector('[aria-label^="Workspace session access"]')).not.toBeNull();
     expect(container.querySelector('[aria-label$="Manage session access"]')).toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  test("offers Fork session from a private session and restores the access trigger", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const privateSession = {
+      ...baseSession,
+      tenancy: { ...baseSession.tenancy!, visibility: "private" as const },
+    };
+
+    await act(async () => {
+      root.render(
+        <SessionTenancyControl
+          session={privateSession}
+          client={{} as OpenGeniCoreClient}
+          managedSession
+          scopeLabel="Engineering"
+          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
+          ownsWorkspaceInvocation={() => true}
+          {...operationAuthority()}
+          onOpenSession={() => undefined}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label$="Manage session access"]',
+    );
+    expect(trigger).not.toBeNull();
+    await chooseAccessAction(container, "Fork session…");
+    expect(container.textContent).toContain("Fork this session?");
+    expect(container.textContent).toContain("continue in a new one");
+    expect(confirmRestoreFocusRef?.current).toBe(trigger);
 
     await act(async () => root.unmount());
     container.remove();

--- a/apps/web/src/components/session/session-tenancy-control.test.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.test.tsx
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { OpenGeniApiError, type Session } from "@opengeni/sdk";
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
-import { act, type ReactNode, type RefObject } from "react";
+import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import * as SonnerPackage from "sonner";
 
@@ -13,7 +13,6 @@ import {
 
 const toastSuccess = mock((_message: string) => undefined);
 const toastInfo = mock((_message: string) => undefined);
-let confirmRestoreFocusRef: RefObject<HTMLElement | null> | undefined;
 
 mock.module("sonner", () => ({
   ...SonnerPackage,
@@ -33,17 +32,14 @@ mock.module("@/components/ui/confirm-dialog", () => ({
     description,
     onConfirm,
     open,
-    restoreFocusRef,
     title,
   }: {
     confirmLabel: string;
     description?: ReactNode;
     onConfirm: () => unknown;
     open: boolean;
-    restoreFocusRef?: RefObject<HTMLElement | null>;
     title: ReactNode;
   }) => {
-    confirmRestoreFocusRef = restoreFocusRef;
     return open ? (
       <div role="dialog">
         <span>{title}</span>
@@ -201,7 +197,6 @@ afterAll(() => {
 beforeEach(() => {
   toastInfo.mockClear();
   toastSuccess.mockClear();
-  confirmRestoreFocusRef = undefined;
 });
 
 describe("SessionTenancyControl", () => {
@@ -241,43 +236,6 @@ describe("SessionTenancyControl", () => {
     expect(container.textContent).toContain("Workspace");
     expect(container.querySelector('[aria-label^="Workspace session access"]')).not.toBeNull();
     expect(container.querySelector('[aria-label$="Manage session access"]')).toBeNull();
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  test("offers Fork session from a private session and restores the access trigger", async () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
-    const privateSession = {
-      ...baseSession,
-      tenancy: { ...baseSession.tenancy!, visibility: "private" as const },
-    };
-
-    await act(async () => {
-      root.render(
-        <SessionTenancyControl
-          session={privateSession}
-          client={{} as OpenGeniCoreClient}
-          managedSession
-          scopeLabel="Engineering"
-          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
-          ownsWorkspaceInvocation={() => true}
-          {...operationAuthority()}
-          onOpenSession={() => undefined}
-        />,
-      );
-    });
-
-    const trigger = container.querySelector<HTMLButtonElement>(
-      'button[aria-label$="Manage session access"]',
-    );
-    expect(trigger).not.toBeNull();
-    await chooseAccessAction(container, "Fork session…");
-    expect(container.textContent).toContain("Fork this session?");
-    expect(container.textContent).toContain("continue in a new one");
-    expect(confirmRestoreFocusRef?.current).toBe(trigger);
 
     await act(async () => root.unmount());
     container.remove();
@@ -617,231 +575,6 @@ describe("SessionTenancyControl", () => {
     await flush();
     expect(epochs).toEqual([4, 5]);
     expect(keys[1]).not.toBe(keys[0]);
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  test("retries an unknown fork with the exact key and navigates only from its receipt", async () => {
-    const keys: string[] = [];
-    const forkSession = mock(async (_workspaceId, _sessionId, request) => {
-      keys.push(request.idempotencyKey);
-      if (keys.length === 1) {
-        throw apiError({ status: 503, code: "upstream_unavailable", outcomeUnknown: true });
-      }
-      return {
-        operationId: crypto.randomUUID(),
-        eventId: crypto.randomUUID(),
-        eventSequence: 9,
-        sessionId: "session-fork",
-        workspaceId: "workspace-a",
-        visibility: "private" as const,
-        authorityEpoch: 1 as const,
-        copiedHistoryItemCount: 4,
-        replay: true,
-      };
-    });
-    const getSession = mock(async () => ({
-      ...baseSession,
-      id: "session-fork",
-      tenancy: {
-        visibility: "private" as const,
-        authorityEpoch: 1,
-        ownedByCurrentUser: true,
-        fork: null,
-      },
-    }));
-    const openSession = mock((_workspaceId: string, _sessionId: string) => undefined);
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
-    await act(async () => {
-      root.render(
-        <SessionTenancyControl
-          session={baseSession}
-          client={{ forkSession, getSession } as unknown as OpenGeniCoreClient}
-          managedSession
-          scopeLabel="Engineering"
-          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
-          ownsWorkspaceInvocation={() => true}
-          {...operationAuthority()}
-          onRefreshSession={async () => undefined}
-          onOpenSession={openSession}
-        />,
-      );
-    });
-    await chooseAccessAction(container, "Fork session…");
-    expect(container.textContent).toContain("copies the session into a new session");
-    expect(container.textContent).toContain("current session stays unchanged");
-    expect(container.textContent).not.toContain("privately");
-    await act(async () => button(container, "Fork session").click());
-    await flush();
-
-    expect(keys).toHaveLength(2);
-    expect(keys[1]).toBe(keys[0]);
-    expect(getSession).toHaveBeenCalledTimes(1);
-    expect(openSession).toHaveBeenCalledTimes(1);
-    expect(openSession).toHaveBeenCalledWith("workspace-a", "session-fork");
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  test("does not navigate a replayed fork whose fresh session is no longer private", async () => {
-    const controller = new SessionTenancyOperationController();
-    const authority = operationAuthority(controller);
-    const forkSession = mock(async () => ({
-      operationId: crypto.randomUUID(),
-      eventId: crypto.randomUUID(),
-      eventSequence: 9,
-      sessionId: "session-fork",
-      workspaceId: "workspace-a",
-      visibility: "private" as const,
-      authorityEpoch: 1 as const,
-      copiedHistoryItemCount: 4,
-      replay: true,
-    }));
-    const getSession = mock(async () => ({
-      ...baseSession,
-      id: "session-fork",
-      tenancy: {
-        visibility: "workspace" as const,
-        authorityEpoch: 2,
-        ownedByCurrentUser: true,
-        fork: null,
-      },
-    }));
-    const openSession = mock((_workspaceId: string, _sessionId: string) => undefined);
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
-    await act(async () => {
-      root.render(
-        <SessionTenancyControl
-          session={baseSession}
-          client={{ forkSession, getSession } as unknown as OpenGeniCoreClient}
-          managedSession
-          scopeLabel="Engineering"
-          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
-          ownsWorkspaceInvocation={() => true}
-          {...authority}
-          onRefreshSession={async () => undefined}
-          onOpenSession={openSession}
-        />,
-      );
-    });
-    await chooseAccessAction(container, "Fork session…");
-    await act(async () => button(container, "Fork session").click());
-    await flush();
-
-    expect(openSession).not.toHaveBeenCalled();
-    expect(container.textContent).toContain(
-      "The fork is no longer an owned private session in this workspace.",
-    );
-    expect(controller.snapshot(authority.operationScope).fork).toBeNull();
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  test("reuses an outcome-unknown fork key after an actual unmount and remount", async () => {
-    const keys: string[] = [];
-    const controller = new SessionTenancyOperationController();
-    const authority = operationAuthority(controller);
-    const forkSession = mock(async (_workspaceId, _sessionId, request) => {
-      keys.push(request.idempotencyKey);
-      if (keys.length <= 2) {
-        throw apiError({ status: 503, code: "upstream_unavailable", outcomeUnknown: true });
-      }
-      return {
-        operationId: crypto.randomUUID(),
-        eventId: crypto.randomUUID(),
-        eventSequence: 9,
-        sessionId: "session-fork",
-        workspaceId: "workspace-a",
-        visibility: "private" as const,
-        authorityEpoch: 1 as const,
-        copiedHistoryItemCount: 4,
-        replay: true,
-      };
-    });
-    const getSession = mock(async () => ({
-      ...baseSession,
-      id: "session-fork",
-      tenancy: {
-        visibility: "private" as const,
-        authorityEpoch: 1,
-        ownedByCurrentUser: true,
-        fork: null,
-      },
-    }));
-    const openSession = mock((_workspaceId: string, _sessionId: string) => undefined);
-    const props = {
-      session: baseSession,
-      client: { forkSession, getSession } as unknown as OpenGeniCoreClient,
-      managedSession: true,
-      scopeLabel: "Engineering",
-      captureWorkspaceInvocation: () => ({ workspaceId: "workspace-a", revision: 1 }),
-      ownsWorkspaceInvocation: () => true,
-      ...authority,
-      onRefreshSession: async () => undefined,
-      onOpenSession: openSession,
-    };
-    const container = document.createElement("div");
-    document.body.append(container);
-    let root = createRoot(container);
-    await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await chooseAccessAction(container, "Fork session…");
-    await act(async () => button(container, "Fork session").click());
-    await flush();
-    await act(async () => root.unmount());
-
-    root = createRoot(container);
-    await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await chooseAccessAction(container, "Retry: Fork session…");
-    await act(async () => dialogButton(container, "Retry fork").click());
-    await flush();
-
-    expect(keys).toHaveLength(3);
-    expect(new Set(keys).size).toBe(1);
-    expect(openSession).toHaveBeenCalledWith("workspace-a", "session-fork");
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  test("does not replay an unknown fork after the principal transition becomes stale", async () => {
-    let current = true;
-    const pending = deferred<never>();
-    const forkSession = mock(async () => await pending.promise);
-    const openSession = mock((_workspaceId: string, _sessionId: string) => undefined);
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
-    await act(async () => {
-      root.render(
-        <SessionTenancyControl
-          session={baseSession}
-          client={{ forkSession } as unknown as OpenGeniCoreClient}
-          managedSession
-          scopeLabel="Engineering"
-          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
-          ownsWorkspaceInvocation={() => current}
-          {...operationAuthority()}
-          onRefreshSession={async () => undefined}
-          onOpenSession={openSession}
-        />,
-      );
-    });
-    await chooseAccessAction(container, "Fork session…");
-    await act(async () => button(container, "Fork session").click());
-    current = false;
-    pending.reject(apiError({ status: 503, code: "upstream_unavailable", outcomeUnknown: true }));
-    await flush();
-
-    expect(forkSession).toHaveBeenCalledTimes(1);
-    expect(openSession).not.toHaveBeenCalled();
-    expect(toastSuccess).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
     container.remove();

--- a/apps/web/src/components/session/session-tenancy-control.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   ChevronDownIcon,
   CircleAlertIcon,
-  CopyPlusIcon,
   Loader2Icon,
   LockKeyholeIcon,
   UsersIcon,
@@ -45,7 +44,7 @@ import {
   type WorkspaceTransitionIdentity,
 } from "@/lib/workspace-transition";
 
-type Confirmation = { kind: "visibility"; visibility: SessionVisibility } | { kind: "fork" };
+type Confirmation = { kind: "visibility"; visibility: SessionVisibility };
 
 export default function SessionRouteAuxiliary(
   props:
@@ -134,7 +133,6 @@ export function SessionTenancyControl({
   ownsWorkspaceInvocation,
   operationController,
   operationScope,
-  onOpenSession,
 }: {
   session: Session;
   events?: SessionEvent[] | undefined;
@@ -159,7 +157,6 @@ export function SessionTenancyControl({
   const visibilityEventSequenceRef = useRef(0);
   const operationSnapshot = operationController.snapshot(operationScope);
   const pendingVisibility = operationSnapshot.visibility;
-  const pendingFork = operationSnapshot.fork;
   const [override, setOverride] = useState(session.tenancy);
   const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
   const [busy, setBusy] = useState(false);
@@ -425,93 +422,6 @@ export function SessionTenancyControl({
     ],
   );
 
-  const createPrivateFork = useCallback(async (): Promise<boolean> => {
-    if (!displayedTenancy || !mayManage) return true;
-    const acceptedTransition = captureWorkspaceInvocation(target.workspaceId);
-    if (!acceptedTransition) return true;
-    const operationSequence = operationSequenceRef.current + 1;
-    operationSequenceRef.current = operationSequence;
-    const attempt = operationController.prepareFork(operationScope, () => crypto.randomUUID());
-    setBusy(true);
-    setFailure(null);
-    let receiptConfirmed = false;
-
-    const invoke = async () =>
-      await runCurrentTransitionInvocation({
-        isCurrent: () => isCurrentInvocation(target, acceptedTransition, operationSequence),
-        request: async () =>
-          await client.forkSession(target.workspaceId, target.sessionId, {
-            idempotencyKey: attempt.idempotencyKey,
-          }),
-      });
-
-    try {
-      let result;
-      try {
-        result = await invoke();
-      } catch (error) {
-        const classified = classifySessionTenancyFailure(error);
-        if (classified.kind !== "outcome_unknown") throw error;
-        if (!isCurrentInvocation(target, acceptedTransition, operationSequence)) return true;
-        // The first request may have committed. Repeating the exact key is the
-        // only authoritative reconciliation because the destination id is not
-        // knowable from the source session alone.
-        result = await invoke();
-      }
-      if (result.status === "stale") return true;
-      const fork = result.value;
-      receiptConfirmed = true;
-      if (fork.workspaceId !== target.workspaceId) {
-        throw new Error("The fork response did not match this workspace.");
-      }
-      const destination = await runCurrentTransitionInvocation({
-        isCurrent: () => isCurrentInvocation(target, acceptedTransition, operationSequence),
-        request: async () =>
-          await client.getSession(fork.workspaceId, fork.sessionId, { fresh: true }),
-      });
-      if (destination.status === "stale") return true;
-      if (
-        destination.value.workspaceId !== target.workspaceId ||
-        destination.value.tenancy?.visibility !== "private" ||
-        destination.value.tenancy.ownedByCurrentUser !== true
-      ) {
-        throw new Error("The fork is no longer an owned private session in this workspace.");
-      }
-      operationController.settleFork(operationScope, attempt);
-      setAnnouncement("Session fork created in this workspace.");
-      toast.success("Session fork created");
-      onOpenSession(fork.workspaceId, fork.sessionId);
-      return true;
-    } catch (error) {
-      if (!isCurrentInvocation(target, acceptedTransition, operationSequence)) return true;
-      const classified = classifySessionTenancyFailure(error);
-      if (classified.reconcile && classified.kind !== "outcome_unknown") {
-        await reconcileSource(target, acceptedTransition, operationSequence).catch(() => null);
-      }
-      if (!isCurrentInvocation(target, acceptedTransition, operationSequence)) return true;
-      const retainAttempt =
-        classified.retainAttempt ||
-        (receiptConfirmed && retryableSessionTenancyReconciliationFailure(error));
-      if (!retainAttempt) operationController.settleFork(operationScope, attempt);
-      setFailure(classified.message);
-      setAnnouncement(classified.message);
-      return !retainAttempt;
-    } finally {
-      if (isCurrentInvocation(target, acceptedTransition, operationSequence)) setBusy(false);
-    }
-  }, [
-    captureWorkspaceInvocation,
-    client,
-    displayedTenancy,
-    isCurrentInvocation,
-    mayManage,
-    onOpenSession,
-    operationController,
-    operationScope,
-    reconcileSource,
-    target,
-  ]);
-
   if (!displayedTenancy) return null;
 
   const privateSession = displayedTenancy.visibility === "private";
@@ -583,18 +493,6 @@ export function SessionTenancyControl({
                 {privateSession ? <UsersIcon /> : <LockKeyholeIcon />}
                 {retryingVisibility ? `Retry: ${visibilityAction}` : visibilityAction}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                aria-label={pendingFork ? "Retry: Fork session…" : "Fork session…"}
-                onSelect={() => setConfirmation({ kind: "fork" })}
-              >
-                <CopyPlusIcon />
-                <span className="flex flex-col">
-                  <span>{pendingFork ? "Retry: Fork session…" : "Fork session…"}</span>
-                  <span className="text-xs font-normal text-muted-foreground">
-                    Copies this session so you can continue in a new one.
-                  </span>
-                </span>
-              </DropdownMenuItem>
               {failure ? (
                 <>
                   <DropdownMenuSeparator />
@@ -626,35 +524,21 @@ export function SessionTenancyControl({
           if (!open) setConfirmation(null);
         }}
         title={
-          confirmation?.kind === "fork"
-            ? "Fork this session?"
-            : confirmation?.visibility === "workspace"
-              ? `Share this session with ${scopeLabel}?`
-              : "Limit this session to you?"
+          confirmation?.visibility === "workspace"
+            ? `Share this session with ${scopeLabel}?`
+            : "Limit this session to you?"
         }
         description={
-          confirmation?.kind === "fork"
-            ? "This copies the session into a new session and opens it so you can continue there. The current session stays unchanged."
-            : confirmation?.visibility === "workspace"
-              ? "People who can access this workspace will be able to open the session after all current work has settled."
-              : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
+          confirmation?.visibility === "workspace"
+            ? "People who can access this workspace will be able to open the session after all current work has settled."
+            : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
         }
-        confirmLabel={
-          confirmation?.kind === "fork"
-            ? pendingFork
-              ? "Retry fork"
-              : "Fork session"
-            : visibilityConfirmLabel
-        }
-        destructive={confirmation?.kind !== "fork" && confirmation?.visibility === "workspace"}
+        confirmLabel={visibilityConfirmLabel}
+        destructive={confirmation?.visibility === "workspace"}
         cancelAutoFocus
         restoreFocusRef={accessTriggerRef}
         onConfirm={() =>
-          confirmation?.kind === "fork"
-            ? createPrivateFork()
-            : confirmation?.kind === "visibility"
-              ? changeVisibility(confirmation.visibility)
-              : true
+          confirmation?.kind === "visibility" ? changeVisibility(confirmation.visibility) : true
         }
       >
         {failure ? (

--- a/apps/web/src/components/session/session-tenancy-control.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.tsx
@@ -1,13 +1,28 @@
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
 import type { Session, SessionEvent, SessionVisibility } from "@opengeni/sdk";
 import { useNavigate } from "@tanstack/react-router";
-import { CopyPlusIcon, Loader2Icon, LockKeyholeIcon, UsersIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  CircleAlertIcon,
+  CopyPlusIcon,
+  Loader2Icon,
+  LockKeyholeIcon,
+  UsersIcon,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Notice } from "@/components/ui/notice";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProblemPanel } from "@/components/common";
 import { useAppContext } from "@/context";
 import { isApiErrorStatus } from "@/api";
@@ -81,33 +96,31 @@ export function SessionTenancyRouteControl({
     : (workspace?.name ?? "this workspace");
 
   return (
-    <div className="shrink-0 px-4 pt-2 sm:px-6">
-      <SessionTenancyControl
-        key={`${context.accessContext.subjectId}:${transition.revision}:${session.workspaceId}:${session.id}`}
-        session={session}
-        events={events}
-        client={context.client}
-        managedSession={
-          context.clientConfig.auth.mode === "managedSession" && context.authSession !== null
-        }
-        scopeLabel={scopeLabel}
-        captureWorkspaceInvocation={context.captureWorkspaceInvocation}
-        ownsWorkspaceInvocation={context.ownsWorkspaceInvocation}
-        operationController={sessionTenancyOperationController}
-        operationScope={{
-          principalId: context.accessContext.subjectId,
-          workspaceId: session.workspaceId,
-          sessionId: session.id,
-          workspaceTransitionRevision: transition.revision,
-        }}
-        onOpenSession={(workspaceId, sessionId) =>
-          void navigate({
-            to: "/workspaces/$workspaceId/sessions/$sessionId",
-            params: { workspaceId, sessionId },
-          })
-        }
-      />
-    </div>
+    <SessionTenancyControl
+      key={`${context.accessContext.subjectId}:${transition.revision}:${session.workspaceId}:${session.id}`}
+      session={session}
+      events={events}
+      client={context.client}
+      managedSession={
+        context.clientConfig.auth.mode === "managedSession" && context.authSession !== null
+      }
+      scopeLabel={scopeLabel}
+      captureWorkspaceInvocation={context.captureWorkspaceInvocation}
+      ownsWorkspaceInvocation={context.ownsWorkspaceInvocation}
+      operationController={sessionTenancyOperationController}
+      operationScope={{
+        principalId: context.accessContext.subjectId,
+        workspaceId: session.workspaceId,
+        sessionId: session.id,
+        workspaceTransitionRevision: transition.revision,
+      }}
+      onOpenSession={(workspaceId, sessionId) =>
+        void navigate({
+          to: "/workspaces/$workspaceId/sessions/$sessionId",
+          params: { workspaceId, sessionId },
+        })
+      }
+    />
   );
 }
 
@@ -448,7 +461,7 @@ export function SessionTenancyControl({
       const fork = result.value;
       receiptConfirmed = true;
       if (fork.workspaceId !== target.workspaceId) {
-        throw new Error("The private copy response did not match this workspace.");
+        throw new Error("The fork response did not match this workspace.");
       }
       const destination = await runCurrentTransitionInvocation({
         isCurrent: () => isCurrentInvocation(target, acceptedTransition, operationSequence),
@@ -464,8 +477,8 @@ export function SessionTenancyControl({
         throw new Error("The fork is no longer an owned private session in this workspace.");
       }
       operationController.settleFork(operationScope, attempt);
-      setAnnouncement("Private copy created in this workspace.");
-      toast.success("Private copy created");
+      setAnnouncement("Session fork created in this workspace.");
+      toast.success("Session fork created");
       onOpenSession(fork.workspaceId, fork.sessionId);
       return true;
     } catch (error) {
@@ -505,72 +518,103 @@ export function SessionTenancyControl({
   const retryingVisibility =
     pendingVisibility?.visibility === alternateVisibility &&
     pendingVisibility.expectedAuthorityEpoch === displayedTenancy.authorityEpoch;
-  const visibilityAction = privateSession ? "Share with workspace" : "Make private";
+  const visibilityAction = privateSession
+    ? "Share this session with workspace…"
+    : "Limit this session to me…";
   const visibilityConfirmLabel = retryingVisibility
-    ? `Retry ${visibilityAction.toLowerCase()}`
-    : visibilityAction;
+    ? privateSession
+      ? "Retry share with workspace"
+      : "Retry limit to me"
+    : privateSession
+      ? "Share with workspace"
+      : "Limit to me";
+  const stateLabel = privateSession ? "Private" : "Workspace";
+  const stateDescription = privateSession
+    ? "Only you can open this session."
+    : `Visible to people in ${scopeLabel}.`;
+  const stateChip = (
+    <span className="inline-flex min-h-8 min-w-0 items-center gap-1.5 rounded-full border border-border bg-surface/55 px-2.5 text-xs font-medium text-fg pointer-coarse:min-h-11">
+      {privateSession ? (
+        <LockKeyholeIcon className="size-3.5 shrink-0 text-brand" aria-hidden="true" />
+      ) : (
+        <UsersIcon className="size-3.5 shrink-0 text-fg-muted" aria-hidden="true" />
+      )}
+      <span className="hidden sm:inline">{stateLabel}</span>
+      {failure ? <CircleAlertIcon className="size-3.5 text-status-waiting" aria-hidden /> : null}
+      {mayManage ? <ChevronDownIcon className="size-3.5 text-fg-muted" aria-hidden /> : null}
+    </span>
+  );
 
   return (
-    <>
-      <section
-        aria-label="Session access"
-        className="mx-auto mb-1 flex w-full max-w-3xl flex-wrap items-center justify-end gap-1.5 text-sm"
-      >
-        <span className="inline-flex min-h-8 min-w-0 items-center gap-1.5 rounded-full border border-border bg-surface/55 px-2.5 font-medium text-fg">
-          {privateSession ? (
-            <LockKeyholeIcon className="size-4 shrink-0 text-brand" aria-hidden="true" />
-          ) : (
-            <UsersIcon className="size-4 shrink-0 text-fg-muted" aria-hidden="true" />
-          )}
-          <span>{privateSession ? "Only me" : "Workspace"}</span>
-          <span className="sr-only">
-            {privateSession
-              ? "Only you can open this session."
-              : `Visible to people in ${scopeLabel}.`}
-          </span>
-        </span>
+    <TooltipProvider delayDuration={300}>
+      <section aria-label="Session access" className="flex shrink-0 items-center">
         {mayManage ? (
-          <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label={privateSession ? "Share with workspace" : visibilityAction}
-              className="min-h-9 pointer-coarse:min-h-11"
-              disabled={busy}
-              onClick={() =>
-                setConfirmation({ kind: "visibility", visibility: alternateVisibility })
-              }
-            >
-              {busy && confirmation?.kind === "visibility" ? (
-                <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
-              ) : null}
-              {privateSession ? "Share" : visibilityAction}
-            </Button>
-            {!privateSession ? (
-              <Button
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={busy}>
+              <button
                 type="button"
-                variant="ghost"
-                size="sm"
-                className="min-h-9 pointer-coarse:min-h-11"
-                disabled={busy}
-                onClick={() => setConfirmation({ kind: "fork" })}
+                aria-label={`${stateLabel} session access. Manage session access`}
+                aria-busy={busy}
+                className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                {busy && confirmation?.kind === "fork" ? (
-                  <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
+                {busy ? (
+                  <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-border bg-surface/55 px-2.5 text-xs font-medium pointer-coarse:min-h-11">
+                    <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
+                    <span className="hidden sm:inline">Updating</span>
+                  </span>
                 ) : (
-                  <CopyPlusIcon className="size-3.5" />
+                  stateChip
                 )}
-                {pendingFork ? "Retry private copy" : "Private copy"}
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
-        {failure ? (
-          <Notice className="basis-full" tone="waiting" title="Access change needs attention">
-            {failure}
-          </Notice>
-        ) : null}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-72">
+              <div className="px-2 py-1.5">
+                <p className="text-sm font-medium">{stateLabel} session</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{stateDescription}</p>
+              </div>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() =>
+                  setConfirmation({ kind: "visibility", visibility: alternateVisibility })
+                }
+              >
+                {privateSession ? <UsersIcon /> : <LockKeyholeIcon />}
+                {retryingVisibility ? `Retry: ${visibilityAction}` : visibilityAction}
+              </DropdownMenuItem>
+              {!privateSession ? (
+                <DropdownMenuItem
+                  aria-label={pendingFork ? "Retry: Fork session…" : "Fork session…"}
+                  onSelect={() => setConfirmation({ kind: "fork" })}
+                >
+                  <CopyPlusIcon />
+                  <span className="flex flex-col">
+                    <span>{pendingFork ? "Retry: Fork session…" : "Fork session…"}</span>
+                    <span className="text-xs font-normal text-muted-foreground">
+                      Copies this session so you can continue in a new one.
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              ) : null}
+              {failure ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <div className="px-2 py-1.5 text-xs text-status-waiting">
+                    <span className="font-medium">Access change needs attention.</span> {failure}
+                  </div>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0} aria-label={`${stateLabel} session access. ${stateDescription}`}>
+                {stateChip}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{stateDescription}</TooltipContent>
+          </Tooltip>
+        )}
         <span className="sr-only" aria-live="polite" aria-atomic="true">
           {announcement}
         </span>
@@ -583,14 +627,14 @@ export function SessionTenancyControl({
         }}
         title={
           confirmation?.kind === "fork"
-            ? "Create a private copy?"
+            ? "Fork this session?"
             : confirmation?.visibility === "workspace"
               ? `Share this session with ${scopeLabel}?`
-              : "Make this session private?"
+              : "Limit this session to you?"
         }
         description={
           confirmation?.kind === "fork"
-            ? "This creates an independent private session in the same workspace. Current work, access grants, connections, and sandbox state stay with the original."
+            ? "This copies the session into a new session and opens it so you can continue there. The current session stays unchanged."
             : confirmation?.visibility === "workspace"
               ? "People who can access this workspace will be able to open the session after all current work has settled."
               : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
@@ -598,8 +642,8 @@ export function SessionTenancyControl({
         confirmLabel={
           confirmation?.kind === "fork"
             ? pendingFork
-              ? "Retry private copy"
-              : "Create private copy"
+              ? "Retry fork"
+              : "Fork session"
             : visibilityConfirmLabel
         }
         destructive={confirmation?.kind !== "fork" && confirmation?.visibility === "workspace"}
@@ -618,6 +662,6 @@ export function SessionTenancyControl({
           </Notice>
         ) : null}
       </ConfirmDialog>
-    </>
+    </TooltipProvider>
   );
 }

--- a/apps/web/src/components/session/session-tenancy-control.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.tsx
@@ -166,6 +166,7 @@ export function SessionTenancyControl({
   const [failure, setFailure] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState("");
   const [, setControllerRevision] = useState(0);
+  const accessTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -552,6 +553,7 @@ export function SessionTenancyControl({
           <DropdownMenu>
             <DropdownMenuTrigger asChild disabled={busy}>
               <button
+                ref={accessTriggerRef}
                 type="button"
                 aria-label={`${stateLabel} session access. Manage session access`}
                 aria-busy={busy}
@@ -581,20 +583,18 @@ export function SessionTenancyControl({
                 {privateSession ? <UsersIcon /> : <LockKeyholeIcon />}
                 {retryingVisibility ? `Retry: ${visibilityAction}` : visibilityAction}
               </DropdownMenuItem>
-              {!privateSession ? (
-                <DropdownMenuItem
-                  aria-label={pendingFork ? "Retry: Fork session…" : "Fork session…"}
-                  onSelect={() => setConfirmation({ kind: "fork" })}
-                >
-                  <CopyPlusIcon />
-                  <span className="flex flex-col">
-                    <span>{pendingFork ? "Retry: Fork session…" : "Fork session…"}</span>
-                    <span className="text-xs font-normal text-muted-foreground">
-                      Copies this session so you can continue in a new one.
-                    </span>
+              <DropdownMenuItem
+                aria-label={pendingFork ? "Retry: Fork session…" : "Fork session…"}
+                onSelect={() => setConfirmation({ kind: "fork" })}
+              >
+                <CopyPlusIcon />
+                <span className="flex flex-col">
+                  <span>{pendingFork ? "Retry: Fork session…" : "Fork session…"}</span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    Copies this session so you can continue in a new one.
                   </span>
-                </DropdownMenuItem>
-              ) : null}
+                </span>
+              </DropdownMenuItem>
               {failure ? (
                 <>
                   <DropdownMenuSeparator />
@@ -648,6 +648,7 @@ export function SessionTenancyControl({
         }
         destructive={confirmation?.kind !== "fork" && confirmation?.visibility === "workspace"}
         cancelAutoFocus
+        restoreFocusRef={accessTriggerRef}
         onConfirm={() =>
           confirmation?.kind === "fork"
             ? createPrivateFork()

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -22,6 +22,7 @@ import {
 } from "@opengeni/react/session";
 import { useNavigate } from "@tanstack/react-router";
 import {
+  BugIcon,
   CheckIcon,
   Loader2Icon,
   MenuIcon,
@@ -825,12 +826,8 @@ function SessionDock(props: {
   const trailingTabs: WorkspaceTab[] = [
     {
       id: "artifacts",
-      label: (
-        <span className="inline-flex items-center gap-1.5">
-          <PanelsTopLeftIcon className="size-3.5" aria-hidden />
-          <span>Artifacts</span>
-        </span>
-      ),
+      label: "Artifacts",
+      icon: <PanelsTopLeftIcon />,
       ...(artifactSummaries.length > 0
         ? {
             badge: (
@@ -859,6 +856,7 @@ function SessionDock(props: {
     trailingTabs.push({
       id: "debug",
       label: "Debug",
+      icon: <BugIcon />,
       content: (
         <Suspense fallback={<LoadingPanel label="Opening debug inspector" />}>
           <LazySessionInspector
@@ -1566,11 +1564,6 @@ function SessionChatPane(props: {
               creditExhausted={props.creditExhausted}
               workspaceId={props.session.workspaceId}
             />
-          ) : null}
-          {props.session.tenancy ? (
-            <Suspense fallback={null}>
-              <LazySessionRouteAuxiliary session={props.session} events={props.events} />
-            </Suspense>
           ) : null}
           <div data-testid="session-timeline" className="min-h-0 min-w-0 flex-1">
             <MessageTimeline

--- a/apps/web/test/session-rail-row-metadata-fixture.tsx
+++ b/apps/web/test/session-rail-row-metadata-fixture.tsx
@@ -1,0 +1,75 @@
+import { createRoot } from "react-dom/client";
+
+import { SessionRowContent } from "../src/components/rail/session-row-content";
+import { cn } from "../src/lib/utils";
+import "../src/styles.css";
+
+const neutral = { kind: "neutral", count: 1, total: 1, label: "Idle" } as const;
+const active = { kind: "active", count: 1, total: 1, label: "Running" } as const;
+const longTitle =
+  "Now I am testing your workspace rail and this title should use every available pixel";
+
+const cases = [
+  { id: "time-only", active: false, depth: 0, summary: neutral, relativeTime: "1h" },
+  { id: "status-time", active: false, depth: 0, summary: active, relativeTime: "2m" },
+  {
+    id: "schedule-date",
+    active: false,
+    depth: 0,
+    summary: neutral,
+    scheduled: true,
+    relativeTime: "1 Aug",
+  },
+  { id: "no-metadata", active: false, depth: 0, summary: neutral },
+  { id: "selected-child", active: true, depth: 1, summary: neutral, relativeTime: "1h" },
+  { id: "unselected-child", active: false, depth: 2, summary: active, relativeTime: "now" },
+] as const;
+
+function SessionRailRowMetadataFixture() {
+  return (
+    <main className="min-h-screen bg-background p-8 text-foreground">
+      <aside
+        data-testid="production-session-rail"
+        className="w-[244px] min-w-0 overflow-x-hidden border border-border bg-surface/40 py-3"
+      >
+        <div className="min-w-0 overflow-x-hidden pb-2 pl-2 pr-3">
+          {cases.map((scenario) => (
+            <div
+              key={scenario.id}
+              data-row-case={scenario.id}
+              className={cn(
+                "group relative flex h-8 w-full items-center gap-1.5 rounded-md py-1 pl-1.5 pr-1 text-left text-sm",
+                scenario.active ? "bg-surface-3 font-medium text-fg" : "text-fg-muted",
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className="flex w-4 shrink-0 items-center"
+                style={scenario.depth > 0 ? { marginLeft: scenario.depth * 12 } : undefined}
+              />
+              <a
+                href={`#${scenario.id}`}
+                aria-current={scenario.active ? "page" : undefined}
+                aria-label={`Open ${longTitle}. Idle`}
+                className="flex h-full min-w-0 flex-1 items-center gap-1 rounded-sm text-left outline-none"
+              >
+                <SessionRowContent
+                  title={longTitle}
+                  stateLabel="Idle"
+                  depthLabel={scenario.depth > 0 ? `Level ${scenario.depth + 1}` : null}
+                  descendantLabel={null}
+                  mobile={false}
+                  summary={scenario.summary}
+                  scheduled={"scheduled" in scenario ? scenario.scheduled : false}
+                  relativeTime={"relativeTime" in scenario ? scenario.relativeTime : undefined}
+                />
+              </a>
+            </div>
+          ))}
+        </div>
+      </aside>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<SessionRailRowMetadataFixture />);

--- a/apps/web/test/session-rail-row-metadata.html
+++ b/apps/web/test/session-rail-row-metadata.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session rail row metadata fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/test/session-rail-row-metadata-fixture.tsx"></script>
+  </body>
+</html>

--- a/apps/web/test/session-tenancy-control-fixture.tsx
+++ b/apps/web/test/session-tenancy-control-fixture.tsx
@@ -1,0 +1,52 @@
+import { createRoot } from "react-dom/client";
+import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
+
+import { SessionTenancyControl } from "../src/components/session/session-tenancy-control";
+import { SessionTenancyOperationController } from "../src/lib/session-tenancy-operation-controller";
+import type { Session } from "../src/types";
+import "../src/styles.css";
+
+const workspaceId = "22222222-2222-4222-8222-222222222222";
+const sessionId = "44444444-4444-4444-8444-444444444444";
+
+function SessionTenancyControlFixture() {
+  return (
+    <main className="flex min-h-screen items-start justify-end p-6">
+      <SessionTenancyControl
+        session={
+          {
+            id: sessionId,
+            workspaceId,
+            accountId: "11111111-1111-4111-8111-111111111111",
+            status: "idle",
+            initialMessage: "Review the private workspace boundary",
+            title: "Private workspace review",
+            titleSource: "user",
+            tenancy: {
+              visibility: "private",
+              authorityEpoch: 3,
+              ownedByCurrentUser: true,
+              fork: null,
+            },
+          } as Session
+        }
+        client={{} as OpenGeniCoreClient}
+        managedSession
+        scopeLabel="Roadmap Personal workspace"
+        captureWorkspaceInvocation={() => ({ workspaceId, revision: 1 })}
+        ownsWorkspaceInvocation={() => true}
+        operationController={new SessionTenancyOperationController()}
+        operationScope={{
+          principalId: "33333333-3333-4333-8333-333333333333",
+          workspaceId,
+          sessionId,
+          workspaceTransitionRevision: 1,
+        }}
+        onRefreshSession={async () => undefined}
+        onOpenSession={() => undefined}
+      />
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<SessionTenancyControlFixture />);

--- a/apps/web/test/session-tenancy-control.html
+++ b/apps/web/test/session-tenancy-control.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session tenancy control fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/test/session-tenancy-control-fixture.tsx"></script>
+  </body>
+</html>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,6 +66,16 @@ export default defineConfig({
               priority: 3,
             },
             {
+              // A few tiny primitives are shared by the initial composer and
+              // the active-session route. Pin that boundary so entry-aware
+              // merging cannot use an icon or label helper to pull the full
+              // session workbench into startup.
+              name: "session-shared-primitives",
+              test: /(?:apps[\\/]web[\\/]src[\\/]lib[\\/](?:format|machine-selectability)\.ts|packages[\\/]react[\\/]src[\\/](?:hooks[\\/]use-machines|workstream-control-event)\.ts|lucide-react[\\/]dist[\\/]esm[\\/]icons[\\/](?:git-branch|rotate-cw|server)\.mjs)$/,
+              includeDependenciesRecursively: false,
+              priority: 16,
+            },
+            {
               // The session workbench is the primary interactive route. Keep
               // its static graph route-aware, but coalesce tiny shared groups
               // so a cold navigation does not fan out into dozens of requests.

--- a/docs/embedding-workbench.md
+++ b/docs/embedding-workbench.md
@@ -177,9 +177,15 @@ being observed.
 | `initialTab` | override the default landing tab. A built-in tab excluded by `surfaces` is ignored. Omit it and the workbench decides **Changes when the session has changes, else Files** from the authoritative source: instant capture stats while cold/offline, live Git while warm. The choice latches before real content paints, so later edits never steal the current tab. |
 | `collapsed` / `onCollapsedChange` | drive the dock open/closed from your own toolbar. |
 
-The machine-state chip (live / waking… / offline — as of `<time>`) is rendered in
-the dock header automatically; its popover carries the machine identity, the
-shared-session disclosure, and a retry when the fleet fails to resolve.
+Workspace surfaces use a vertical, keyboard-navigable activity rail. Up/Down
+move between panels and Home/End jump to the ends. The rail becomes icon-first
+when a desktop split is narrow, with accessible names and tooltips, and keeps
+readable labels in overlays and maximized views. Visited panels stay mounted.
+
+The machine-state chip is rendered in the dock header automatically. Managed
+cold compute reads `Sleeping` with saved-workspace freshness, for example
+`Sleeping · saved 2m ago`; this is capture freshness, not a heartbeat. A
+Connected Machine that is genuinely unreachable reads `Offline`.
 
 ## 5. Theming
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -678,7 +678,8 @@ capability document so every surface degrades to a reason instead of crashing.
   firehose and the real interactive PTY over the minted `pty-ws` cell.
 - `useDesktopStream` — the noVNC socket, hot-swapped on box rollover via
   `stream.url.rotated`.
-- Components: `WorkspaceDock` (the resizable/collapsible right-hand dock),
+- Components: `WorkspaceDock` (the resizable/collapsible right-hand dock with a
+  vertical activity rail, persistent visited panels, and a panel-local Hide action),
   `FileBrowser` / `SandboxFiles`, `DiffView` / `PierreDiff` / `PierreFile`,
   `CodeEditor`, `SandboxTerminal`, and `DesktopViewer`.
 

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -3,7 +3,7 @@
 
    The M5/M6 harnesses render sub-components (WorkbenchChanges, FileBrowser,
    SandboxTerminal) in isolation. M7 reviews the WHOLE dock — frame + header +
-   machine chip + tab strip + every surface — in each state of the
+   machine chip + activity rail + every surface — in each state of the
    matrix. This module drives the real `<SandboxWorkspace>` through a mock client
    whose capability / capture / machine / git responses are chosen by a state key,
    so one harness + one screenshot runner covers every matrix cell.

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -758,7 +758,9 @@ function Notice({
           </span>
         ) : null}
         {title ? <p className="font-medium text-og-fg">{title}</p> : null}
-        <div className="leading-5">{children}</div>
+        <div data-contrast-audited className="leading-5">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -125,17 +125,6 @@ function captureDegradedMessage(reason: string): string {
   }
 }
 
-function WorkbenchTabLabel({ icon, children }: { icon: ReactNode; children: ReactNode }) {
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <span className="[&>svg]:size-3.5" aria-hidden>
-        {icon}
-      </span>
-      <span>{children}</span>
-    </span>
-  );
-}
-
 function WorkbenchSurfaceLoading({ name }: { name: "Browser" | "Desktop" }) {
   return (
     <CenteredState
@@ -262,7 +251,7 @@ function workspaceTurnInFlight(events: SessionEvent[]): boolean {
 export type WorkspaceMachine = {
   /** Whether at least one built-in workbench surface is enabled. */
   enabled: boolean;
-  /** The derived live/waking/offline chip model. */
+  /** The derived live/waking/sleeping-or-offline chip model. */
   chip: MachineChip;
   /** The machine these surfaces are bound to (the Modal group box or a
    *  self-hosted machine), or null while the fleet is still resolving. */
@@ -718,7 +707,8 @@ export function useSandboxWorkspaceTabs(
     if (changesEnabled)
       list.push({
         id: WORKBENCH_TAB_CHANGES,
-        label: <WorkbenchTabLabel icon={<GitCompareArrowsIcon />}>Changes</WorkbenchTabLabel>,
+        label: "Changes",
+        icon: <GitCompareArrowsIcon />,
         badge: dirtyCount > 0 ? <DirtyBadge count={dirtyCount} /> : undefined,
         content: (
           <ChangesTabBody
@@ -750,7 +740,8 @@ export function useSandboxWorkspaceTabs(
     if (filesEnabled)
       list.push({
         id: WORKBENCH_TAB_FILES,
-        label: <WorkbenchTabLabel icon={<FileCode2Icon />}>Files</WorkbenchTabLabel>,
+        label: "Files",
+        icon: <FileCode2Icon />,
         content: (
           <SandboxFiles
             key={sessionId}
@@ -796,7 +787,8 @@ export function useSandboxWorkspaceTabs(
     if (terminalOn) {
       list.push({
         id: WORKBENCH_TAB_TERMINAL,
-        label: <WorkbenchTabLabel icon={<SquareTerminalIcon />}>Terminal</WorkbenchTabLabel>,
+        label: "Terminal",
+        icon: <SquareTerminalIcon />,
         content: (
           <div className="h-full bg-og-bg p-1">
             <SandboxTerminal
@@ -821,7 +813,8 @@ export function useSandboxWorkspaceTabs(
     if (browserEnabled) {
       list.push({
         id: WORKBENCH_TAB_BROWSER,
-        label: <WorkbenchTabLabel icon={<Globe2Icon />}>Browser</WorkbenchTabLabel>,
+        label: "Browser",
+        icon: <Globe2Icon />,
         content: (
           <Suspense fallback={<WorkbenchSurfaceLoading name="Browser" />}>
             <LazyBrowserViewer
@@ -857,7 +850,8 @@ export function useSandboxWorkspaceTabs(
     if (desktopEnabled) {
       list.push({
         id: WORKBENCH_TAB_DESKTOP,
-        label: <WorkbenchTabLabel icon={<MonitorIcon />}>Desktop</WorkbenchTabLabel>,
+        label: "Desktop",
+        icon: <MonitorIcon />,
         content: (
           <Suspense fallback={<WorkbenchSurfaceLoading name="Desktop" />}>
             <LazyComputerViewer
@@ -1200,7 +1194,7 @@ function chipDotClass(state: MachineChip["state"]): string {
 }
 
 /**
- * The dock-header machine status: one quiet, truthful live/waking/offline
+ * The dock-header machine status: one quiet, truthful live/waking/resting
  * indicator. It is intentionally not interactive; detailed machine controls do
  * not belong in a transient popover above the workspace tabs.
  */

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -30,6 +30,10 @@ import { cn } from "../lib/cn";
 export type WorkspaceTab = {
   id: string;
   label: ReactNode;
+  /** Optional icon used by the compact activity rail. */
+  icon?: ReactNode | undefined;
+  /** Accessible name when `label` is not plain text. */
+  ariaLabel?: string | undefined;
   /** Rendered as the active surface. */
   content: ReactNode;
   /** A small badge after the label (e.g. dirty count, live pill). */
@@ -46,9 +50,9 @@ export type WorkspaceDockProps = {
   /** Controlled collapsed state for hosts that expose their own dock toggle. */
   collapsed?: boolean | undefined;
   onCollapsedChange?: ((collapsed: boolean) => void) | undefined;
-  /** Keep the built-in collapse control when the host controls collapsed state. */
+  /** Keep the panel-local Hide workspace control when the host controls collapsed state. */
   showCollapseControl?: boolean | undefined;
-  /** A status accessory pinned to the right of the tab strip, left of the
+  /** A status accessory pinned to the right of the workspace header, left of the
    *  maximize/collapse controls (e.g. the machine-state chip). Renders in both
    *  the docked header and the full-screen overlay header. */
   headerAccessory?: ReactNode | undefined;
@@ -133,7 +137,7 @@ export function WorkspaceDock({
   onActiveTabChange,
   collapsed: collapsedProp,
   onCollapsedChange,
-  showCollapseControl = false,
+  showCollapseControl = true,
   headerAccessory,
   mobileLeadingControl,
   autoSaveId = "og.session.dock",
@@ -152,11 +156,9 @@ export function WorkspaceDock({
   const [maximized, setMaximized] = useState(false);
   const [internalTab, setInternalTab] = useState(tabs[0]?.id ?? "");
   const collapsed = collapsedProp ?? internalCollapsed;
-  // When the host supplies `collapsed` it owns the open/close affordance (e.g.
-  // the app header's panel toggle) — the dock must not offer a SECOND
-  // open/close control (duplicate buttons with near-identical icons read as a
-  // bug). Standalone (uncontrolled) usage keeps the built-in collapse button
-  // and the thin re-open rail as its only affordances.
+  // The host header remains the stable reopen action. The open panel also owns
+  // a local Hide workspace action so a user never has to hunt elsewhere to
+  // dismiss it; standalone usage keeps the thin reopen rail as well.
   const hostControlled = collapsedProp !== undefined;
   const previousCollapsedRef = useRef(collapsed);
 
@@ -251,7 +253,18 @@ export function WorkspaceDock({
         return;
       }
       const target = returnFocusRef.current;
-      if (target?.isConnected) target.focus();
+      if (target?.isConnected) {
+        target.focus();
+        return;
+      }
+      // A controlled desktop dock can be restored open on the initial render,
+      // so there may be no opener to remember. Never leave focus parked on the
+      // now-hidden workspace chrome; fall back to the host's primary surface.
+      rootRef.current
+        ?.querySelector<HTMLElement>(
+          '[data-workspace-primary] button:not([disabled]), [data-workspace-primary] a[href], [data-workspace-primary] input:not([disabled]), [data-workspace-primary] textarea:not([disabled]), [data-workspace-primary] select:not([disabled]), [data-workspace-primary] [tabindex]:not([tabindex="-1"])',
+        )
+        ?.focus();
     });
     return () => cancelAnimationFrame(frame);
   }, [collapsed, hostControlled, narrow]);
@@ -383,7 +396,7 @@ export function WorkspaceDock({
             leading={mobileLeadingControl}
             accessory={headerAccessory}
             controls={
-              <ChromeButton onClick={collapse} title="Close workspace" label="Close workspace">
+              <ChromeButton onClick={collapse} title="Hide workspace" label="Hide workspace">
                 <XIcon className="size-4" />
               </ChromeButton>
             }
@@ -426,7 +439,7 @@ export function WorkspaceDock({
             )}
           </ChromeButton>
           {hostControlled && !showCollapseControl ? null : (
-            <ChromeButton onClick={collapse} title="Collapse" label="Collapse dock">
+            <ChromeButton onClick={collapse} title="Hide workspace" label="Hide workspace">
               <PanelRightCloseIcon className="size-3.5" />
             </ChromeButton>
           )}
@@ -498,7 +511,7 @@ export function WorkspaceDock({
       </Group>
 
       {/* Collapsed rail: the standalone fallback re-open affordance. Hidden
-          when the host controls collapse — its own toggle is the one way in. */}
+          when the host controls collapse — its header remains the stable way in. */}
       {collapsed && !maximized && !hostControlled && (
         <button
           ref={reopenRef}
@@ -562,24 +575,19 @@ function DockChrome({
   const active = tabs.find((t) => t.id === current) ?? tabs[0];
   const tabsetId = useId();
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const tabListRef = useRef<HTMLDivElement | null>(null);
   const [visitedTabs, setVisitedTabs] = useState<Set<string>>(() => new Set());
-  const [tabOverflow, setTabOverflow] = useState({ start: false, end: false });
   const activeId = active?.id ?? "";
-  const activeTabIndex = tabs.findIndex((tab) => tab.id === activeId);
 
-  // A desktop dock can be much narrower than the viewport after the user drags
-  // its separator. Viewport breakpoints therefore cannot protect the tab strip:
-  // the status + controls used to squeeze it to zero width, leaving visible but
-  // unclickable ARIA tabs. At narrow *dock* widths, give status/controls their
-  // own row and the horizontally scrollable tabs the complete second row.
+  // Dock width, not viewport width, chooses rail density. A narrow split keeps
+  // the icon-first activity rail usable without stealing the panel's content
+  // width; overlays and maximized views retain readable labels.
   useDockLayoutEffect(() => {
     const node = chromeRef.current;
     if (!node) return;
     const update = () => {
       const desktop =
         typeof window.matchMedia !== "function" || window.matchMedia("(min-width: 1024px)").matches;
-      const next = desktop && node.getBoundingClientRect().width < 420;
+      const next = desktop && node.getBoundingClientRect().width < 440;
       setCompact((previous) => (previous === next ? previous : next));
     };
     update();
@@ -592,11 +600,6 @@ function DockChrome({
     return () => observer.disconnect();
   }, []);
 
-  const keepActiveTabVisible = useCallback(() => {
-    const selected = activeTabIndex >= 0 ? tabRefs.current[activeTabIndex] : null;
-    selected?.scrollIntoView({ block: "nearest", inline: "nearest" });
-  }, [activeTabIndex]);
-
   useEffect(() => {
     if (!activeId) return;
     setVisitedTabs((previous) => {
@@ -606,55 +609,6 @@ function DockChrome({
       return next;
     });
   }, [activeId]);
-
-  // A controlled/initial tab can become active without receiving focus (for
-  // example, a host routing a guarded diff into Files). Native scrolling only
-  // follows focus, so keep the selected tab inside the horizontally scrollable
-  // strip even when state — rather than a click or arrow key — selected it.
-  useDockLayoutEffect(() => {
-    keepActiveTabVisible();
-  }, [activeId, keepActiveTabVisible]);
-
-  // Hidden scrollbars keep the chrome quiet, but without an edge cue a clipped
-  // host label reads like corrupted copy. Fade only the edge(s) with more tabs,
-  // and recompute after scrolling, resizing, or late font metrics.
-  useDockLayoutEffect(() => {
-    const list = tabListRef.current;
-    if (!list) return;
-    const update = () => {
-      const max = Math.max(0, list.scrollWidth - list.clientWidth);
-      const next = { start: list.scrollLeft > 1, end: list.scrollLeft < max - 1 };
-      setTabOverflow((previous) =>
-        previous.start === next.start && previous.end === next.end ? previous : next,
-      );
-    };
-    update();
-    list.addEventListener("scroll", update, { passive: true });
-    const observer =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(() => {
-            keepActiveTabVisible();
-            update();
-          });
-    observer?.observe(list);
-    for (const tab of tabRefs.current) {
-      if (tab) observer?.observe(tab);
-    }
-    return () => {
-      list.removeEventListener("scroll", update);
-      observer?.disconnect();
-    };
-  }, [activeId, keepActiveTabVisible, tabs.length]);
-
-  const tabMask =
-    tabOverflow.start && tabOverflow.end
-      ? "linear-gradient(to right, transparent 0, black 14px, black calc(100% - 14px), transparent 100%)"
-      : tabOverflow.start
-        ? "linear-gradient(to right, transparent 0, black 14px, black 100%)"
-        : tabOverflow.end
-          ? "linear-gradient(to right, black 0, black calc(100% - 14px), transparent 100%)"
-          : undefined;
 
   const activateTab = (index: number) => {
     const tab = tabs[index];
@@ -668,8 +622,8 @@ function DockChrome({
   const onTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
     if (tabs.length === 0) return;
     let nextIndex: number | null = null;
-    if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
-    else if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+    if (event.key === "ArrowDown") nextIndex = (index + 1) % tabs.length;
+    else if (event.key === "ArrowUp") nextIndex = (index - 1 + tabs.length) % tabs.length;
     else if (event.key === "Home") nextIndex = 0;
     else if (event.key === "End") nextIndex = tabs.length - 1;
     if (nextIndex === null) return;
@@ -678,115 +632,106 @@ function DockChrome({
   };
 
   return (
-    <>
-      <div
-        ref={chromeRef}
-        data-dock-chrome
-        data-compact={compact ? "true" : undefined}
-        className={cn(
-          "grid shrink-0 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-x-2 border-b border-og-border px-1.5 py-1 max-[1023px]:grid-cols-[auto_minmax(0,1fr)_auto] max-[1023px]:gap-y-0 max-[1023px]:px-2 max-[1023px]:pb-1 max-[1023px]:pt-0 min-[640px]:max-[1023px]:grid-cols-[auto_minmax(0,1fr)_auto_auto]",
-          compact && "gap-y-1",
-        )}
-        style={compact ? { gridTemplateColumns: "minmax(0, 1fr) auto" } : undefined}
-      >
-        <div
-          className={cn(
-            "flex min-w-0 shrink-0 items-center max-[1023px]:min-h-11 min-[640px]:max-[1023px]:col-start-1 min-[640px]:max-[1023px]:row-start-1",
-            compact && "hidden",
-          )}
-        >
+    <div
+      ref={chromeRef}
+      data-dock-chrome
+      data-compact={compact ? "true" : undefined}
+      className="flex h-full min-h-0 min-w-0 flex-col"
+    >
+      <div className="flex min-h-10 shrink-0 items-center gap-2 border-b border-og-border px-2 max-[1023px]:min-h-12">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           {leading ?? (
-            <span className="hidden truncate px-1 text-og-sm font-semibold text-og-fg max-[1023px]:inline">
+            <span className="hidden truncate text-og-sm font-semibold text-og-fg max-[1023px]:inline">
               Workspace
             </span>
           )}
         </div>
-        {/* The tab list scrolls horizontally when it can't fit — it must never
-            grow into or overlap the chrome controls (they stay shrink-0). The
-            scrollbar is hidden to keep the strip calm. On the narrow overlay it
-            owns a full second row, so status/close chrome can never squeeze the
-            canonical workspace navigation out of view. Tablets have enough
-            width to retain the denser single-row chrome, with this same strip
-            absorbing any unusually long host-injected labels. */}
+        <div className="min-w-0 shrink text-og-fg-muted">{accessory}</div>
+        <div className="flex shrink-0 items-center gap-0.5 text-og-fg-subtle">{controls}</div>
+      </div>
+      <div className="flex min-h-0 min-w-0 flex-1">
         <div
-          ref={tabListRef}
           className={cn(
-            "flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-[1023px]:col-span-3 max-[1023px]:row-start-2 max-[1023px]:w-full min-[640px]:max-[1023px]:col-span-1 min-[640px]:max-[1023px]:col-start-2 min-[640px]:max-[1023px]:row-start-1",
-            compact && "col-span-2 col-start-1 row-start-2 w-full",
+            "flex shrink-0 flex-col gap-1 overflow-x-hidden overflow-y-auto border-r border-og-border bg-og-surface-1/45 p-1.5",
+            compact ? "w-12" : "w-32 max-[1023px]:w-36",
           )}
           role="tablist"
-          aria-orientation="horizontal"
-          style={{
-            maskImage: tabMask,
-            WebkitMaskImage: tabMask,
-            scrollPaddingInline: "16px",
-          }}
+          aria-label="Workspace panels"
+          aria-orientation="vertical"
         >
-          {tabs.map((tab, index) => (
-            <button
-              key={tab.id}
-              ref={(node) => {
-                tabRefs.current[index] = node;
-              }}
-              id={`${tabsetId}-tab-${index}`}
-              type="button"
-              role="tab"
-              aria-selected={tab.id === current}
-              aria-controls={`${tabsetId}-panel-${index}`}
-              tabIndex={tab.id === current ? 0 : -1}
-              onClick={() => onTab(tab.id)}
-              onKeyDown={(event) => onTabKeyDown(event, index)}
-              className={cn(
-                "flex min-h-7 shrink-0 items-center justify-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
-                tab.id === current
-                  ? "bg-og-accent-soft text-og-fg"
-                  : "text-og-fg-subtle hover:text-og-fg",
-              )}
-            >
-              <span data-contrast-audited>{tab.label}</span>
-              {tab.badge}
-            </button>
-          ))}
-        </div>
-        <div
-          className={cn(
-            "flex min-w-0 shrink-0 items-center justify-self-end min-[640px]:max-[1023px]:col-start-3 min-[640px]:max-[1023px]:row-start-1",
-            compact && "col-start-1 row-start-1 justify-self-start",
-          )}
-        >
-          {accessory}
-        </div>
-        <div
-          className={cn(
-            "flex shrink-0 items-center gap-0.5 text-og-fg-subtle min-[640px]:max-[1023px]:col-start-4 min-[640px]:max-[1023px]:row-start-1",
-            compact && "col-start-2 row-start-1",
-          )}
-        >
-          {controls}
-        </div>
-      </div>
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        {tabs.length > 0 ? (
-          tabs.map((tab, index) => {
-            const selected = tab.id === activeId;
-            const shouldMount = selected || visitedTabs.has(tab.id);
+          {tabs.map((tab, index) => {
+            const tabName = tab.ariaLabel ?? (typeof tab.label === "string" ? tab.label : tab.id);
             return (
-              <div
+              <button
                 key={tab.id}
-                id={`${tabsetId}-panel-${index}`}
-                aria-labelledby={`${tabsetId}-tab-${index}`}
-                className="h-full min-h-0 min-w-0 overflow-hidden"
-                hidden={!selected}
-                role="tabpanel"
+                ref={(node) => {
+                  tabRefs.current[index] = node;
+                }}
+                id={`${tabsetId}-tab-${index}`}
+                type="button"
+                role="tab"
+                aria-label={compact && tab.icon ? tabName : undefined}
+                title={compact && tab.icon ? tabName : undefined}
+                aria-selected={tab.id === current}
+                aria-controls={`${tabsetId}-panel-${index}`}
+                tabIndex={tab.id === current ? 0 : -1}
+                onClick={() => onTab(tab.id)}
+                onKeyDown={(event) => onTabKeyDown(event, index)}
+                className={cn(
+                  "group relative flex min-h-9 w-full items-center gap-2 rounded-og-md px-2 text-left text-og-xs font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 pointer-coarse:min-h-11",
+                  compact && "justify-center px-1",
+                  tab.id === current
+                    ? "bg-og-accent-soft text-og-fg shadow-[inset_2px_0_0_var(--og-color-accent)]"
+                    : "text-og-fg-subtle hover:bg-og-surface-2 hover:text-og-fg",
+                )}
               >
-                {shouldMount ? tab.content : null}
-              </div>
+                {tab.icon ? (
+                  <span
+                    className="flex size-4 shrink-0 items-center justify-center [&>svg]:size-4"
+                    aria-hidden
+                  >
+                    {tab.icon}
+                  </span>
+                ) : null}
+                {!compact || !tab.icon ? (
+                  <span data-contrast-audited className="min-w-0 flex-1 truncate">
+                    {tab.label}
+                  </span>
+                ) : null}
+                {tab.badge ? (
+                  <span
+                    className={cn("shrink-0", compact && "absolute -right-0.5 -top-0.5 scale-90")}
+                  >
+                    {tab.badge}
+                  </span>
+                ) : null}
+              </button>
             );
-          })
-        ) : (
-          <div className="h-full min-h-0 min-w-0" aria-label="Workspace" role="tabpanel" />
-        )}
+          })}
+        </div>
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          {tabs.length > 0 ? (
+            tabs.map((tab, index) => {
+              const selected = tab.id === activeId;
+              const shouldMount = selected || visitedTabs.has(tab.id);
+              return (
+                <div
+                  key={tab.id}
+                  id={`${tabsetId}-panel-${index}`}
+                  aria-labelledby={`${tabsetId}-tab-${index}`}
+                  className="h-full min-h-0 min-w-0 overflow-hidden"
+                  hidden={!selected}
+                  role="tabpanel"
+                >
+                  {shouldMount ? tab.content : null}
+                </div>
+              );
+            })
+          ) : (
+            <div className="h-full min-h-0 min-w-0" aria-label="Workspace" role="tabpanel" />
+          )}
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/packages/react/src/hooks/use-machine-chip.ts
+++ b/packages/react/src/hooks/use-machine-chip.ts
@@ -4,13 +4,13 @@ import type { SessionCapabilitiesState } from "./use-session-capabilities";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 import { connectionStatusForState } from "../types/machines";
 
-/** The one truthful machine indicator. Honest staleness beats
- *  fake liveness: a cold/asleep box reads "offline — as of <time>", never "live". */
+/** The one truthful machine indicator. Managed cold compute is sleeping; a
+ *  Connected Machine that is genuinely unreachable remains offline. */
 export type MachineChipState = "live" | "waking" | "offline";
 
 export type MachineChip = {
   state: MachineChipState;
-  /** A ready-to-render label ("Live" / "Waking…" / "Offline — as of 3m ago"). */
+  /** A ready-to-render label ("Live" / "Waking…" / "Sleeping · saved 3m ago"). */
   label: string;
   /** The capture time backing an offline/stale label (ISO), or null. M4 may
    *  reformat this; `label` already embeds a relative form. */
@@ -64,7 +64,8 @@ export function formatAsOf(capturedAt: string, now: number): string {
 export function deriveMachineChip(input: DeriveMachineChipInput): MachineChip {
   const now = input.now ?? Date.now();
   const asOf = input.capturedAt ?? null;
-  const offlineLabel = asOf ? `Offline — as of ${formatAsOf(asOf, now)}` : "Offline";
+  const managedRestingLabel = asOf ? `Sleeping · saved ${formatAsOf(asOf, now)}` : "Sleeping";
+  const offlineLabel = "Offline";
 
   // A connected machine has no Modal group lease, so capability negotiation
   // legitimately reports `cold` until a stream holder is minted. Its fleet
@@ -86,6 +87,16 @@ export function deriveMachineChip(input: DeriveMachineChipInput): MachineChip {
   const selfhostedOffline =
     input.activeIsSelfhosted === true && input.activeMachineState === "offline";
 
+  // Capability negotiation has definitively failed. A retained warm intent
+  // must not turn that error into the optimistic Waking state.
+  if (input.capabilitiesState === "error") {
+    return {
+      state: "offline",
+      label: input.activeIsSelfhosted === true ? offlineLabel : managedRestingLabel,
+      asOf,
+    };
+  }
+
   // 2. Actively coming up: negotiation in flight, an edit/terminal is warming, or
   //    the active machine is (re)connecting. Never when self-hosted is hard-offline.
   const machineWarming =
@@ -97,8 +108,14 @@ export function deriveMachineChip(input: DeriveMachineChipInput): MachineChip {
     return { state: "waking", label: "Waking…", asOf };
   }
 
-  // 3. Cold / asleep / offline / error → honest stale label.
-  return { state: "offline", label: offlineLabel, asOf };
+  // 3. Managed cold compute is sleeping with saved-workspace freshness. A
+  // Connected Machine is only described as Offline when its reachability is
+  // genuinely unavailable; capture time is not a heartbeat.
+  return {
+    state: "offline",
+    label: input.activeIsSelfhosted === true ? offlineLabel : managedRestingLabel,
+    asOf,
+  };
 }
 
 export type UseMachineChipOptions = DeriveMachineChipInput;

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -372,6 +372,9 @@
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-translate-z: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-scale-z: 1;
   --tw-rotate-x: initial;
   --tw-rotate-y: initial;
   --tw-rotate-z: initial;
@@ -436,9 +439,6 @@
   --tw-backdrop-sepia: initial;
   --tw-duration: initial;
   --tw-ease: initial;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-scale-z: 1;
   --tw-content: "";
 }
 /*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */
@@ -544,6 +544,9 @@
 :where(.og-root).end,:where(.og-root) .end {
     inset-inline-end: var(--spacing);
   }
+:where(.og-root).-top-0\.5,:where(.og-root) .-top-0\.5 {
+    top: calc(var(--spacing) * -0.5);
+  }
 :where(.og-root).-top-3,:where(.og-root) .-top-3 {
     top: calc(var(--spacing) * -3);
   }
@@ -567,6 +570,9 @@
   }
 :where(.og-root).top-10,:where(.og-root) .top-10 {
     top: calc(var(--spacing) * 10);
+  }
+:where(.og-root).-right-0\.5,:where(.og-root) .-right-0\.5 {
+    right: calc(var(--spacing) * -0.5);
   }
 :where(.og-root).-right-3,:where(.og-root) .-right-3 {
     right: calc(var(--spacing) * -3);
@@ -645,9 +651,6 @@
   }
 :where(.og-root).z-\[2147483647\],:where(.og-root) .z-\[2147483647\] {
     z-index: 2147483647;
-  }
-:where(.og-root).col-span-2,:where(.og-root) .col-span-2 {
-    grid-column: span 2 / span 2;
   }
 :where(.og-root).col-span-full,:where(.og-root) .col-span-full {
     grid-column: 1 / -1;
@@ -1099,6 +1102,12 @@
 :where(.og-root).w-11,:where(.og-root) .w-11 {
     width: calc(var(--spacing) * 11);
   }
+:where(.og-root).w-12,:where(.og-root) .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+:where(.og-root).w-32,:where(.og-root) .w-32 {
+    width: calc(var(--spacing) * 32);
+  }
 :where(.og-root).w-40,:where(.og-root) .w-40 {
     width: calc(var(--spacing) * 40);
   }
@@ -1283,6 +1292,12 @@
     --tw-translate-y: calc(-50% - 2px);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+:where(.og-root).scale-90,:where(.og-root) .scale-90 {
+    --tw-scale-x: 90%;
+    --tw-scale-y: 90%;
+    --tw-scale-z: 90%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
 :where(.og-root).rotate-45,:where(.og-root) .rotate-45 {
     rotate: 45deg;
   }
@@ -1381,9 +1396,6 @@
   }
 :where(.og-root).grid-cols-\[auto_minmax\(0\,1fr\)\],:where(.og-root) .grid-cols-\[auto_minmax\(0\,1fr\)\] {
     grid-template-columns: auto minmax(0,1fr);
-  }
-:where(.og-root).grid-cols-\[auto_minmax\(0\,1fr\)_auto_auto\],:where(.og-root) .grid-cols-\[auto_minmax\(0\,1fr\)_auto_auto\] {
-    grid-template-columns: auto minmax(0,1fr) auto auto;
   }
 :where(.og-root).grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,1fr\)\],:where(.og-root) .grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,1fr\)\] {
     grid-template-columns: minmax(0,1fr) minmax(0,1fr);
@@ -1517,9 +1529,6 @@
 :where(.og-root).gap-y-0\.5,:where(.og-root) .gap-y-0\.5 {
     row-gap: calc(var(--spacing) * 0.5);
   }
-:where(.og-root).gap-y-1,:where(.og-root) .gap-y-1 {
-    row-gap: calc(var(--spacing) * 1);
-  }
 :where(.og-root).gap-y-1\.5,:where(.og-root) .gap-y-1\.5 {
     row-gap: calc(var(--spacing) * 1.5);
   }
@@ -1551,12 +1560,6 @@
   }
 :where(.og-root).self-start,:where(.og-root) .self-start {
     align-self: flex-start;
-  }
-:where(.og-root).justify-self-end,:where(.og-root) .justify-self-end {
-    justify-self: flex-end;
-  }
-:where(.og-root).justify-self-start,:where(.og-root) .justify-self-start {
-    justify-self: flex-start;
   }
 :where(.og-root).truncate,:where(.og-root) .truncate {
     overflow: hidden;
@@ -2119,6 +2122,12 @@
     background-color: var(--og-color-surface-1);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--og-color-surface-1) 35%, transparent);
+    }
+  }
+:where(.og-root).bg-og-surface-1\/45,:where(.og-root) .bg-og-surface-1\/45 {
+    background-color: var(--og-color-surface-1);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--og-color-surface-1) 45%, transparent);
     }
   }
 :where(.og-root).bg-og-surface-1\/70,:where(.og-root) .bg-og-surface-1\/70 {
@@ -2852,6 +2861,10 @@
   }
 :where(.og-root).shadow-2xl,:where(.og-root) .shadow-2xl {
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+:where(.og-root).shadow-\[inset_2px_0_0_var\(--og-color-accent\)\],:where(.og-root) .shadow-\[inset_2px_0_0_var\(--og-color-accent\)\] {
+    --tw-shadow: inset 2px 0 0 var(--tw-shadow-color, var(--og-color-accent));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 :where(.og-root).shadow-lg,:where(.og-root) .shadow-lg {
@@ -4241,16 +4254,6 @@
       transition-property: none;
     }
   }
-:where(.og-root).max-\[1023px\]\:col-span-3,:where(.og-root) .max-\[1023px\]\:col-span-3 {
-    @media (width < 1023px) {
-      grid-column: span 3 / span 3;
-    }
-  }
-:where(.og-root).max-\[1023px\]\:row-start-2,:where(.og-root) .max-\[1023px\]\:row-start-2 {
-    @media (width < 1023px) {
-      grid-row-start: 2;
-    }
-  }
 :where(.og-root).max-\[1023px\]\:-mx-\[19px\],:where(.og-root) .max-\[1023px\]\:-mx-\[19px\] {
     @media (width < 1023px) {
       margin-inline: calc(19px * -1);
@@ -4272,44 +4275,24 @@
       min-height: calc(var(--spacing) * 11);
     }
   }
+:where(.og-root).max-\[1023px\]\:min-h-12,:where(.og-root) .max-\[1023px\]\:min-h-12 {
+    @media (width < 1023px) {
+      min-height: calc(var(--spacing) * 12);
+    }
+  }
 :where(.og-root).max-\[1023px\]\:w-11,:where(.og-root) .max-\[1023px\]\:w-11 {
     @media (width < 1023px) {
       width: calc(var(--spacing) * 11);
     }
   }
-:where(.og-root).max-\[1023px\]\:w-full,:where(.og-root) .max-\[1023px\]\:w-full {
+:where(.og-root).max-\[1023px\]\:w-36,:where(.og-root) .max-\[1023px\]\:w-36 {
     @media (width < 1023px) {
-      width: 100%;
+      width: calc(var(--spacing) * 36);
     }
   }
 :where(.og-root).max-\[1023px\]\:min-w-11,:where(.og-root) .max-\[1023px\]\:min-w-11 {
     @media (width < 1023px) {
       min-width: calc(var(--spacing) * 11);
-    }
-  }
-:where(.og-root).max-\[1023px\]\:grid-cols-\[auto_minmax\(0\,1fr\)_auto\],:where(.og-root) .max-\[1023px\]\:grid-cols-\[auto_minmax\(0\,1fr\)_auto\] {
-    @media (width < 1023px) {
-      grid-template-columns: auto minmax(0,1fr) auto;
-    }
-  }
-:where(.og-root).max-\[1023px\]\:gap-y-0,:where(.og-root) .max-\[1023px\]\:gap-y-0 {
-    @media (width < 1023px) {
-      row-gap: calc(var(--spacing) * 0);
-    }
-  }
-:where(.og-root).max-\[1023px\]\:px-2,:where(.og-root) .max-\[1023px\]\:px-2 {
-    @media (width < 1023px) {
-      padding-inline: calc(var(--spacing) * 2);
-    }
-  }
-:where(.og-root).max-\[1023px\]\:pt-0,:where(.og-root) .max-\[1023px\]\:pt-0 {
-    @media (width < 1023px) {
-      padding-top: calc(var(--spacing) * 0);
-    }
-  }
-:where(.og-root).max-\[1023px\]\:pb-1,:where(.og-root) .max-\[1023px\]\:pb-1 {
-    @media (width < 1023px) {
-      padding-bottom: calc(var(--spacing) * 1);
     }
   }
 :where(.og-root).max-sm\:hidden,:where(.og-root) .max-sm\:hidden {
@@ -4380,55 +4363,6 @@
 :where(.og-root).min-\[400px\]\:inline,:where(.og-root) .min-\[400px\]\:inline {
     @media (width >= 400px) {
       display: inline;
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:col-span-1,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:col-span-1 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-column: span 1 / span 1;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:col-start-1,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:col-start-1 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-column-start: 1;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:col-start-2,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:col-start-2 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-column-start: 2;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:col-start-3,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:col-start-3 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-column-start: 3;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:col-start-4,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:col-start-4 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-column-start: 4;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:row-start-1,:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:row-start-1 {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-row-start: 1;
-      }
-    }
-  }
-:where(.og-root).min-\[640px\]\:max-\[1023px\]\:grid-cols-\[auto_minmax\(0\,1fr\)_auto_auto\],:where(.og-root) .min-\[640px\]\:max-\[1023px\]\:grid-cols-\[auto_minmax\(0\,1fr\)_auto_auto\] {
-    @media (width >= 640px) {
-      @media (width < 1023px) {
-        grid-template-columns: auto minmax(0,1fr) auto auto;
-      }
     }
   }
 :where(.og-root).sm\:col-span-1,:where(.og-root) .sm\:col-span-1 {
@@ -4889,6 +4823,12 @@
     &>svg {
       width: calc(var(--spacing) * 3.5);
       height: calc(var(--spacing) * 3.5);
+    }
+  }
+:where(.og-root).\[\&\>svg\]\:size-4,:where(.og-root) .\[\&\>svg\]\:size-4 {
+    &>svg {
+      width: calc(var(--spacing) * 4);
+      height: calc(var(--spacing) * 4);
     }
   }
 :where(.og-root).\[\&\>ul\]\:my-1,:where(.og-root) .\[\&\>ul\]\:my-1 {

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -1282,8 +1282,18 @@ describe("capture-driven default tab (Refinement 2)", () => {
 // ── Refinement 2: no post-paint content switch (component level) ──────────────
 
 describe("SandboxWorkspace capture-driven default renders with no content switch", () => {
-  function selectedTabText(container: HTMLElement): string {
-    return container.querySelector('[role="tab"][aria-selected="true"]')?.textContent ?? "";
+  function tabName(element: HTMLElement | null): string {
+    return element?.getAttribute("aria-label") ?? element?.textContent ?? "";
+  }
+
+  function selectedTabName(container: HTMLElement): string {
+    return tabName(container.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]'));
+  }
+
+  function findTab(container: HTMLElement, name: string): HTMLElement | undefined {
+    return [...container.querySelectorAll<HTMLElement>('[role="tab"]')].find(
+      (element) => tabName(element).trim() === name,
+    );
   }
 
   test("pure embedder, changes present: Changes is the selected tab before AND after resolve", async () => {
@@ -1306,13 +1316,13 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
     await flush();
     // Pending (capture unresolved): the dock falls back to its first tab (Changes);
     // Files is NOT shown first. The body is a loader, not real content.
-    expect(selectedTabText(rendered.container)).toContain("Changes");
+    expect(selectedTabName(rendered.container)).toBe("Changes");
     await act(async () => {
       resolveCapture(captureAvailable(fakeManifest(2)));
     });
     await flush();
     // Default resolved to Changes → the first REAL content paint is Changes: no switch.
-    expect(selectedTabText(rendered.container)).toContain("Changes");
+    expect(selectedTabName(rendered.container)).toBe("Changes");
     await rendered.unmount();
   });
 
@@ -1332,7 +1342,7 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
       ),
     );
     await flush();
-    expect(selectedTabText(rendered.container)).toContain("Files");
+    expect(selectedTabName(rendered.container)).toBe("Files");
     await rendered.unmount();
   });
 
@@ -1355,11 +1365,9 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
       ),
     );
     await flush();
-    expect(selectedTabText(rendered.container)).toContain("Files");
+    expect(selectedTabName(rendered.container)).toBe("Files");
 
-    const changesTab = [...rendered.container.querySelectorAll<HTMLElement>('[role="tab"]')].find(
-      (element) => element.textContent?.includes("Changes"),
-    );
+    const changesTab = findTab(rendered.container, "Changes");
     await act(async () => {
       changesTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
@@ -1391,7 +1399,7 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
     );
     await flush();
 
-    expect(selectedTabText(rendered.container)).toContain("Changes");
+    expect(selectedTabName(rendered.container)).toBe("Changes");
     const degraded = rendered.container.querySelector("[data-opengeni-changes-degraded]");
     expect(degraded?.getAttribute("role")).toBe("status");
     expect(degraded?.textContent).toContain("Showing the latest captured revision");
@@ -1415,18 +1423,16 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
       );
     const rendered = await renderComponent(workspace(SESSION_ID));
     await flush();
-    const filesTab = [...rendered.container.querySelectorAll<HTMLElement>('[role="tab"]')].find(
-      (element) => element.textContent?.includes("Files"),
-    );
+    const filesTab = findTab(rendered.container, "Files");
     expect(filesTab).toBeDefined();
     await act(async () => {
       filesTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    expect(selectedTabText(rendered.container)).toContain("Files");
+    expect(selectedTabName(rendered.container)).toBe("Files");
 
     await rendered.rerender(workspace(SECOND_SESSION_ID));
     await flush();
-    expect(selectedTabText(rendered.container)).toContain("Changes");
+    expect(selectedTabName(rendered.container)).toBe("Changes");
     await rendered.unmount();
   });
 });

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -2493,7 +2493,7 @@ describe("deriveMachineChip", () => {
       }),
     ).toEqual({
       state: "offline",
-      label: "Offline — as of 5m ago",
+      label: "Sleeping · saved 5m ago",
       asOf: "2026-07-08T12:00:00.000Z",
     });
   });
@@ -2506,7 +2506,22 @@ describe("deriveMachineChip", () => {
     expect(deriveMachineChip({ activeMachineState: "reconnecting" }).state).toBe("waking");
   });
 
-  test("cold/idle → offline, labelled 'as of <time>'", () => {
+  test("a capability error stays offline-state even when warm intent is retained", () => {
+    const chip = deriveMachineChip({
+      liveness: "cold",
+      capabilitiesState: "error",
+      wantsWarm: true,
+      capturedAt: "2026-07-08T12:00:00.000Z",
+      now: NOW,
+    });
+    expect(chip).toEqual({
+      state: "offline",
+      label: "Sleeping · saved 5m ago",
+      asOf: "2026-07-08T12:00:00.000Z",
+    });
+  });
+
+  test("managed cold/idle is sleeping with saved-workspace freshness", () => {
     const chip = deriveMachineChip({
       liveness: "cold",
       capturedAt: "2026-07-08T12:00:00.000Z",
@@ -2514,7 +2529,7 @@ describe("deriveMachineChip", () => {
     });
     expect(chip.state).toBe("offline");
     expect(chip.asOf).toBe("2026-07-08T12:00:00.000Z");
-    expect(chip.label).toBe("Offline — as of 5m ago");
+    expect(chip.label).toBe("Sleeping · saved 5m ago");
   });
 
   test("self-hosted offline is honest offline even if warm was requested", () => {
@@ -2527,10 +2542,10 @@ describe("deriveMachineChip", () => {
       now: NOW,
     });
     expect(chip.state).toBe("offline");
-    expect(chip.label).toBe("Offline — as of 1h ago");
+    expect(chip.label).toBe("Offline");
   });
 
-  test("offline with no capture time reads a bare 'Offline'", () => {
-    expect(deriveMachineChip({ liveness: "cold" }).label).toBe("Offline");
+  test("managed sleeping with no capture time reads a bare 'Sleeping'", () => {
+    expect(deriveMachineChip({ liveness: "cold" }).label).toBe("Sleeping");
   });
 });

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -66,7 +66,7 @@ async function withNarrowViewport(run: () => Promise<void>): Promise<void> {
 }
 
 describe("WorkspaceDock", () => {
-  test("gives tabs a full row when the desktop dock itself is narrow", async () => {
+  test("uses an icon-first vertical rail when the desktop dock itself is narrow", async () => {
     const originalResizeObserver = globalThis.ResizeObserver;
     const originalMatchMedia = window.matchMedia;
     const originalRect = HTMLElement.prototype.getBoundingClientRect;
@@ -104,19 +104,40 @@ describe("WorkspaceDock", () => {
           primary={<div>Chat pane</div>}
           headerAccessory={<div>Offline — as of just now</div>}
           tabs={[
-            { id: "changes", label: "Changes", content: <div>Changes content</div> },
-            { id: "files", label: "Files", content: <div>Files content</div> },
-            { id: "terminal", label: "Terminal", content: <div>Terminal content</div> },
-            { id: "browser", label: "Browser", content: <div>Browser content</div> },
+            {
+              id: "changes",
+              label: "Changes",
+              icon: <span>C</span>,
+              content: <div>Changes content</div>,
+            },
+            {
+              id: "files",
+              label: "Files",
+              icon: <span>F</span>,
+              content: <div>Files content</div>,
+            },
+            {
+              id: "terminal",
+              label: "Terminal",
+              icon: <span>T</span>,
+              content: <div>Terminal content</div>,
+            },
+            {
+              id: "browser",
+              label: "Browser",
+              icon: <span>B</span>,
+              content: <div>Browser content</div>,
+            },
           ]}
         />,
       );
       const chrome = rendered.container.querySelector<HTMLElement>("[data-dock-chrome]");
       expect(chrome?.dataset.compact).toBe("true");
+      expect(
+        rendered.container.querySelector('[role="tablist"]')?.getAttribute("aria-orientation"),
+      ).toBe("vertical");
 
-      const browserTab = [...rendered.container.querySelectorAll('[role="tab"]')].find(
-        (tab) => tab.textContent === "Browser",
-      );
+      const browserTab = rendered.container.querySelector('[role="tab"][aria-label="Browser"]');
       await click(browserTab ?? null);
       expect(browserTab?.getAttribute("aria-selected")).toBe("true");
 
@@ -125,6 +146,11 @@ describe("WorkspaceDock", () => {
         for (const callback of callbacks) callback([], {} as ResizeObserver);
       });
       expect(chrome?.dataset.compact).toBeUndefined();
+      expect(
+        [...rendered.container.querySelectorAll('[role="tab"]')].find((tab) =>
+          tab.textContent?.includes("Browser"),
+        ),
+      ).not.toBeUndefined();
     } finally {
       await rendered?.unmount();
       globalThis.ResizeObserver = originalResizeObserver;
@@ -161,7 +187,8 @@ describe("WorkspaceDock", () => {
     expect(panelFor(tabs[0])?.hidden).toBe(false);
 
     tabs[0]?.focus();
-    await press(tabs[0] ?? null, "ArrowRight");
+    expect(tabs[0]?.closest('[role="tablist"]')?.getAttribute("aria-orientation")).toBe("vertical");
+    await press(tabs[0] ?? null, "ArrowDown");
     expect(document.activeElement).toBe(tabs[1] ?? null);
     expect(rendered.container.textContent ?? "").toContain("Files content");
     expect(tabs.map((tab) => tab.tabIndex)).toEqual([-1, 0, -1]);
@@ -172,7 +199,7 @@ describe("WorkspaceDock", () => {
     expect(document.activeElement).toBe(tabs[2] ?? null);
     expect(rendered.container.textContent ?? "").toContain("Terminal content");
 
-    await press(tabs[2] ?? null, "ArrowRight");
+    await press(tabs[2] ?? null, "ArrowDown");
     expect(document.activeElement).toBe(tabs[0] ?? null);
     expect(rendered.container.textContent ?? "").toContain("Changes content");
 
@@ -214,7 +241,7 @@ describe("WorkspaceDock", () => {
     await click(findTab("Files"));
     expect(rendered.container.textContent ?? "").toContain("File state 1");
 
-    await click(rendered.container.querySelector('[title="Collapse"]'));
+    await click(rendered.container.querySelector('[title="Hide workspace"]'));
     await click(rendered.container.querySelector('[title="Open workspace"]'));
     expect(rendered.container.textContent ?? "").toContain("File state 1");
 
@@ -257,16 +284,30 @@ describe("WorkspaceDock", () => {
     await rendered.unmount();
   });
 
-  test("a host-controlled dock offers no built-in open/close controls", async () => {
-    // The host's own toggle is the ONE open/close affordance: no chrome
-    // Collapse button (it duplicated the host toggle) and no re-open rail.
+  test("a host-controlled dock keeps a panel-local hide action and no duplicate reopen rail", async () => {
     const rendered = await renderComponent(<ControlledDock onCollapsedChange={() => {}} />);
 
     expect(rendered.container.textContent ?? "").toContain("Run content");
-    expect(rendered.container.querySelector('[title="Collapse"]')).toBeNull();
+    expect(rendered.container.querySelector('[title="Hide workspace"]')).not.toBeNull();
     expect(rendered.container.querySelector('[title="Open workspace"]')).toBeNull();
     // Maximize remains: a distinct mode, not an open/close duplicate.
     expect(rendered.container.querySelector('[title="Maximize"]')).not.toBeNull();
+
+    await rendered.unmount();
+  });
+
+  test("an initially open controlled dock restores focus outside its hidden surface", async () => {
+    const rendered = await renderComponent(<ControlledDock onCollapsedChange={() => {}} />);
+    const hide = rendered.container.querySelector<HTMLElement>('[title="Hide workspace"]');
+    hide?.focus();
+
+    await click(hide ?? null);
+    await flush(20);
+
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Host open workspace");
+    expect(
+      rendered.container.querySelector("[data-workspace-surface]")?.getAttribute("aria-hidden"),
+    ).toBe("true");
 
     await rendered.unmount();
   });
@@ -282,7 +323,7 @@ describe("WorkspaceDock", () => {
 
     expect(rendered.container.textContent ?? "").toContain("Run content");
 
-    await click(rendered.container.querySelector('[title="Collapse"]'));
+    await click(rendered.container.querySelector('[title="Hide workspace"]'));
     await flush(20);
 
     expect(
@@ -317,7 +358,7 @@ describe("WorkspaceDock", () => {
       );
 
     const first = await renderDock();
-    await click(first.container.querySelector('[title="Collapse"]'));
+    await click(first.container.querySelector('[title="Hide workspace"]'));
     await flush(20);
     expect(JSON.parse(window.localStorage.getItem(storageKey) ?? "null")).toEqual(expandedLayout);
     await first.unmount();
@@ -379,7 +420,7 @@ describe("WorkspaceDock", () => {
       expect(primary?.getAttribute("aria-hidden")).toBe("true");
 
       // The overlay's own close control drives the same collapsed contract.
-      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      await click(rendered.container.querySelector('[aria-label="Hide workspace"]'));
       expect(changes.at(-1)).toBe(true);
       expect(
         rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
@@ -405,7 +446,7 @@ describe("WorkspaceDock", () => {
       expect(primary?.getAttribute("aria-hidden")).toBe("true");
       expect(document.activeElement?.getAttribute("role")).toBe("tab");
 
-      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      await click(rendered.container.querySelector('[aria-label="Hide workspace"]'));
       await flush(20);
       expect(document.activeElement).toBe(hostOpen ?? null);
 
@@ -426,7 +467,7 @@ describe("WorkspaceDock", () => {
         rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
       ).not.toBeNull();
 
-      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      await click(rendered.container.querySelector('[aria-label="Hide workspace"]'));
       await flush(20);
       const reopen = rendered.container.querySelector<HTMLElement>('[title="Open workspace"]');
       expect(reopen).not.toBeNull();

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -31,6 +31,7 @@ const PERSONAL_WORKSPACE_ACCESSIBILITY_E2E =
   "test/e2e/personal-workspace-accessibility.browser.e2e.ts";
 const PERSONAL_RESOURCE_ATTACHMENTS_E2E = "test/e2e/personal-resource-attachments.browser.e2e.ts";
 const WORKSPACE_SWITCHER_TRIGGER_E2E = "test/e2e/workspace-switcher-trigger.browser.e2e.ts";
+const SESSION_RAIL_ROW_METADATA_E2E = "test/e2e/session-rail-row-metadata.browser.e2e.ts";
 
 describe("fail-closed change impact", () => {
   test("documentation-only changes retain every non-runtime public guard", () => {
@@ -88,6 +89,7 @@ describe("fail-closed change impact", () => {
       PERSONAL_RESOURCE_ATTACHMENTS_E2E,
       PERSONAL_WORKSPACE_ACCESSIBILITY_E2E,
       "test/e2e/react-compiled-css.browser.e2e.ts",
+      SESSION_RAIL_ROW_METADATA_E2E,
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
       WORKSPACE_SWITCHER_TRIGGER_E2E,
@@ -258,6 +260,7 @@ describe("fail-closed change impact", () => {
       PERSONAL_RESOURCE_ATTACHMENTS_E2E,
       PERSONAL_WORKSPACE_ACCESSIBILITY_E2E,
       "test/e2e/react-compiled-css.browser.e2e.ts",
+      SESSION_RAIL_ROW_METADATA_E2E,
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
       WORKSPACE_SWITCHER_TRIGGER_E2E,

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -241,6 +241,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
   ],
   "test/e2e/personal-workspace-accessibility.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/workspace-switcher-trigger.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
+  "test/e2e/session-rail-row-metadata.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/personal-resource-attachments.browser.e2e.ts": [
     "opengeni-web",
     "@opengeni/react",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -21,6 +21,7 @@ const testFiles =
         "./test/e2e/realtime-demo.browser.e2e.ts",
         "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
+        "./test/e2e/session-rail-row-metadata.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",
         "./test/e2e/user-message-disclosure.browser.e2e.ts",
         "./test/e2e/workspace-switcher-trigger.browser.e2e.ts",

--- a/test/e2e/personal-workspace-accessibility.browser.e2e.ts
+++ b/test/e2e/personal-workspace-accessibility.browser.e2e.ts
@@ -7,6 +7,7 @@ import { renderPersonalWorkspaceAccessibilityFixture } from "../../apps/web/test
 describe("Personal workspace accessibility in Chromium", () => {
   let browser: Browser;
   let page: Page;
+  let tenancyPage: Page;
   let switcherPage: Page;
   let web: StartedProcess;
 
@@ -42,6 +43,10 @@ describe("Personal workspace accessibility in Chromium", () => {
     await page.setContent(renderPersonalWorkspaceAccessibilityFixture());
     switcherPage = await browser.newPage();
     await switcherPage.goto(`${baseUrl}/test/active-organization-switcher.html`, {
+      waitUntil: "networkidle",
+    });
+    tenancyPage = await browser.newPage();
+    await tenancyPage.goto(`${baseUrl}/test/session-tenancy-control.html`, {
       waitUntil: "networkidle",
     });
   }, 60_000);
@@ -119,23 +124,45 @@ describe("Personal workspace accessibility in Chromium", () => {
   });
 
   test("activated private-session controls expose exact state and keyboard actions", async () => {
-    const surface = page.locator("#personal-session-tenancy");
-    const region = surface.getByRole("region", { name: "Session access", exact: true });
-    const snapshot = await region.ariaSnapshot();
+    const region = tenancyPage.getByRole("region", { name: "Session access", exact: true });
+    const trigger = region.getByRole("button", {
+      name: "Private session access. Manage session access",
+      exact: true,
+    });
 
-    expect(snapshot).toContain("Only me");
-    expect(snapshot).toContain("Only you can open this session.");
-    expect(snapshot).toContain('button "Share with workspace"');
-    expect(snapshot).not.toContain("Private copy");
+    for (const viewport of [
+      { width: 1100, height: 760 },
+      { width: 320, height: 740 },
+    ]) {
+      await tenancyPage.setViewportSize(viewport);
+      await trigger.focus();
+      await trigger.press("Enter");
+      const menu = tenancyPage.getByRole("menu");
+      await menu.waitFor();
+      expect(await menu.textContent()).toContain("Private session");
+      expect(await menu.textContent()).toContain("Only you can open this session.");
+      expect(
+        await menu.getByRole("menuitem", { name: "Share this session with workspace…" }).count(),
+      ).toBe(1);
+      expect(await menu.getByRole("menuitem", { name: "Private copy" }).count()).toBe(0);
+      expect(await menu.getByRole("menuitem", { name: /Fork session/ }).count()).toBe(0);
+      await tenancyPage.keyboard.press("Escape");
+      await menu.waitFor({ state: "hidden" });
+    }
 
-    await page.setViewportSize({ width: 320, height: 740 });
-    expect(await region.getAttribute("class")).toContain("flex-wrap");
-    expect(await surface.getByRole("button", { name: "Share with workspace" }).count()).toBe(1);
-    expect(await surface.getByRole("button", { name: "Private copy" }).count()).toBe(0);
-
-    await page.locator("body").press("Tab");
-    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toBe("Share");
-  });
+    await trigger.press("Enter");
+    await tenancyPage.getByRole("menuitem", { name: "Share this session with workspace…" }).click();
+    const dialog = tenancyPage.getByRole("dialog", {
+      name: "Share this session with Roadmap Personal workspace?",
+    });
+    await dialog.waitFor();
+    expect(await dialog.getByRole("button", { name: "Share with workspace" }).count()).toBe(1);
+    await tenancyPage.keyboard.press("Escape");
+    await tenancyPage.waitForFunction(
+      (element) => element === document.activeElement,
+      await trigger.elementHandle(),
+    );
+  }, 15_000);
 
   test("a suspended membership never labels the workspace Personal", async () => {
     const menuitem = page.locator("#suspended-personal-menuitem");

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1276,7 +1276,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         await setTheme(page, theme);
         await expectNoPageOverflow(page);
         const pin = page.getByRole("button", { name: /^(Pin|Unpin) session$/ });
-        const inspector = page.getByRole("button", { name: /session panel$/ });
+        const inspector = page.getByRole("button", { name: /^(Open|Hide) workspace$/ });
         const hamburger = page.getByRole("button", { name: "Open navigation" });
         for (const control of [pin, inspector, hamburger]) {
           const box = await control.boundingBox();

--- a/test/e2e/session-rail-row-metadata.browser.e2e.ts
+++ b/test/e2e/session-rail-row-metadata.browser.e2e.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Page } from "playwright";
+
+describe("Session rail row metadata in Chromium", () => {
+  let browser: Browser;
+  let page: Page;
+  let web: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        ".",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${new URL("../..", import.meta.url).pathname}/apps/web`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/test/session-rail-row-metadata.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage({ viewport: { width: 900, height: 640 } });
+    await page.goto(`${baseUrl}/test/session-rail-row-metadata.html`, { waitUntil: "networkidle" });
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  }, 30_000);
+
+  test("contains every production-width row and keeps titles clear of real metadata", async () => {
+    const rail = page.getByTestId("production-session-rail");
+    expect((await rail.boundingBox())?.width).toBe(244);
+    expect(await rail.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+
+    for (const id of [
+      "time-only",
+      "status-time",
+      "schedule-date",
+      "no-metadata",
+      "selected-child",
+      "unselected-child",
+    ]) {
+      const row = page.locator(`[data-row-case="${id}"]`);
+      const link = row.locator("a");
+      expect(await row.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+        true,
+      );
+      expect(await link.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+        true,
+      );
+      expect(await link.getAttribute("aria-label")).toContain(
+        "Now I am testing your workspace rail",
+      );
+
+      const metadata = row.locator("[data-session-row-metadata]");
+      if ((await metadata.count()) === 0) continue;
+      const titleBox = await row.locator("[data-session-row-title]").boundingBox();
+      const metadataBox = await metadata.boundingBox();
+      expect(titleBox).not.toBeNull();
+      expect(metadataBox).not.toBeNull();
+      expect(titleBox!.x + titleBox!.width).toBeLessThanOrEqual(metadataBox!.x + 0.5);
+    }
+  });
+
+  test("uses more title width whenever status, schedule, or all metadata is absent", async () => {
+    const width = async (id: string) =>
+      (await page.locator(`[data-row-case="${id}"] [data-session-row-title]`).boundingBox())!.width;
+
+    expect(await width("time-only")).toBeGreaterThan(await width("status-time"));
+    expect(await width("no-metadata")).toBeGreaterThan(await width("time-only"));
+    expect(await width("selected-child")).toBeLessThan(await width("time-only"));
+    expect(await page.locator('[data-row-case="selected-child"]').getAttribute("class")).toContain(
+      "bg-surface-3",
+    );
+  });
+});

--- a/test/e2e/workbench.browser.e2e.ts
+++ b/test/e2e/workbench.browser.e2e.ts
@@ -390,7 +390,9 @@ describe("workbench browser acceptance", () => {
           const selectedRect = selectedTab?.getBoundingClientRect();
           const tablistRect = tablist?.getBoundingClientRect();
           const workspaceRect = workspace?.getBoundingClientRect();
-          const chrome = workspace?.firstElementChild?.getBoundingClientRect();
+          const chromeHeader = workspace
+            ?.querySelector<HTMLElement>("[data-dock-chrome] > :first-child")
+            ?.getBoundingClientRect();
           return {
             pageOverflow: document.documentElement.scrollWidth - viewport.width,
             selectedTabClipped:
@@ -409,7 +411,7 @@ describe("workbench browser acceptance", () => {
               workspaceRect.top < -1 ||
               workspaceRect.right > viewport.width + 1 ||
               workspaceRect.bottom > viewport.height + 1,
-            chromeHeight: chrome?.height ?? null,
+            chromeHeaderHeight: chromeHeader?.height ?? null,
           };
         });
         if (
@@ -421,8 +423,8 @@ describe("workbench browser acceptance", () => {
           failures.push({ width, height, audit });
         }
         if (width >= 640 && width < 1024) {
-          expect(audit.chromeHeight).not.toBeNull();
-          expect(audit.chromeHeight ?? Infinity).toBeLessThanOrEqual(52);
+          expect(audit.chromeHeaderHeight).not.toBeNull();
+          expect(audit.chromeHeaderHeight ?? Infinity).toBeLessThanOrEqual(52);
         }
         if (width === 375 || width === 2560) {
           await capturePageScreenshot(page, {
@@ -523,7 +525,7 @@ describe("workbench browser acceptance", () => {
     }
   }, 30_000);
 
-  test("Unicode paths and long host tabs remain bounded and keyboard-scroll into view", async () => {
+  test("Unicode paths and long host tabs remain bounded in the vertical activity rail", async () => {
     const context = await browser.newContext({
       viewport: { width: 320, height: 720 },
       isMobile: true,
@@ -536,11 +538,9 @@ describe("workbench browser acceptance", () => {
       });
       await waitForWorkbenchVisualReady(page);
       const tablist = page.getByRole("tablist");
-      expect(await tablist.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(
+      expect(await tablist.getAttribute("aria-orientation")).toBe("vertical");
+      expect(await tablist.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
         true,
-      );
-      expect(await tablist.evaluate((element) => getComputedStyle(element).maskImage)).not.toBe(
-        "none",
       );
 
       const changes = page.getByRole("tab", { name: /Changes/ });
@@ -551,9 +551,6 @@ describe("workbench browser acceptance", () => {
       });
       expect(await trailing.getAttribute("aria-selected")).toBe("true");
       expect(await tabIsFullyVisible(trailing)).toBe(true);
-      expect(await tablist.evaluate((element) => getComputedStyle(element).maskImage)).not.toBe(
-        "none",
-      );
 
       await page.keyboard.press("Home");
       const leading = page.getByRole("tab", { name: "Deployments and observability" });
@@ -718,7 +715,7 @@ describe("workbench browser acceptance", () => {
     const tabs = page.getByRole("tablist").getByRole("tab");
     expect(await tabs.nth(0).evaluate((tab) => tab === document.activeElement)).toBe(true);
     await tabs.nth(0).focus();
-    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowDown");
     expect(await tabs.nth(1).getAttribute("aria-selected")).toBe("true");
     expect(await tabs.nth(1).getAttribute("tabindex")).toBe("0");
     const panelId = await tabs.nth(1).getAttribute("aria-controls");
@@ -729,7 +726,7 @@ describe("workbench browser acceptance", () => {
 
     await page.keyboard.press("End");
     expect(await tabs.last().getAttribute("aria-selected")).toBe("true");
-    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowDown");
     expect(await tabs.nth(0).getAttribute("aria-selected")).toBe("true");
 
     const dialog = page.locator('[role="dialog"][aria-label="Workspace"]');
@@ -737,7 +734,7 @@ describe("workbench browser acceptance", () => {
     expect(await primary.getAttribute("inert")).not.toBeNull();
     expect(await primary.getAttribute("aria-hidden")).toBe("true");
     const dialogHandle = await dialog.elementHandle();
-    await page.getByRole("button", { name: "Close workspace" }).click();
+    await page.getByRole("button", { name: "Hide workspace" }).click();
     await expectEventually(async () => page.locator('[title="Open workspace"]:focus').count());
     expect(await dialog.getAttribute("hidden")).not.toBeNull();
     expect(await primary.getAttribute("inert")).toBeNull();
@@ -776,9 +773,9 @@ describe("workbench browser acceptance", () => {
       await expectEventually(async () => (await chrome.getAttribute("data-compact")) === "true");
       const tabs = page.getByRole("tablist").getByRole("tab");
       await tabs.first().focus();
-      await page.keyboard.press("ArrowRight");
-      await page.keyboard.press("ArrowRight");
-      await page.keyboard.press("ArrowRight");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("ArrowDown");
       const browserTab = page.getByRole("tab", { name: "Browser" });
       expect(await browserTab.isVisible()).toBe(true);
       expect(await browserTab.getAttribute("aria-selected")).toBe("true");
@@ -822,7 +819,7 @@ describe("workbench browser acceptance", () => {
     expect(await surface.getAttribute("role")).toBeNull();
     expect(await primary.getAttribute("inert")).toBeNull();
     expect(await primary.getAttribute("aria-hidden")).toBeNull();
-    await page.getByTitle("Collapse").click();
+    await page.getByTitle("Hide workspace").click();
     await expectEventually(async () => page.locator('[title="Open workspace"]:focus').count());
     expect(await surface.getAttribute("aria-hidden")).toBe("true");
     expect(await surfaceHandle?.evaluate((element) => element.isConnected)).toBe(true);


### PR DESCRIPTION
## Summary

- replace the horizontally scrolling workspace tabs with a responsive vertical activity rail, persistent visited panels, and explicit Hide/Open workspace controls
- move authoritative session access beside the title with compact read-only and menu states, while withholding the existing private-only copy action until a truthful workspace-level Fork contract exists
- restore focus to the access trigger after visibility confirmation while preserving tenancy retries and reconciliation
- distinguish managed Sleeping saved-workspace freshness from genuine Connected Machine Offline state
- keep session-rail date, status, and schedule metadata on one line while reserving only the width that actually renders, so long parent and child titles use the remaining rail width
- pin the small app/session shared primitives at the existing lazy boundary so the redesigned route stays inside every current bundle envelope

The tenancy implementation remains lazy-loaded. Existing initial, direct-session, file-count, per-file, lazy, and CSS bundle limits remain unchanged.

## Verification

- focused component and state tests across workspace dock/capture, session header/access, and session metadata
- real Chromium coverage for access-menu keyboard activation, desktop and narrow states, visibility confirmation focus return, and production 244px rail metadata geometry
- fail-closed CI impact ownership for the new browser acceptance
- apps/web and packages/react typechecks
- repository-wide typecheck
- packages/react build and compiled CSS check
- production web build and bundle budget
- repository lint, repository format check, and git diff check
- independent exact-head code review requested

Linear: [OPE-287](https://linear.app/cloudgeni/issue/OPE-287/redesign-the-session-workspace-dock-and-visibility-controls)