### PR TITLE
fix(web): open workspace switcher and widen API pool

### DIFF
--- a/.changeset/workspace-switcher-opens.md
+++ b/.changeset/workspace-switcher-opens.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Give the API a wider postgres pool so rail polls no longer jam a 10-wide checkout, and make the workspace switcher open and list every accessible workspace.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -294,6 +294,7 @@ export async function startApi() {
   // strategy.
   const searchPath = dbSearchPath(settings);
   const dbClient = createDb(settings.databaseUrl, {
+    max: 32,
     ...(searchPath ? { searchPath } : {}),
     rlsStrategy: settings.rlsStrategy,
   });

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -65,9 +65,6 @@ export function SwitcherBlock() {
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
   const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
-  const orgWorkspaces = activeAccountId
-    ? workspacesInOrg(context.workspaces, activeAccountId)
-    : context.workspaces;
   const activeIsPersonal = isPersonalWorkspace(activeWorkspace, context.managedSelfContext);
 
   const createAccountId = workspaceCreationAccountId(
@@ -147,7 +144,8 @@ export function SwitcherBlock() {
     return (
       <>
         <WorkspaceMenu
-          workspaces={orgWorkspaces}
+          orgs={orgs}
+          workspaces={context.workspaces}
           activeWorkspaceId={rail.workspaceId}
           canCreate={createAccountId !== null}
           onSelect={rail.openWorkspace}
@@ -189,7 +187,8 @@ export function SwitcherBlock() {
       />
 
       <WorkspaceMenu
-        workspaces={orgWorkspaces}
+        orgs={orgs}
+        workspaces={context.workspaces}
         activeWorkspaceId={rail.workspaceId}
         canCreate={createAccountId !== null}
         onSelect={rail.openWorkspace}
@@ -348,6 +347,7 @@ export function WorkspaceSwitcherTrigger(props: {
 }
 
 function WorkspaceMenu(props: {
+  orgs: OrgOption[];
   workspaces: Workspace[];
   activeWorkspaceId: string;
   canCreate: boolean;
@@ -362,32 +362,46 @@ function WorkspaceMenu(props: {
   children: ReactNode;
 }) {
   const rail = useRail();
+  const grouped = props.orgs.map((org) => ({
+    org,
+    workspaces: workspacesInOrg(props.workspaces, org.accountId),
+  }));
+  const trigger = <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>;
   return (
     <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>
-        </TooltipTrigger>
-        {rail.collapsed ? <TooltipContent side="right">Switch workspace</TooltipContent> : null}
-      </Tooltip>
+      {rail.collapsed ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="right">Switch workspace</TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
       <DropdownMenuContent
         align={props.align}
         className="min-w-60"
         side={rail.collapsed ? "right" : "bottom"}
       >
-        <DropdownMenuLabel className="text-fg-subtle">Workspaces</DropdownMenuLabel>
-        {props.workspaces.map((workspace) => (
-          <DropdownMenuItem
-            key={workspace.id}
-            aria-current={workspace.id === props.activeWorkspaceId ? "page" : undefined}
-            onSelect={() => props.onSelect(workspace.id)}
-          >
-            <WorkspaceMenuItemContent
-              workspace={workspace}
-              activeWorkspaceId={props.activeWorkspaceId}
-              managedSelfContext={props.managedSelfContext}
-            />
-          </DropdownMenuItem>
+        {grouped.map(({ org, workspaces }, index) => (
+          <div key={org.accountId}>
+            {index > 0 ? <DropdownMenuSeparator /> : null}
+            <DropdownMenuLabel className="text-fg-subtle">
+              {props.orgs.length > 1 ? org.label : "Workspaces"}
+            </DropdownMenuLabel>
+            {workspaces.map((workspace) => (
+              <DropdownMenuItem
+                key={workspace.id}
+                aria-current={workspace.id === props.activeWorkspaceId ? "page" : undefined}
+                onSelect={() => props.onSelect(workspace.id)}
+              >
+                <WorkspaceMenuItemContent
+                  workspace={workspace}
+                  activeWorkspaceId={props.activeWorkspaceId}
+                  managedSelfContext={props.managedSelfContext}
+                />
+              </DropdownMenuItem>
+            ))}
+          </div>
         ))}
         <DropdownMenuSeparator />
         {props.activeWorkspace && props.canControl ? (

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -34,6 +34,11 @@ describe("managed self-context surfaces", () => {
     );
     expect(switcherSource).toContain('<span className="sr-only"> Paused</span>');
     expect(switcherSource.match(/<PersonalWorkspaceBadge/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(switcherSource).toContain("workspaces={context.workspaces}");
+    expect(switcherSource).toContain("{rail.collapsed ? (");
+    expect(switcherSource).not.toContain(
+      "<TooltipTrigger asChild>\n          <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>",
+    );
   });
 
   test("replaces personal member management with owner-only guidance", () => {


### PR DESCRIPTION
## Summary
- Rail workspace menu no longer nests a Tooltip around DropdownMenuTrigger (clicks were swallowed).
- Menu lists every accessible workspace, grouped by org, so switching is not limited to the current org.
- API postgres pool `max` 10 → 32 so session/events/lineage/queue/machines/list no longer serialize on a 10-wide checkout.

Keyset session-list pagination already landed in #1690; staging is still on `efcd85af` (Aug 20) and still 429s the Cloudgeni workspace.

## Test plan
- [ ] Click the workspace selector on a logged-in rail: menu opens
- [ ] Select another workspace: URL and session list change
- [ ] With >1 org, both orgs' workspaces appear in the menu
- [ ] Staging after this SHA: `GET /sessions?view=page&limit=50` on the dogfood workspace returns 200, not 429

Made with [Cursor](https://cursor.com)