### PR TITLE
fix(web): stop GitHub catalog hydrate from blocking new-session send

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1869,6 +1869,7 @@ describe("GitHub repository resources", () => {
     const manualResource = resources[2] as Extract<ResourceRef, { kind: "repository" }>;
     const hydrated = rehydrateRepositoryResources(resources, [privateRepo, publicRepo]);
     expect(hydrated).toEqual([privateResource, manualResource]);
+    expect(rehydrateRepositoryResources(resources, [], { catalogReady: false })).toEqual(resources);
     expect(repositorySelectionFromResources(hydrated, [privateRepo, publicRepo])).toEqual({
       manualRepos: [{ id: 1, url: manualResource.uri, ref: "main" }],
       selectedRepoIds: new Set([privateRepo.id]),

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -1263,8 +1263,9 @@ export function RootRouteComponent() {
         }
         // A failed status/catalog request is unavailable/unknown, not proof
         // that the last-known installation or repository identities vanished.
-        // Keep the last successful snapshot and readiness fence so draft
-        // hydration cannot project it to [] and autosave destructive loss.
+        // Keep the last successful snapshot and leave readiness unchanged: a
+        // first-load failure must not look like an empty catalog, or draft
+        // hydration would drop GitHub-identity repos and autosave that loss.
         setGithubStatusFailed(true);
         toast.error("GitHub status unavailable", {
           description: String(error),
@@ -1283,32 +1284,40 @@ export function RootRouteComponent() {
       const refreshId = mcpRefreshId.current + 1;
       mcpRefreshId.current = refreshId;
       const requestKey = `${accessKeyVersion}:${workspaceId}`;
-      const result = await runCurrentWorkspaceRequest({
-        signal,
-        requestId: refreshId,
-        currentRequestId: () => mcpRefreshId.current,
-        request: async () =>
-          await Promise.all([
-            runSingleFlight(
-              mcpCatalogRequests.current,
-              requestKey,
-              async () => await client.listCapabilities(workspaceId),
-            ),
-            client.listApiIntegrations(workspaceId),
-          ]),
-      });
-      if (!result) {
-        return;
+      try {
+        const result = await runCurrentWorkspaceRequest({
+          signal,
+          requestId: refreshId,
+          currentRequestId: () => mcpRefreshId.current,
+          request: async () =>
+            await Promise.all([
+              runSingleFlight(
+                mcpCatalogRequests.current,
+                requestKey,
+                async () => await client.listCapabilities(workspaceId),
+              ),
+              client.listApiIntegrations(workspaceId),
+            ]),
+        });
+        if (!result) {
+          return;
+        }
+        const [catalog, apiIntegrations] = result;
+        setWorkspaceMcpServers(
+          mergeMcpServerOptions(
+            enabledWorkspaceCapabilityMcpServers(catalog.items),
+            installedApiIntegrationMcpServers(apiIntegrations.integrations),
+          ),
+        );
+        setWorkspaceCapabilityCatalog(catalog.items);
+        setWorkspaceMcpCatalogReady(true);
+      } catch (error) {
+        if (signal?.aborted || mcpRefreshId.current !== refreshId) throw error;
+        // Fail-open: an unavailable catalog must not leave the create composer
+        // stuck on draft hydrate / canSend=false.
+        setWorkspaceMcpCatalogReady(true);
+        throw error;
       }
-      const [catalog, apiIntegrations] = result;
-      setWorkspaceMcpServers(
-        mergeMcpServerOptions(
-          enabledWorkspaceCapabilityMcpServers(catalog.items),
-          installedApiIntegrationMcpServers(apiIntegrations.integrations),
-        ),
-      );
-      setWorkspaceCapabilityCatalog(catalog.items);
-      setWorkspaceMcpCatalogReady(true);
     },
     [accessKeyVersion, client],
   );

--- a/apps/web/src/lib/session-tools.ts
+++ b/apps/web/src/lib/session-tools.ts
@@ -333,7 +333,12 @@ export function sameRepositoryUri(resource: ResourceRef, uri: string): boolean {
 export function rehydrateRepositoryResources(
   resources: ResourceRef[],
   repositories: GitHubRepository[],
+  options?: { catalogReady?: boolean },
 ): ResourceRef[] {
+  // An unreadied catalog is unknown, not empty. Dropping GitHub-identity rows
+  // here would autosave that loss and brick the create composer while the
+  // first status/list request is still in flight or has failed.
+  if (options?.catalogReady === false) return resources;
   return resources.flatMap<ResourceRef>((resource) => {
     if (resource.kind !== "repository") return [resource];
     const hasGitHubIdentity =

--- a/apps/web/src/lib/use-new-session-draft.test.tsx
+++ b/apps/web/src/lib/use-new-session-draft.test.tsx
@@ -650,4 +650,38 @@ describe("useNewSessionDraft", () => {
     expect(hook.result.current.draft.revision).toBe(9);
     await hook.unmount();
   });
+
+  test("reload before catalogs are ready does not fetch", async () => {
+    let reads = 0;
+    const draftClient = client({
+      getNewSessionDraft: async () => {
+        reads += 1;
+        return remote(1, { text: "hydrated" });
+      },
+    });
+    const hook = await renderHook(
+      (props: { resourceHydrationReady: boolean }) => {
+        const [value, setValue] = useState(() => editable());
+        const draft = useNewSessionDraft({
+          client: draftClient,
+          workspaceId: WORKSPACE_A,
+          value,
+          onApplyRemote: setValue,
+          restoreReadyFiles: () => {},
+          resourceHydrationReady: props.resourceHydrationReady,
+        });
+        return { draft, value };
+      },
+      { resourceHydrationReady: false },
+    );
+    expect(reads).toBe(0);
+    expect(hook.result.current.draft.loading).toBe(true);
+
+    await hook.rerender({ resourceHydrationReady: true });
+    await flush();
+    expect(reads).toBe(1);
+    expect(hook.result.current.value.text).toBe("hydrated");
+    expect(hook.result.current.draft.loading).toBe(false);
+    await hook.unmount();
+  });
 });

--- a/apps/web/src/lib/use-new-session-draft.ts
+++ b/apps/web/src/lib/use-new-session-draft.ts
@@ -173,10 +173,10 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
   );
 
   const reload = useCallback(async (): Promise<void> => {
+    if (!resourceHydrationReady) return;
     const generation = targetGeneration.current;
     loadingRef.current = true;
     setLoading(true);
-    if (!resourceHydrationReady) return;
     try {
       const remote = await readRemote();
       if (remote && generation === targetGeneration.current) applyRemote(remote);

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -304,7 +304,9 @@ function SessionsIndexRouteContent({
     ],
   );
   const hydrateResources = useLatestCallback((resources: NewSessionDraftEditable["resources"]) =>
-    rehydrateRepositoryResources(resources, context.githubRepos),
+    rehydrateRepositoryResources(resources, context.githubRepos, {
+      catalogReady: context.githubCatalogReady,
+    }),
   );
   const setModel = context.setModel;
   const setReasoningEffort = context.setReasoningEffort;
@@ -356,7 +358,9 @@ function SessionsIndexRouteContent({
     onApplyRemote: applyRemoteDraft,
     restoreReadyFiles: attachments.restoreReadyFiles,
     hydrateResources,
-    resourceHydrationReady: context.githubCatalogReady && context.workspaceMcpCatalogReady,
+    // Tool policy needs the MCP catalog. GitHub is optional: an unreadied
+    // catalog must not keep the create composer disabled / unsendable.
+    resourceHydrationReady: context.workspaceMcpCatalogReady,
   });
   const busy = context.busy || submitting;
   const privateCreateUnavailable =
@@ -435,7 +439,15 @@ function SessionsIndexRouteContent({
             // lost on navigate, but do not consume it — text stays for later.
             if (realtimeModel) {
               const flushed = await newSessionDraft.flush();
-              if (!flushed) return null;
+              if (!flushed) {
+                toast.error("Couldn't save the draft", {
+                  description:
+                    newSessionDraft.error?.message ??
+                    newSessionDraft.conflict?.message ??
+                    "Resolve the draft conflict, then try again.",
+                });
+                return null;
+              }
               const submission = submissionFromSessionDraft(draft, firstPartyMcpToolPolicy.default);
               const created = await context.startSession(
                 workspaceId,
@@ -466,7 +478,15 @@ function SessionsIndexRouteContent({
 
             const submittedResources = persistedValue.resources;
             const flushed = await newSessionDraft.flush();
-            if (!flushed) return null;
+            if (!flushed) {
+              toast.error("Couldn't save the draft", {
+                description:
+                  newSessionDraft.error?.message ??
+                  newSessionDraft.conflict?.message ??
+                  "Resolve the draft conflict, then try again.",
+              });
+              return null;
+            }
             const submission = submissionFromSessionDraft(
               draft,
               firstPartyMcpToolPolicy.default,


### PR DESCRIPTION
## Summary
- Create-composer Send no longer waits on GitHub catalog readiness, so a slow or failed GitHub status/list cannot leave the draft loading and the composer disabled.
- An unreadied GitHub catalog is treated as unknown (pass through repo identities) rather than empty, so hydration cannot autosave destructive repo loss.
- MCP catalog first-load failure fail-opens; a failed draft flush now toasts instead of failing silently.

## Test plan
- [x] `bun test apps/web/src/lib/use-new-session-draft.test.tsx apps/web/src/App.test.ts apps/web/src/context-principal-transition.test.ts`
- [ ] Reload `/workspaces/:id/sessions?channelId=…` after deploy and confirm Send enables after MCP catalog load even if GitHub is down
- [ ] If a draft conflict banner or personal-resource card is showing, those still correctly block send


Made with [Cursor](https://cursor.com)