### PR TITLE
fix(web): raise direct-session gzip budget one KiB

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -71,6 +71,9 @@ const budgets = {
   // client, measuring 1,500,166 initial raw bytes and 2,083,879 direct-session
   // raw bytes on macOS/arm64. Advance only those raw envelopes by one KiB;
   // every compressed, file-count, lazy-chunk, and CSS cap remains unchanged.
+  // The rail workspace switcher lists every accessible workspace instead of
+  // the current org only. Linux/x64 production CI measured the direct-session
+  // gzip graph at 579,618 bytes, 34 over the 566 KiB envelope.
   initialRaw: 1466 * kib,
   // The managed personal-resource create/composer controls plus current main
   // measured 1,484,426 initial raw and 577,450 direct-session gzip bytes on
@@ -86,7 +89,7 @@ const budgets = {
   initialFileGzip: 77 * kib,
   initialFiles: 17,
   directSessionRaw: 2036 * kib,
-  directSessionGzip: 566 * kib,
+  directSessionGzip: 567 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,


### PR DESCRIPTION
## Summary
- Linux/x64 production CI for #1701 failed web image build: \`direct session gzip graph: 579618 bytes exceeds 579584\`.
- Advance only that gzip envelope 566 → 567 KiB so canary-sha web images can publish and staging can pick up the switcher.

## Test plan
- [ ] Main CI \`Build worker and web workload images\` succeeds
- [ ] Staging canary of the merge SHA deploys \`opengeni-web:canary-sha-*\`

Made with [Cursor](https://cursor.com)