### PR TITLE
fix(runtime): teach sandbox:/workspace file links

### DIFF
--- a/.changeset/sandbox-file-link-instructions.md
+++ b/.changeset/sandbox-file-link-instructions.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Teach agents to emit `sandbox:/workspace/...` markdown file links with an optional line number, matching the session renderer.

--- a/packages/runtime/src/operational-instructions.ts
+++ b/packages/runtime/src/operational-instructions.ts
@@ -3,9 +3,9 @@
  *
  * Adapted from the Codex gpt-5.6-sol model instruction template cached on
  * 2026-08-17 (SHA-256 cbefa6b0bede0e332d957fca70ccacf9f12f4c0ecdf81b819e5cbe1a3b16e265).
- * Product-specific identity, wire-channel, compaction, shell-input, and
- * skill-loading details are generalized; the behavioral rules otherwise remain
- * intentionally close to that source.
+ * Product-specific identity, wire-channel, compaction, shell-input, file-link
+ * targets, and skill-loading details are generalized; the behavioral rules
+ * otherwise remain intentionally close to that source.
  *
  * Keep this outside the configurable persona template: workspace/session
  * customization may refine the agent, but cannot remove the operational
@@ -61,10 +61,10 @@ Your answer is being rendered by an application for the user. Follow these guide
 
 - You may format with GitHub-flavored Markdown.
 - When referencing a real local file, prefer a clickable markdown link.
-  * Clickable file links should look like [app.py](/abs/path/app.py:12): plain label, absolute target, with optional line number inside the target.
-  * If a file path has spaces, wrap the target in angle brackets: [My Report.md](</abs/path/My Project/My Report.md:3>).
+  * Clickable file links should look like [app.py](sandbox:/workspace/app.py:12): plain label, sandbox:/workspace/... target, with optional line number after the path.
+  * If a file path has spaces, wrap the target in angle brackets: [My Report.md](<sandbox:/workspace/My Project/My Report.md:3>).
   * Do not wrap markdown links in backticks, or put backticks inside the label or target. This confuses the markdown renderer.
-  * Do not use URIs like file://, vscode://, or https:// for file links.
+  * Do not use URIs like file://, vscode://, or https:// for file links, and do not use host-absolute paths.
   * Do not provide ranges of lines.
   * Avoid repeating the same filename multiple times when one grouping is clearer.
 

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -12,6 +12,17 @@ describe("provider-neutral operational instructions", () => {
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("`final` channel");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("skill://");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("orchestrator");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("/abs/path");
+  });
+
+  test("teaches OpenGeni sandbox file links with optional line numbers", () => {
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "[app.py](sandbox:/workspace/app.py:12)",
+    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "[My Report.md](<sandbox:/workspace/My Project/My Report.md:3>)",
+    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Do not provide ranges of lines.");
   });
 
   test("is non-configurable and precedes every workspace persona", () => {

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -16,9 +16,7 @@ describe("provider-neutral operational instructions", () => {
   });
 
   test("teaches OpenGeni sandbox file links with optional line numbers", () => {
-    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
-      "[app.py](sandbox:/workspace/app.py:12)",
-    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.py](sandbox:/workspace/app.py:12)");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "[My Report.md](<sandbox:/workspace/My Project/My Report.md:3>)",
     );


### PR DESCRIPTION
## Summary
- Point the non-configurable operational instructions at OpenGeni's clickable file-link shape: `[app.py](sandbox:/workspace/app.py:12)`.
- Keep optional line numbers, angle-bracket spaces, and the no-`file://` / no-range rules. Drop Codex `/abs/path` targets the session renderer does not open.

## Test plan
- [x] `bun test packages/runtime/test/operational-instructions.test.ts`
- [ ] Follow-up: renderer accepts `:line` and opens the Files viewer at that line.


Made with [Cursor](https://cursor.com)