### PR TITLE
fix(web): unblock sandbox file-link CI on main

### DIFF
--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -619,6 +619,7 @@ export function SessionRoute({
   useEffect(() => {
     setSandboxFileRequest(null);
   }, [sessionId]);
+  const setInspectorOpen = context.setInspectorOpen;
   const openSandboxFileAtLine = useCallback(
     (path: string, line: number) => {
       sandboxFileRequestSeq.current += 1;
@@ -627,9 +628,9 @@ export function SessionRoute({
         line,
         requestId: sandboxFileRequestSeq.current,
       });
-      context.setInspectorOpen(true);
+      setInspectorOpen(true);
     },
-    [context.setInspectorOpen],
+    [setInspectorOpen],
   );
 
   if (!session) {
@@ -1035,15 +1036,16 @@ function SessionChatPane(props: {
     },
     [context.client, props.session.id, props.session.workspaceId],
   );
+  const onOpenSandboxFile = props.onOpenSandboxFile;
   const handleSandboxFile = useCallback(
     async (path: string, line?: number) => {
       if (line != null && line > 0) {
-        props.onOpenSandboxFile(path, line);
+        onOpenSandboxFile(path, line);
         return;
       }
       await downloadSandboxFile(path);
     },
-    [downloadSandboxFile, props.onOpenSandboxFile],
+    [downloadSandboxFile, onOpenSandboxFile],
   );
   const terminal = isTerminalSessionStatus(props.session.status);
   const agentsSignal = useMemo(() => {

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -511,12 +511,9 @@ function LineNumberedFile({
               data-opengeni-file-line={lineNumber}
               {...(focused ? { "data-opengeni-focus-line": "" } : {})}
               aria-current={focused ? "location" : undefined}
-              className={cn(
-                "flex gap-3 px-2 py-0.5 leading-6",
-                focused && "bg-og-accent-soft ring-1 ring-inset ring-og-accent/50",
-              )}
+              className={cn("flex gap-3 px-2 py-0.5 leading-6", focused && "bg-og-accent-soft")}
             >
-              <span className="w-10 shrink-0 select-none text-right tabular-nums text-og-fg-subtle">
+              <span className="w-11 shrink-0 select-none text-right tabular-nums text-og-fg-subtle">
                 {lineNumber}
               </span>
               <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words">{text || " "}</pre>

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -74,6 +74,9 @@ const budgets = {
   // The rail workspace switcher lists every accessible workspace instead of
   // the current org only. Linux/x64 production CI measured the direct-session
   // gzip graph at 579,618 bytes, 34 over the 566 KiB envelope.
+  // Opening sandbox file links at a cited Files line adds the numbered viewer
+  // plus session wiring to the direct-session graph. macOS/arm64 production
+  // measured 2,086,125 raw / 580,320 gzip bytes; gzip still fits 567 KiB.
   initialRaw: 1466 * kib,
   // The managed personal-resource create/composer controls plus current main
   // measured 1,484,426 initial raw and 577,450 direct-session gzip bytes on
@@ -88,7 +91,7 @@ const budgets = {
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2036 * kib,
+  directSessionRaw: 2038 * kib,
   directSessionGzip: 567 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,


### PR DESCRIPTION
## Summary
- `#1706` / `#1707` are already on `main`, but that head fails CI: oxlint hook deps (`--deny-warnings`), compiled CSS stale from new Tailwind utilities (`w-10`, `ring-og-accent/50`), and the production web build over the direct-session **raw** envelope.
- Keep the cited-line Files highlight, but only use already-compiled utilities (`bg-og-accent-soft`, `w-11`).
- Raise `directSessionRaw` 2036 → 2038 KiB from a measured macOS/arm64 production graph of 2,086,125 raw / 580,320 gzip (gzip still fits 567 KiB).

## Test plan
- [x] `bunx oxlint --deny-warnings` on the session route
- [x] `bun run --cwd packages/react check:css`
- [x] `bun test packages/react/test/compiled-css.test.ts packages/react/test/sandbox-components.test.tsx`
- [x] `bun scripts/check-web-bundle-budget.ts` after `apps/web` production build
- [ ] CI Source/type contracts, unit shard 5, package/bundle contracts, and production-web E2E/visual jobs green


Made with [Cursor](https://cursor.com)