### PR TITLE
fix(web): repair sandbox file-link build contracts

### DIFF
--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -152,6 +152,7 @@ export function SessionRoute({
   realtimeAutostartModel?: SessionRealtimeModel | undefined;
 }) {
   const context = useAppContext();
+  const setInspectorOpen = context.setInspectorOpen;
   const rail = useRail();
   const navigate = useNavigate();
   const consumeRealtimeAutostart = useCallback(() => {
@@ -627,9 +628,9 @@ export function SessionRoute({
         line,
         requestId: sandboxFileRequestSeq.current,
       });
-      context.setInspectorOpen(true);
+      setInspectorOpen(true);
     },
-    [context.setInspectorOpen],
+    [setInspectorOpen],
   );
 
   if (!session) {
@@ -1000,6 +1001,7 @@ function SessionChatPane(props: {
   onOpenSandboxFile: (path: string, line: number) => void;
 }) {
   const context = useAppContext();
+  const onOpenSandboxFile = props.onOpenSandboxFile;
   const modelCatalog = useWorkspaceModelCatalog(props.session.workspaceId);
   const fleet = useMachines({
     sessionId: props.session.id,
@@ -1038,12 +1040,12 @@ function SessionChatPane(props: {
   const handleSandboxFile = useCallback(
     async (path: string, line?: number) => {
       if (line != null && line > 0) {
-        props.onOpenSandboxFile(path, line);
+        onOpenSandboxFile(path, line);
         return;
       }
       await downloadSandboxFile(path);
     },
-    [downloadSandboxFile, props.onOpenSandboxFile],
+    [downloadSandboxFile, onOpenSandboxFile],
   );
   const terminal = isTerminalSessionStatus(props.session.status);
   const agentsSignal = useMemo(() => {

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -1096,6 +1096,9 @@
 :where(.og-root).w-7,:where(.og-root) .w-7 {
     width: calc(var(--spacing) * 7);
   }
+:where(.og-root).w-10,:where(.og-root) .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
 :where(.og-root).w-11,:where(.og-root) .w-11 {
     width: calc(var(--spacing) * 11);
   }
@@ -2909,6 +2912,12 @@
     --tw-ring-color: var(--og-color-accent);
     @supports (color: color-mix(in lab, red, red)) {
       --tw-ring-color: color-mix(in oklab, var(--og-color-accent) 45%, transparent);
+    }
+  }
+:where(.og-root).ring-og-accent\/50,:where(.og-root) .ring-og-accent\/50 {
+    --tw-ring-color: var(--og-color-accent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-ring-color: color-mix(in oklab, var(--og-color-accent) 50%, transparent);
     }
   }
 :where(.og-root).ring-og-border\/60,:where(.og-root) .ring-og-border\/60 {

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -74,6 +74,10 @@ const budgets = {
   // The rail workspace switcher lists every accessible workspace instead of
   // the current org only. Linux/x64 production CI measured the direct-session
   // gzip graph at 579,618 bytes, 34 over the 566 KiB envelope.
+  // Sandbox file-line citations add the direct-session viewer handoff and
+  // measure 2,086,612 raw bytes on the canonical local production build. Raise
+  // only that graph to its next whole-KiB envelope; compressed, file-count,
+  // lazy-chunk, initial, and CSS caps remain unchanged.
   initialRaw: 1466 * kib,
   // The managed personal-resource create/composer controls plus current main
   // measured 1,484,426 initial raw and 577,450 direct-session gzip bytes on
@@ -88,7 +92,7 @@ const budgets = {
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2036 * kib,
+  directSessionRaw: 2038 * kib,
   directSessionGzip: 567 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,


### PR DESCRIPTION
## Summary
- regenerate the committed React CSS for the width and ring utilities introduced by sandbox file-line links
- make the new file-open callbacks satisfy the exhaustive dependency contract
- advance only the measured direct-session raw bundle envelope to the next whole KiB

## Verification
- `bun run lint`
- `bunx oxfmt --check apps/web/src/routes/session.tsx scripts/check-web-bundle-budget.ts`
- `cd packages/react && bun run check:css && bun test --timeout 30000 test/compiled-css.test.ts`
- `cd apps/web && bun run build`
