### PR TITLE
fix(web): repair workspace switcher activation and overflow

### DIFF
--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -14,7 +14,7 @@ import {
   PlusIcon,
   SettingsIcon,
 } from "lucide-react";
-import { forwardRef, useState, type ReactNode } from "react";
+import { forwardRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { WorkspaceNameDialog } from "@/components/rail/workspace-name-dialog";
@@ -39,6 +39,7 @@ import {
 } from "@/lib/org";
 import { isPersonalWorkspace, type ManagedSelfContext } from "@/lib/managed-self-context";
 import { workspaceCreationAccountId } from "@/lib/workspaces";
+import { cn } from "@/lib/utils";
 import type { Workspace } from "@/types";
 
 function workspaceInitial(workspace: Workspace | null): string {
@@ -54,6 +55,9 @@ function activeOrganizationLabel(orgs: OrgOption[], activeAccountId: string | nu
     `Org ${shortAccountId(activeAccountId)}`
   );
 }
+
+export const WORKSPACE_SWITCHER_GRID_CLASS =
+  "grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-3 pt-1";
 
 export function SwitcherBlock() {
   const context = useAppContext();
@@ -144,6 +148,7 @@ export function SwitcherBlock() {
     return (
       <>
         <WorkspaceMenu
+          collapsed={rail.collapsed}
           orgs={orgs}
           workspaces={context.workspaces}
           activeWorkspaceId={rail.workspaceId}
@@ -177,7 +182,7 @@ export function SwitcherBlock() {
   }
 
   return (
-    <div className="grid gap-1.5 px-3 pt-1">
+    <div className={WORKSPACE_SWITCHER_GRID_CLASS}>
       <OrganizationSwitcherLine
         orgs={orgs}
         currentLabel={currentOrgLabel}
@@ -187,6 +192,7 @@ export function SwitcherBlock() {
       />
 
       <WorkspaceMenu
+        collapsed={rail.collapsed}
         orgs={orgs}
         workspaces={context.workspaces}
         activeWorkspaceId={rail.workspaceId}
@@ -299,59 +305,76 @@ export function OrganizationSwitcherLine(props: {
   );
 }
 
+type WorkspaceSwitcherTriggerProps = {
+  activeWorkspace: Workspace | null;
+  activeOrganizationLabel: string;
+  personal: boolean;
+  collapsed: boolean;
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">;
+
 export const WorkspaceSwitcherTrigger = forwardRef<
   HTMLButtonElement,
+  WorkspaceSwitcherTriggerProps
+>(function WorkspaceSwitcherTrigger(
   {
-    activeWorkspace: Workspace | null;
-    activeOrganizationLabel: string;
-    personal: boolean;
-    collapsed: boolean;
-  }
->(function WorkspaceSwitcherTrigger(props, ref) {
-  const workspaceLabel =
-    props.activeWorkspace?.name ?? (props.collapsed ? "switch workspace" : "none");
-  const accessibleLabel = `${props.activeOrganizationLabel}. ${
-    props.personal ? "Personal workspace" : "Workspace"
+    activeWorkspace,
+    activeOrganizationLabel: organizationLabel,
+    personal,
+    collapsed,
+    className,
+    ...buttonProps
+  },
+  ref,
+) {
+  const workspaceLabel = activeWorkspace?.name ?? (collapsed ? "switch workspace" : "none");
+  const accessibleLabel = `${organizationLabel}. ${
+    personal ? "Personal workspace" : "Workspace"
   }: ${workspaceLabel}. Switch workspace`;
 
-  if (props.collapsed) {
+  if (collapsed) {
     return (
       <button
+        {...buttonProps}
         ref={ref}
         type="button"
         aria-label={accessibleLabel}
-        className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+        className={cn(
+          "mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none",
+          className,
+        )}
       >
-        {workspaceInitial(props.activeWorkspace)}
+        {workspaceInitial(activeWorkspace)}
       </button>
     );
   }
 
   return (
     <button
+      {...buttonProps}
       ref={ref}
       type="button"
       aria-label={accessibleLabel}
-      className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+      className={cn(
+        "group flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none",
+        className,
+      )}
     >
       <Avatar size="sm" className="rounded-md">
         <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
-          {workspaceInitial(props.activeWorkspace)}
+          {workspaceInitial(activeWorkspace)}
         </AvatarFallback>
       </Avatar>
-      <span
-        className="min-w-0 flex-1 truncate text-sm font-medium"
-        title={props.activeWorkspace?.name}
-      >
-        {props.activeWorkspace?.name ?? "Select workspace"}
+      <span className="min-w-0 flex-1 truncate text-sm font-medium" title={activeWorkspace?.name}>
+        {activeWorkspace?.name ?? "Select workspace"}
       </span>
-      {props.personal ? <PersonalWorkspaceBadge decorative /> : null}
+      {personal ? <PersonalWorkspaceBadge decorative /> : null}
       <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
     </button>
   );
 });
 
-function WorkspaceMenu(props: {
+export function WorkspaceMenu(props: {
+  collapsed: boolean;
   orgs: OrgOption[];
   workspaces: Workspace[];
   activeWorkspaceId: string;
@@ -366,7 +389,6 @@ function WorkspaceMenu(props: {
   align: "start" | "end";
   children: ReactNode;
 }) {
-  const rail = useRail();
   const grouped = props.orgs.map((org) => ({
     org,
     workspaces: workspacesInOrg(props.workspaces, org.accountId),
@@ -374,7 +396,7 @@ function WorkspaceMenu(props: {
   const trigger = <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>;
   return (
     <DropdownMenu>
-      {rail.collapsed ? (
+      {props.collapsed ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex">{trigger}</span>
@@ -387,7 +409,7 @@ function WorkspaceMenu(props: {
       <DropdownMenuContent
         align={props.align}
         className="min-w-60"
-        side={rail.collapsed ? "right" : "bottom"}
+        side={props.collapsed ? "right" : "bottom"}
       >
         {grouped.map(({ org, workspaces }, index) => (
           <div key={org.accountId}>

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -36,7 +36,7 @@ describe("managed self-context surfaces", () => {
     expect(switcherSource.match(/<PersonalWorkspaceBadge/g)?.length).toBeGreaterThanOrEqual(2);
     expect(switcherSource).toContain("workspaces={context.workspaces}");
     expect(switcherSource).toContain("export const WorkspaceSwitcherTrigger = forwardRef");
-    expect(switcherSource).toContain("{rail.collapsed ? (");
+    expect(switcherSource).toContain("{props.collapsed ? (");
     expect(switcherSource).toContain('<span className="inline-flex">{trigger}</span>');
     expect(switcherSource).not.toContain("<TooltipTrigger asChild>{trigger}</TooltipTrigger>");
     expect(switcherSource).not.toContain(

--- a/apps/web/test/workspace-switcher-trigger-fixture.tsx
+++ b/apps/web/test/workspace-switcher-trigger-fixture.tsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+import { CheckIcon, SearchIcon } from "lucide-react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import {
+  OrganizationSwitcherLine,
+  WORKSPACE_SWITCHER_GRID_CLASS,
+  WorkspaceMenu,
+  WorkspaceSwitcherTrigger,
+} from "../src/components/rail/switcher-block";
+import { TooltipProvider } from "../src/components/ui/tooltip";
+import type { ManagedSelfContext } from "../src/lib/managed-self-context";
+import type { Workspace } from "../src/types";
+import "../src/styles.css";
+
+const accountId = "11111111-1111-4111-8111-111111111111";
+const secondAccountId = "22222222-2222-4222-8222-222222222222";
+
+function workspace(id: string, name: string, workspaceAccountId = accountId): Workspace {
+  return {
+    id,
+    accountId: workspaceAccountId,
+    name,
+    slug: null,
+    externalSource: null,
+    externalId: null,
+    agentInstructions: null,
+    settings: {},
+    inferenceControl: {
+      state: "active",
+      revision: 1,
+      reason: null,
+      changedBy: null,
+      changedAt: "2026-08-21T10:00:00.000Z",
+    },
+    createdAt: "2026-08-21T10:00:00.000Z",
+    updatedAt: "2026-08-21T10:00:00.000Z",
+  };
+}
+
+const workspaces = [
+  workspace("workspace-default", "Default workspace"),
+  workspace("workspace-product", "Product Testing"),
+  workspace("workspace-personal", "Personal workspace"),
+  workspace("workspace-research", "Research Sandbox", secondAccountId),
+];
+
+const organizations = [
+  {
+    accountId,
+    label: "CloudGeni Product Engineering and Reliability",
+    canManage: true,
+  },
+  {
+    accountId: secondAccountId,
+    label: "CloudGeni Research",
+    canManage: false,
+  },
+];
+
+const selfContext: ManagedSelfContext = {
+  identity: {
+    credentialGeneration: 1,
+    managedUserId: "user-one",
+    subjectId: "user:user-one",
+  },
+  memberships: [
+    {
+      id: "membership-one",
+      organizationId: accountId,
+      status: "active",
+      personalWorkspaceId: "workspace-personal",
+    },
+  ],
+};
+
+function WorkspaceSwitcherFixture() {
+  const collapsed = new URLSearchParams(window.location.search).get("mode") === "collapsed";
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState("workspace-personal");
+  const [lastAction, setLastAction] = useState("None");
+  const activeWorkspace =
+    workspaces.find((candidate) => candidate.id === activeWorkspaceId) ?? workspaces[0]!;
+  return (
+    <TooltipProvider>
+      <main className="flex min-h-screen bg-background text-foreground">
+        <aside
+          data-testid="production-rail"
+          className={
+            collapsed
+              ? "flex w-14 min-w-0 flex-col overflow-hidden border-r border-border bg-surface/40 py-4"
+              : "flex w-full min-w-0 flex-col overflow-hidden border-r border-border bg-surface/40 py-4 sm:w-[244px]"
+          }
+        >
+          <div className="mb-5 flex min-w-0 items-center gap-2 px-3 text-sm font-semibold">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-brand text-xs font-bold text-white">
+              OG
+            </span>
+            {collapsed ? null : <span className="min-w-0 truncate">OpenGeni</span>}
+          </div>
+          <section aria-label="Workspace switcher preview">
+            {collapsed ? (
+              <WorkspaceMenu
+                collapsed
+                orgs={organizations}
+                workspaces={workspaces}
+                activeWorkspaceId={activeWorkspaceId}
+                canCreate
+                onSelect={setActiveWorkspaceId}
+                onCreate={() => setLastAction("New workspace")}
+                activeWorkspace={activeWorkspace}
+                managedSelfContext={selfContext}
+                canControl={false}
+                controlBusy={false}
+                onToggleControl={() => {}}
+                align="start"
+              >
+                <WorkspaceSwitcherTrigger
+                  activeWorkspace={activeWorkspace}
+                  activeOrganizationLabel="CloudGeni Product Engineering and Reliability"
+                  personal={activeWorkspace.id === "workspace-personal"}
+                  collapsed
+                />
+              </WorkspaceMenu>
+            ) : (
+              <div className={WORKSPACE_SWITCHER_GRID_CLASS}>
+                <OrganizationSwitcherLine
+                  orgs={organizations}
+                  currentLabel="CloudGeni Product Engineering and Reliability"
+                  activeAccountId={accountId}
+                  onSelect={() => {}}
+                  workspaceId={null}
+                />
+                <WorkspaceMenu
+                  collapsed={false}
+                  orgs={organizations}
+                  workspaces={workspaces}
+                  activeWorkspaceId={activeWorkspaceId}
+                  canCreate
+                  onSelect={(workspaceId) => {
+                    const selected = workspaces.find((candidate) => candidate.id === workspaceId)!;
+                    setActiveWorkspaceId(workspaceId);
+                    setLastAction(`Opened ${selected.name}`);
+                  }}
+                  onCreate={() => setLastAction("New workspace")}
+                  activeWorkspace={activeWorkspace}
+                  managedSelfContext={selfContext}
+                  canControl={false}
+                  controlBusy={false}
+                  onToggleControl={() => {}}
+                  align="start"
+                >
+                  <WorkspaceSwitcherTrigger
+                    activeWorkspace={activeWorkspace}
+                    activeOrganizationLabel="CloudGeni Product Engineering and Reliability"
+                    personal={activeWorkspace.id === "workspace-personal"}
+                    collapsed={false}
+                  />
+                </WorkspaceMenu>
+              </div>
+            )}
+          </section>
+
+          {collapsed ? null : (
+            <>
+              <label className="mt-5 flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-xs text-fg-subtle">
+                <SearchIcon className="size-3.5" />
+                <span>Search sessions</span>
+              </label>
+              <div className="mt-4 grid gap-1 text-sm">
+                <p className="px-2 py-1 font-medium">Sessions</p>
+                <p className="rounded-md bg-surface-2 px-2 py-2 text-fg-muted">
+                  Review workspace switcher
+                </p>
+                <p className="px-2 py-2 text-fg-subtle">Tool selection redesign</p>
+              </div>
+            </>
+          )}
+
+          <output data-testid="last-action" className="sr-only">
+            {lastAction}
+          </output>
+        </aside>
+        {collapsed ? (
+          <section className="flex flex-1 items-start justify-center p-8">
+            <div className="w-full max-w-xl rounded-xl border border-border bg-surface-1 p-8">
+              <CheckIcon className="mb-3 size-5 text-status-success" />
+              <h1 className="text-lg font-semibold">Workspace switcher interaction check</h1>
+              <p className="mt-2 text-sm text-fg-muted">
+                The collapsed rail keeps its tooltip while the same button remains keyboard and
+                pointer accessible.
+              </p>
+            </div>
+          </section>
+        ) : (
+          <section className="hidden flex-1 items-start justify-center p-10 sm:flex">
+            <div className="w-full max-w-2xl rounded-xl border border-border bg-surface-1 p-10">
+              <p className="text-xs font-medium uppercase tracking-wide text-fg-subtle">
+                Workspace
+              </p>
+              <h1 className="mt-2 text-xl font-semibold">Session overview</h1>
+              <p className="mt-2 max-w-lg text-sm text-fg-muted">
+                Open the workspace selector to move between shared and personal workspaces.
+              </p>
+            </div>
+          </section>
+        )}
+      </main>
+    </TooltipProvider>
+  );
+}
+
+const rootRoute = createRootRoute({ component: WorkspaceSwitcherFixture });
+const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/" });
+const settingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/workspaces/$workspaceId/settings",
+});
+const router = createRouter({
+  routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+  history: createMemoryHistory({ initialEntries: ["/"] }),
+});
+
+createRoot(document.getElementById("root")!).render(<RouterProvider router={router} />);

--- a/apps/web/test/workspace-switcher-trigger.html
+++ b/apps/web/test/workspace-switcher-trigger.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workspace switcher trigger fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/test/workspace-switcher-trigger-fixture.tsx"></script>
+  </body>
+</html>

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -30,6 +30,7 @@ const CURATED_ARTIFACT_BROWSER_E2E = [
 const PERSONAL_WORKSPACE_ACCESSIBILITY_E2E =
   "test/e2e/personal-workspace-accessibility.browser.e2e.ts";
 const PERSONAL_RESOURCE_ATTACHMENTS_E2E = "test/e2e/personal-resource-attachments.browser.e2e.ts";
+const WORKSPACE_SWITCHER_TRIGGER_E2E = "test/e2e/workspace-switcher-trigger.browser.e2e.ts";
 
 describe("fail-closed change impact", () => {
   test("documentation-only changes retain every non-runtime public guard", () => {
@@ -89,6 +90,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/react-compiled-css.browser.e2e.ts",
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
+      WORKSPACE_SWITCHER_TRIGGER_E2E,
     ]);
     expect(sdk.browserAcceptanceLanes).toEqual(["interaction", "knowledge", "workbench"]);
     expect(sdk.artifactRuntimeRequired).toBe(false);
@@ -258,6 +260,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/react-compiled-css.browser.e2e.ts",
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
+      WORKSPACE_SWITCHER_TRIGGER_E2E,
     ]);
     expect(tests.e2e).not.toContain("test/e2e/codex-overview.e2e.ts");
     expect(OPT_IN_TESTS["test/e2e/codex-overview.e2e.ts"]).toContain("browser-acceptance");

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -240,6 +240,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
     "@opengeni/testing",
   ],
   "test/e2e/personal-workspace-accessibility.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
+  "test/e2e/workspace-switcher-trigger.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/personal-resource-attachments.browser.e2e.ts": [
     "opengeni-web",
     "@opengeni/react",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -23,6 +23,7 @@ const testFiles =
         "./test/e2e/session-pins.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",
         "./test/e2e/user-message-disclosure.browser.e2e.ts",
+        "./test/e2e/workspace-switcher-trigger.browser.e2e.ts",
         "./test/e2e/workbench.browser.e2e.ts",
       ];
 

--- a/test/e2e/workspace-switcher-trigger.browser.e2e.ts
+++ b/test/e2e/workspace-switcher-trigger.browser.e2e.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Page } from "playwright";
+
+describe("Workspace switcher trigger in Chromium", () => {
+  let browser: Browser;
+  let page: Page;
+  let web: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        ".",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${new URL("../..", import.meta.url).pathname}/apps/web`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/test/workspace-switcher-trigger.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage({ viewport: { width: 1120, height: 760 } });
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  }, 30_000);
+
+  test("pointer activation opens every expected workspace and destination", async () => {
+    await page.goto(`${baseUrl}/test/workspace-switcher-trigger.html`, {
+      waitUntil: "networkidle",
+    });
+    const trigger = page.locator('button[aria-label$="Switch workspace"]');
+
+    expect(await trigger.getAttribute("aria-label")).toBe(
+      "CloudGeni Product Engineering and Reliability. Personal workspace: Personal workspace. Switch workspace",
+    );
+    expect(await trigger.getAttribute("aria-haspopup")).toBe("menu");
+    expect(await trigger.getAttribute("aria-expanded")).toBe("false");
+    const triggerBox = await trigger.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    await page.mouse.click(
+      triggerBox!.x + triggerBox!.width / 2,
+      triggerBox!.y + triggerBox!.height / 2,
+    );
+    expect(await trigger.getAttribute("aria-expanded")).toBe("true");
+
+    for (const label of [
+      "Default workspace",
+      "Product Testing",
+      "Research Sandbox",
+      "New workspace…",
+      "Settings",
+    ]) {
+      expect(await page.getByRole("menuitem", { name: label, exact: true }).isVisible()).toBe(true);
+    }
+    expect(
+      await page.getByRole("menuitem", { name: /Personal workspace/, exact: false }).isVisible(),
+    ).toBe(true);
+
+    const rail = page.getByTestId("production-rail");
+    expect(await rail.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    expect(await trigger.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+      true,
+    );
+    const visualWorkspaceLabel = trigger.locator("span.truncate");
+    expect(
+      await visualWorkspaceLabel.evaluate((element) => element.scrollWidth > element.clientWidth),
+    ).toBe(true);
+    expect(await trigger.getByText("Personal", { exact: true }).isVisible()).toBe(true);
+
+    await page.getByRole("menuitem", { name: "Product Testing", exact: true }).click();
+    expect(await page.getByTestId("last-action").textContent()).toBe("Opened Product Testing");
+  });
+
+  test("the narrow expanded rail contains the same trigger without page overflow", async () => {
+    await page.setViewportSize({ width: 320, height: 760 });
+    await page.goto(`${baseUrl}/test/workspace-switcher-trigger.html`, {
+      waitUntil: "networkidle",
+    });
+    const trigger = page.locator('button[aria-label$="Switch workspace"]');
+    const triggerBox = await trigger.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true);
+    expect(
+      await page
+        .getByTestId("production-rail")
+        .evaluate((element) => element.scrollWidth <= element.clientWidth),
+    ).toBe(true);
+
+    await page.mouse.click(
+      triggerBox!.x + triggerBox!.width / 2,
+      triggerBox!.y + triggerBox!.height / 2,
+    );
+    expect(await page.getByRole("menuitem", { name: "Settings", exact: true }).isVisible()).toBe(
+      true,
+    );
+  });
+
+  test("Enter and Space open the collapsed tooltip-wrapped trigger and Escape restores focus", async () => {
+    await page.setViewportSize({ width: 1120, height: 760 });
+    await page.goto(`${baseUrl}/test/workspace-switcher-trigger.html?mode=collapsed`, {
+      waitUntil: "networkidle",
+    });
+    const trigger = page.locator('button[aria-label$="Switch workspace"]');
+
+    await trigger.focus();
+    await trigger.press("Enter");
+    expect(await page.getByRole("menuitem", { name: "Settings", exact: true }).isVisible()).toBe(
+      true,
+    );
+    await page.keyboard.press("Escape");
+    expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(true);
+
+    await trigger.press("Space");
+    expect(
+      await page.getByRole("menuitem", { name: "Product Testing", exact: true }).isVisible(),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- forward Radix trigger props and the button ref through `WorkspaceSwitcherTrigger`, restoring pointer and keyboard activation in expanded and collapsed rails
- contain the workspace selector in a zero-minimum grid/flex track so Personal badges, chevrons, and long identity labels truncate without widening the rail
- replace the ineffective source-string guard with Chromium coverage for pointer, Enter/Space, focus return, cross-organization entries, production-width overflow, and narrow layout

## Root cause

`DropdownMenuTrigger asChild` injected its handlers, ARIA state, and ref into `WorkspaceSwitcherTrigger`, but that custom component accepted only its own display props and dropped everything before rendering the real button. Separately, the expanded rail used an auto-minimum grid track around a flex trigger whose Personal badge and chevron could not shrink, allowing intrinsic width to escape the 244px rail.

This preserves the all-organization workspace menu and API pool change merged in #1701.

## Verification

- `bun run typecheck` (`apps/web`)
- `bun test apps/web/src/managed-self-context-surface.test.ts`
- `bun scripts/run-browser-e2e.ts ./test/e2e/workspace-switcher-trigger.browser.e2e.ts`
- `bun scripts/run-browser-e2e.ts ./test/e2e/personal-workspace-accessibility.browser.e2e.ts`
- focused `oxlint`, `oxfmt --check`, and `git diff --check`

Linear: [OPE-299](https://linear.app/cloudgeni/issue/OPE-299/fix-workspace-switcher-trigger-activation)
