### PR TITLE
fix(web): make the workspace switcher button actually a menu trigger

### DIFF
--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createRef, type RefObject } from "react";
+import { createRoot } from "react-dom/client";
+
+import { WorkspaceSwitcherTrigger } from "@/components/rail/switcher-block";
+import type { Workspace } from "@/types";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+const workspace = {
+  id: "ws-1",
+  name: "cloudgeni",
+  inferenceControl: { state: "active" },
+} as Workspace;
+
+describe("WorkspaceSwitcherTrigger", () => {
+  test("forwards the Radix asChild ref onto the native button", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const ref: RefObject<HTMLButtonElement | null> = createRef();
+    await act(async () => {
+      root.render(
+        <WorkspaceSwitcherTrigger
+          ref={ref}
+          activeWorkspace={workspace}
+          activeOrganizationLabel="Org 049d0b24"
+          personal={false}
+          collapsed={false}
+        />,
+      );
+    });
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current?.getAttribute("aria-label")).toContain("Switch workspace");
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+});

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -14,7 +14,7 @@ import {
   PlusIcon,
   SettingsIcon,
 } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { forwardRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { WorkspaceNameDialog } from "@/components/rail/workspace-name-dialog";
@@ -299,12 +299,15 @@ export function OrganizationSwitcherLine(props: {
   );
 }
 
-export function WorkspaceSwitcherTrigger(props: {
-  activeWorkspace: Workspace | null;
-  activeOrganizationLabel: string;
-  personal: boolean;
-  collapsed: boolean;
-}) {
+export const WorkspaceSwitcherTrigger = forwardRef<
+  HTMLButtonElement,
+  {
+    activeWorkspace: Workspace | null;
+    activeOrganizationLabel: string;
+    personal: boolean;
+    collapsed: boolean;
+  }
+>(function WorkspaceSwitcherTrigger(props, ref) {
   const workspaceLabel =
     props.activeWorkspace?.name ?? (props.collapsed ? "switch workspace" : "none");
   const accessibleLabel = `${props.activeOrganizationLabel}. ${
@@ -314,6 +317,7 @@ export function WorkspaceSwitcherTrigger(props: {
   if (props.collapsed) {
     return (
       <button
+        ref={ref}
         type="button"
         aria-label={accessibleLabel}
         className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
@@ -325,6 +329,7 @@ export function WorkspaceSwitcherTrigger(props: {
 
   return (
     <button
+      ref={ref}
       type="button"
       aria-label={accessibleLabel}
       className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
@@ -344,7 +349,7 @@ export function WorkspaceSwitcherTrigger(props: {
       <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
     </button>
   );
-}
+});
 
 function WorkspaceMenu(props: {
   orgs: OrgOption[];
@@ -371,7 +376,9 @@ function WorkspaceMenu(props: {
     <DropdownMenu>
       {rail.collapsed ? (
         <Tooltip>
-          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">{trigger}</span>
+          </TooltipTrigger>
           <TooltipContent side="right">Switch workspace</TooltipContent>
         </Tooltip>
       ) : (

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -35,7 +35,12 @@ describe("managed self-context surfaces", () => {
     expect(switcherSource).toContain('<span className="sr-only"> Paused</span>');
     expect(switcherSource.match(/<PersonalWorkspaceBadge/g)?.length).toBeGreaterThanOrEqual(2);
     expect(switcherSource).toContain("workspaces={context.workspaces}");
+    expect(switcherSource).toContain("export const WorkspaceSwitcherTrigger = forwardRef");
     expect(switcherSource).toContain("{rail.collapsed ? (");
+    expect(switcherSource).toContain('<span className="inline-flex">{trigger}</span>');
+    expect(switcherSource).not.toContain(
+      "<TooltipTrigger asChild>{trigger}</TooltipTrigger>",
+    );
     expect(switcherSource).not.toContain(
       "<TooltipTrigger asChild>\n          <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>",
     );

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -38,9 +38,7 @@ describe("managed self-context surfaces", () => {
     expect(switcherSource).toContain("export const WorkspaceSwitcherTrigger = forwardRef");
     expect(switcherSource).toContain("{rail.collapsed ? (");
     expect(switcherSource).toContain('<span className="inline-flex">{trigger}</span>');
-    expect(switcherSource).not.toContain(
-      "<TooltipTrigger asChild>{trigger}</TooltipTrigger>",
-    );
+    expect(switcherSource).not.toContain("<TooltipTrigger asChild>{trigger}</TooltipTrigger>");
     expect(switcherSource).not.toContain(
       "<TooltipTrigger asChild>\n          <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>",
     );


### PR DESCRIPTION
## Summary
- Staging still no-ops the workspace switcher on \`canary-sha-90902771\`: sidebar lists sessions, click on **cloudgeni** does not open a menu.
- Cause: \`WorkspaceSwitcherTrigger\` was a function component without \`forwardRef\`, so Radix \`asChild\` never attached to the \`<button>\`.
- Also stop wrapping \`DropdownMenuTrigger\` in \`TooltipTrigger asChild\` (collapsed rail). Tooltip now wraps a \`span\`.

## Test plan
- [ ] \`bun test apps/web/src/components/rail/switcher-block.test.tsx apps/web/src/managed-self-context-surface.test.ts\`
- [ ] Staging: expanded rail, click workspace name, menu lists other workspaces, selecting one navigates

Made with [Cursor](https://cursor.com)