### PR TITLE
fix(web): actually open the workspace switcher menu

### DIFF
--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -21,11 +21,12 @@ const workspace = {
 } as Workspace;
 
 describe("WorkspaceSwitcherTrigger", () => {
-  test("forwards the Radix asChild ref onto the native button", async () => {
+  test("forwards the Radix asChild ref and rest handlers onto the native button", async () => {
     const host = document.createElement("div");
     document.body.append(host);
     const root = createRoot(host);
     const ref: RefObject<HTMLButtonElement | null> = createRef();
+    let pointerDown = 0;
     await act(async () => {
       root.render(
         <WorkspaceSwitcherTrigger
@@ -34,11 +35,16 @@ describe("WorkspaceSwitcherTrigger", () => {
           activeOrganizationLabel="Org 049d0b24"
           personal={false}
           collapsed={false}
+          onPointerDown={() => {
+            pointerDown += 1;
+          }}
         />,
       );
     });
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     expect(ref.current?.getAttribute("aria-label")).toContain("Switch workspace");
+    ref.current?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(pointerDown).toBe(1);
     await act(async () => {
       root.unmount();
     });

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -14,7 +14,7 @@ import {
   PlusIcon,
   SettingsIcon,
 } from "lucide-react";
-import { forwardRef, useState, type ReactNode } from "react";
+import { forwardRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { WorkspaceNameDialog } from "@/components/rail/workspace-name-dialog";
@@ -306,46 +306,47 @@ export const WorkspaceSwitcherTrigger = forwardRef<
     activeOrganizationLabel: string;
     personal: boolean;
     collapsed: boolean;
-  }
->(function WorkspaceSwitcherTrigger(props, ref) {
-  const workspaceLabel =
-    props.activeWorkspace?.name ?? (props.collapsed ? "switch workspace" : "none");
-  const accessibleLabel = `${props.activeOrganizationLabel}. ${
-    props.personal ? "Personal workspace" : "Workspace"
+  } & ButtonHTMLAttributes<HTMLButtonElement>
+>(function WorkspaceSwitcherTrigger(
+  { activeWorkspace, activeOrganizationLabel, personal, collapsed, ...rest },
+  ref,
+) {
+  const workspaceLabel = activeWorkspace?.name ?? (collapsed ? "switch workspace" : "none");
+  const accessibleLabel = `${activeOrganizationLabel}. ${
+    personal ? "Personal workspace" : "Workspace"
   }: ${workspaceLabel}. Switch workspace`;
 
-  if (props.collapsed) {
+  if (collapsed) {
     return (
       <button
-        ref={ref}
         type="button"
         aria-label={accessibleLabel}
         className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+        {...rest}
+        ref={ref}
       >
-        {workspaceInitial(props.activeWorkspace)}
+        {workspaceInitial(activeWorkspace)}
       </button>
     );
   }
 
   return (
     <button
-      ref={ref}
       type="button"
       aria-label={accessibleLabel}
       className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+      {...rest}
+      ref={ref}
     >
       <Avatar size="sm" className="rounded-md">
         <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
-          {workspaceInitial(props.activeWorkspace)}
+          {workspaceInitial(activeWorkspace)}
         </AvatarFallback>
       </Avatar>
-      <span
-        className="min-w-0 flex-1 truncate text-sm font-medium"
-        title={props.activeWorkspace?.name}
-      >
-        {props.activeWorkspace?.name ?? "Select workspace"}
+      <span className="min-w-0 flex-1 truncate text-sm font-medium" title={activeWorkspace?.name}>
+        {activeWorkspace?.name ?? "Select workspace"}
       </span>
-      {props.personal ? <PersonalWorkspaceBadge decorative /> : null}
+      {personal ? <PersonalWorkspaceBadge decorative /> : null}
       <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
     </button>
   );

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -308,11 +308,11 @@ export const WorkspaceSwitcherTrigger = forwardRef<
     collapsed: boolean;
   } & ButtonHTMLAttributes<HTMLButtonElement>
 >(function WorkspaceSwitcherTrigger(
-  { activeWorkspace, activeOrganizationLabel, personal, collapsed, ...rest },
+  { activeWorkspace, activeOrganizationLabel: organizationLabel, personal, collapsed, ...rest },
   ref,
 ) {
   const workspaceLabel = activeWorkspace?.name ?? (collapsed ? "switch workspace" : "none");
-  const accessibleLabel = `${activeOrganizationLabel}. ${
+  const accessibleLabel = `${organizationLabel}. ${
     personal ? "Personal workspace" : "Workspace"
   }: ${workspaceLabel}. Switch workspace`;
 

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -36,6 +36,7 @@ describe("managed self-context surfaces", () => {
     expect(switcherSource.match(/<PersonalWorkspaceBadge/g)?.length).toBeGreaterThanOrEqual(2);
     expect(switcherSource).toContain("workspaces={context.workspaces}");
     expect(switcherSource).toContain("export const WorkspaceSwitcherTrigger = forwardRef");
+    expect(switcherSource).toContain("{...rest}");
     expect(switcherSource).toContain("{rail.collapsed ? (");
     expect(switcherSource).toContain('<span className="inline-flex">{trigger}</span>');
     expect(switcherSource).not.toContain("<TooltipTrigger asChild>{trigger}</TooltipTrigger>");


### PR DESCRIPTION
## Summary
- Staging on \`67feac97\` still no-ops the workspace click: sidebar works, menu never opens.
- \`asChild\` needs both \`forwardRef\` **and** \`{...rest}\` so Radix pointer/ARIA handlers land on the \`<button>\`.

## Test plan
- [ ] \`bun test apps/web/src/components/rail/switcher-block.test.tsx\`
- [ ] Staging: click the workspace name, menu opens, switch workspace

Made with [Cursor](https://cursor.com)