### PR TITLE
Fix paused descendant status aggregation

### DIFF
--- a/apps/web/src/lib/sessions-group-channels.test.ts
+++ b/apps/web/src/lib/sessions-group-channels.test.ts
@@ -20,10 +20,48 @@ function session(patch: Partial<Session> & Pick<Session, "id">): Session {
     pinnedAt: null,
     pinVersion: 0,
     createdBy: { kind: "subject", subjectId: "user:test" },
+    effectiveControl: activeControl(),
     createdAt: "2026-08-01T00:00:00.000Z",
     updatedAt: "2026-08-01T00:00:00.000Z",
     ...patch,
   } as Session;
+}
+
+function activeControl(): Session["effectiveControl"] {
+  return {
+    state: "active",
+    controlVersion: 0,
+    controlEtag: "active-0",
+    directState: "active",
+    primaryBlocker: null,
+    additionalBlockerCount: 0,
+    blockers: [],
+    resumeOptions: [],
+    override: null,
+    settlement: null,
+  };
+}
+
+function pausedControl(): Session["effectiveControl"] {
+  const blocker = {
+    kind: "session" as const,
+    sessionId: "paused",
+    displayName: "Paused here",
+    actor: null,
+    reason: null,
+    changedAt: null,
+    revision: 1,
+  };
+  return {
+    ...activeControl(),
+    state: "paused",
+    controlVersion: 1,
+    controlEtag: "paused-1",
+    directState: "paused",
+    primaryBlocker: blocker,
+    blockers: [blocker],
+    resumeOptions: [],
+  };
 }
 
 const CHANNELS = [
@@ -156,6 +194,27 @@ describe("summarizeRailNodes", () => {
     expect(summarizeRailNodes(forest.running)).toMatchObject({
       kind: "active",
       label: "1 working",
+    });
+  });
+
+  test("does not count a paused queued child as working", () => {
+    const forest = buildRailForest([
+      session({ id: "root" }),
+      session({
+        id: "paused",
+        parentSessionId: "root",
+        status: "queued",
+        effectiveControl: pausedControl(),
+      }),
+    ]);
+    const nodes = forest.grouped.flatMap((bucket) => bucket.sessions);
+
+    expect(forest.running).toEqual([]);
+    expect(summarizeRailNodes(nodes)).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 2,
+      label: "Read",
     });
   });
 

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -34,6 +34,14 @@ export function isRunningStatus(status: SessionStatus): boolean {
   return RUNNING_STATUSES.has(status);
 }
 
+function hasActiveEffectiveControl(session: Session): boolean {
+  return (session.effectiveControl?.state ?? "active") === "active";
+}
+
+function isEffectivelyRunning(session: Session): boolean {
+  return hasActiveEffectiveControl(session) && isRunningStatus(session.status);
+}
+
 /** Most-recent activity timestamp for a session (updatedAt, then createdAt). */
 export function sessionActivityTime(session: Session): number {
   const updated = Date.parse(session.updatedAt);
@@ -112,11 +120,9 @@ export type GroupedSessions = {
  * within each bucket. Empty groups are dropped.
  */
 export function groupSessionsForRail(sessions: Session[], now: Date = new Date()): GroupedSessions {
-  const running = sessions
-    .filter((session) => isRunningStatus(session.status))
-    .sort(compareSessionActivity);
+  const running = sessions.filter(isEffectivelyRunning).sort(compareSessionActivity);
   const rest = sessions
-    .filter((session) => !isRunningStatus(session.status))
+    .filter((session) => !isEffectivelyRunning(session))
     .sort(compareSessionActivity);
 
   const buckets = new Map<SessionRecencyGroup, Session[]>();
@@ -197,10 +203,11 @@ function ownRailStatusCounts(
     attention: session.status === "requires_action" ? 1 : 0,
     failed: session.status === "failed" ? 1 : 0,
     active:
-      session.status === "running" ||
-      session.status === "queued" ||
-      session.status === "recovering" ||
-      session.status === "waiting_capacity"
+      hasActiveEffectiveControl(session) &&
+      (session.status === "running" ||
+        session.status === "queued" ||
+        session.status === "recovering" ||
+        session.status === "waiting_capacity")
         ? 1
         : 0,
     unread: session.unread ? 1 : 0,
@@ -474,10 +481,10 @@ export function groupSessionsForBrowse(
 ): SessionForest {
   const now = options.now ?? new Date();
   const running = sessions
-    .filter((session) => isRunningStatus(session.status))
+    .filter(isEffectivelyRunning)
     .sort(compareSessionActivity)
     .map((session) => ({ session, children: [], hasActiveDescendant: false }));
-  const rest = sessions.filter((session) => !isRunningStatus(session.status));
+  const rest = sessions.filter((session) => !isEffectivelyRunning(session));
   if (groupBy === "created") {
     const buckets = new Map<SessionRecencyGroup, Session[]>();
     for (const session of rest) {
@@ -557,7 +564,7 @@ export function nodeIsActive(node: SessionTreeNode): boolean {
   const summarizedActive = Boolean(
     stats && stats.runningDescendants + stats.queuedDescendants + stats.attentionDescendants > 0,
   );
-  return isRunningStatus(node.session.status) || node.hasActiveDescendant || summarizedActive;
+  return isEffectivelyRunning(node.session) || node.hasActiveDescendant || summarizedActive;
 }
 
 /** Bucket already-built roots using the rail's activity and recency rules. */
@@ -740,12 +747,13 @@ function addRemovedCounts(target: RemovedCounts, source: RemovedCounts): void {
 
 function subtreeCounts(node: SessionTreeNode): RemovedCounts {
   const status = node.session.status;
+  const active = hasActiveEffectiveControl(node.session);
   const counts: RemovedCounts = {
     total: 1,
-    running: status === "running" || status === "recovering" ? 1 : 0,
-    queued: status === "queued" || status === "waiting_capacity" ? 1 : 0,
+    running: active && (status === "running" || status === "recovering") ? 1 : 0,
+    queued: active && (status === "queued" || status === "waiting_capacity") ? 1 : 0,
     attention: status === "requires_action" ? 1 : 0,
-    paused: node.session.effectiveControl.state === "paused" ? 1 : 0,
+    paused: node.session.effectiveControl?.state === "paused" ? 1 : 0,
     failed: status === "failed" ? 1 : 0,
   };
   const stats = node.session.treeStats;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27702,9 +27702,39 @@ export async function sessionTreeStatsForSessions(
         stats."activelyWorkingDescendants",
         stats.truncated
       from ${schema.sessions} root
+      join ${schema.workspaceInferenceControls} workspace_control
+        on workspace_control.workspace_id = root.workspace_id
       cross join lateral (
-        with recursive descendants(id, status, last_sequence, depth, path) as (
-          select root.id, root.status, root.last_sequence, 0, array[root.id]::uuid[]
+        with recursive descendants(
+          id,
+          status,
+          last_sequence,
+          effective_pause_revision,
+          depth,
+          path
+        ) as (
+          select
+            root.id,
+            root.status,
+            root.last_sequence,
+            greatest(
+              case
+                when workspace_control.workspace_state = 'paused'
+                  and workspace_control.workspace_pause_revision is not null
+                  and (
+                    root.subtree_run_override_revision is null
+                    or root.subtree_run_override_revision <= workspace_control.workspace_pause_revision
+                  )
+                  then workspace_control.workspace_pause_revision
+                else null
+              end,
+              case
+                when root.direct_control_state = 'paused' then root.direct_pause_revision
+                else null
+              end
+            ),
+            0,
+            array[root.id]::uuid[]
 
           union all
 
@@ -27712,6 +27742,24 @@ export async function sessionTreeStatsForSessions(
             child.id,
             child.status,
             child.last_sequence,
+            greatest(
+              case
+                -- A subtree resume defeats every inherited pause older than it.
+                -- Preserve only the strongest still-undefeated blocker, then
+                -- apply the child's own pause (which its own override cannot defeat).
+                when descendants.effective_pause_revision is not null
+                  and (
+                    child.subtree_run_override_revision is null
+                    or child.subtree_run_override_revision <= descendants.effective_pause_revision
+                  )
+                  then descendants.effective_pause_revision
+                else null
+              end,
+              case
+                when child.direct_control_state = 'paused' then child.direct_pause_revision
+                else null
+              end
+            ),
             descendants.depth + 1,
             descendants.path || child.id
           from descendants
@@ -27725,11 +27773,18 @@ export async function sessionTreeStatsForSessions(
         ), bounded as materialized (
           -- PostgreSQL evaluates the recursive producer only as far as this
           -- unsorted LIMIT is consumed. One extra descendant is lookahead.
-          select id, status, last_sequence, depth, path
+          select id, status, last_sequence, effective_pause_revision, depth, path
           from descendants
           limit ${SESSION_TREE_STATS_MAX_DESCENDANTS + 2}
         ), numbered as (
-          select id, status, last_sequence, depth, path, row_number() over () as ordinal
+          select
+            id,
+            status,
+            last_sequence,
+            effective_pause_revision,
+            depth,
+            path,
+            row_number() over () as ordinal
           from bounded
         )
         select
@@ -27741,11 +27796,15 @@ export async function sessionTreeStatsForSessions(
           )::int as "totalDescendants",
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
-              and depth > 0 and status in ('running', 'recovering')
+              and depth > 0
+              and effective_pause_revision is null
+              and status in ('running', 'recovering')
           )::int as "runningDescendants",
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
-              and depth > 0 and status in ('queued', 'waiting_capacity')
+              and depth > 0
+              and effective_pause_revision is null
+              and status in ('queued', 'waiting_capacity')
           )::int as "queuedDescendants",
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
@@ -27753,7 +27812,7 @@ export async function sessionTreeStatsForSessions(
           )::int as "attentionDescendants",
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
-              and depth > 0 and status = 'paused'
+              and depth > 0 and effective_pause_revision is not null
           )::int as "pausedDescendants",
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -260,6 +260,105 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     });
   });
 
+  test("counts effective pauses and excludes paused descendants from active totals", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const root = await session({ ...workspace, message: "effective pause root" });
+    const pausedChild = await session({
+      ...workspace,
+      message: "directly paused queued child",
+      parentSessionId: root.id,
+    });
+    const inheritedGrandchild = await session({
+      ...workspace,
+      message: "inherited paused running grandchild",
+      parentSessionId: pausedChild.id,
+    });
+    const resumedGreatGrandchild = await session({
+      ...workspace,
+      message: "resumed queued great-grandchild",
+      parentSessionId: inheritedGrandchild.id,
+    });
+    await executeSessionActivity(
+      workspace.workspaceId,
+      sql`
+        update sessions
+        set
+          status = case
+            when id = ${pausedChild.id} then 'queued'
+            when id = ${inheritedGrandchild.id} then 'running'
+            when id = ${resumedGreatGrandchild.id} then 'queued'
+            else status
+          end,
+          direct_control_state = case
+            when id = ${pausedChild.id} then 'paused'
+            else direct_control_state
+          end,
+          direct_pause_revision = case
+            when id = ${pausedChild.id} then 10
+            else direct_pause_revision
+          end,
+          subtree_run_override_revision = case
+            when id = ${resumedGreatGrandchild.id} then 11
+            else subtree_run_override_revision
+          end,
+          control_version = case
+            when id = ${pausedChild.id} then 10
+            when id = ${resumedGreatGrandchild.id} then 11
+            else control_version
+          end,
+          updated_at = now()
+        where id in (
+          ${pausedChild.id},
+          ${inheritedGrandchild.id},
+          ${resumedGreatGrandchild.id}
+        )
+      `,
+    );
+
+    const directPauseStats = await withWorkspaceRls(db, workspace.workspaceId, (scoped) =>
+      sessionTreeStatsForSessions(scoped, workspace.workspaceId, [root.id]),
+    );
+    expect(directPauseStats.get(root.id)).toMatchObject({
+      totalDescendants: 3,
+      runningDescendants: 0,
+      queuedDescendants: 1,
+      pausedDescendants: 2,
+    });
+
+    await admin`
+      update workspace_inference_controls
+      set revision = 20, workspace_state = 'paused', workspace_pause_revision = 20
+      where workspace_id = ${workspace.workspaceId}`;
+    const workspacePauseStats = await withWorkspaceRls(db, workspace.workspaceId, (scoped) =>
+      sessionTreeStatsForSessions(scoped, workspace.workspaceId, [root.id]),
+    );
+    expect(workspacePauseStats.get(root.id)).toMatchObject({
+      totalDescendants: 3,
+      runningDescendants: 0,
+      queuedDescendants: 0,
+      pausedDescendants: 3,
+    });
+
+    await executeSessionActivity(
+      workspace.workspaceId,
+      sql`
+        update sessions
+        set subtree_run_override_revision = 21, control_version = 21, updated_at = now()
+        where id = ${resumedGreatGrandchild.id}
+      `,
+    );
+    const resumedStats = await withWorkspaceRls(db, workspace.workspaceId, (scoped) =>
+      sessionTreeStatsForSessions(scoped, workspace.workspaceId, [root.id]),
+    );
+    expect(resumedStats.get(root.id)).toMatchObject({
+      totalDescendants: 3,
+      runningDescendants: 0,
+      queuedDescendants: 1,
+      pausedDescendants: 2,
+    });
+  });
+
   test("bounds deep, wide, and overlapping descendant summaries with explicit lower bounds", async () => {
     if (!available) return;
     const workspace = await freshWorkspace({ maxNestedAgentDepth: 64 });


### PR DESCRIPTION
## Summary

- derive `pausedDescendants` from the existing workspace/session effective-control algebra
- exclude effectively paused `running`/`queued` descendants from active tree totals
- make loaded and synthetic rail trees apply the same effective-control check
- cover direct pauses, inherited pauses, workspace pauses, and newer subtree resume overrides
- preserve the prior active default for legacy or partial session projections

## Verification

- `bun run typecheck`
- `bun test apps/web/src/App.test.ts apps/web/src/lib/session-browse.test.ts apps/web/src/lib/sessions-group-channels.test.ts` (127 passed)
- targeted `oxlint` and `format:check` on all changed web files
- read-only SQL validation confirms effectively paused descendants are separated from active lifecycle totals

The real-Postgres regression is checked in for CI; the local database harness was unavailable.