### PR TITLE
fix(ci): repair current main validation

### DIFF
--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -184,7 +184,12 @@ import {
   deriveBrowserViewGrantToken,
   deriveComputerSessionControllerTokens,
 } from "../browser-controller-authority";
-import { controllerCacheAllowsHostFetch, controllerCachedUrlIsUsable, shouldPersistControllerDataPlaneUrl, withCachedController } from "../controller-data-plane";
+import {
+  controllerCacheAllowsHostFetch,
+  controllerCachedUrlIsUsable,
+  shouldPersistControllerDataPlaneUrl,
+  withCachedController,
+} from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
 import {
   browserStateArtifactAad,
@@ -201,7 +206,10 @@ import {
 import { managedNetworkRouteForPlacement } from "../browser-network-route";
 import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
-import { createInteractionFrameProxyAttachment, placementUsesInteractionFrameProxy } from "../interaction-frame-proxy";
+import {
+  createInteractionFrameProxyAttachment,
+  placementUsesInteractionFrameProxy,
+} from "../interaction-frame-proxy";
 import {
   observeAuthMutation,
   observeBrowserActionResult,
@@ -2896,10 +2904,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
     if (!sandboxGroupId || !placement.lease?.instanceId || !placement.session.resolveExposedPort) {
       return placement;
     }
-    if (
-      placement.lease.backend === "opensandbox" &&
-      deps.settings.openSandboxSignedEndpoints
-    ) {
+    if (placement.lease.backend === "opensandbox" && deps.settings.openSandboxSignedEndpoints) {
       if (!placement.lease.controllerDataPlaneUrl) return placement;
       const lease = await recordLeaseControllerDataPlaneUrl(deps.db, {
         accountId: grant.accountId,

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -86,11 +86,19 @@ import {
   deriveComputerViewGrantToken,
 } from "../browser-controller-authority";
 import { connectedMachineComputerAccessError } from "../connected-machine-computer-access";
-import { controllerCacheAllowsHostFetch, controllerCachedUrlIsUsable, shouldPersistControllerDataPlaneUrl, withCachedController } from "../controller-data-plane";
+import {
+  controllerCacheAllowsHostFetch,
+  controllerCachedUrlIsUsable,
+  shouldPersistControllerDataPlaneUrl,
+  withCachedController,
+} from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
 import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
-import { createInteractionFrameProxyAttachment, placementUsesInteractionFrameProxy } from "../interaction-frame-proxy";
+import {
+  createInteractionFrameProxyAttachment,
+  placementUsesInteractionFrameProxy,
+} from "../interaction-frame-proxy";
 import { observeComputerActionResult, observeLifecycleResult } from "../interaction-metrics";
 import { withChannelA, withChannelARead, type ChannelAOperation } from "../sandbox/channel-a";
 
@@ -1034,10 +1042,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
     ) {
       return placement;
     }
-    if (
-      placement.lease.backend === "opensandbox" &&
-      deps.settings.openSandboxSignedEndpoints
-    ) {
+    if (placement.lease.backend === "opensandbox" && deps.settings.openSandboxSignedEndpoints) {
       if (!placement.lease.controllerDataPlaneUrl) return placement;
       const lease = await recordLeaseControllerDataPlaneUrl(deps.db, {
         accountId: grant.accountId,
@@ -1090,10 +1095,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       cachedUrl:
         sandboxGroupId &&
         cachedUrl &&
-        !(
-          placement.lease?.backend === "opensandbox" &&
-          deps.settings.openSandboxSignedEndpoints
-        ) &&
+        !(placement.lease?.backend === "opensandbox" && deps.settings.openSandboxSignedEndpoints) &&
         controllerCachedUrlIsUsable(cachedUrl)
           ? cachedUrl
           : null,

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -101,7 +101,10 @@ describe("BrowserSession route discipline", () => {
     );
     expect(attachment).toContain("requestOrigin(context, deps.settings)");
     expect(attachment).toContain("client.addAllowedOrigins([origin])");
-    expect(attachment).toContain("placementUsesInteractionFrameProxy(placement.lease?.backend)");
+    expect(attachment).toContain("placementUsesInteractionFrameProxy(placement.lease?.backend, {");
+    expect(attachment).toContain(
+      "openSandboxSignedEndpoints: deps.settings.openSandboxSignedEndpoints",
+    );
     expect(attachment).toContain("createInteractionFrameProxyAttachment");
     expect(attachment).toContain("publicBaseUrl: deps.settings.publicBaseUrl");
     expect(attachment).toContain('context.req.header("x-forwarded-proto")');

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -43,7 +43,10 @@ describe("ComputerSession route discipline", () => {
     expect(attachment).toContain('record.session.platform === "linux"');
     expect(attachment).toContain("client.computerRfbStreamUrl");
     expect(attachment).toContain("COMPUTER_RFB_WEBSOCKET_PROTOCOL");
-    expect(attachment).toContain("placementUsesInteractionFrameProxy(placement.lease?.backend)");
+    expect(attachment).toContain("placementUsesInteractionFrameProxy(placement.lease?.backend, {");
+    expect(attachment).toContain(
+      "openSandboxSignedEndpoints: deps.settings.openSandboxSignedEndpoints",
+    );
     expect(attachment).toContain("createInteractionFrameProxyAttachment");
     expect(attachment).toContain("publicBaseUrl: deps.settings.publicBaseUrl");
     expect(attachment).toContain('context.req.header("x-forwarded-proto")');

--- a/apps/api/test/controller-data-plane.test.ts
+++ b/apps/api/test/controller-data-plane.test.ts
@@ -111,8 +111,7 @@ describe("signed controller cache", () => {
   const expired =
     "ws://127.0.0.1:28888/sbx-1/7682/1/sigsigsig/v1/browser-sessions/session/targets/t/frames";
   const freshExpires = Math.floor(Date.parse("2099-01-01T00:00:00.000Z") / 1000).toString(36);
-  const fresh =
-    `ws://127.0.0.1:28888/sbx-1/7682/${freshExpires}/sigsigsig/v1/browser-sessions/session/targets/t/frames`;
+  const fresh = `ws://127.0.0.1:28888/sbx-1/7682/${freshExpires}/sigsigsig/v1/browser-sessions/session/targets/t/frames`;
 
   test("does not persist OpenSandbox signed URLs as durable controller cache", () => {
     expect(isOpenSandboxSignedControllerUrl(fresh)).toBe(true);

--- a/apps/api/test/interaction-frame-proxy.test.ts
+++ b/apps/api/test/interaction-frame-proxy.test.ts
@@ -40,7 +40,8 @@ describe("interaction frame proxy", () => {
     const attachment = createInteractionFrameProxyAttachment({
       requestUrl: `${publicOrigin}/v1/workspaces/workspace/computer-sessions/session/attachments`,
       rootSecret,
-      upstreamUrl: "ws://127.0.0.1:18090/v1/sandboxes/box/proxy/7682/v1/computer-sessions/cs/targets/screen%3A0/rfb",
+      upstreamUrl:
+        "ws://127.0.0.1:18090/v1/sandboxes/box/proxy/7682/v1/computer-sessions/cs/targets/screen%3A0/rfb",
       upstreamProtocols: [
         "binary",
         "opengeni.computer.rfb.v1",

--- a/apps/worker/src/sandbox-archive-storage.ts
+++ b/apps/worker/src/sandbox-archive-storage.ts
@@ -130,10 +130,7 @@ export async function deleteUnpublishedWorkspaceArchiveObject(
   objectStorage: ObjectStorage | null | undefined,
   ref: WorkspaceArchiveObjectRef | undefined,
   metrics?: {
-    onWorkspaceArchiveObject?: (input: {
-      outcome: "deleted_unpublished";
-      backend: string;
-    }) => void;
+    onWorkspaceArchiveObject?: (input: { outcome: "deleted_unpublished"; backend: string }) => void;
   },
 ): Promise<void> {
   if (!objectStorage || !ref) return;

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -385,7 +385,10 @@ export function safeSnapshotError(error: unknown): {
         status?: unknown;
         statusCode?: unknown;
       };
-      if (typeof candidate.name === "string" && /^[A-Z][A-Za-z0-9]{2,62}Error$/u.test(candidate.name)) {
+      if (
+        typeof candidate.name === "string" &&
+        /^[A-Z][A-Za-z0-9]{2,62}Error$/u.test(candidate.name)
+      ) {
         fields.causeName = candidate.name;
       }
       if (typeof candidate.code === "string" && /^[a-z0-9_]{1,64}$/u.test(candidate.code)) {
@@ -557,7 +560,9 @@ async function materializeSpawnEnvelopeArchive(
   if (!envelope || typeof envelope !== "object") return envelope;
   const record = envelope as Record<string, unknown>;
   const sessionState =
-    record.sessionState && typeof record.sessionState === "object" && !Array.isArray(record.sessionState)
+    record.sessionState &&
+    typeof record.sessionState === "object" &&
+    !Array.isArray(record.sessionState)
       ? (record.sessionState as Record<string, unknown>)
       : null;
   if (!sessionState || !parseWorkspaceArchiveObjectRef(sessionState.workspaceArchiveRef)) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2084,21 +2084,21 @@ function objectStorageConfiguredForWorkspaceArchives(settings: Settings): boolea
     case "azure-blob":
       return Boolean(
         settings.objectStorageAzureConnectionString ||
-          (settings.objectStorageAzureAccountName && settings.objectStorageAzureAccountKey),
+        (settings.objectStorageAzureAccountName && settings.objectStorageAzureAccountKey),
       );
     case "gcs":
       return Boolean(
         settings.objectStorageGcsCredentialsJson ||
-          settings.objectStorageGcsKeyFilename ||
-          settings.objectStorageGcsProjectId,
+        settings.objectStorageGcsKeyFilename ||
+        settings.objectStorageGcsProjectId,
       );
     case "aws-s3":
       return true;
     case "s3-compatible":
       return Boolean(
         settings.objectStorageEndpoint &&
-          settings.objectStorageAccessKeyId &&
-          settings.objectStorageSecretAccessKey,
+        settings.objectStorageAccessKeyId &&
+        settings.objectStorageSecretAccessKey,
       );
     default: {
       const _exhaustive: never = settings.objectStorageBackend;
@@ -2389,7 +2389,9 @@ export function getSettings(): Settings {
     openSandboxTtlSeconds: optional("OPENGENI_OPENSANDBOX_TTL_SECONDS"),
     openSandboxUseServerProxy: optional("OPENGENI_OPENSANDBOX_USE_SERVER_PROXY"),
     openSandboxSignedEndpoints: optional("OPENGENI_OPENSANDBOX_SIGNED_ENDPOINTS"),
-    openSandboxSignedEndpointTtlSeconds: optional("OPENGENI_OPENSANDBOX_SIGNED_ENDPOINT_TTL_SECONDS"),
+    openSandboxSignedEndpointTtlSeconds: optional(
+      "OPENGENI_OPENSANDBOX_SIGNED_ENDPOINT_TTL_SECONDS",
+    ),
     openSandboxChannelBPublicBaseUrl: optional("OPENGENI_OPENSANDBOX_CHANNEL_B_PUBLIC_BASE_URL"),
     openSandboxInteractionFrameProxy: optional("OPENGENI_OPENSANDBOX_INTERACTION_FRAME_PROXY"),
     openSandboxPoolRef: optional("OPENGENI_OPENSANDBOX_POOL_REF"),

--- a/packages/contracts/src/sandbox-snapshots.ts
+++ b/packages/contracts/src/sandbox-snapshots.ts
@@ -106,7 +106,10 @@ export function workspaceArchivePayloadPresent(
   sessionState: Record<string, unknown> | null | undefined,
 ): boolean {
   if (!sessionState) return false;
-  if (typeof sessionState.workspaceArchive === "string" && sessionState.workspaceArchive.length > 0) {
+  if (
+    typeof sessionState.workspaceArchive === "string" &&
+    sessionState.workspaceArchive.length > 0
+  ) {
     return true;
   }
   return parseWorkspaceArchiveObjectRef(sessionState.workspaceArchiveRef) !== null;

--- a/packages/contracts/test/sandbox-snapshots.test.ts
+++ b/packages/contracts/test/sandbox-snapshots.test.ts
@@ -26,7 +26,8 @@ describe("omitInlineWorkspaceArchiveWhenObjectRefPresent", () => {
         accountId: "11111111-1111-4111-8111-111111111111",
         workspaceId: "22222222-2222-4222-8222-222222222222",
         sandboxGroupId: "33333333-3333-4333-8333-333333333333",
-        revision: "wa1:1900000000001:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        revision:
+          "wa1:1900000000001:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       }),
     };
     const durable = omitInlineWorkspaceArchiveWhenObjectRefPresent({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37204,8 +37204,8 @@ function evaluateColdLostSnapshot(
   const inlineBytes = decodeCanonicalBase64(base64);
   const inlineObjectMismatch = Boolean(
     inlineBytes &&
-      objectRef &&
-      (sha256String(inlineBytes) !== objectRef.sha256 || inlineBytes.length !== objectRef.bytes),
+    objectRef &&
+    (sha256String(inlineBytes) !== objectRef.sha256 || inlineBytes.length !== objectRef.bytes),
   );
   const bytes = inlineBytes;
   const referenceBytes = inlineBytes?.length ?? objectRef?.bytes ?? null;
@@ -44041,7 +44041,9 @@ export async function persistDrainSnapshot(
           : {}),
         ...(published.workspaceArchive ? { workspaceArchive: published.workspaceArchive } : {}),
         workspaceArchiveMeta,
-        ...(published.workspaceArchiveRef ? { workspaceArchiveRef: published.workspaceArchiveRef } : {}),
+        ...(published.workspaceArchiveRef
+          ? { workspaceArchiveRef: published.workspaceArchiveRef }
+          : {}),
         resumeState,
         livenessGuard: coldLatePublication ? "cold_late" : "draining",
         previousArchive: rotation.previousArchive,
@@ -44655,7 +44657,9 @@ export async function persistWarmSnapshot(
         captureId: input.captureId,
         ...(published.workspaceArchive ? { workspaceArchive: published.workspaceArchive } : {}),
         workspaceArchiveMeta,
-        ...(published.workspaceArchiveRef ? { workspaceArchiveRef: published.workspaceArchiveRef } : {}),
+        ...(published.workspaceArchiveRef
+          ? { workspaceArchiveRef: published.workspaceArchiveRef }
+          : {}),
         resumeState: guard[0]!.resume_state,
         livenessGuard,
         previousArchive: rotation.previousArchive,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -44251,6 +44251,7 @@ async function foldWorkspaceArchiveOntoLease(
     archive: archiveProjectionFromResumeState(folded),
   };
   const foldedJson = JSON.stringify(folded);
+  const inlineWorkspaceArchive = input.workspaceArchive ?? null;
   // Publication and GC must serialize on the provider-object receipt itself.
   // Merely checking its state in a lease UPDATE subquery permits a write-skew:
   // a concurrent failed callback can mark the object delete_pending after the
@@ -44279,7 +44280,7 @@ async function foldWorkspaceArchiveOntoLease(
         and artifact.source_workspace_generation = lease.workspace_generation
         and artifact.provenance = 'native_capture'
         and artifact.provider_backend = lease.backend
-        and artifact.archive_base64 = ${input.workspaceArchive}
+        and artifact.archive_base64 = ${inlineWorkspaceArchive}
         and artifact.descriptor_revision =
           coalesce(${input.workspaceArchiveMeta?.revision ?? null}, '')
         and artifact.state in ('candidate', 'delete_pending', 'delete_failed')
@@ -44333,7 +44334,7 @@ async function foldWorkspaceArchiveOntoLease(
             and artifact.source_instance_id = ${input.expectedInstanceId}
             and artifact.source_workspace_generation = lease.workspace_generation
             and artifact.provenance = 'native_capture'
-            and artifact.archive_base64 = ${input.workspaceArchive}
+            and artifact.archive_base64 = ${inlineWorkspaceArchive}
             and artifact.descriptor_revision =
               coalesce(${input.workspaceArchiveMeta?.revision ?? null}, '')
             and artifact.state in ('candidate', 'delete_pending', 'delete_failed')

--- a/packages/runtime/src/sandbox/browser-control-client.ts
+++ b/packages/runtime/src/sandbox/browser-control-client.ts
@@ -1592,9 +1592,7 @@ async function requestExposedController(
         /* metrics must not affect Channel B */
       }
     }
-    throw new BrowserControlTransportError(
-      `browser controller returned HTTP ${response.status}`,
-    );
+    throw new BrowserControlTransportError(`browser controller returned HTTP ${response.status}`);
   }
   return parseEnvelope(responseText, response.status);
 }

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -166,9 +166,10 @@ export type ChannelASession = {
   supportsPty?(): boolean;
   /** Provider-native directory listing. Channel A uses this for depth-1 Files
    *  trees when present so a slow exec data plane cannot stall the dock. */
-  listDir?(args: { path: string; runAs?: string }): Promise<
-    Array<{ name: string; path: string; type: "file" | "dir" | "other" }>
-  >;
+  listDir?(args: {
+    path: string;
+    runAs?: string;
+  }): Promise<Array<{ name: string; path: string; type: "file" | "dir" | "other" }>>;
 };
 
 export type WorkspaceFileImportRequest = {
@@ -2374,7 +2375,9 @@ export class SandboxChannelAService {
   private async fsListFromNativeListDir(req: FsListRequest): Promise<FsListResponse> {
     const listDir = this.session.listDir;
     if (!listDir) {
-      throw new ChannelAUnavailableError("Workspace files are temporarily unavailable. Retry the file list.");
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file list.",
+      );
     }
     const root = assertSafeRelPathOrRoot(req.path);
     const listed = await listDir({

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -1873,12 +1873,7 @@ export async function establishSandboxSessionFromEnvelope(
       const fallbackClient = (
         opts.clientFactory
           ? opts.clientFactory(backend, fallbackSettings, environment)
-          : createSandboxClientForBackend(
-              backend,
-              fallbackSettings,
-              environment,
-              opts.metrics,
-            )
+          : createSandboxClientForBackend(backend, fallbackSettings, environment, opts.metrics)
       ) as ResumeCapableClient | undefined;
       if (!fallbackClient?.create) {
         throw new SandboxConfigError(

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -154,7 +154,8 @@ function modalWorkspaceAbsolutePath(path: string, workspaceRoot: string): string
 
 function installModalListDirCompatibility(session: MutableModalSandboxSession): void {
   if (typeof session.listDir === "function") return;
-  if (typeof session.execCommand !== "function" || typeof session.readFile !== "function") return;
+  const execCommand = session.execCommand;
+  if (typeof execCommand !== "function" || typeof session.readFile !== "function") return;
   const workspaceRoot = session.state?.manifest?.root;
   if (!workspaceRoot) {
     throw new Error("Modal listDir compatibility requires a manifest workspace root");
@@ -162,8 +163,11 @@ function installModalListDirCompatibility(session: MutableModalSandboxSession): 
   session.listDir = async (args) => {
     const absoluteResultPaths = args.path.startsWith("/");
     const relativePath = modalWorkspaceRelativePath(args.path, workspaceRoot);
+    // This function is the provider's listDir compatibility surface. Do not
+    // pass it back into Channel A as a native accelerator or fsList() recurses
+    // into this shim instead of using Modal's command data plane.
     const service = new SandboxChannelAService({
-      session: session as ChannelASession,
+      session: { execCommand: execCommand.bind(session) },
       workspaceRoot,
       ...(args.runAs ? { runAs: args.runAs } : {}),
     });

--- a/packages/runtime/src/sandbox/providers/opensandbox-adapter.ts
+++ b/packages/runtime/src/sandbox/providers/opensandbox-adapter.ts
@@ -57,10 +57,7 @@ import { lstat, readFile as readLocalFile, readdir } from "node:fs/promises";
 import { posix } from "node:path";
 import { SandboxConfigError, SandboxExactResumeInstanceUnavailableError } from "../errors";
 import { nextDurableOpId } from "../op-correlation";
-import {
-  parseOpenSandboxSignedUriPath,
-  redactOpenSandboxSignedUriPath,
-} from "../stream-port";
+import { parseOpenSandboxSignedUriPath, redactOpenSandboxSignedUriPath } from "../stream-port";
 import type { RuntimeMetricsHooks } from "../../metrics";
 
 const WORKSPACE_ROOT = "/workspace";
@@ -294,9 +291,7 @@ function assertStateMatchesOptions(
 }
 
 function isAllowedPrivatePath(absolute: string): boolean {
-  return ALLOWED_PRIVATE_ROOTS.some(
-    (root) => absolute === root || absolute.startsWith(`${root}/`),
-  );
+  return ALLOWED_PRIVATE_ROOTS.some((root) => absolute === root || absolute.startsWith(`${root}/`));
 }
 
 function workspacePath(path: string, options: { allowPrivate?: boolean } = {}): string {
@@ -1374,7 +1369,8 @@ tar ${excludeArgs.join(" ")} --sort=name --mtime='@0' --owner=0 --group=0 --nume
         sandboxId: this.state.sandboxId,
         port,
         expiresAtSeconds: parsed?.expiresAtSeconds ?? null,
-        path: typeof resolved.path === "string" ? redactOpenSandboxSignedUriPath(resolved.path) : null,
+        path:
+          typeof resolved.path === "string" ? redactOpenSandboxSignedUriPath(resolved.path) : null,
       });
       if (signed) {
         recordSignedEndpointMetric(this.options.metrics, { outcome: "minted", port });
@@ -1441,9 +1437,7 @@ function endpointToExposedPort(
   // Channel B is browser → provider-tunnel direct. When we use the lifecycle
   // server proxy, rewrite the advertised host to the configured base URL so a
   // local port-forward (or in-cluster DNS) is what the viewer actually opens.
-  const url = rewriteToBaseUrl
-    ? new URL(`${reported.pathname}${reported.search}`, base)
-    : reported;
+  const url = rewriteToBaseUrl ? new URL(`${reported.pathname}${reported.search}`, base) : reported;
   const tls = url.protocol === "https:" || url.protocol === "wss:";
   return {
     host: url.hostname,

--- a/packages/runtime/src/sandbox/stream-port.ts
+++ b/packages/runtime/src/sandbox/stream-port.ts
@@ -161,8 +161,7 @@ export function joinExposedPortPath(endpointPath: string | undefined, requestPat
   return `${prefix}${requestPath}`;
 }
 
-const OPENSANDBOX_LIFECYCLE_PROXY_PATH =
-  /\/v1\/sandboxes\/[^/]+\/proxy\/\d+(?:\/|$)/u;
+const OPENSANDBOX_LIFECYCLE_PROXY_PATH = /\/v1\/sandboxes\/[^/]+\/proxy\/\d+(?:\/|$)/u;
 /** OSEP-0011 URI mode: `/{sandbox_id}/{port}/{expires_b36}/{signature}/…`. */
 const OPENSANDBOX_SIGNED_URI_PATH =
   /^\/([^/]{1,128})\/(\d{1,5})\/([0-9a-z]{1,13})\/([0-9a-z]{8,64})(?:\/|$)/iu;

--- a/packages/runtime/test/opensandbox-adapter.test.ts
+++ b/packages/runtime/test/opensandbox-adapter.test.ts
@@ -112,7 +112,11 @@ class FakeOpenSandbox {
       ) {
         self.executedCommands.push(command);
         const cwd = options?.workingDirectory;
-        if (cwd && !self.files.has(cwd) && ![...self.files.keys()].some((path) => path.startsWith(`${cwd}/`))) {
+        if (
+          cwd &&
+          !self.files.has(cwd) &&
+          ![...self.files.keys()].some((path) => path.startsWith(`${cwd}/`))
+        ) {
           throw new SandboxApiException({
             message: `invalid request, validation error working directory does not exist: ${cwd}: stat ${cwd}: no such file or directory`,
             statusCode: 400,

--- a/packages/runtime/test/stream-port.test.ts
+++ b/packages/runtime/test/stream-port.test.ts
@@ -113,9 +113,9 @@ describe("exposedPortAllowsHostFetch", () => {
         "ws://127.0.0.1:28888/sbx-1/7682/s6ph0/sigsigsig/v1/browser-sessions/x",
       ),
     ).toBe(true);
-    expect(
-      exposedPortAllowsHostFetch("ws://127.0.0.1:18090/v1/sandboxes/sbx-1/proxy/7682"),
-    ).toBe(false);
+    expect(exposedPortAllowsHostFetch("ws://127.0.0.1:18090/v1/sandboxes/sbx-1/proxy/7682")).toBe(
+      false,
+    );
     expect(
       exposedPortAllowsHostFetch({
         host: "127.0.0.1",
@@ -132,11 +132,17 @@ describe("exposedPortAllowsHostFetch", () => {
     expect(redactOpenSandboxSignedUriPath("/v1/sandboxes/sbx-1/proxy/7682")).toBe(
       "/v1/sandboxes/sbx-1/proxy/7682",
     );
-    expect(signedEndpointNeedsRefresh("/sbx-1/7682/s6ph0/sigsigsig", signed!.expiresAtSeconds * 1000 - 60_000)).toBe(
-      false,
-    );
     expect(
-      signedEndpointNeedsRefresh("/sbx-1/7682/s6ph0/sigsigsig", signed!.expiresAtSeconds * 1000 - 1_000),
+      signedEndpointNeedsRefresh(
+        "/sbx-1/7682/s6ph0/sigsigsig",
+        signed!.expiresAtSeconds * 1000 - 60_000,
+      ),
+    ).toBe(false);
+    expect(
+      signedEndpointNeedsRefresh(
+        "/sbx-1/7682/s6ph0/sigsigsig",
+        signed!.expiresAtSeconds * 1000 - 1_000,
+      ),
     ).toBe(true);
   });
 });

--- a/packages/runtime/test/workspace-archive.test.ts
+++ b/packages/runtime/test/workspace-archive.test.ts
@@ -272,19 +272,30 @@ describe("verified workspace archives", () => {
       mkdirSync(join(root, ".gnupg"), { recursive: true });
       writeFileSync(join(root, "retained.txt"), "retained");
       const run = () => {
-        const result = Bun.spawnSync(["/bin/bash", "-c", command.replace("cd /workspace", `cd ${shellQuote(root)}`)], {
-          stdout: "pipe",
-          stderr: "pipe",
-        });
+        const result = Bun.spawnSync(
+          ["/bin/bash", "-c", command.replace("cd /workspace", `cd ${shellQuote(root)}`)],
+          {
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        );
         expect(result.exitCode).toBe(0);
         return Buffer.from(result.stdout).toString("utf8");
       };
       const withoutSocket = run();
       const socketPath = join(root, ".gnupg", "S.gpg-agent");
-      const socket = Bun.spawnSync(["python3", "-c", "import socket, sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])", socketPath], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+      const socket = Bun.spawnSync(
+        [
+          "python3",
+          "-c",
+          "import socket, sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])",
+          socketPath,
+        ],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
       expect(socket.exitCode).toBe(0);
       expect(run()).toBe(withoutSocket);
     } finally {

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -106,7 +106,11 @@ const budgets = {
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2063 * kib,
+  // The OpenSandbox session work on current main measures 2,112,678 bytes in
+  // the Linux/x64 CI production build. Advance only the direct-session raw
+  // envelope to the next whole KiB; gzip, file-count, lazy, CSS, and all other
+  // graph limits stay fixed.
+  directSessionRaw: 2064 * kib,
   directSessionGzip: 575 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,

--- a/scripts/operator/opensandbox-conformance.ts
+++ b/scripts/operator/opensandbox-conformance.ts
@@ -83,9 +83,7 @@ async function main(): Promise<void> {
     ttlSeconds: args.ttlSeconds,
     useServerProxy: true,
     signedEndpoints: args.signedEndpoints,
-    ...(args.channelBPublicBaseUrl
-      ? { channelBPublicBaseUrl: args.channelBPublicBaseUrl }
-      : {}),
+    ...(args.channelBPublicBaseUrl ? { channelBPublicBaseUrl: args.channelBPublicBaseUrl } : {}),
     readyTimeoutSeconds: args.readyTimeoutSeconds,
     resourceLimits: { cpu: "1", memory: "1Gi" },
     resourceRequests: { cpu: "250m", memory: "512Mi" },

--- a/scripts/operator/opensandbox-inject-secure-access-runtime-config.ts
+++ b/scripts/operator/opensandbox-inject-secure-access-runtime-config.ts
@@ -59,7 +59,10 @@ type DeploymentDoc = {
 };
 
 function isServerDeploymentRaw(document: string): boolean {
-  return /^\s*kind:\s*Deployment\s*$/mu.test(document) && /^\s*name:\s*opensandbox-server\s*$/mu.test(document);
+  return (
+    /^\s*kind:\s*Deployment\s*$/mu.test(document) &&
+    /^\s*name:\s*opensandbox-server\s*$/mu.test(document)
+  );
 }
 
 function secretEnv(container: Container, name: string): EnvVar {
@@ -70,7 +73,10 @@ function secretEnv(container: Container, name: string): EnvVar {
   return { name: found.name, valueFrom: { secretKeyRef: { ...found.valueFrom.secretKeyRef } } };
 }
 
-function upsertVolume(volumes: Array<Record<string, unknown>>, volume: Record<string, unknown>): Array<Record<string, unknown>> {
+function upsertVolume(
+  volumes: Array<Record<string, unknown>>,
+  volume: Record<string, unknown>,
+): Array<Record<string, unknown>> {
   const name = volume.name;
   return [...volumes.filter((entry) => entry.name !== name), volume];
 }
@@ -83,7 +89,9 @@ export function injectSecureAccessRuntimeConfig(doc: DeploymentDoc): DeploymentD
   const spec = doc.spec?.template?.spec;
   const main = spec?.containers?.find((container) => container.name === "main");
   if (!spec || !main?.image) {
-    throw new Error("opensandbox-server Deployment is missing spec.template.spec.containers[name=main]");
+    throw new Error(
+      "opensandbox-server Deployment is missing spec.template.spec.containers[name=main]",
+    );
   }
 
   const hasSecureAccessEnv = (main.env ?? []).some(
@@ -119,12 +127,16 @@ export function injectSecureAccessRuntimeConfig(doc: DeploymentDoc): DeploymentD
     ],
   };
 
-  const otherInits = (spec.initContainers ?? []).filter((container) => container.name !== INIT_NAME);
+  const otherInits = (spec.initContainers ?? []).filter(
+    (container) => container.name !== INIT_NAME,
+  );
   spec.initContainers = [...otherInits, initContainer];
 
   main.args = ["--config", RUNTIME_CONFIG_PATH];
   main.env = (main.env ?? []).map((entry) =>
-    entry.name === "SANDBOX_CONFIG_PATH" ? { name: "SANDBOX_CONFIG_PATH", value: RUNTIME_CONFIG_PATH } : entry,
+    entry.name === "SANDBOX_CONFIG_PATH"
+      ? { name: "SANDBOX_CONFIG_PATH", value: RUNTIME_CONFIG_PATH }
+      : entry,
   );
   main.volumeMounts = upsertMount(main.volumeMounts ?? [], {
     name: RUNTIME_VOLUME,
@@ -148,7 +160,9 @@ export function rewriteOpenSandboxManifests(raw: string): string {
     if (!isServerDeploymentRaw(body) && !isServerDeploymentRaw(chunk)) {
       return chunk;
     }
-    const parsed = Bun.YAML.parse(body.startsWith("kind:") || body.startsWith("apiVersion:") ? body : chunk) as DeploymentDoc | DeploymentDoc[];
+    const parsed = Bun.YAML.parse(
+      body.startsWith("kind:") || body.startsWith("apiVersion:") ? body : chunk,
+    ) as DeploymentDoc | DeploymentDoc[];
     const doc = Array.isArray(parsed) ? parsed[0] : parsed;
     if (!doc || doc.kind !== "Deployment" || doc.metadata?.name !== "opensandbox-server") {
       return chunk;

--- a/scripts/operator/opensandbox-operator.test.ts
+++ b/scripts/operator/opensandbox-operator.test.ts
@@ -132,9 +132,13 @@ describe("OpenSandbox operator harnesses", () => {
       "OPENSANDBOX_INGRESS_IMAGE=docker.io/opensandbox/ingress@sha256:450cdae23c7987e6b4974e56577f9569cc0eb7e48e54eff88c11f023db3b35b4",
     );
     const rendered = await new Promise<string>((resolvePromise, reject) => {
-      const child = spawn("bash", [resolve(import.meta.dir, "opensandbox-image-post-renderer.sh")], {
-        cwd: resolve(import.meta.dir, "../.."),
-      });
+      const child = spawn(
+        "bash",
+        [resolve(import.meta.dir, "opensandbox-image-post-renderer.sh")],
+        {
+          cwd: resolve(import.meta.dir, "../.."),
+        },
+      );
       let stdout = "";
       let stderr = "";
       child.stdout.on("data", (chunk) => {
@@ -166,16 +170,20 @@ describe("OpenSandbox operator harnesses", () => {
       source,
       `[ingress]\nmode = "gateway"\n\ngateway.address = "gw.example"\ngateway.route.mode = "uri"\n`,
     );
-    const child = spawn("python3", [resolve(import.meta.dir, "opensandbox-materialize-secure-access-config.py")], {
-      cwd: dir,
-      env: {
-        ...process.env,
-        SANDBOX_CONFIG_PATH: source,
-        OPENSANDBOX_RUNTIME_CONFIG_PATH: dest,
-        OPENSANDBOX_SECURE_ACCESS_KEYS: "a=dGVzdC1rZXktYnl0ZXMtZm9yLXVuaXQ=",
-        OPENSANDBOX_SECURE_ACCESS_ACTIVE_KEY: "a",
+    const child = spawn(
+      "python3",
+      [resolve(import.meta.dir, "opensandbox-materialize-secure-access-config.py")],
+      {
+        cwd: dir,
+        env: {
+          ...process.env,
+          SANDBOX_CONFIG_PATH: source,
+          OPENSANDBOX_RUNTIME_CONFIG_PATH: dest,
+          OPENSANDBOX_SECURE_ACCESS_KEYS: "a=dGVzdC1rZXktYnl0ZXMtZm9yLXVuaXQ=",
+          OPENSANDBOX_SECURE_ACCESS_ACTIVE_KEY: "a",
+        },
       },
-    });
+    );
     const stderr = await new Promise<string>((resolvePromise, reject) => {
       let out = "";
       let err = "";
@@ -242,9 +250,13 @@ metadata:
   name: opensandbox-server
 `;
     const rendered = await new Promise<string>((resolvePromise, reject) => {
-      const child = spawn("bash", [resolve(import.meta.dir, "opensandbox-image-post-renderer.sh")], {
-        cwd: resolve(import.meta.dir, "../.."),
-      });
+      const child = spawn(
+        "bash",
+        [resolve(import.meta.dir, "opensandbox-image-post-renderer.sh")],
+        {
+          cwd: resolve(import.meta.dir, "../.."),
+        },
+      );
       let stdout = "";
       let stderr = "";
       child.stdout.on("data", (chunk) => {

--- a/scripts/operator/opensandbox-signed-endpoint-proof.ts
+++ b/scripts/operator/opensandbox-signed-endpoint-proof.ts
@@ -23,7 +23,8 @@ const IMAGE =
   process.env.OPENGENI_OPENSANDBOX_IMAGE ??
   "ogosbpreview1c91.azurecr.io/opengeni-sandbox@sha256:2723fb371ae8de327f50fa0b10a33fdc921056afabfdacc22c804d9924e614c6";
 const BASE_URL = process.env.OPENGENI_OPENSANDBOX_BASE_URL ?? "http://127.0.0.1:18090";
-const PUBLIC_BASE = process.env.OPENGENI_OPENSANDBOX_CHANNEL_B_PUBLIC_BASE_URL ?? "http://127.0.0.1:28888";
+const PUBLIC_BASE =
+  process.env.OPENGENI_OPENSANDBOX_CHANNEL_B_PUBLIC_BASE_URL ?? "http://127.0.0.1:28888";
 const BEARER = "m2-browserd-token";
 const SUBPROTOCOL = "opengeni.test.subprotocol";
 const OUT = ".agent/generated/opensandbox/signed-endpoint-proof.json";
@@ -167,86 +168,87 @@ try {
     return { sandboxId };
   });
   if (created && session) {
-  await step("start-http-auth-server", async () => {
-    await session!.writeFile({ path: "m2-http.py", content: HTTP_PY });
-    const retained = await runWithToolCallCorrelation("m2-http", () =>
-      session!.exec({ cmd: "python3 /workspace/m2-http.py", yieldTimeMs: 0 }),
-    );
-    if (retained.sessionId === undefined) throw new Error("HTTP server did not yield");
-    return { sessionId: retained.sessionId };
-  });
-  await step("start-ws-subprotocol-server", async () => {
-    await session!.writeFile({ path: "m2-ws.py", content: WS_PY });
-    const retained = await runWithToolCallCorrelation("m2-ws", () =>
-      session!.exec({ cmd: "python3 /workspace/m2-ws.py", yieldTimeMs: 0 }),
-    );
-    if (retained.sessionId === undefined) throw new Error("WS server did not yield");
-    return { sessionId: retained.sessionId };
-  });
-  await step("signed-http-authorization", async () => {
-    const endpoint = await session!.resolveExposedPort(8080);
-    const url = endpoint.url!;
-    const path = new URL(url).pathname;
-    if (isLifecycleProxy(path)) throw new Error(`lifecycle proxy path ${path}`);
-    if (!isSignedUri(path)) throw new Error(`not OSEP URI: ${path}`);
-    if (new URL(url).host !== "127.0.0.1:28888") throw new Error(`host rewrite failed: ${url}`);
-    const denied = await retry(30_000, async () => {
-      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
-      if (response.status !== 401) throw new Error(`expected 401 without bearer, got ${response.status}`);
-      return response.status;
+    await step("start-http-auth-server", async () => {
+      await session!.writeFile({ path: "m2-http.py", content: HTTP_PY });
+      const retained = await runWithToolCallCorrelation("m2-http", () =>
+        session!.exec({ cmd: "python3 /workspace/m2-http.py", yieldTimeMs: 0 }),
+      );
+      if (retained.sessionId === undefined) throw new Error("HTTP server did not yield");
+      return { sessionId: retained.sessionId };
     });
-    const allowed = await retry(15_000, async () => {
-      const response = await fetch(url, {
-        headers: { authorization: `Bearer ${BEARER}` },
-        signal: AbortSignal.timeout(5_000),
+    await step("start-ws-subprotocol-server", async () => {
+      await session!.writeFile({ path: "m2-ws.py", content: WS_PY });
+      const retained = await runWithToolCallCorrelation("m2-ws", () =>
+        session!.exec({ cmd: "python3 /workspace/m2-ws.py", yieldTimeMs: 0 }),
+      );
+      if (retained.sessionId === undefined) throw new Error("WS server did not yield");
+      return { sessionId: retained.sessionId };
+    });
+    await step("signed-http-authorization", async () => {
+      const endpoint = await session!.resolveExposedPort(8080);
+      const url = endpoint.url!;
+      const path = new URL(url).pathname;
+      if (isLifecycleProxy(path)) throw new Error(`lifecycle proxy path ${path}`);
+      if (!isSignedUri(path)) throw new Error(`not OSEP URI: ${path}`);
+      if (new URL(url).host !== "127.0.0.1:28888") throw new Error(`host rewrite failed: ${url}`);
+      const denied = await retry(30_000, async () => {
+        const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+        if (response.status !== 401)
+          throw new Error(`expected 401 without bearer, got ${response.status}`);
+        return response.status;
       });
-      const body = await response.text();
-      if (!response.ok || !body.includes('"ok":true')) {
-        throw new Error(`bearer fetch failed ${response.status} ${body.slice(0, 200)}`);
+      const allowed = await retry(15_000, async () => {
+        const response = await fetch(url, {
+          headers: { authorization: `Bearer ${BEARER}` },
+          signal: AbortSignal.timeout(5_000),
+        });
+        const body = await response.text();
+        if (!response.ok || !body.includes('"ok":true')) {
+          throw new Error(`bearer fetch failed ${response.status} ${body.slice(0, 200)}`);
+        }
+        return body;
+      });
+      return {
+        path: redactPath(path),
+        unauthorizedStatus: denied,
+        authorizedBody: allowed,
+        lifecycleProxy: false,
+      };
+    });
+    await step("signed-websocket-subprotocol", async () => {
+      const endpoint = await session!.resolveExposedPort(8765);
+      const url = endpoint.url!.replace(/^http/u, "ws");
+      const path = new URL(url).pathname;
+      if (isLifecycleProxy(path)) throw new Error(`lifecycle proxy path ${path}`);
+      if (!isSignedUri(path)) throw new Error(`not OSEP URI: ${path}`);
+      const result = await retry(30_000, async () => {
+        return await new Promise<{ protocol: string; message: string }>((resolve, reject) => {
+          const ws = new WebSocket(url, [SUBPROTOCOL]);
+          const timer = setTimeout(() => {
+            ws.close();
+            reject(new Error("websocket timeout"));
+          }, 8_000);
+          ws.addEventListener("open", () => {
+            /* wait for payload */
+          });
+          ws.addEventListener("message", (event) => {
+            clearTimeout(timer);
+            const message = typeof event.data === "string" ? event.data : String(event.data);
+            const protocol = ws.protocol;
+            ws.close();
+            resolve({ protocol, message });
+          });
+          ws.addEventListener("error", () => {
+            clearTimeout(timer);
+            reject(new Error(`websocket error protocol=${ws.protocol}`));
+          });
+        });
+      });
+      if (result.protocol !== SUBPROTOCOL) {
+        throw new Error(`subprotocol not preserved: ${result.protocol || "<empty>"}`);
       }
-      return body;
+      return { path: redactPath(path), ...result };
     });
-    return {
-      path: redactPath(path),
-      unauthorizedStatus: denied,
-      authorizedBody: allowed,
-      lifecycleProxy: false,
-    };
-  });
-  await step("signed-websocket-subprotocol", async () => {
-    const endpoint = await session!.resolveExposedPort(8765);
-    const url = endpoint.url!.replace(/^http/u, "ws");
-    const path = new URL(url).pathname;
-    if (isLifecycleProxy(path)) throw new Error(`lifecycle proxy path ${path}`);
-    if (!isSignedUri(path)) throw new Error(`not OSEP URI: ${path}`);
-    const result = await retry(30_000, async () => {
-      return await new Promise<{ protocol: string; message: string }>((resolve, reject) => {
-        const ws = new WebSocket(url, [SUBPROTOCOL]);
-        const timer = setTimeout(() => {
-          ws.close();
-          reject(new Error("websocket timeout"));
-        }, 8_000);
-        ws.addEventListener("open", () => {
-          /* wait for payload */
-        });
-        ws.addEventListener("message", (event) => {
-          clearTimeout(timer);
-          const message = typeof event.data === "string" ? event.data : String(event.data);
-          const protocol = ws.protocol;
-          ws.close();
-          resolve({ protocol, message });
-        });
-        ws.addEventListener("error", () => {
-          clearTimeout(timer);
-          reject(new Error(`websocket error protocol=${ws.protocol}`));
-        });
-      });
-    });
-    if (result.protocol !== SUBPROTOCOL) {
-      throw new Error(`subprotocol not preserved: ${result.protocol || "<empty>"}`);
-    }
-    return { path: redactPath(path), ...result };
-  });
   }
 } finally {
   await (session as OpenSandboxSession | null)?.delete().catch(() => undefined);

--- a/scripts/operator/opensandbox-signed-endpoint-proof.ts
+++ b/scripts/operator/opensandbox-signed-endpoint-proof.ts
@@ -1,5 +1,5 @@
 /**
- * Dossier §16 / §22 Channel B signed-endpoint proof.
+ * OpenSandbox Channel B signed-endpoint proof.
  *
  * Mints OSEP-0011 signed URIs against a live OpenSandbox box and proves:
  *   - JSON host-fetch forwards the browserd Bearer (not lifecycle `/proxy/`)


### PR DESCRIPTION
Summary:
- format the OpenSandbox changes already landed on main
- update the computer-session route contract for signed-endpoint options
- advance only the direct-session raw bundle envelope by one KiB

Validation:
- bun run format:check
- bun run lint
- bun run typecheck
- targeted API, runtime, contract, and operator tests
- bun run --cwd apps/web build