### PR TITLE
fix(runtime): make repository clone origin/HEAD best-effort for non-branch refs

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8942,7 +8942,7 @@ export function repositoryCloneCommand(
     // refs/remotes/origin/, so a PR ref (pull/N/head), a tag, or a commit SHA
     // must not turn a successful fetch into a failed clone.
     '  if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref" >/dev/null; then',
-    '    git -C "$tmp" remote set-head origin "$ref" >/dev/null',
+    '    git -C "$tmp" remote set-head origin "$ref" >/dev/null || true',
     "  fi",
     '  if ! git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; then',
     '    rm -rf "$tmp"',

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8931,7 +8931,20 @@ export function repositoryCloneCommand(
     '  rm -rf "$tmp"',
     // Fetch failures must not leak the pid-suffixed tmp clone beside the mount
     // (set -eu would exit before any cleanup).
-    '  if ! { git init "$tmp" >/dev/null && git -C "$tmp" remote add origin "$uri" && git -C "$tmp" fetch --depth 1 --no-tags --filter=blob:none origin "$ref" && git -C "$tmp" remote set-head origin "$ref" && git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; }; then',
+    '  if ! { git init "$tmp" >/dev/null && git -C "$tmp" remote add origin "$uri" && git -C "$tmp" fetch --depth 1 --no-tags --filter=blob:none origin "$ref"; }; then',
+    '    rm -rf "$tmp"',
+    '    echo "Repository resource fetch failed for $target" >&2',
+    "    exit 1",
+    "  fi",
+    // origin/HEAD is best-effort: workspace capture diffs the branch against it
+    // when present and already treats a missing origin/HEAD as additive. `git
+    // remote set-head` only accepts a branch that the fetch materialized under
+    // refs/remotes/origin/, so a PR ref (pull/N/head), a tag, or a commit SHA
+    // must not turn a successful fetch into a failed clone.
+    '  if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref" >/dev/null; then',
+    '    git -C "$tmp" remote set-head origin "$ref" >/dev/null',
+    "  fi",
+    '  if ! git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; then',
     '    rm -rf "$tmp"',
     '    echo "Repository resource fetch failed for $target" >&2',
     "    exit 1",

--- a/packages/runtime/test/lifecycle-scripts.test.ts
+++ b/packages/runtime/test/lifecycle-scripts.test.ts
@@ -1087,7 +1087,7 @@ describe("lifecycle scripts — real sh execution semantics", () => {
       line.includes('if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref"'),
     );
     const setHeadIndex = lines.findIndex((line) =>
-      line.includes('git -C "$tmp" remote set-head origin "$ref"'),
+      line.includes('git -C "$tmp" remote set-head origin "$ref" >/dev/null || true'),
     );
     const checkoutIndex = lines.findIndex((line) =>
       line.includes('if ! git -C "$tmp" checkout --detach FETCH_HEAD'),
@@ -1098,7 +1098,9 @@ describe("lifecycle scripts — real sh execution semantics", () => {
     expect(setHeadIndex).toBe(guardIndex + 1);
     expect(lines[setHeadIndex + 1]).toBe("  fi");
     expect(checkoutIndex).toBeGreaterThan(setHeadIndex);
-    // set-head never shares the failure gate with fetch or checkout.
+    // set-head never shares the failure gate with fetch or checkout, and an
+    // unexpected set-head failure after the guard cannot exit the set -e shell.
+    expect(lines[setHeadIndex].trim().endsWith("|| true")).toBe(true);
     expect(lines[fetchIndex]).not.toContain("set-head");
     expect(lines[checkoutIndex]).not.toContain("set-head");
     expect(lines[setHeadIndex]).not.toContain("exit 1");
@@ -1109,7 +1111,7 @@ describe("lifecycle scripts — real sh execution semantics", () => {
     ).toHaveLength(2);
   });
 
-  test("clone by branch sets origin/HEAD; PR ref and commit SHA clone without origin/HEAD (previously set-head failed the clone)", () => {
+  test("clone by branch sets origin/HEAD; PR ref, tag, and commit SHA clone without origin/HEAD (previously set-head failed the clone)", () => {
     const root = mkdtempSync(join(tmpdir(), "opengeni-clone-"));
     try {
       const origin = makeOrigin(root);
@@ -1118,12 +1120,15 @@ describe("lifecycle scripts — real sh execution semantics", () => {
       }).trim();
       // GitHub-style PR ref outside refs/heads/: fetchable, never remote-tracked.
       execFileSync("git", ["-C", origin, "update-ref", "refs/pull/1/head", sha]);
+      // Lightweight tag: fetched by short name, never under refs/remotes/origin/.
+      execFileSync("git", ["-C", origin, "tag", "v1.0", sha]);
       const home = join(root, "home");
       mkdirSync(home, { recursive: true });
       const env = { HOME: home };
       const cases: { ref: string; expectOriginHead: boolean }[] = [
         { ref: "main", expectOriginHead: true },
         { ref: "pull/1/head", expectOriginHead: false },
+        { ref: "v1.0", expectOriginHead: false },
         { ref: sha, expectOriginHead: false },
       ];
       for (const [index, { ref, expectOriginHead }] of cases.entries()) {

--- a/packages/runtime/test/lifecycle-scripts.test.ts
+++ b/packages/runtime/test/lifecycle-scripts.test.ts
@@ -49,6 +49,7 @@ describe("lifecycle scripts — real sh execution semantics", () => {
       githubInstallationId: 123,
       githubRepositoryId: 456,
     },
+    ref = "main",
   ): string {
     const generated = repositoryCloneCommand([
       { ...resource, mountPath: resource.mountPath ?? "repos/test/repository" },
@@ -60,7 +61,7 @@ describe("lifecycle scripts — real sh execution semantics", () => {
           !line.startsWith("start_repository_clone '") && line !== "wait_repository_clone_batch",
       )
       .join("\n");
-    return `${withoutInvocations}\nclone_repository '${target}' '${uri}' 'main' ''`;
+    return `${withoutInvocations}\nclone_repository '${target}' '${uri}' '${ref}' ''`;
   }
 
   function setupScript(
@@ -1064,6 +1065,98 @@ describe("lifecycle scripts — real sh execution semantics", () => {
       expect(
         existsSync(parent) ? readdirSync(parent).filter((f) => f.includes(".tmp.")) : [],
       ).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("clone script guards origin/HEAD behind the remote-tracking ref check and keeps fetch + checkout failure-gated", () => {
+    const command = repositoryCloneCommand([
+      {
+        kind: "repository",
+        uri: "https://github.com/acme/repo.git",
+        ref: "pull/1720/head",
+        mountPath: "repos/github.com/acme/repo",
+      },
+    ]);
+    const lines = command.split("\n");
+    const fetchIndex = lines.findIndex((line) =>
+      line.includes('git -C "$tmp" fetch --depth 1 --no-tags --filter=blob:none origin "$ref"'),
+    );
+    const guardIndex = lines.findIndex((line) =>
+      line.includes('if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref"'),
+    );
+    const setHeadIndex = lines.findIndex((line) =>
+      line.includes('git -C "$tmp" remote set-head origin "$ref"'),
+    );
+    const checkoutIndex = lines.findIndex((line) =>
+      line.includes('if ! git -C "$tmp" checkout --detach FETCH_HEAD'),
+    );
+
+    expect(fetchIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeGreaterThan(fetchIndex);
+    expect(setHeadIndex).toBe(guardIndex + 1);
+    expect(lines[setHeadIndex + 1]).toBe("  fi");
+    expect(checkoutIndex).toBeGreaterThan(setHeadIndex);
+    // set-head never shares the failure gate with fetch or checkout.
+    expect(lines[fetchIndex]).not.toContain("set-head");
+    expect(lines[checkoutIndex]).not.toContain("set-head");
+    expect(lines[setHeadIndex]).not.toContain("exit 1");
+    expect(
+      lines.filter((line) =>
+        line.includes('echo "Repository resource fetch failed for $target" >&2'),
+      ),
+    ).toHaveLength(2);
+  });
+
+  test("clone by branch sets origin/HEAD; PR ref and commit SHA clone without origin/HEAD (previously set-head failed the clone)", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-clone-"));
+    try {
+      const origin = makeOrigin(root);
+      const sha = execFileSync("git", ["-C", origin, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim();
+      // GitHub-style PR ref outside refs/heads/: fetchable, never remote-tracked.
+      execFileSync("git", ["-C", origin, "update-ref", "refs/pull/1/head", sha]);
+      const home = join(root, "home");
+      mkdirSync(home, { recursive: true });
+      const env = { HOME: home };
+      const cases: { ref: string; expectOriginHead: boolean }[] = [
+        { ref: "main", expectOriginHead: true },
+        { ref: "pull/1/head", expectOriginHead: false },
+        { ref: sha, expectOriginHead: false },
+      ];
+      for (const [index, { ref, expectOriginHead }] of cases.entries()) {
+        const target = join(root, "ws", "repos", "acme", `repo-${index}`);
+        const run = runScript(
+          cloneScriptWithTarget(target, `file://${origin}`, undefined, ref),
+          env,
+        );
+        expect({ ref, status: run.status, output: run.output }).toEqual({
+          ref,
+          status: 0,
+          output: expect.stringContaining(`Repository resource ready at ${target}`),
+        });
+        expect(existsSync(join(target, "README.md"))).toBe(true);
+        expect(
+          execFileSync("git", ["-C", target, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+        ).toBe(sha);
+        const originHead = (() => {
+          try {
+            return execFileSync(
+              "git",
+              ["-C", target, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD"],
+              { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+            ).trim();
+          } catch {
+            return null;
+          }
+        })();
+        expect({ ref, originHead }).toEqual({ ref, originHead: expectOriginHead ? sha : null });
+        expect(
+          readdirSync(join(root, "ws", "repos", "acme")).filter((f) => f.includes(".tmp.")),
+        ).toEqual([]);
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4035,6 +4035,14 @@ describe("runtime event normalization", () => {
     expect(command).toContain(
       'git -C "$tmp" fetch --depth 1 --no-tags --filter=blob:none origin "$ref"',
     );
+    // origin/HEAD is best-effort (branch refs only); a PR ref, tag, or SHA must not
+    // fail the clone because `remote set-head` rejects it.
+    expect(command).toContain(
+      'if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref" >/dev/null; then',
+    );
+    expect(command).toContain('git -C "$tmp" remote set-head origin "$ref" >/dev/null');
+    expect(command).toContain('if ! git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; then');
+    expect(command).not.toContain('origin "$ref" && git -C "$tmp" remote set-head');
     expect(command).toContain('git -C "$target" rev-parse --is-inside-work-tree >/dev/null');
     expect(command).toContain("Repository resource ready at $target");
     expect(command).toContain("ensure_git");

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4040,7 +4040,7 @@ describe("runtime event normalization", () => {
     expect(command).toContain(
       'if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref" >/dev/null; then',
     );
-    expect(command).toContain('git -C "$tmp" remote set-head origin "$ref" >/dev/null');
+    expect(command).toContain('git -C "$tmp" remote set-head origin "$ref" >/dev/null || true');
     expect(command).toContain('if ! git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; then');
     expect(command).not.toContain('origin "$ref" && git -C "$tmp" remote set-head');
     expect(command).toContain('git -C "$target" rev-parse --is-inside-work-tree >/dev/null');


### PR DESCRIPTION
## Problem

A child session with repository resource `{ uri: ".../opengeni.git", ref: "pull/1720/head" }` failed during sandbox setup:

```
Repository clone hook failed with exit code 1: ... * branch refs/pull/1720/head -> FETCH_HEAD
error: Not a valid ref: refs/remotes/origin/pull/1720/head
Repository resource fetch failed for /workspace/repos/github.com/Cloudgeni-ai/opengeni
```

`repositoryCloneCommand` (`packages/runtime/src/index.ts`) ran `git remote set-head origin "$ref"` inside the same `if ! { ... }` failure gate as fetch and checkout. `set-head` only accepts a branch that the fetch materialized under `refs/remotes/origin/`; for a PR ref, a tag, or a commit SHA the fetch succeeds (FETCH_HEAD is fine) but set-head fails and the whole clone is reported as failed. set-head was added in #1157 so `origin/HEAD` exists for workspace-capture branch diffs, which already treat a missing `origin/HEAD` as additive.

## Fix

Fetch + checkout stay the failure-gated core (same `set -eu`, same tmp-dir cleanup, same `Repository resource fetch failed for $target` message, still `exit 1`). `origin/HEAD` is best-effort: set-head runs only when `git rev-parse --verify --quiet "refs/remotes/origin/$ref"` succeeds, otherwise it is skipped silently.

```sh
if ! { git init "$tmp" >/dev/null && git -C "$tmp" remote add origin "$uri" && git -C "$tmp" fetch --depth 1 --no-tags --filter=blob:none origin "$ref"; }; then
  rm -rf "$tmp"
  echo "Repository resource fetch failed for $target" >&2
  exit 1
fi
if git -C "$tmp" rev-parse --verify --quiet "refs/remotes/origin/$ref" >/dev/null; then
  git -C "$tmp" remote set-head origin "$ref" >/dev/null
fi
if ! git -C "$tmp" checkout --detach FETCH_HEAD >/dev/null; then
  rm -rf "$tmp"
  echo "Repository resource fetch failed for $target" >&2
  exit 1
fi
```

The subpath extraction path shares the same fetch and is unchanged. The OpenSandbox adapter's `git_repo` materialization uses `git clone --no-checkout` + fetch + `checkout --detach FETCH_HEAD` without set-head, so it was never affected.

## Tests

- `packages/runtime/test/lifecycle-scripts.test.ts`: string-shape test that set-head is guarded behind the rev-parse check and no longer shares the failure gate; real-`sh` test with a local origin that clones by branch (`origin/HEAD` set), by a `refs/pull/1/head` custom ref, and by full SHA (both succeed, HEAD at the commit, no `origin/HEAD`, no leaked `.tmp.` clone).
- `packages/runtime/test/runtime.test.ts`: pinned the new command shape.
- `bun test packages/runtime/test/lifecycle-scripts.test.ts` (19 pass), `bun test packages/runtime/test/runtime.test.ts` (281 pass), `tsc --noEmit -p packages/runtime` clean.

Docs do not describe the clone hook's origin/HEAD behaviour, so no doc change; the rationale lives in the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
