### PR TITLE
fix(runtime): preserve published tools on deferred setup failure

### DIFF
--- a/.changeset/fix-deferred-tool-cleanup-ownership.md
+++ b/.changeset/fix-deferred-tool-cleanup-ownership.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Keep already-published eager and in-process model tool servers alive when deferred MCP preparation fails, so recovery surfaces the original preparation error and finalization still releases every resource exactly once.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3747,6 +3747,7 @@ export async function prepareAgentTools(
       }),
     );
   }
+  const exposesDeferredPreparation = deferNonEager && deferredEntries.length > 0;
   const completePreparation = async (): Promise<PreparedAgentTools> => {
     let attemptToolEnvironment: AttemptToolEnvironment | null = null;
     try {
@@ -3807,11 +3808,17 @@ export async function prepareAgentTools(
         codexConnectorNamespaces,
       };
     } catch (error) {
-      await localToolServer?.close().catch(() => undefined);
+      // In deferred mode the eager and in-process servers have already been
+      // published to the Agent. The provisional PreparedAgentTools below owns
+      // them until turn finalization; a background preparation failure may
+      // clean up only resources acquired by that deferred preparation.
+      if (!exposesDeferredPreparation) {
+        await localToolServer?.close().catch(() => undefined);
+        await connectedEagerBestEffort?.close().catch(() => undefined);
+        await connectedEagerRequired?.close().catch(() => undefined);
+      }
       await connectedDeferredBestEffort?.close().catch(() => undefined);
       await connectedDeferredRequired?.close().catch(() => undefined);
-      await connectedEagerBestEffort?.close().catch(() => undefined);
-      await connectedEagerRequired?.close().catch(() => undefined);
       throw error;
     }
   };
@@ -3863,8 +3870,19 @@ export async function prepareAgentTools(
     attemptToolEnvironment: null,
     resolvedMcpConnectionIds,
     close: async () => {
-      const prepared = await ready;
-      await prepared.close();
+      try {
+        const prepared = await ready;
+        await prepared.close();
+      } catch (error) {
+        // completePreparation already released any deferred resources. The
+        // provisional owner must still release the eager and in-process
+        // servers that remained live so the Agent could observe the original
+        // preparation failure instead of a synthetic "server is closed" race.
+        await localToolServer?.close().catch(() => undefined);
+        await connectedEagerBestEffort?.close().catch(() => undefined);
+        await connectedEagerRequired?.close().catch(() => undefined);
+        throw error;
+      }
     },
     codexConnectorNamespaces,
     ready,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3748,6 +3748,11 @@ export async function prepareAgentTools(
     );
   }
   const exposesDeferredPreparation = deferNonEager && deferredEntries.length > 0;
+  const closePublishedServers = async (): Promise<void> => {
+    await localToolServer?.close().catch(() => undefined);
+    await connectedEagerBestEffort?.close().catch(() => undefined);
+    await connectedEagerRequired?.close().catch(() => undefined);
+  };
   const completePreparation = async (): Promise<PreparedAgentTools> => {
     let attemptToolEnvironment: AttemptToolEnvironment | null = null;
     try {
@@ -3813,9 +3818,7 @@ export async function prepareAgentTools(
       // them until turn finalization; a background preparation failure may
       // clean up only resources acquired by that deferred preparation.
       if (!exposesDeferredPreparation) {
-        await localToolServer?.close().catch(() => undefined);
-        await connectedEagerBestEffort?.close().catch(() => undefined);
-        await connectedEagerRequired?.close().catch(() => undefined);
+        await closePublishedServers();
       }
       await connectedDeferredBestEffort?.close().catch(() => undefined);
       await connectedDeferredRequired?.close().catch(() => undefined);
@@ -3840,13 +3843,27 @@ export async function prepareAgentTools(
     },
   );
   void ready.catch(() => undefined);
-  await Promise.all(
-    [...(connectedEagerRequired?.active ?? []), ...(connectedEagerBestEffort?.active ?? [])].map(
-      async (server) => {
-        if (server instanceof PrefixedMcpServer) await server.freezeTools();
-      },
-    ),
-  );
+  try {
+    await Promise.all(
+      [...(connectedEagerRequired?.active ?? []), ...(connectedEagerBestEffort?.active ?? [])].map(
+        async (server) => {
+          if (server instanceof PrefixedMcpServer) await server.freezeTools();
+        },
+      ),
+    );
+  } catch (error) {
+    // Publication did not complete, so no caller can own these resources.
+    // Join the bounded deferred preparation and let its complete owner close
+    // every server when available; if preparation itself failed, it already
+    // released deferred resources and this scope still owns eager/local ones.
+    const fullyPrepared = await ready.catch(() => null);
+    if (fullyPrepared) {
+      await fullyPrepared.close().catch(() => undefined);
+    } else {
+      await closePublishedServers();
+    }
+    throw error;
+  }
 
   const deferredServers = deferredEntries.map(
     (entry) =>
@@ -3870,19 +3887,18 @@ export async function prepareAgentTools(
     attemptToolEnvironment: null,
     resolvedMcpConnectionIds,
     close: async () => {
+      let prepared: PreparedAgentTools;
       try {
-        const prepared = await ready;
-        await prepared.close();
+        prepared = await ready;
       } catch (error) {
         // completePreparation already released any deferred resources. The
         // provisional owner must still release the eager and in-process
         // servers that remained live so the Agent could observe the original
         // preparation failure instead of a synthetic "server is closed" race.
-        await localToolServer?.close().catch(() => undefined);
-        await connectedEagerBestEffort?.close().catch(() => undefined);
-        await connectedEagerRequired?.close().catch(() => undefined);
+        await closePublishedServers();
         throw error;
       }
+      await prepared.close();
     },
     codexConnectorNamespaces,
     ready,

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -8078,6 +8078,137 @@ describe("runtime event normalization", () => {
     }
   });
 
+  test("keeps published local and eager servers live when deferred preparation fails", async () => {
+    const deferredFailure = new Error("synthetic deferred MCP preparation failure");
+    let rejectDeferred!: (error: Error) => void;
+    const deferredConnect = new Promise<void>((_resolve, reject) => {
+      rejectDeferred = reject;
+    });
+    let eagerCloseCount = 0;
+    let deferredCloseCount = 0;
+    const makeServer = (
+      name: string,
+      connect: () => Promise<void>,
+      onClose: () => void,
+    ): MCPServer => ({
+      name,
+      cacheToolsList: false,
+      connect,
+      async close() {
+        onClose();
+      },
+      async listTools() {
+        return [
+          {
+            name: "lookup",
+            description: `Lookup through ${name}`,
+            inputSchema: {
+              type: "object" as const,
+              properties: {},
+              additionalProperties: false,
+            },
+          },
+        ];
+      },
+      async callTool() {
+        return [{ type: "text", text: name }];
+      },
+      async invalidateToolsCache() {},
+    });
+    const eager = makeServer(
+      "eager-inner",
+      async () => {},
+      () => {
+        eagerCloseCount += 1;
+      },
+    );
+    const deferred = makeServer(
+      "deferred-inner",
+      async () => await deferredConnect,
+      () => {
+        deferredCloseCount += 1;
+      },
+    );
+    const settings = testSettings({
+      sandboxBackend: "none",
+      mcpServers: [
+        {
+          id: "eager",
+          name: "Eager",
+          url: "https://eager.invalid/mcp",
+          cacheToolsList: false,
+        },
+        {
+          id: "deferred",
+          name: "Deferred",
+          url: "https://deferred.invalid/mcp",
+          cacheToolsList: false,
+        },
+      ],
+    });
+    const prepared = await prepareAgentTools(
+      settings,
+      [
+        { kind: "mcp", id: "eager", eager: true },
+        { kind: "mcp", id: "deferred" },
+      ],
+      {
+        accountId: "11111111-1111-4111-8111-111111111111",
+        workspaceId: "22222222-2222-4222-8222-222222222222",
+        sessionId: "33333333-3333-4333-8333-333333333333",
+        turnId: "44444444-4444-4444-8444-444444444444",
+        attemptId: "55555555-5555-4555-8555-555555555555",
+        executionGeneration: 2,
+        deferNonEagerUntilToolDemand: true,
+        localMcpServers: [
+          { id: "eager", server: eager },
+          { id: "deferred", server: deferred },
+        ],
+        attemptToolDefinitions: [
+          {
+            identity: { serverId: "interaction", toolName: "browser_observe" },
+            modelName: "interaction__browser_observe",
+            codemodePath: ["interaction", "browser", "observe"],
+            description: "Observe one exact browser target.",
+            inputSchema: {
+              type: "object",
+              properties: { targetId: { type: "string" } },
+              required: ["targetId"],
+              additionalProperties: false,
+            },
+            source: "interaction",
+            approval: "none",
+            execute: async () => ({ content: [{ type: "text", text: "observed" }] }),
+          },
+        ],
+      },
+    );
+    const local = prepared.mcpServers.find(
+      (server) => server.name === "opengeni-attempt-local-tools",
+    );
+    const publishedEager = prepared.mcpServers.find((server) => server.name.includes("eager"));
+    expect(local).toBeDefined();
+    expect(publishedEager).toBeDefined();
+    expect((await local!.listTools()).map((tool) => tool.name)).toEqual([
+      "interaction__browser_observe",
+    ]);
+
+    rejectDeferred(deferredFailure);
+    await expect(prepared.ready!).rejects.toBe(deferredFailure);
+
+    expect(eagerCloseCount).toBe(0);
+    expect(deferredCloseCount).toBe(1);
+    expect((await local!.listTools()).map((tool) => tool.name)).toEqual([
+      "interaction__browser_observe",
+    ]);
+    expect((await publishedEager!.listTools()).map((tool) => tool.name)).toEqual(["eager__lookup"]);
+
+    await expect(prepared.close()).rejects.toBe(deferredFailure);
+    expect(eagerCloseCount).toBe(1);
+    expect(deferredCloseCount).toBe(1);
+    await expect(local!.listTools()).rejects.toThrow("local model tool server is closed");
+  });
+
   test("SDK MCP lifecycle logs are structural while callers receive exact errors", async () => {
     const sentinel = "synthetic-mcp-lifecycle-boundary-123456";
     const registryId = "registry-mcp-lifecycle-boundary";

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -8209,6 +8209,125 @@ describe("runtime event normalization", () => {
     await expect(local!.listTools()).rejects.toThrow("local model tool server is closed");
   });
 
+  test("closes unpublished eager and deferred servers when eager schema freezing fails", async () => {
+    const eagerFailure = new Error("synthetic eager schema failure");
+    let eagerCloseCount = 0;
+    let deferredCloseCount = 0;
+    const settings = testSettings({
+      sandboxBackend: "none",
+      mcpServers: [
+        { id: "eager", name: "Eager", url: "https://eager.invalid/mcp" },
+        { id: "deferred", name: "Deferred", url: "https://deferred.invalid/mcp" },
+      ],
+    });
+    const server = (
+      name: string,
+      listTools: () => Promise<RuntimeMcpTool[]>,
+      onClose: () => void,
+    ): MCPServer => ({
+      name,
+      cacheToolsList: false,
+      async connect() {},
+      async close() {
+        onClose();
+      },
+      listTools,
+      async callTool() {
+        return [];
+      },
+      async invalidateToolsCache() {},
+    });
+
+    await expect(
+      prepareAgentTools(
+        settings,
+        [
+          { kind: "mcp", id: "eager", eager: true },
+          { kind: "mcp", id: "deferred" },
+        ],
+        {
+          deferNonEagerUntilToolDemand: true,
+          localMcpServers: [
+            {
+              id: "eager",
+              server: server(
+                "eager-inner",
+                async () => {
+                  throw eagerFailure;
+                },
+                () => {
+                  eagerCloseCount += 1;
+                },
+              ),
+            },
+            {
+              id: "deferred",
+              server: server(
+                "deferred-inner",
+                async () => [],
+                () => {
+                  deferredCloseCount += 1;
+                },
+              ),
+            },
+          ],
+        },
+      ),
+    ).rejects.toBe(eagerFailure);
+    expect(eagerCloseCount).toBe(1);
+    expect(deferredCloseCount).toBe(1);
+  });
+
+  test("does not close eager servers twice when fully prepared cleanup fails", async () => {
+    const closeFailure = new Error("synthetic eager close failure");
+    let eagerCloseCount = 0;
+    let deferredCloseCount = 0;
+    const makeServer = (name: string, eager: boolean): MCPServer => ({
+      name,
+      cacheToolsList: false,
+      async connect() {},
+      async close() {
+        if (eager) {
+          eagerCloseCount += 1;
+          throw closeFailure;
+        }
+        deferredCloseCount += 1;
+      },
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        return [];
+      },
+      async invalidateToolsCache() {},
+    });
+    const settings = testSettings({
+      sandboxBackend: "none",
+      mcpServers: [
+        { id: "eager", name: "Eager", url: "https://eager.invalid/mcp" },
+        { id: "deferred", name: "Deferred", url: "https://deferred.invalid/mcp" },
+      ],
+    });
+    const prepared = await prepareAgentTools(
+      settings,
+      [
+        { kind: "mcp", id: "eager", eager: true },
+        { kind: "mcp", id: "deferred" },
+      ],
+      {
+        deferNonEagerUntilToolDemand: true,
+        localMcpServers: [
+          { id: "eager", server: makeServer("eager-inner", true) },
+          { id: "deferred", server: makeServer("deferred-inner", false) },
+        ],
+      },
+    );
+    await prepared.ready;
+    await expect(prepared.close()).rejects.toBe(closeFailure);
+    expect(eagerCloseCount).toBe(1);
+    expect(deferredCloseCount).toBe(1);
+  });
+
   test("SDK MCP lifecycle logs are structural while callers receive exact errors", async () => {
     const sentinel = "synthetic-mcp-lifecycle-boundary-123456";
     const registryId = "registry-mcp-lifecycle-boundary";


### PR DESCRIPTION
## Summary

- keep already-published eager and in-process tool servers alive when deferred MCP preparation fails
- restrict background failure cleanup to resources owned by deferred preparation
- close all resources when eager schema publication fails before ownership can transfer
- avoid closing eager servers twice when fully prepared cleanup itself reports an error
- add regression tests covering all three lifecycle boundaries

## Problem

A worker replacement can recover an active turn while deferred MCP preparation continues in the background. If that deferred preparation fails, its cleanup previously closed eager and in-process tool servers that had already been published to the live Agent. The next model or tool-list cycle then failed with the misleading secondary error `local model tool server is closed`, masking the original deferred setup failure.

This is an asynchronous resource-ownership race in progressive tool preparation. It is independent of any particular deployment, customer, workspace, repository, or session.

## Review-driven hardening

An independent review of the first revision found a pre-publication cleanup gap and a double-close path. Head `bfd220d2e` fixes both and adds focused tests for them.

## Validation

- `bun run --cwd packages/runtime typecheck`
- `bunx oxfmt --check packages/runtime/src/index.ts packages/runtime/test/runtime.test.ts .changeset/fix-deferred-tool-cleanup-ownership.md`
- `bunx oxlint --deny-warnings packages/runtime/src/index.ts packages/runtime/test/runtime.test.ts`
- `bun test packages/runtime/test/runtime.test.ts --timeout 30000` (287 pass, 0 fail)
- `git diff --check`
