### PR TITLE
fix(api): reuse linked computer display for headed browsers

### DIFF
--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -480,6 +480,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
                       await ensureHeadedBrowserDisplayStack(
                         placement.session,
                         preparedSession.headless,
+                        linkedComputer !== null,
                       );
                       return await client.createSession({
                         browserSessionId: preparedSession.id,
@@ -2430,6 +2431,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
                   await ensureHeadedBrowserDisplayStack(
                     placement.session,
                     prepared.session.headless,
+                    linkedComputer !== null,
                   );
                   return await client.createSession({
                     browserSessionId,
@@ -3148,7 +3150,11 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       placement: placement.placement,
     });
     try {
-      await ensureHeadedBrowserDisplayStack(placement.session, record.session.headless);
+      await ensureHeadedBrowserDisplayStack(
+        placement.session,
+        record.session.headless,
+        linkedComputer !== null,
+      );
       await client.createSession({
         browserSessionId: record.session.id,
         controllerGeneration: binding.controllerGeneration,
@@ -3372,12 +3378,20 @@ function assertCreateReplay(
 async function ensureHeadedBrowserDisplayStack(
   session: BrowserControlPlacementSession,
   headless: boolean,
+  linkedComputer: boolean,
 ): Promise<void> {
-  if (headless) return;
+  if (!browserNeedsStandaloneDisplayStack({ headless, linkedComputer })) return;
   if (typeof session.exec !== "function" && typeof session.execCommand !== "function") return;
   await ensureDisplayStack(session, {
     telemetryContext: { callerKind: "viewer" },
   });
+}
+
+export function browserNeedsStandaloneDisplayStack(input: {
+  headless: boolean;
+  linkedComputer: boolean;
+}): boolean {
+  return !input.headless && !input.linkedComputer;
 }
 
 async function ensureLinkedComputerController(

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -4,6 +4,7 @@ import type { FileAsset } from "@opengeni/contracts";
 import { HTTPException } from "hono/http-exception";
 import { allowedCorsOrigin, validateInteractionRequestOrigin } from "../src/http/cors";
 import {
+  browserNeedsStandaloneDisplayStack,
   browserFileAuthoritySubjectId,
   interactionActorForGrant,
   requireAuthorizedBrowserUploadFiles,
@@ -331,6 +332,24 @@ describe("BrowserSession route discipline", () => {
       binding.indexOf("await client.createComputerSession"),
     );
     expect(binding).toContain("isMissingLinkedComputerControllerSession(error)");
+  });
+
+  test("uses a linked ComputerSession display without bootstrapping a standalone desktop", async () => {
+    expect(browserNeedsStandaloneDisplayStack({ headless: false, linkedComputer: true })).toBe(
+      false,
+    );
+    expect(browserNeedsStandaloneDisplayStack({ headless: false, linkedComputer: false })).toBe(
+      true,
+    );
+    expect(browserNeedsStandaloneDisplayStack({ headless: true, linkedComputer: false })).toBe(
+      false,
+    );
+
+    const source = await readFile(routeUrl, "utf8");
+    expect(source.match(/linkedComputer !== null,/gu)).toHaveLength(3);
+    expect(source).toContain(
+      "if (!browserNeedsStandaloneDisplayStack({ headless, linkedComputer })) return;",
+    );
   });
 
   test("publishes encrypted profile state only after durable dispatch", async () => {


### PR DESCRIPTION
## Summary
- skip standalone desktop bootstrap when a headed managed browser is linked to an already-active ComputerSession
- preserve existing bootstrap behavior for unlinked headed browsers
- add regression coverage for linked, unlinked, and headless paths

## Why
A linked ComputerSession already owns and supplies the exact graphical launch environment. Running the generic standalone display bootstrap first is redundant and can reject otherwise valid connected-machine desktops before browserd receives the create request.

## Verification
- `bun test apps/api/test/browser-session-routes.test.ts`
- `bun run typecheck`
- `bun run lint -- apps/api/src/routes/browser-sessions.ts apps/api/test/browser-session-routes.test.ts`
- `bunx oxfmt --check apps/api/src/routes/browser-sessions.ts apps/api/test/browser-session-routes.test.ts`
- `bun run check:public-hygiene`
- `git diff --check`