### PR TITLE
fix: reconcile merged web bundle budget

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -120,7 +120,11 @@ const budgets = {
   // production graph measures 2,121,826 raw / 588,620 gzip bytes. Advance only
   // the raw aggregate to its next whole-KiB envelope; gzip, file-count, initial,
   // per-file, lazy-chunk, and CSS caps remain unchanged.
-  directSessionRaw: 2073 * kib,
+  // The exact merged-main Linux/x64 workload build, which also embeds the
+  // immutable deployment revision, measures 2,122,755 raw bytes. Advance only
+  // this aggregate to the next whole-KiB envelope; every compressed, file-count,
+  // per-file, lazy-chunk, CSS, and initial-graph cap remains unchanged.
+  directSessionRaw: 2074 * kib,
   directSessionGzip: 576 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,


### PR DESCRIPTION
## Summary
- reconcile the direct-session raw bundle envelope with the exact merged-main Linux workload measurement
- keep every gzip, per-file, file-count, lazy, CSS, and initial-graph cap unchanged

## Verification
- `bun run format:check`
- `bun run lint`
- exact Bun 1.3.14 production web build with the merged deployment revision
- Linux/amd64 `docker/opengeni.Dockerfile` web target with the merged deployment revision