### PR TITLE
fix(slack): distinguish staging bot identity

### DIFF
--- a/.changeset/staging-slack-visible-identity.md
+++ b/.changeset/staging-slack-visible-identity.md
@@ -1,0 +1,10 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/deployment": patch
+"@opengeni/sdk": patch
+---
+
+Allow the managed staging Slack app and bot to use the visibly distinct `OpenGeni Staging` identity. The manifest, runtime configuration, installation verification, durable binding contract, SDK, web projection, and deployment artifacts now preserve one closed environment-qualified display-name setting while production continues to default to `OpenGeni`.

--- a/.changeset/staging-slack-visible-identity.md
+++ b/.changeset/staging-slack-visible-identity.md
@@ -3,7 +3,6 @@
 "@opengeni/config": patch
 "@opengeni/contracts": patch
 "@opengeni/db": patch
-"@opengeni/deployment": patch
 "@opengeni/sdk": patch
 ---
 

--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,10 @@ OPENGENI_INTEGRATIONS_ENABLED=false
 #   ${{OPENGENI_PUBLIC_BASE_URL}}/v1/integrations/oauth/callback  # hosted MCP
 #   ${{OPENGENI_PUBLIC_BASE_URL}}/v1/integrations/slack/callback
 # Use a distinct Slack app and credential triplet for every deployed environment.
-# These optional values customize only `bun run slack:manifest`; the installed
-# bot user's display name remains exactly OpenGeni for verification.
+# The app and bot display names must match the same deployment identity. The
+# API validates the bot name again before accepting an installation.
 # OPENGENI_SLACK_APP_NAME=OpenGeni Staging
+# OPENGENI_SLACK_BOT_DISPLAY_NAME=OpenGeni Staging
 # OPENGENI_SLACK_COMMAND=/opengeni-staging
 # OPENGENI_SLACK_SHORTCUT_NAME=Open in OpenGeni Staging
 # OPENGENI_SLACK_CLIENT_ID=

--- a/apps/api/src/integrations/slack-bot.ts
+++ b/apps/api/src/integrations/slack-bot.ts
@@ -8,6 +8,7 @@ import {
   hasOpenGeniSlackBotSearchScopes,
   type AccessGrant,
   type ConnectionMetadata,
+  type OpenGeniSlackBotDisplayName,
   type OpenGeniSlackBotConnectionMetadata,
 } from "@opengeni/contracts";
 import {
@@ -369,6 +370,7 @@ export async function verifyOpenGeniSlackBotCredential(
   token: string,
   fetchImpl: FetchLike = fetch,
   now: Date = new Date(),
+  expectedDisplayName: OpenGeniSlackBotDisplayName = "OpenGeni",
 ): Promise<VerifiedOpenGeniSlackBot> {
   const authResponse = await slackApiFetch(fetchImpl, "auth.test", token, {});
   const grantedScopes = parseGrantedScopes(authResponse.response.headers.get("x-oauth-scopes"));
@@ -391,10 +393,10 @@ export async function verifyOpenGeniSlackBotCredential(
   }
   const profile = slackRecord(user.profile);
   const displayName = slackString(profile?.display_name) || slackString(profile?.real_name);
-  if (displayName !== "OpenGeni") {
+  if (displayName !== expectedDisplayName) {
     throw new SlackBotCredentialVerificationError(
       "identity_mismatch",
-      'Slack bot display name must be exactly "OpenGeni"',
+      `Slack bot display name must be exactly ${JSON.stringify(expectedDisplayName)}`,
     );
   }
 
@@ -407,7 +409,7 @@ export async function verifyOpenGeniSlackBotCredential(
       slackTeamName,
       botUserId,
       botId,
-      botDisplayName: "OpenGeni",
+      botDisplayName: expectedDisplayName,
       verifiedAt: now.toISOString(),
     },
   };

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -299,7 +299,12 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
         deps.slackFetch ?? fetch,
       );
       stage = "credential_verification";
-      const verified = await verifyOpenGeniSlackBotCredential(token, deps.slackFetch ?? fetch);
+      const verified = await verifyOpenGeniSlackBotCredential(
+        token,
+        deps.slackFetch ?? fetch,
+        new Date(),
+        settings.slackBotDisplayName,
+      );
       stage = "permission_recheck";
       await requireSlackInstallCallbackGrant(db, state);
       stage = "persistence";

--- a/apps/api/test/slack-bot.test.ts
+++ b/apps/api/test/slack-bot.test.ts
@@ -900,6 +900,14 @@ describe("OpenGeni Slack bot credential verification", () => {
     expect(exact.calls.map((call) => call.method)).toEqual(["auth.test", "users.info"]);
     expect(exact.calls.every((call) => call.query === "")).toBe(true);
 
+    const staging = await verifyOpenGeniSlackBotCredential(
+      fixtureBotToken(),
+      fakeSlack({ displayName: "OpenGeni Staging" }).fetch,
+      new Date("2026-01-02T03:04:05.000Z"),
+      "OpenGeni Staging",
+    );
+    expect(staging.metadata.botDisplayName).toBe("OpenGeni Staging");
+
     await expect(
       verifyOpenGeniSlackBotCredential(
         fixtureBotToken(),

--- a/apps/web/src/lib/slack-bot.test.ts
+++ b/apps/web/src/lib/slack-bot.test.ts
@@ -114,6 +114,11 @@ describe("OpenGeni Slack bot UI connection filtering", () => {
       slackTeamId: "T_TEST",
       botDisplayName: "OpenGeni",
     });
+    expect(
+      openGeniSlackBotUiMetadata(
+        connection({ metadata: { ...valid.metadata, botDisplayName: "OpenGeni Staging" } }),
+      ),
+    ).toMatchObject({ botDisplayName: "OpenGeni Staging" });
   });
 
   test("prefers an active reinstall target over a newer revoked connection", () => {

--- a/apps/web/src/lib/slack-bot.ts
+++ b/apps/web/src/lib/slack-bot.ts
@@ -13,7 +13,7 @@ export type OpenGeniSlackBotUiMetadata = {
   slackTeamName: string;
   botId: string;
   botUserId: string;
-  botDisplayName: "OpenGeni";
+  botDisplayName: "OpenGeni" | "OpenGeni Staging";
 };
 
 export function openGeniSlackBotUiMetadata(
@@ -33,7 +33,7 @@ export function openGeniSlackBotUiMetadata(
     typeof metadata.slackTeamName !== "string" ||
     typeof metadata.botId !== "string" ||
     typeof metadata.botUserId !== "string" ||
-    metadata.botDisplayName !== "OpenGeni"
+    (metadata.botDisplayName !== "OpenGeni" && metadata.botDisplayName !== "OpenGeni Staging")
   ) {
     return null;
   }
@@ -73,7 +73,7 @@ export function preferredOpenGeniSlackBotConnection(
  */
 export function openGeniSlackBotConnectionLabel(connection: ConnectionMetadata): string | null {
   const metadata = openGeniSlackBotUiMetadata(connection);
-  return metadata ? `${metadata.slackTeamName} · OpenGeni` : null;
+  return metadata ? `${metadata.slackTeamName} · ${metadata.botDisplayName}` : null;
 }
 
 export type OpenGeniSlackBotConnectionOption = {
@@ -114,7 +114,8 @@ export function openGeniSlackBotConnectionOptions(
     const metadata = openGeniSlackBotUiMetadata(connection);
     return metadata ? [{ connection, metadata }] : [];
   });
-  const named = (row: (typeof rows)[number]) => `${row.metadata.slackTeamName} · OpenGeni`;
+  const named = (row: (typeof rows)[number]) =>
+    `${row.metadata.slackTeamName} · ${row.metadata.botDisplayName}`;
   const withTeamId = (row: (typeof rows)[number]) => `${named(row)} · ${row.metadata.slackTeamId}`;
   const byName = tally(rows, named);
   const byTeamId = tally(rows, withTeamId);

--- a/docs/slack-bot.md
+++ b/docs/slack-bot.md
@@ -5,7 +5,7 @@ One configured Slack app can serve Slack's hosted MCP and OpenGeni's separate bo
 | Connection | Slack author | OpenGeni ownership | Intended use |
 | --- | --- | --- | --- |
 | Personal hosted Slack MCP | The Slack human who authenticated, with Slack's configured app attribution | The exact authenticating OpenGeni subject | Interactive personal Slack tools only, including private-channel, DM, and MPIM search |
-| OpenGeni workspace bot | The `OpenGeni` bot user | The one OpenGeni workspace that installed it | Shared agents, first-party bot tools, bot-token public search, and explicitly bound scheduled tasks |
+| OpenGeni workspace bot | The deployment's configured bot user (`OpenGeni` in production, `OpenGeni Staging` in managed staging) | The one OpenGeni workspace that installed it | Shared agents, first-party bot tools, bot-token public search, and explicitly bound scheduled tasks |
 
 The two authorities are never substituted for one another. Nothing reads or posts until the capability is enabled or the bot is installed and an agent invokes a tool.
 
@@ -16,7 +16,7 @@ The two authorities are never substituted for one another. Nothing reads or post
 Slack renders the message author from the OAuth principal and renders `Sent using @…` from Slack app/provider metadata. An existing internal app may be reused for hosted MCP and may retain its current name. The first-party workspace-bot flow is stricter: if that surface is used, an authorized Slack app administrator must configure the same app as follows rather than adding generated text or changing message payloads:
 
 1. Set the production Slack app name to `OpenGeni`. Use an environment-qualified app name such as `OpenGeni Staging` for a non-production deployment so administrators can distinguish simultaneous installations.
-2. Set the bot user display name to exactly `OpenGeni`.
+2. Set the bot user display name to the deployment's exact configured identity: `OpenGeni` in production or `OpenGeni Staging` in managed staging.
 3. Configure both exact redirect URLs:
    - `${OPENGENI_PUBLIC_BASE_URL}/v1/integrations/oauth/callback` for hosted MCP OAuth.
    - `${OPENGENI_PUBLIC_BASE_URL}/v1/integrations/slack/callback` for workspace-bot installation.
@@ -25,6 +25,7 @@ Slack renders the message author from the OAuth principal and renders `Sent usin
    - `OPENGENI_SLACK_CLIENT_ID`
    - `OPENGENI_SLACK_CLIENT_SECRET`
    - `OPENGENI_SLACK_SIGNING_SECRET` (required before workspace-bot installation is offered, because Events API, commands, shortcuts, and interactive actions all depend on signature verification)
+   - `OPENGENI_SLACK_BOT_DISPLAY_NAME` (`OpenGeni` by default; `OpenGeni Staging` in managed staging)
    - `OPENGENI_INTEGRATIONS_ENABLED=true`
    - `OPENGENI_INTEGRATIONS_STATE_SECRET`
    - `OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`
@@ -164,12 +165,13 @@ The production defaults above are customizable for a separate non-production app
 ```bash
 OPENGENI_PUBLIC_BASE_URL=https://staging.app.opengeni.ai \
 OPENGENI_SLACK_APP_NAME='OpenGeni Staging' \
+OPENGENI_SLACK_BOT_DISPLAY_NAME='OpenGeni Staging' \
 OPENGENI_SLACK_COMMAND=/opengeni-staging \
 OPENGENI_SLACK_SHORTCUT_NAME='Open in OpenGeni Staging' \
 bun run slack:manifest
 ```
 
-This changes the provider app name, slash command, shortcut label, and every provider callback URL. Keep `OPENGENI_SLACK_COMMAND` set to the same exact command in the API runtime so signed command delivery and the generated provider manifest cannot drift. The bot user's display name remains exactly `OpenGeni` for credential verification. For managed Kubernetes, `bun run deployment:runtime-artifacts` carries `OPENGENI_SLACK_CLIENT_ID`, `OPENGENI_SLACK_CLIENT_SECRET`, `OPENGENI_SLACK_SIGNING_SECRET`, and `OPENGENI_SLACK_COMMAND` into the generated runtime environment. Populate the three credential values from the matching environment's Slack app before publishing the runtime Secret; a staging release must never reuse the production triplet.
+This changes the provider app name, bot display name, slash command, shortcut label, and every provider callback URL. Keep `OPENGENI_SLACK_BOT_DISPLAY_NAME` and `OPENGENI_SLACK_COMMAND` set to the same exact values in the API runtime so installation verification, signed command delivery, and the generated provider manifest cannot drift. For managed Kubernetes, `bun run deployment:runtime-artifacts` carries `OPENGENI_SLACK_CLIENT_ID`, `OPENGENI_SLACK_CLIENT_SECRET`, `OPENGENI_SLACK_SIGNING_SECRET`, `OPENGENI_SLACK_BOT_DISPLAY_NAME`, and `OPENGENI_SLACK_COMMAND` into the generated runtime environment. Populate the three credential values from the matching environment's Slack app before publishing the runtime Secret; a staging release must never reuse the production triplet.
 
 Generate the canonical JSON manifest with `bun run slack:manifest`. It defaults to the managed `https://app.opengeni.ai` base URL. Self-hosted deployments set their stable HTTPS `OPENGENI_PUBLIC_BASE_URL` before running the same command; every redirect, command, event, and interaction URL is derived from that value. The bot scopes remain the narrow first-party bot allowlist; the separate user scopes cover the full current Slack-hosted MCP tool catalog and `settings.is_mcp_enabled` enables that provider surface. Bot verification evaluates only the granted bot-token scopes, so hosted-MCP user scopes do not widen the bot principal. `reactions:read` is read-only and exists only for optional reaction summon; `reactions:write` belongs only to the hosted-MCP user principal. `search:read.public`, `search:read.files`, and `search:read.users` are the bot-token scopes Slack's Real-time Search API accepts (`OPENGENI_SLACK_BOT_SEARCH_SCOPES`); `search:read.private`, `search:read.im`, and `search:read.mpim` are user-token only and stay on the personal principal. Do not enable Socket Mode or token rotation, or add bot-side `channels:join`, `chat:write.public`, `chat:write.customize`, administrative, or enterprise-search scopes; Slack's native "Invite Them" prompt handles channels the bot has not joined. The canonical bot allowlist accepts the required manifest scopes plus the explicitly safe extras `team:read`, `reactions:read`, and the three bot search scopes; every other bot extra or unknown future scope fails closed across installation verification, core routing, and browser Installed-state projection. Like `reactions:read`, the search scopes are requested but not required for eligibility: an installation made before they were requested keeps working for mentions, commands, DMs, shortcuts, and tools, and gains bot search only after a reinstall with the canonical manifest (`hasOpenGeniSlackBotSearchScopes`).
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,6 +11,7 @@ import {
   ReasoningEffort,
   FIRST_PARTY_MCP_TOOL_NAMES,
   FirstPartyMcpToolName,
+  OpenGeniSlackBotDisplayName,
   SandboxBackend,
   SessionMcpApprovalPolicy,
   SEEDANCE_2_5_MODEL_ID,
@@ -386,6 +387,7 @@ const SettingsSchema = z.object({
   slackClientId: z.string().optional(),
   slackClientSecret: z.string().optional(),
   slackSigningSecret: z.string().optional(),
+  slackBotDisplayName: OpenGeniSlackBotDisplayName.default("OpenGeni"),
   slackCommand: z
     .string()
     .trim()
@@ -2261,6 +2263,7 @@ export function getSettings(): Settings {
     slackClientId: optional("OPENGENI_SLACK_CLIENT_ID"),
     slackClientSecret: optional("OPENGENI_SLACK_CLIENT_SECRET"),
     slackSigningSecret: optional("OPENGENI_SLACK_SIGNING_SECRET"),
+    slackBotDisplayName: optional("OPENGENI_SLACK_BOT_DISPLAY_NAME"),
     slackCommand: optional("OPENGENI_SLACK_COMMAND"),
     googleDriveClientId: optional("OPENGENI_GOOGLE_DRIVE_CLIENT_ID"),
     googleDriveClientSecret: optional("OPENGENI_GOOGLE_DRIVE_CLIENT_SECRET"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -419,6 +419,7 @@ describe("OpenGeni Slack interaction settings", () => {
     OPENGENI_INTEGRATIONS_STATE_SECRET: "state-secret",
     OPENGENI_SLACK_CLIENT_ID: "slack-client-id",
     OPENGENI_SLACK_CLIENT_SECRET: "slack-client-secret",
+    OPENGENI_SLACK_BOT_DISPLAY_NAME: "OpenGeni Staging",
     OPENGENI_SLACK_COMMAND: "/opengeni-staging",
   };
 
@@ -427,6 +428,7 @@ describe("OpenGeni Slack interaction settings", () => {
     expect(settings.slackClientId).toBe("slack-client-id");
     expect(settings.slackClientSecret).toBe("slack-client-secret");
     expect(settings.slackSigningSecret).toBeUndefined();
+    expect(settings.slackBotDisplayName).toBe("OpenGeni Staging");
     expect(settings.slackCommand).toBe("/opengeni-staging");
   });
 
@@ -439,7 +441,11 @@ describe("OpenGeni Slack interaction settings", () => {
   });
 
   test("defaults and validates the signed Slack slash command", () => {
+    expect(withEnv({}, () => getSettings()).slackBotDisplayName).toBe("OpenGeni");
     expect(withEnv({}, () => getSettings()).slackCommand).toBe("/opengeni");
+    expect(() =>
+      withEnv({ OPENGENI_SLACK_BOT_DISPLAY_NAME: "OpenGeni Preview" }, () => getSettings()),
+    ).toThrow();
     expect(() => withEnv({ OPENGENI_SLACK_COMMAND: "/OpenGeni" }, () => getSettings())).toThrow();
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8083,7 +8083,7 @@ export const ScheduledTaskRunAcceptedExecution = /* @__PURE__ */ z
             slackTeamName: z.string().min(1).max(256),
             botUserId: z.string().min(1).max(64),
             botId: z.string().min(1).max(64),
-            botDisplayName: z.literal("OpenGeni"),
+            botDisplayName: z.enum(["OpenGeni", "OpenGeni Staging"]),
             verifiedAt: z.string().datetime({ offset: true }),
           })
           .passthrough(),
@@ -9536,6 +9536,8 @@ export const OPENGENI_PERSONAL_SLACK_MCP_URL = "https://mcp.slack.com/mcp" as co
 export const OPENGENI_SLACK_BOT_CREDENTIAL_ROLE = "opengeni_slack_bot" as const;
 export const OPENGENI_SLACK_BOT_CREDENTIAL_LABEL = "OpenGeni Slack bot" as const;
 export const OPENGENI_SLACK_BOT_SESSION_METADATA_KEY = "opengeniSlackBotConnectionId" as const;
+export const OpenGeniSlackBotDisplayName = z.enum(["OpenGeni", "OpenGeni Staging"]);
+export type OpenGeniSlackBotDisplayName = z.infer<typeof OpenGeniSlackBotDisplayName>;
 export const OpenGeniSlackBotConnectionMetadata = z
   .object({
     credentialRole: z.literal(OPENGENI_SLACK_BOT_CREDENTIAL_ROLE),
@@ -9544,7 +9546,7 @@ export const OpenGeniSlackBotConnectionMetadata = z
     slackTeamName: z.string().min(1).max(256),
     botUserId: z.string().min(1).max(64),
     botId: z.string().min(1).max(64),
-    botDisplayName: z.literal("OpenGeni"),
+    botDisplayName: OpenGeniSlackBotDisplayName,
     verifiedAt: z.string().datetime({ offset: true }),
   })
   .passthrough();
@@ -9725,7 +9727,7 @@ export const SlackInstallationBinding = z.object({
   slackTeamName: z.string().min(1).max(256),
   botId: z.string().min(1).max(64),
   botUserId: z.string().min(1).max(64),
-  botDisplayName: z.literal("OpenGeni"),
+  botDisplayName: OpenGeniSlackBotDisplayName,
   state: SlackInstallationBindingState,
   quarantineReason: z.string().min(1).nullable(),
   version: z.number().int().positive(),

--- a/packages/contracts/src/slack-bot-scopes.ts
+++ b/packages/contracts/src/slack-bot-scopes.ts
@@ -89,6 +89,7 @@ export const OPENGENI_MANAGED_PUBLIC_BASE_URL = "https://app.opengeni.ai" as con
 
 export type OpenGeniSlackBotManifestOptions = Readonly<{
   appName?: string;
+  botDisplayName?: string;
   slashCommand?: string;
   shortcutName?: string;
 }>;
@@ -134,6 +135,12 @@ export function buildOpenGeniSlackBotManifest(
 ) {
   const baseUrl = normalizedSlackManifestBaseUrl(publicBaseUrl);
   const appName = normalizedSlackManifestText(options.appName, "OpenGeni", "app name", 35);
+  const botDisplayName = normalizedSlackManifestText(
+    options.botDisplayName,
+    "OpenGeni",
+    "bot display name",
+    80,
+  );
   const slashCommand = normalizedSlackCommand(options.slashCommand);
   const shortcutName = normalizedSlackManifestText(
     options.shortcutName,
@@ -149,7 +156,7 @@ export function buildOpenGeniSlackBotManifest(
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },
-      bot_user: { display_name: "OpenGeni", always_online: false },
+      bot_user: { display_name: botDisplayName, always_online: false },
       slash_commands: [
         {
           command: slashCommand,

--- a/packages/contracts/test/slack-reaction-settings.test.ts
+++ b/packages/contracts/test/slack-reaction-settings.test.ts
@@ -117,11 +117,12 @@ describe("Slack reaction summon workspace settings", () => {
 
     const staging = buildOpenGeniSlackBotManifest("https://staging.app.opengeni.ai", {
       appName: "OpenGeni Staging",
+      botDisplayName: "OpenGeni Staging",
       slashCommand: "/opengeni-staging",
       shortcutName: "Open in OpenGeni Staging",
     });
     expect(staging.display_information.name).toBe("OpenGeni Staging");
-    expect(staging.features.bot_user.display_name).toBe("OpenGeni");
+    expect(staging.features.bot_user.display_name).toBe("OpenGeni Staging");
     expect(staging.features.slash_commands[0]!.command).toBe("/opengeni-staging");
     expect(staging.features.shortcuts[0]!.name).toBe("Open in OpenGeni Staging");
     expect(staging.settings.interactivity.request_url).toBe(

--- a/packages/db/drizzle/0321_slack_bot_environment_display_name.sql
+++ b/packages/db/drizzle/0321_slack_bot_environment_display_name.sql
@@ -1,0 +1,15 @@
+-- deployment-mode: rolling
+-- Slack app and bot names are environment-scoped human-facing identity. Keep
+-- the accepted set closed while allowing the managed staging principal to be
+-- visibly distinct from production in a shared Slack workspace.
+ALTER TABLE slack_installation_bindings
+  DROP CONSTRAINT slack_installation_bindings_identity_check;
+
+ALTER TABLE slack_installation_bindings
+  ADD CONSTRAINT slack_installation_bindings_identity_check CHECK (
+    octet_length(slack_team_id) BETWEEN 1 AND 64
+    AND octet_length(slack_team_name) BETWEEN 1 AND 256
+    AND octet_length(bot_id) BETWEEN 1 AND 64
+    AND octet_length(bot_user_id) BETWEEN 1 AND 64
+    AND bot_display_name IN ('OpenGeni', 'OpenGeni Staging')
+  );

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9157,7 +9157,7 @@ export async function listSlackInstallationBindings(
         slackTeamName: binding.slackTeamName,
         botId: binding.botId,
         botUserId: binding.botUserId,
-        botDisplayName: "OpenGeni" as const,
+        botDisplayName: binding.botDisplayName as "OpenGeni" | "OpenGeni Staging",
         state: binding.state,
         quarantineReason: binding.quarantineReason,
         version: binding.version,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1763,7 +1763,7 @@ export const slackInstallationBindings = pgTable(
         and octet_length(${table.slackTeamName}) between 1 and 256
         and octet_length(${table.botId}) between 1 and 64
         and octet_length(${table.botUserId}) between 1 and 64
-        and ${table.botDisplayName} = 'OpenGeni'`,
+        and ${table.botDisplayName} in ('OpenGeni', 'OpenGeni Staging')`,
     ),
     versionPositive: check("slack_installation_bindings_version_check", sql`${table.version} > 0`),
   }),

--- a/packages/db/test/migration-0321-slack-bot-environment-display-name.test.ts
+++ b/packages/db/test/migration-0321-slack-bot-environment-display-name.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+
+const migrationUrl = new URL(
+  "../drizzle/0321_slack_bot_environment_display_name.sql",
+  import.meta.url,
+);
+
+let shared: SharedTestDatabase | null = null;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("migration-0321-slack-display-name");
+});
+
+afterAll(async () => shared?.release());
+
+describe("migration 0321 Slack bot environment display name", () => {
+  test("is a rolling constraint-only expansion", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+    expect(source).toContain("DROP CONSTRAINT slack_installation_bindings_identity_check");
+    expect(source).toContain("bot_display_name IN ('OpenGeni', 'OpenGeni Staging')");
+    expect(source).not.toMatch(/\b(?:UPDATE|DELETE|INSERT)\b/iu);
+  });
+
+  test("accepts only the production and managed-staging bot names", async () => {
+    if (!shared) return;
+    const [constraint] = await shared.admin<Array<{ definition: string }>>`
+      select pg_get_constraintdef(oid) as definition
+      from pg_constraint
+      where conrelid = 'slack_installation_bindings'::regclass
+        and conname = 'slack_installation_bindings_identity_check'`;
+    expect(constraint?.definition).toContain(
+      "bot_display_name = ANY (ARRAY['OpenGeni'::text, 'OpenGeni Staging'::text])",
+    );
+  });
+});

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -2194,6 +2194,7 @@ function runtimeEnvValues(
     valueEnv("OPENGENI_SLACK_CLIENT_ID", env.OPENGENI_SLACK_CLIENT_ID),
     valueEnv("OPENGENI_SLACK_CLIENT_SECRET", env.OPENGENI_SLACK_CLIENT_SECRET),
     valueEnv("OPENGENI_SLACK_SIGNING_SECRET", env.OPENGENI_SLACK_SIGNING_SECRET),
+    valueEnv("OPENGENI_SLACK_BOT_DISPLAY_NAME", env.OPENGENI_SLACK_BOT_DISPLAY_NAME),
     valueEnv("OPENGENI_SLACK_COMMAND", env.OPENGENI_SLACK_COMMAND),
     ...(publicBaseUrl ? [valueEnv("OPENGENI_PUBLIC_BASE_URL", publicBaseUrl)] : []),
     ...(contract.product.accessMode === "managed" ||

--- a/packages/deployment/test/deployment.test.ts
+++ b/packages/deployment/test/deployment.test.ts
@@ -745,6 +745,7 @@ describe("deployment contract", () => {
         OPENGENI_SLACK_CLIENT_ID: "slack-staging-client",
         OPENGENI_SLACK_CLIENT_SECRET: "slack-staging-secret",
         OPENGENI_SLACK_SIGNING_SECRET: "slack-staging-signing-secret",
+        OPENGENI_SLACK_BOT_DISPLAY_NAME: "OpenGeni Staging",
         OPENGENI_SLACK_COMMAND: "/opengeni-staging",
         OPENGENI_GITHUB_PERSONAL_OAUTH_ENABLED: "true",
         OPENGENI_GITHUB_PERSONAL_OAUTH_CLIENT_ID: "github-personal-staging",
@@ -795,6 +796,7 @@ describe("deployment contract", () => {
     expect(artifacts.runtimeEnv).toContain(
       "OPENGENI_SLACK_SIGNING_SECRET=slack-staging-signing-secret",
     );
+    expect(artifacts.runtimeEnv).toContain("OPENGENI_SLACK_BOT_DISPLAY_NAME=OpenGeni Staging");
     expect(artifacts.runtimeEnv).toContain("OPENGENI_SLACK_COMMAND=/opengeni-staging");
     expect(artifacts.runtimeEnv).toContain("OPENGENI_GITHUB_PERSONAL_OAUTH_ENABLED=true");
     expect(artifacts.runtimeEnv).toContain(

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -820,7 +820,7 @@ export type SlackInstallationBinding = {
   slackTeamName: string;
   botId: string;
   botUserId: string;
-  botDisplayName: "OpenGeni";
+  botDisplayName: "OpenGeni" | "OpenGeni Staging";
   state: SlackInstallationBindingState;
   quarantineReason: string | null;
   version: number;

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -62,6 +62,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     integrationsStateSecret: undefined,
     integrationsAllowPrivateNetworkTargets: false,
     integrationsOauthClientsJson: "{}",
+    slackBotDisplayName: "OpenGeni",
     slackCommand: "/opengeni",
     googleDriveSyncMaxItems: 500,
     googleDriveSyncMaxBytes: 500_000_000,

--- a/scripts/generate-slack-bot-manifest.ts
+++ b/scripts/generate-slack-bot-manifest.ts
@@ -10,6 +10,7 @@ process.stdout.write(
   `${JSON.stringify(
     buildOpenGeniSlackBotManifest(publicBaseUrl, {
       appName: process.env.OPENGENI_SLACK_APP_NAME,
+      botDisplayName: process.env.OPENGENI_SLACK_BOT_DISPLAY_NAME,
       slashCommand: process.env.OPENGENI_SLACK_COMMAND,
       shortcutName: process.env.OPENGENI_SLACK_SHORTCUT_NAME,
     }),

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -571,6 +571,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0321_slack_bot_environment_display_name.sql")) {
+        return includesActivation
+          ? "3fa4d5e5322376e0f635e6d00f315a22013f4985c65b65cf10db16749391fc63"
+          : "2d060aed60093b5270721b845f0d6782c2d07574d3b887a8dd4da12da704c696";
+      }
       if (migrations.has("0310_channel_project_order.sql")) {
         return includesActivation
           ? "0f1aa9ad9747be5968dfa9374a0c623fcb10a0e4095350f13df81b0bc40679ca"
@@ -1216,7 +1221,8 @@ describe("release schema contract", () => {
         (migrations.has("0307_session_attention_state.sql") ? 1 : 0) +
         (migrations.has("0308_session_archives.sql") ? 1 : 0) +
         (migrations.has("0309_channel_project_pins.sql") ? 1 : 0) +
-        (migrations.has("0310_channel_project_order.sql") ? 1 : 0),
+        (migrations.has("0310_channel_project_order.sql") ? 1 : 0) +
+        (migrations.has("0321_slack_bot_environment_display_name.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1251,161 +1257,165 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0310_channel_project_order.sql")
-        ? "0310_channel_project_order.sql"
-        : migrations.has("0309_channel_project_pins.sql")
-          ? "0309_channel_project_pins.sql"
-          : migrations.has("0308_session_archives.sql")
-            ? "0308_session_archives.sql"
-            : migrations.has("0307_session_attention_state.sql")
-              ? "0307_session_attention_state.sql"
-              : migrations.has("0303_session_tenancy_product_activation.sql")
-                ? "0303_session_tenancy_product_activation.sql"
-                : migrations.has("0302_personal_workspace_session_ownership.sql")
-                  ? "0302_personal_workspace_session_ownership.sql"
-                  : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
-                    ? "0301_session_snapshot_and_pin_visibility.sql"
-                    : migrations.has("0300_tenancy_backfill_ledger.sql")
-                      ? "0300_tenancy_backfill_ledger.sql"
-                      : migrations.has("0299_organization_membership_lock_order.sql")
-                        ? "0299_organization_membership_lock_order.sql"
-                        : migrations.has("0298_organization_tenancy_parity.sql")
-                          ? "0298_organization_tenancy_parity.sql"
-                          : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
-                            ? "0295_retire_legacy_standing_memory_mode.sql"
-                            : migrations.has("0294_preference_activation_authority.sql")
-                              ? "0294_preference_activation_authority.sql"
-                              : migrations.has("0293_confirm_time_rule_rebaseline.sql")
-                                ? "0293_confirm_time_rule_rebaseline.sql"
-                                : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
-                                  ? "0292_truthful_tenancy_inventory_counters.sql"
-                                  : migrations.has(
-                                        "0291_resource_authority_classification_assertion.sql",
-                                      )
-                                    ? "0291_resource_authority_classification_assertion.sql"
-                                    : migrations.has("0290_organization_membership_backfill.sql")
-                                      ? "0290_organization_membership_backfill.sql"
-                                      : migrations.has("0289_session_composer_policy_authority.sql")
-                                        ? "0289_session_composer_policy_authority.sql"
-                                        : migrations.has("0288_attached_browser_reenrollment.sql")
-                                          ? "0288_attached_browser_reenrollment.sql"
-                                          : migrations.has(
-                                                "0287_open_suffix_pending_tool_calls.sql",
-                                              )
-                                            ? "0287_open_suffix_pending_tool_calls.sql"
+      migrations.has("0321_slack_bot_environment_display_name.sql")
+        ? "0321_slack_bot_environment_display_name.sql"
+        : migrations.has("0310_channel_project_order.sql")
+          ? "0310_channel_project_order.sql"
+          : migrations.has("0309_channel_project_pins.sql")
+            ? "0309_channel_project_pins.sql"
+            : migrations.has("0308_session_archives.sql")
+              ? "0308_session_archives.sql"
+              : migrations.has("0307_session_attention_state.sql")
+                ? "0307_session_attention_state.sql"
+                : migrations.has("0303_session_tenancy_product_activation.sql")
+                  ? "0303_session_tenancy_product_activation.sql"
+                  : migrations.has("0302_personal_workspace_session_ownership.sql")
+                    ? "0302_personal_workspace_session_ownership.sql"
+                    : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
+                      ? "0301_session_snapshot_and_pin_visibility.sql"
+                      : migrations.has("0300_tenancy_backfill_ledger.sql")
+                        ? "0300_tenancy_backfill_ledger.sql"
+                        : migrations.has("0299_organization_membership_lock_order.sql")
+                          ? "0299_organization_membership_lock_order.sql"
+                          : migrations.has("0298_organization_tenancy_parity.sql")
+                            ? "0298_organization_tenancy_parity.sql"
+                            : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
+                              ? "0295_retire_legacy_standing_memory_mode.sql"
+                              : migrations.has("0294_preference_activation_authority.sql")
+                                ? "0294_preference_activation_authority.sql"
+                                : migrations.has("0293_confirm_time_rule_rebaseline.sql")
+                                  ? "0293_confirm_time_rule_rebaseline.sql"
+                                  : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
+                                    ? "0292_truthful_tenancy_inventory_counters.sql"
+                                    : migrations.has(
+                                          "0291_resource_authority_classification_assertion.sql",
+                                        )
+                                      ? "0291_resource_authority_classification_assertion.sql"
+                                      : migrations.has("0290_organization_membership_backfill.sql")
+                                        ? "0290_organization_membership_backfill.sql"
+                                        : migrations.has(
+                                              "0289_session_composer_policy_authority.sql",
+                                            )
+                                          ? "0289_session_composer_policy_authority.sql"
+                                          : migrations.has("0288_attached_browser_reenrollment.sql")
+                                            ? "0288_attached_browser_reenrollment.sql"
                                             : migrations.has(
-                                                  "0286_widen_task_note_expiry_ceiling.sql",
+                                                  "0287_open_suffix_pending_tool_calls.sql",
                                                 )
-                                              ? "0286_widen_task_note_expiry_ceiling.sql"
+                                              ? "0287_open_suffix_pending_tool_calls.sql"
                                               : migrations.has(
-                                                    "0285_organization_tenancy_inventory.sql",
+                                                    "0286_widen_task_note_expiry_ceiling.sql",
                                                   )
-                                                ? "0285_organization_tenancy_inventory.sql"
+                                                ? "0286_widen_task_note_expiry_ceiling.sql"
                                                 : migrations.has(
-                                                      "0284_truthful_human_confirmed_review_reason.sql",
+                                                      "0285_organization_tenancy_inventory.sql",
                                                     )
-                                                  ? "0284_truthful_human_confirmed_review_reason.sql"
+                                                  ? "0285_organization_tenancy_inventory.sql"
                                                   : migrations.has(
-                                                        "0283_editable_spreadsheet_authored_state.sql",
+                                                        "0284_truthful_human_confirmed_review_reason.sql",
                                                       )
-                                                    ? "0283_editable_spreadsheet_authored_state.sql"
+                                                    ? "0284_truthful_human_confirmed_review_reason.sql"
                                                     : migrations.has(
-                                                          "0282_variable_set_session_attach_attribution.sql",
+                                                          "0283_editable_spreadsheet_authored_state.sql",
                                                         )
-                                                      ? "0282_variable_set_session_attach_attribution.sql"
+                                                      ? "0283_editable_spreadsheet_authored_state.sql"
                                                       : migrations.has(
-                                                            "0281_viewer_holder_authority_claims.sql",
+                                                            "0282_variable_set_session_attach_attribution.sql",
                                                           )
-                                                        ? "0281_viewer_holder_authority_claims.sql"
+                                                        ? "0282_variable_set_session_attach_attribution.sql"
                                                         : migrations.has(
-                                                              "0280_connection_and_variable_set_audit_attribution.sql",
+                                                              "0281_viewer_holder_authority_claims.sql",
                                                             )
-                                                          ? "0280_connection_and_variable_set_audit_attribution.sql"
+                                                          ? "0281_viewer_holder_authority_claims.sql"
                                                           : migrations.has(
-                                                                "0279_workspace_connection_use_lane.sql",
+                                                                "0280_connection_and_variable_set_audit_attribution.sql",
                                                               )
-                                                            ? "0279_workspace_connection_use_lane.sql"
+                                                            ? "0280_connection_and_variable_set_audit_attribution.sql"
                                                             : migrations.has(
-                                                                  "0278_workspace_membership_removal_fencing.sql",
+                                                                  "0279_workspace_connection_use_lane.sql",
                                                                 )
-                                                              ? "0278_workspace_membership_removal_fencing.sql"
+                                                              ? "0279_workspace_connection_use_lane.sql"
                                                               : migrations.has(
-                                                                    "0277_workspace_writer_authority_attribution.sql",
+                                                                    "0278_workspace_membership_removal_fencing.sql",
                                                                   )
-                                                                ? "0277_workspace_writer_authority_attribution.sql"
+                                                                ? "0278_workspace_membership_removal_fencing.sql"
                                                                 : migrations.has(
-                                                                      "0276_onboarding_proposal_initiating_human_guc.sql",
+                                                                      "0277_workspace_writer_authority_attribution.sql",
                                                                     )
-                                                                  ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                                                                  ? "0277_workspace_writer_authority_attribution.sql"
                                                                   : migrations.has(
-                                                                        "0275_scheduled_connection_authority.sql",
+                                                                        "0276_onboarding_proposal_initiating_human_guc.sql",
                                                                       )
-                                                                    ? "0275_scheduled_connection_authority.sql"
+                                                                    ? "0276_onboarding_proposal_initiating_human_guc.sql"
                                                                     : migrations.has(
-                                                                          "0274_human_confirmed_knowledge_review.sql",
+                                                                          "0275_scheduled_connection_authority.sql",
                                                                         )
-                                                                      ? "0274_human_confirmed_knowledge_review.sql"
+                                                                      ? "0275_scheduled_connection_authority.sql"
                                                                       : migrations.has(
-                                                                            "0272_human_confirmed_learning_activation.sql",
+                                                                            "0274_human_confirmed_knowledge_review.sql",
                                                                           )
-                                                                        ? "0272_human_confirmed_learning_activation.sql"
+                                                                        ? "0274_human_confirmed_knowledge_review.sql"
                                                                         : migrations.has(
-                                                                              "0271_company_brain_retrieval_only_default.sql",
+                                                                              "0272_human_confirmed_learning_activation.sql",
                                                                             )
-                                                                          ? "0271_company_brain_retrieval_only_default.sql"
+                                                                          ? "0272_human_confirmed_learning_activation.sql"
                                                                           : migrations.has(
-                                                                                "0270_governed_learning_history_inspection.sql",
+                                                                                "0271_company_brain_retrieval_only_default.sql",
                                                                               )
-                                                                            ? "0270_governed_learning_history_inspection.sql"
+                                                                            ? "0271_company_brain_retrieval_only_default.sql"
                                                                             : migrations.has(
-                                                                                  "0269_governed_learning_activation_controller.sql",
+                                                                                  "0270_governed_learning_history_inspection.sql",
                                                                                 )
-                                                                              ? "0269_governed_learning_activation_controller.sql"
+                                                                              ? "0270_governed_learning_history_inspection.sql"
                                                                               : migrations.has(
-                                                                                    "0268_governed_learning_decision_receipts.sql",
+                                                                                    "0269_governed_learning_activation_controller.sql",
                                                                                   )
-                                                                                ? "0268_governed_learning_decision_receipts.sql"
+                                                                                ? "0269_governed_learning_activation_controller.sql"
                                                                                 : migrations.has(
-                                                                                      "0266_company_brain_context_receipt_inspection.sql",
+                                                                                      "0268_governed_learning_decision_receipts.sql",
                                                                                     )
-                                                                                  ? "0266_company_brain_context_receipt_inspection.sql"
+                                                                                  ? "0268_governed_learning_decision_receipts.sql"
                                                                                   : migrations.has(
-                                                                                        "0261_preference_knowledge_proposal_actor_binding.sql",
+                                                                                        "0266_company_brain_context_receipt_inspection.sql",
                                                                                       )
-                                                                                    ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                                                                    ? "0266_company_brain_context_receipt_inspection.sql"
                                                                                     : migrations.has(
-                                                                                          "0260_task_note_knowledge_promotion.sql",
+                                                                                          "0261_preference_knowledge_proposal_actor_binding.sql",
                                                                                         )
-                                                                                      ? "0260_task_note_knowledge_promotion.sql"
+                                                                                      ? "0261_preference_knowledge_proposal_actor_binding.sql"
                                                                                       : migrations.has(
-                                                                                            "0259_company_brain_context_selection_receipts.sql",
+                                                                                            "0260_task_note_knowledge_promotion.sql",
                                                                                           )
-                                                                                        ? "0259_company_brain_context_selection_receipts.sql"
+                                                                                        ? "0260_task_note_knowledge_promotion.sql"
                                                                                         : migrations.has(
-                                                                                              "0258_three_scope_document_knowledge_authority.sql",
+                                                                                              "0259_company_brain_context_selection_receipts.sql",
                                                                                             )
-                                                                                          ? "0258_three_scope_document_knowledge_authority.sql"
+                                                                                          ? "0259_company_brain_context_selection_receipts.sql"
                                                                                           : migrations.has(
-                                                                                                "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                                                                "0258_three_scope_document_knowledge_authority.sql",
                                                                                               )
-                                                                                            ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                                                                            ? "0258_three_scope_document_knowledge_authority.sql"
                                                                                             : migrations.has(
-                                                                                                  "0255_company_brain_governed_write_proposals.sql",
+                                                                                                  "0257_goal_revision_decisions_and_root_constraints.sql",
                                                                                                 )
-                                                                                              ? "0255_company_brain_governed_write_proposals.sql"
+                                                                                              ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                                                                               : migrations.has(
-                                                                                                    "0248_terraform_stacks_component_resolution_fence.sql",
+                                                                                                    "0255_company_brain_governed_write_proposals.sql",
                                                                                                   )
-                                                                                                ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                                                                ? "0255_company_brain_governed_write_proposals.sql"
                                                                                                 : migrations.has(
-                                                                                                      "0247_terraform_stacks_provenance_repair.sql",
+                                                                                                      "0248_terraform_stacks_component_resolution_fence.sql",
                                                                                                     )
-                                                                                                  ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                  ? "0248_terraform_stacks_component_resolution_fence.sql"
                                                                                                   : migrations.has(
-                                                                                                        "0263_organization_membership_lifecycle.sql",
+                                                                                                        "0247_terraform_stacks_provenance_repair.sql",
                                                                                                       )
-                                                                                                    ? "0263_organization_membership_lifecycle.sql"
-                                                                                                    : latestCompatibleMigration,
+                                                                                                    ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                    : migrations.has(
+                                                                                                          "0263_organization_membership_lifecycle.sql",
+                                                                                                        )
+                                                                                                      ? "0263_organization_membership_lifecycle.sql"
+                                                                                                      : latestCompatibleMigration,
     );
     expect(migrations.get("0289_session_composer_policy_authority.sql")).toMatchObject({
       sha256: "478e7ba49b6940bdd849223a0965b7dcc20a0d4428f0fc85078961dbd3984285",


### PR DESCRIPTION
## Summary
- make the Slack bot display name a closed deployment setting
- accept and preserve `OpenGeni Staging` through manifest, install verification, DB, SDK, and web UI
- carry the setting through runtime deployment artifacts and add a rolling constraint migration

## Verification
- 228 focused tests passed, including real PostgreSQL migration coverage
- all 31 TypeScript projects pass typecheck
- repository formatting and diff checks pass