### PR TITLE
fix(computer-native): clear clippy lints that block Agent CI

### DIFF
--- a/agent/crates/opengeni-agent-macos-ffi/src/ffi/ax.rs
+++ b/agent/crates/opengeni-agent-macos-ffi/src/ffi/ax.rs
@@ -764,12 +764,10 @@ pub(super) fn list_targets(shareable_windows: &[ShareableWindow]) -> Vec<MacTarg
             let is_main = focused
                 && window
                     .bool_attribute(kAXMainAttribute)
-                    .ok()
-                    .is_some_and(bool::from);
+                    .is_ok_and(bool::from);
             let minimized = window
                 .bool_attribute(kAXMinimizedAttribute)
-                .ok()
-                .is_some_and(bool::from);
+                .is_ok_and(bool::from);
             if fingerprint.title.as_deref().is_none_or(str::is_empty)
                 && matched.is_none()
                 && !is_main
@@ -1057,13 +1055,11 @@ pub(super) fn focus_target(target: &MacTargetInfo) -> Result<(), MacFfiError> {
     };
     let was_application_frontmost = application_element
         .bool_attribute(kAXFrontmostAttribute)
-        .ok()
-        .is_some_and(bool::from);
+        .is_ok_and(bool::from);
     let was_window_main = window.as_ref().is_none_or(|window| {
         window
             .bool_attribute(kAXMainAttribute)
-            .ok()
-            .is_some_and(bool::from)
+            .is_ok_and(bool::from)
     });
     // AXFrontmost below is the exact per-PID foreground primitive. AppKit's
     // activateWithOptions is bundle-oriented and can synchronously stall for a
@@ -1119,13 +1115,11 @@ pub(super) fn focus_target(target: &MacTargetInfo) -> Result<(), MacFfiError> {
     loop {
         let application_frontmost = application_element
             .bool_attribute(kAXFrontmostAttribute)
-            .ok()
-            .is_some_and(bool::from);
+            .is_ok_and(bool::from);
         let window_main = window.as_ref().is_none_or(|window| {
             window
                 .bool_attribute(kAXMainAttribute)
-                .ok()
-                .is_some_and(bool::from)
+                .is_ok_and(bool::from)
         });
         if application_frontmost && window_main {
             break;
@@ -1355,8 +1349,7 @@ pub(super) fn run_background_application(
         let first_window_exists = application_element.as_ref().is_some_and(|element| {
             element
                 .windows_bounded(1)
-                .ok()
-                .is_some_and(|(windows, _)| !windows.is_empty())
+                .is_ok_and(|(windows, _)| !windows.is_empty())
         });
         if first_window_exists && first_window_seen_at.is_none() {
             first_window_seen_at = Some(Instant::now());

--- a/agent/crates/opengeni-computer-native/src/linux.rs
+++ b/agent/crates/opengeni-computer-native/src/linux.rs
@@ -2093,9 +2093,8 @@ fn cache_snapshot_complete(items: &[CacheItem]) -> bool {
     items.iter().all(|item| {
         item.children >= 0
             && usize::try_from(item.children).is_ok_and(|expected| {
-                object_key(&item.object).ok().is_some_and(|key| {
-                    observed_children.get(&key).copied().unwrap_or(0) == expected
-                })
+                object_key(&item.object)
+                    .is_ok_and(|key| observed_children.get(&key).copied().unwrap_or(0) == expected)
             })
     })
 }
@@ -2589,7 +2588,6 @@ fn ambiguous(context: &str, error: impl std::fmt::Display) -> NativeAdapterError
 #[cfg(test)]
 mod live_tests {
     use std::fs;
-    use std::os::unix::fs::PermissionsExt as _;
     use std::time::{Duration, Instant};
 
     use tokio::io::{AsyncBufReadExt as _, BufReader};

--- a/agent/crates/opengeni-computer-native/src/rpc.rs
+++ b/agent/crates/opengeni-computer-native/src/rpc.rs
@@ -493,7 +493,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::Value;
     use sha2::{Digest as _, Sha256};
-    use tokio::io::{duplex, split, AsyncWriteExt as _};
+    use tokio::io::{duplex, split};
 
     use super::*;
     use crate::{


### PR DESCRIPTION
## Why

Agent CI's `fmt + clippy` job on `main` has been red since bf770505d (run 32595855239). Nothing in `agent/crates/opengeni-computer-native` changed (last touch d34dd9a79); the job installs `dtolnay/rust-toolchain@stable`, and stable moved from rustc 1.97.1 to 1.98.0 on 2026-08-18, which added the lints below under `-D warnings`.

## What

- `crates/opengeni-computer-native/src/linux.rs` and `src/rpc.rs`: the `#[cfg(test)]` modules re-imported `std::os::unix::fs::PermissionsExt as _` and `tokio::io::AsyncWriteExt as _`, which `use super::*` already brings into scope from the parent module. rustc 1.98 reports those redundant underscore imports as unused, so they are removed. The parent-level imports stay and the test bodies (`Permissions::from_mode`, `write_all`) still resolve through the glob.
- `linux.rs` `cache_snapshot_complete`: `.ok().is_some_and(..)` on a `Result` becomes `.is_ok_and(..)` (clippy's suggestion; identical semantics).
- `crates/opengeni-agent-macos-ffi/src/ffi/ax.rs`: the same `.ok().is_some_and` -> `.is_ok_and` rewrite in seven places. These do not block the ubuntu lint job (the crate's body is macOS-only) but they fail `cargo clippy -D warnings` on any macOS host with 1.98, so they are fixed in the same mechanical way.

No behaviour change. `Result::is_ok_and` is stable since Rust 1.70, inside the workspace MSRV of 1.82. Not a publishable npm package, so no changeset.

## Verification (local, Rust 1.98.0 to match CI)

From `agent/`:

- `cargo fmt --all --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings` (macOS host): clean
- `cargo clippy -p opengeni-computer-native --all-targets --all-features --target x86_64-unknown-linux-gnu -- -D warnings`: reproduces exactly the three CI errors on unfixed `main`, clean with this change (linux.rs only compiles for `target_os = "linux"`, so this is the relevant check)
- `cargo test -p opengeni-computer-native`: 16 passed (macOS; the Linux AT-SPI live tests are Linux-only)
- `cargo test -p opengeni-agent-macos-ffi`: 4 passed, 1 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
