### PR TITLE
fix(slack): verify OAuth bot by app identity

### DIFF
--- a/apps/api/src/integrations/slack-bot.ts
+++ b/apps/api/src/integrations/slack-bot.ts
@@ -114,6 +114,11 @@ export type DownloadedSlackReactionImage = Readonly<{
   bytes: Uint8Array;
 }>;
 
+export type ExchangedOpenGeniSlackAuthorization = Readonly<{
+  accessToken: string;
+  appId: string;
+}>;
+
 export async function exchangeOpenGeniSlackAuthorizationCode(
   input: {
     code: string;
@@ -122,7 +127,7 @@ export async function exchangeOpenGeniSlackAuthorizationCode(
     redirectUri: string;
   },
   fetchImpl: FetchLike = fetch,
-): Promise<string> {
+): Promise<ExchangedOpenGeniSlackAuthorization> {
   const body = new URLSearchParams({
     code: input.code,
     client_id: input.clientId,
@@ -166,7 +171,13 @@ export async function exchangeOpenGeniSlackAuthorizationCode(
       message: "Slack installation did not return a bot token",
     });
   }
-  return accessToken;
+  const appId = slackString(record.app_id);
+  if (!appId) {
+    throw new HTTPException(502, {
+      message: "Slack installation did not return an app identity",
+    });
+  }
+  return { accessToken, appId };
 }
 
 export type SlackBotReceipt = {
@@ -362,15 +373,18 @@ export class SlackBotCredentialVerificationError extends HTTPException {
 
 /**
  * Validates a write-only xoxb credential before it can enter encrypted storage.
- * Slack does not expose the app's display_information name to this scope set;
- * users.info provides the authoritative installed bot display name, while the
- * documented manifest fixes the app name itself to the same exact value.
+ * The OAuth exchange's app_id is the immutable app authority. Slack bot profile
+ * names are mutable presentation data and may lag manifest/App Home changes, so
+ * they must not decide whether a credential belongs to this installation.
  */
 export async function verifyOpenGeniSlackBotCredential(
   token: string,
+  expected: Readonly<{
+    appId: string;
+    displayName: OpenGeniSlackBotDisplayName;
+  }>,
   fetchImpl: FetchLike = fetch,
   now: Date = new Date(),
-  expectedDisplayName: OpenGeniSlackBotDisplayName = "OpenGeni",
 ): Promise<VerifiedOpenGeniSlackBot> {
   const authResponse = await slackApiFetch(fetchImpl, "auth.test", token, {});
   const grantedScopes = parseGrantedScopes(authResponse.response.headers.get("x-oauth-scopes"));
@@ -392,11 +406,11 @@ export async function verifyOpenGeniSlackBotCredential(
     );
   }
   const profile = slackRecord(user.profile);
-  const displayName = slackString(profile?.display_name) || slackString(profile?.real_name);
-  if (displayName !== expectedDisplayName) {
+  const installedAppId = slackString(profile?.api_app_id);
+  if (installedAppId !== expected.appId) {
     throw new SlackBotCredentialVerificationError(
       "identity_mismatch",
-      `Slack bot display name must be exactly ${JSON.stringify(expectedDisplayName)}`,
+      "Slack credential does not belong to the authorized Slack app",
     );
   }
 
@@ -409,7 +423,7 @@ export async function verifyOpenGeniSlackBotCredential(
       slackTeamName,
       botUserId,
       botId,
-      botDisplayName: expectedDisplayName,
+      botDisplayName: expected.displayName,
       verifiedAt: now.toISOString(),
     },
   };

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -289,7 +289,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
       }
       const slack = requireOpenGeniSlackOAuthSettings(settings);
       const redirectUri = `${baseUrl}/v1/integrations/slack/callback`;
-      const token = await exchangeOpenGeniSlackAuthorizationCode(
+      const authorization = await exchangeOpenGeniSlackAuthorizationCode(
         {
           code,
           clientId: slack.clientId,
@@ -300,10 +300,13 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
       );
       stage = "credential_verification";
       const verified = await verifyOpenGeniSlackBotCredential(
-        token,
+        authorization.accessToken,
+        {
+          appId: authorization.appId,
+          displayName: settings.slackBotDisplayName,
+        },
         deps.slackFetch ?? fetch,
         new Date(),
-        settings.slackBotDisplayName,
       );
       stage = "permission_recheck";
       await requireSlackInstallCallbackGrant(db, state);
@@ -311,7 +314,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
       const connection = await persistOpenGeniSlackBotConnection({
         deps,
         state,
-        token,
+        token: authorization.accessToken,
         verified,
       });
       return c.redirect(

--- a/apps/api/test/slack-bot.test.ts
+++ b/apps/api/test/slack-bot.test.ts
@@ -181,6 +181,9 @@ function fakeSlack(
   options: {
     scopes?: string[];
     displayName?: string;
+    realName?: string;
+    oauthAppId?: string;
+    installedAppId?: string;
     teamId?: string;
     botUserId?: string;
     botId?: string;
@@ -319,7 +322,11 @@ function fakeSlack(
           );
     }
     if (method === "oauth.v2.access") {
-      return Response.json({ ok: true, access_token: fixtureBotToken() });
+      return Response.json({
+        ok: true,
+        access_token: fixtureBotToken(),
+        app_id: options.oauthAppId ?? "A_OPEN_GENI",
+      });
     }
     if (method === "auth.test") {
       return Response.json(
@@ -342,7 +349,8 @@ function fakeSlack(
           deleted: false,
           profile: {
             display_name: options.displayName ?? "OpenGeni",
-            real_name: "OpenGeni",
+            real_name: options.realName ?? "OpenGeni",
+            api_app_id: options.installedAppId ?? "A_OPEN_GENI",
           },
         },
       });
@@ -811,7 +819,7 @@ describe("OpenGeni Slack bot credential verification", () => {
   test("exchanges the authorization code server-side with the configured callback", async () => {
     let requestUrl = "";
     let requestInit: RequestInit | undefined;
-    const token = await exchangeOpenGeniSlackAuthorizationCode(
+    const authorization = await exchangeOpenGeniSlackAuthorizationCode(
       {
         code: "authorization-code",
         clientId: "client-id",
@@ -821,11 +829,18 @@ describe("OpenGeni Slack bot credential verification", () => {
       (async (input, init) => {
         requestUrl = String(input);
         requestInit = init;
-        return Response.json({ ok: true, access_token: fixtureBotToken() });
+        return Response.json({
+          ok: true,
+          access_token: fixtureBotToken(),
+          app_id: "A_OPEN_GENI",
+        });
       }) as typeof globalThis.fetch,
     );
 
-    expect(token).toBe(fixtureBotToken());
+    expect(authorization).toEqual({
+      accessToken: fixtureBotToken(),
+      appId: "A_OPEN_GENI",
+    });
     expect(requestUrl).toBe("https://slack.com/api/oauth.v2.access");
     expect(requestInit?.method).toBe("POST");
     expect(requestInit?.redirect).toBe("error");
@@ -862,6 +877,10 @@ describe("OpenGeni Slack bot credential verification", () => {
           })) as typeof globalThis.fetch,
       ),
     ).rejects.toThrow();
+    await expect(
+      exchangeOpenGeniSlackAuthorizationCode(input, (async () =>
+        Response.json({ ok: true, access_token: fixtureBotToken() })) as typeof globalThis.fetch),
+    ).rejects.toThrow("did not return an app identity");
   });
 
   test("accepts only required plus canonical safe optional scopes", async () => {
@@ -885,6 +904,7 @@ describe("OpenGeni Slack bot credential verification", () => {
     const exact = fakeSlack({ scopes: OPENGENI_SLACK_BOT_REQUIRED_SCOPES });
     const verified = await verifyOpenGeniSlackBotCredential(
       fixtureBotToken(),
+      { appId: "A_OPEN_GENI", displayName: "OpenGeni" },
       exact.fetch,
       new Date("2026-01-02T03:04:05.000Z"),
     );
@@ -902,15 +922,16 @@ describe("OpenGeni Slack bot credential verification", () => {
 
     const staging = await verifyOpenGeniSlackBotCredential(
       fixtureBotToken(),
-      fakeSlack({ displayName: "OpenGeni Staging" }).fetch,
+      { appId: "A_OPEN_GENI", displayName: "OpenGeni Staging" },
+      fakeSlack({ displayName: "", realName: "OpenGeni" }).fetch,
       new Date("2026-01-02T03:04:05.000Z"),
-      "OpenGeni Staging",
     );
     expect(staging.metadata.botDisplayName).toBe("OpenGeni Staging");
 
     await expect(
       verifyOpenGeniSlackBotCredential(
         fixtureBotToken(),
+        { appId: "A_OPEN_GENI", displayName: "OpenGeni" },
         fakeSlack({
           scopes: OPENGENI_SLACK_BOT_REQUIRED_SCOPES.filter((scope) => scope !== "groups:history"),
         }).fetch,
@@ -929,6 +950,7 @@ describe("OpenGeni Slack bot credential verification", () => {
       await expect(
         verifyOpenGeniSlackBotCredential(
           fixtureBotToken(),
+          { appId: "A_OPEN_GENI", displayName: "OpenGeni" },
           fakeSlack({ scopes: [...OPENGENI_SLACK_BOT_REQUIRED_SCOPES, unsafe] }).fetch,
         ),
       ).rejects.toThrow("do not satisfy");
@@ -936,6 +958,7 @@ describe("OpenGeni Slack bot credential verification", () => {
     await expect(
       verifyOpenGeniSlackBotCredential(
         fixtureBotToken(),
+        { appId: "A_OPEN_GENI", displayName: "OpenGeni" },
         fakeSlack({
           scopes: [...OPENGENI_SLACK_BOT_REQUIRED_SCOPES, "chat:write.public"],
         }).fetch,
@@ -944,9 +967,10 @@ describe("OpenGeni Slack bot credential verification", () => {
     await expect(
       verifyOpenGeniSlackBotCredential(
         fixtureBotToken(),
-        fakeSlack({ displayName: "Personal Slack user" }).fetch,
+        { appId: "A_DIFFERENT_APP", displayName: "OpenGeni" },
+        fakeSlack().fetch,
       ),
-    ).rejects.toThrow('display name must be exactly "OpenGeni"');
+    ).rejects.toThrow("does not belong to the authorized Slack app");
   });
 });
 
@@ -1502,7 +1526,7 @@ describe("OpenGeni Slack bot connection", () => {
     const workspace = await freshWorkspace();
     const cases = [
       {
-        slack: fakeSlack({ displayName: "Not OpenGeni" }),
+        slack: fakeSlack({ installedAppId: "A_DIFFERENT_APP" }),
         reason: "identity_mismatch",
       },
       {


### PR DESCRIPTION
## Summary
- retain Slack OAuth `app_id` alongside the write-only bot token
- verify the installed bot's immutable `profile.api_app_id` instead of mutable/stale profile names
- keep the configured environment display name as presentation metadata
- cover staging's empty display name + legacy `OpenGeni` real name and mismatched app IDs

## Verification
- `bun test apps/api/test/slack-bot.test.ts` (51 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

Linear: [OPE-324](https://linear.app/cloudgeni/issue/OPE-324/verify-slack-bot-oauth-identity-by-app-id-not-stale-profile-name)