### PR TITLE
fix(integrations): prefer DCR for dual-mode OAuth servers

### DIFF
--- a/.changeset/generic-mcp-oauth-registration.md
+++ b/.changeset/generic-mcp-oauth-registration.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Prefer OAuth Dynamic Client Registration whenever an MCP authorization server advertises both DCR and Client ID Metadata Documents. This avoids provider authorization failures caused by treating the metadata-document URL as a universally accepted client ID while retaining explicit provider-profile overrides for either registration mechanism.

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -51,7 +51,6 @@ import { ApiHttpError } from "../http/api-error";
 import {
   DEFAULT_OAUTH_PROFILE,
   DEPLOYMENT_MANAGED_CLIENTS,
-  PREFER_DCR_ISSUERS,
   builtInOAuthProfileByKey,
   assertAuthorizationServerNotReserved,
   assertAuthorizationServerPins,
@@ -991,11 +990,8 @@ async function registerOAuthClient(
   if (operator) {
     return operator;
   }
-  // Some issuers (Linear) advertise CIMD but reject its client metadata URL at
-  // the authorization endpoint while documenting DCR as their interactive
-  // setup; both the issuer list and a catalog profile's `clientSource: "dcr"`
-  // prefer the simultaneously advertised registration endpoint.
-  if (profile.clientSource === "dcr" || prefersDynamicClientRegistration(as)) {
+  const selfRegistration = preferredOAuthSelfRegistration(as, profile.clientSource);
+  if (selfRegistration === "dcr") {
     return await getOrCreateDynamicClientRegistration(
       db,
       settings,
@@ -1005,7 +1001,7 @@ async function registerOAuthClient(
       signal,
     );
   }
-  if (as.clientIdMetadataDocumentSupported) {
+  if (selfRegistration === "cimd") {
     return {
       method: "cimd",
       issuer: as.issuer,
@@ -1030,8 +1026,22 @@ async function registerOAuthClient(
   return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes, signal);
 }
 
-function prefersDynamicClientRegistration(as: AuthorizationServerMetadata): boolean {
-  return Boolean(as.registrationEndpoint && PREFER_DCR_ISSUERS.has(normalizedIssuerKey(as.issuer)));
+export function preferredOAuthSelfRegistration(
+  as: Pick<
+    AuthorizationServerMetadata,
+    "clientIdMetadataDocumentSupported" | "registrationEndpoint"
+  >,
+  clientSource: OAuthProviderProfile["clientSource"],
+): "cimd" | "dcr" | null {
+  if (clientSource === "dcr") return "dcr";
+  if (clientSource === "cimd" && as.clientIdMetadataDocumentSupported) return "cimd";
+  // DCR produces an authorization-server-issued client id and is therefore the
+  // interoperable default whenever the server advertises both registration
+  // mechanisms. A reviewed provider profile may explicitly force CIMD for a
+  // server whose registration endpoint is unsuitable.
+  if (clientSource !== "cimd" && as.registrationEndpoint) return "dcr";
+  if (as.clientIdMetadataDocumentSupported) return "cimd";
+  return null;
 }
 
 async function getOrCreateDynamicClientRegistration(

--- a/apps/api/src/integrations/oauth-profiles.ts
+++ b/apps/api/src/integrations/oauth-profiles.ts
@@ -97,10 +97,9 @@ export type OAuthProviderProfile = {
    */
   postDiscoveryProviderDomain?: { domain: string; message: string };
   /**
-   * Client registration preference. `dcr` prefers the advertised registration
-   * endpoint over CIMD (the Linear compatibility override, now data);
-   * `deployment_managed`/`cimd` follow the ordinary resolution order, which
-   * already tries operator and deployment clients first and CIMD next.
+   * Client registration preference. `dcr` or `cimd` forces that advertised
+   * self-registration mechanism after operator/deployment clients. Without an
+   * explicit preference, DCR wins when both mechanisms are advertised.
    */
   clientSource?: "deployment_managed" | "cimd" | "dcr";
   /** Send RFC 8707 `resource` on authorize and token requests. */
@@ -226,13 +225,6 @@ const RESERVED_AUTHORIZATION_SERVERS: readonly {
     message: `Slack OAuth is allowed only for ${OFFICIAL_SLACK_MCP_URL}`,
   },
 ];
-
-/**
- * Issuers whose advertised CIMD support is broken and whose documented
- * interactive setup uses DCR; the simultaneously advertised registration
- * endpoint is preferred. Linear is the only known case.
- */
-export const PREFER_DCR_ISSUERS: ReadonlySet<string> = new Set(["https://mcp.linear.app"]);
 
 export type DeploymentManagedClientKey = "slack";
 

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -35,6 +35,7 @@ import {
   assertSlackAuthorizationServer,
   buildAuthorizationUrl,
   chooseMcpAuthorizeScopes,
+  preferredOAuthSelfRegistration,
 } from "../src/integrations/oauth-client";
 import { builtInOAuthProfileByKey } from "../src/integrations/oauth-profiles";
 
@@ -48,6 +49,47 @@ let settings: Settings;
 
 const rawKey = randomBytes(32);
 const encryptionKey = rawKey.toString("base64");
+
+describe("OAuth self-registration selection", () => {
+  test("prefers DCR generically when both DCR and CIMD are advertised", () => {
+    expect(
+      preferredOAuthSelfRegistration(
+        {
+          registrationEndpoint: "https://auth.example/register",
+          clientIdMetadataDocumentSupported: true,
+        },
+        undefined,
+      ),
+    ).toBe("dcr");
+  });
+
+  test("retains explicit CIMD and DCR profile authority", () => {
+    const dual = {
+      registrationEndpoint: "https://auth.example/register",
+      clientIdMetadataDocumentSupported: true,
+    };
+    expect(preferredOAuthSelfRegistration(dual, "cimd")).toBe("cimd");
+    expect(preferredOAuthSelfRegistration(dual, "dcr")).toBe("dcr");
+  });
+
+  test("uses the only advertised self-registration mechanism", () => {
+    expect(
+      preferredOAuthSelfRegistration(
+        { registrationEndpoint: undefined, clientIdMetadataDocumentSupported: true },
+        undefined,
+      ),
+    ).toBe("cimd");
+    expect(
+      preferredOAuthSelfRegistration(
+        {
+          registrationEndpoint: "https://auth.example/register",
+          clientIdMetadataDocumentSupported: false,
+        },
+        undefined,
+      ),
+    ).toBe("dcr");
+  });
+});
 
 beforeAll(async () => {
   shared = await acquireSharedTestDatabase("api_connections");
@@ -2214,11 +2256,10 @@ describe("connections routes", () => {
     expect(nonOfficialResourceText).toContain("https://mcp.slack.com/mcp");
   });
 
-  test("oauth start prefers DCR for Linear when DCR and CIMD are advertised", async () => {
+  test("oauth start prefers DCR generically when DCR and CIMD are advertised", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const as = startFakeAuthorizationServer({
-      issuer: "https://mcp.linear.app",
       clientIdMetadataDocumentSupported: true,
       dcr: true,
       scopesSupported: ["read", "write"],
@@ -2238,9 +2279,9 @@ describe("connections routes", () => {
             "content-type": "application/json",
           },
           body: JSON.stringify({
-            providerDomain: "linear.app",
+            providerDomain: "dual-registration.example.com",
             mcpUrl: mcp.url,
-            returnPath: "/integrations?connect_item=linear",
+            returnPath: "/integrations?connect_item=dual-registration",
           }),
         },
       );

--- a/data/catalog/curated.json
+++ b/data/catalog/curated.json
@@ -173,11 +173,7 @@
       "category": "project-management",
       "featured": true,
       "official": true,
-      "oauthProfile": { "clientSource": "dcr" },
-      "notes": [
-        "Name only. Tier, provenance, auth kind, and scopes stay snapshot-derived.",
-        "Linear advertises CIMD but only issues MCP-accepted tokens to DCR clients; oauthProfile.clientSource expresses that compatibility override as data (the OAuth client also keeps the issuer on its prefer-DCR list for deployments with a stale catalog)."
-      ]
+      "notes": ["Name only. Tier, provenance, auth kind, and scopes stay snapshot-derived."]
     },
     {
       "mcpUrl": "https://mcp.asana.com/v2/mcp",

--- a/docs/integrations-design.md
+++ b/docs/integrations-design.md
@@ -209,12 +209,12 @@ DISCOVER   probe server URL unauthenticated
            → pick AS; RFC 8414 / OIDC-discovery metadata (both well-known path orders)
            → REQUIRE code_challenge_methods_supported ∋ S256, else abort with clear error
 REGISTER   priority: (1) operator pre-registered creds for this AS
-           (2) CIMD if client_id_metadata_document_supported — client_id is our hosted
-               metadata URL (§5.3), unless this AS is in the DCR-compatibility
-               override set
-           (3) DCR (RFC 7591) if registration_endpoint — minted client_id stored per AS
+           (2) DCR (RFC 7591) if registration_endpoint — minted client_id stored per AS
                and registered with the same resolved scope used for authorization
+           (3) CIMD if it is the only advertised self-registration mechanism — client_id
+               is our hosted metadata URL (§5.3)
            (4) manual client-credential entry in UI
+           A reviewed provider profile may explicitly force DCR or CIMD.
 AUTHORIZE  authorize URL: PKCE S256, state = signed payload (§5.2),
            resource = canonical MCP server URI (RFC 8707, ALWAYS sent),
            scope = requestedScopes when supplied (step-up), else 401-challenge
@@ -239,7 +239,7 @@ The callback route must NOT call `requireAccessGrant` — a browser redirect car
 
 DCR-minted OAuth clients are deployment-wide authorization-server identity, not per-workspace user credentials. They live in `integration_oauth_clients`, keyed by AS issuer, with `client_secret` encrypted under the variable-sets key when present. This keeps one DCR client reusable across many workspace connections to the same AS, while the actual access/refresh tokens remain in workspace-scoped `connections.credential_encrypted`. Operator pre-registered clients are read from `OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON` and are not copied into Postgres.
 
-Some authorization servers advertise both CIMD and DCR but only issue MCP-accepted tokens to DCR clients. Linear's MCP server (`https://mcp.linear.app`) is in this compatibility set: operator credentials still win when configured, otherwise OpenGeni dynamically registers and reuses a confidential DCR client with Linear's resolved `read write` MCP scope even though Linear's metadata also says `client_id_metadata_document_supported=true`. Stale Linear DCR clients registered before that policy are replaced on the next connect attempt. The override is data twice over: Linear's curated catalog row carries `oauthProfile.clientSource: "dcr"`, and the OAuth client keeps the issuer on its prefer-DCR list for deployments with a stale catalog (§5.2.2).
+Some authorization servers advertise both CIMD and DCR but reject a metadata-document URL as the authorization `client_id`. OpenGeni therefore prefers the authorization-server-issued DCR identity whenever both mechanisms are advertised. The DCR client is reused deployment-wide and replaced when its registered endpoints, redirect URI, or scope policy becomes stale. A reviewed provider profile may explicitly force CIMD when a server's advertised registration endpoint is unsuitable (§5.2.2).
 
 ### 5.2.2 Provider OAuth quirks as data (profiles)
 
@@ -259,8 +259,8 @@ catalog, then default:
 
 - **Built-in profiles** (hosted Slack MCP, official Gmail) live in code as data
   because their fences are security invariants that must not depend on catalog
-  import state. Reserved authorization servers (Google's) and the DCR
-  compatibility issuer list are adjacent data tables. Deployment-managed client
+  import state. Reserved authorization servers (Google's) are an adjacent data
+  table. Deployment-managed client
   credentials (Slack's `OPENGENI_SLACK_CLIENT_ID`/`SECRET`) resolve through a
   keyed table that only built-in profiles can reference.
 - **Catalog profiles** ride a global catalog row as `metadata.oauthProfile`

--- a/scripts/catalog-curation.test.ts
+++ b/scripts/catalog-curation.test.ts
@@ -312,11 +312,8 @@ describe("curated fields flow through import normalization", () => {
     const dbInput = catalogRowToDbInput(linear, { importBatchId: "batch-1" });
     expect(dbInput.category).toBe("project-management");
     expect(dbInput.metadata).toMatchObject({ curation: { featured: true, official: true } });
-    // The committed overlay expresses Linear's DCR-compatibility override as
-    // profile data, and the importer carries it into the row metadata the
-    // OAuth client resolves at start time.
-    expect(linear.oauthProfile).toEqual({ clientSource: "dcr" });
-    expect(dbInput.metadata).toMatchObject({ oauthProfile: { clientSource: "dcr" } });
+    expect(linear.oauthProfile).toBeUndefined();
+    expect(dbInput.metadata).not.toHaveProperty("oauthProfile");
   });
 
   test("the curated Gmail presentation flows through normalization into the DB metadata", () => {


### PR DESCRIPTION
## Summary

- prefer Dynamic Client Registration when an MCP authorization server advertises both DCR and CIMD
- preserve explicit provider-profile authority to force either registration mechanism
- remove the Linear-only issuer/catalog workaround and document the generic policy
- add database-free selection tests plus provider-neutral start/callback lifecycle coverage

## Reproduction

- PostHog's authenticated authorization page rejects the generated CIMD URL with `invalid_request` / `Invalid client_id parameter value`
- Sentry returns HTTP 500 for the same client-metadata URL pattern
- both authorization servers advertise `registration_endpoint` and `client_id_metadata_document_supported: true`
- both live DCR endpoints returned HTTP 201 public clients, and their authorization endpoints accepted those registered client IDs with HTTP 200

## Verification

- `bun test apps/api/test/connections-routes.test.ts scripts/catalog-curation.test.ts` — 76 pass; database-backed route bodies were unavailable locally, while the new pure selection tests executed
- `bun run typecheck --project apps/api` — pass
- targeted oxlint — pass
- targeted oxfmt check — pass
- hosted CI — all required source/type, unit, real-service, recovery, E2E, browser, package, deployment, and native artifact checks passed
