### PR TITLE
fix(codex): follow realtime provider config

### DIFF
--- a/apps/api/src/codex-realtime.ts
+++ b/apps/api/src/codex-realtime.ts
@@ -5,6 +5,7 @@ import {
   CodexRealtimeError,
   CodexReloginRequired,
   createCodexRealtimeCall,
+  fetchCodexRealtimeProviderConfig,
   selectCodexCredentialId,
   type CodexAuthHeaders,
   type CodexFetch,
@@ -295,8 +296,13 @@ export function buildSessionCodexRealtimeBroker(
         },
         tokenResolver: (credentialId) =>
           buildCodexTokenResolver(db, settings, workspaceId, credentialId),
-        createCall: async (auth, callInput, options) =>
-          await createCodexRealtimeCall(auth, callInput, fetchImpl, options),
+        createCall: async (auth, callInput, options) => {
+          const providerConfig = await fetchCodexRealtimeProviderConfig(auth, fetchImpl, options);
+          return await createCodexRealtimeCall(auth, callInput, fetchImpl, {
+            ...options,
+            providerConfig,
+          });
+        },
       },
       { ...input, sessionId },
     );

--- a/apps/api/test/session-realtime-routes.test.ts
+++ b/apps/api/test/session-realtime-routes.test.ts
@@ -75,8 +75,19 @@ beforeAll(async () => {
     documentIndexer: { indexDocument: noop },
     getDocumentServices: () => ({}) as never,
     codexFetch: async (input, init) => {
-      providerCalls += 1;
       const request = new Request(input, init);
+      if (request.url.endsWith("/wham/statsig/bootstrap")) {
+        return Response.json({
+          statsigPayload: JSON.stringify({
+            dynamic_configs: {
+              "3566525122": {
+                value: { architecture: "avas", model: "gpt-live-1-codex", version: "v3" },
+              },
+            },
+          }),
+        });
+      }
+      providerCalls += 1;
       if (request.url.endsWith("/v1/realtime/client-secrets")) {
         const body = (await request.json()) as { model?: string; expiresIn?: number };
         expect(request.headers.get("authorization")).toBe("Bearer gateway-test-key");

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -54,12 +54,19 @@ export const CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT = Math.floor(
 // this pinned to the latest stable Codex release we have verified end-to-end.
 export const CODEX_CLIENT_VERSION = "0.145.0";
 
-// Native ChatGPT/Codex subscription WebRTC call creation. Verified against
-// openai/codex 0.145.0 commit bd2de422aa287b97b06ca6425a10935bcf1b3731.
+// Public OpenGeni selector for native ChatGPT/Codex subscription WebRTC. This
+// remains stable for persisted sessions; the provider's remotely configured
+// model is resolved separately before call creation.
 export const CODEX_REALTIME_MODEL = "gpt-live-1-boulder-alpha";
 export const CODEX_REALTIME_VERSION = "v3";
 export const CODEX_REALTIME_DEFAULT_VOICE = "cove";
 export const CODEX_REALTIME_CALL_TIMEOUT_MS = 15_000;
+export const CODEX_REALTIME_CONFIG_TIMEOUT_MS = 5_000;
+export const CODEX_REALTIME_CONFIG_ID = "3566525122";
+// Verified live on 2026-08-23. Used only when the authenticated remote config
+// is transiently unavailable or malformed; it is not the persisted model id.
+export const CODEX_REALTIME_PROVIDER_MODEL_FALLBACK = "gpt-live-1-codex";
+export const CODEX_REALTIME_PROVIDER_ARCHITECTURE_FALLBACK = "avas";
 
 export const CODEX_REFRESH_WINDOW_MS = 5 * 60 * 1000; // proactive refresh when within 5 min of exp (spec §1.1)
 export const CODEX_REFRESH_FALLBACK_MS = 8 * 24 * 60 * 60 * 1000; // 8 days when exp is unparseable

--- a/packages/codex/src/realtime.ts
+++ b/packages/codex/src/realtime.ts
@@ -1,10 +1,15 @@
 import { codexSubscriptionHeaders, type CodexAuthHeaders } from "./api-client";
 import {
   CODEX_REALTIME_CALL_TIMEOUT_MS,
+  CODEX_REALTIME_CONFIG_ID,
+  CODEX_REALTIME_CONFIG_TIMEOUT_MS,
   CODEX_REALTIME_DEFAULT_VOICE,
   CODEX_REALTIME_MODEL,
+  CODEX_REALTIME_PROVIDER_ARCHITECTURE_FALLBACK,
+  CODEX_REALTIME_PROVIDER_MODEL_FALLBACK,
   CODEX_REALTIME_VERSION,
   CODEX_RESPONSES_BASE,
+  CODEX_WHAM_BASE,
 } from "./constants";
 import type { CodexFetch } from "./device-code";
 import {
@@ -13,8 +18,9 @@ import {
   type CodexRealtimeInitialItem,
 } from "./realtime-v3";
 
-const CODEX_REALTIME_CALL_URL = `${CODEX_RESPONSES_BASE}/realtime/calls?intent=quicksilver&architecture=avas`;
 const MAX_REALTIME_SDP_BYTES = 1024 * 1024;
+const MAX_REALTIME_PROVIDER_VALUE_LENGTH = 128;
+const REALTIME_PROVIDER_VALUE = /^[a-z0-9][a-z0-9._-]*$/i;
 const REALTIME_CALL_ID =
   /^(?:rtc_.+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
@@ -78,7 +84,107 @@ export class CodexRealtimeError extends Error {
 export type CodexRealtimeCallOptions = {
   signal?: AbortSignal | undefined;
   timeoutMs?: number | undefined;
+  providerConfig?: CodexRealtimeProviderConfig | undefined;
 };
+
+export type CodexRealtimeProviderConfig = {
+  architecture: string;
+  model: string;
+  version: typeof CODEX_REALTIME_VERSION;
+};
+
+const FALLBACK_REALTIME_PROVIDER_CONFIG: CodexRealtimeProviderConfig = {
+  architecture: CODEX_REALTIME_PROVIDER_ARCHITECTURE_FALLBACK,
+  model: CODEX_REALTIME_PROVIDER_MODEL_FALLBACK,
+  version: CODEX_REALTIME_VERSION,
+};
+
+/**
+ * Resolve the provider-controlled Codex voice model without changing the
+ * stable OpenGeni model id. ChatGPT rotates this config independently of Codex
+ * releases; pinning the old value caused deterministic call-creation failures.
+ */
+export async function fetchCodexRealtimeProviderConfig(
+  auth: CodexAuthHeaders,
+  fetchImpl: CodexFetch = fetch,
+  options: {
+    signal?: AbortSignal | undefined;
+    timeoutMs?: number | undefined;
+  } = {},
+): Promise<CodexRealtimeProviderConfig> {
+  if (options.signal?.aborted) {
+    throw new CodexRealtimeError("cancelled", "Codex realtime request cancelled");
+  }
+  const controller = new AbortController();
+  const timeoutMs = options.timeoutMs ?? CODEX_REALTIME_CONFIG_TIMEOUT_MS;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const onAbort = (): void => controller.abort(options.signal?.reason);
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    const response = await fetchImpl(`${CODEX_WHAM_BASE}/wham/statsig/bootstrap`, {
+      method: "POST",
+      headers: {
+        ...codexSubscriptionHeaders(auth),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        app_session_id: crypto.randomUUID(),
+        app_version: auth.clientVersion,
+        brand_name: "Codex",
+        build_flavor: "stable",
+        locale: "en-US",
+        stable_id: auth.chatgptAccountId ?? "opengeni-server",
+        system_name: "OpenGeni",
+        system_version: "server",
+        window_type: "local",
+      }),
+      signal: controller.signal,
+    });
+    if (response.status === 401) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new CodexRealtimeError(
+        "authentication",
+        "Codex subscription rejected authentication",
+        response.status,
+      );
+    }
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      return FALLBACK_REALTIME_PROVIDER_CONFIG;
+    }
+    const outer = (await response.json().catch(() => null)) as {
+      statsigPayload?: unknown;
+    } | null;
+    if (typeof outer?.statsigPayload !== "string") return FALLBACK_REALTIME_PROVIDER_CONFIG;
+    const payload = JSON.parse(outer.statsigPayload) as {
+      dynamic_configs?: Record<string, { value?: Record<string, unknown> }>;
+    };
+    const value = payload.dynamic_configs?.[CODEX_REALTIME_CONFIG_ID]?.value;
+    const version = value?.version;
+    if (version !== undefined && version !== CODEX_REALTIME_VERSION) {
+      throw new CodexRealtimeError(
+        "incompatible",
+        `Codex realtime remote configuration requires ${String(version)}`,
+      );
+    }
+    const architecture = validProviderValue(value?.architecture)
+      ? value.architecture
+      : FALLBACK_REALTIME_PROVIDER_CONFIG.architecture;
+    const model = validProviderValue(value?.model)
+      ? value.model
+      : FALLBACK_REALTIME_PROVIDER_CONFIG.model;
+    return { architecture, model, version: CODEX_REALTIME_VERSION };
+  } catch (error) {
+    if (error instanceof CodexRealtimeError) throw error;
+    if (options.signal?.aborted) {
+      throw new CodexRealtimeError("cancelled", "Codex realtime request cancelled");
+    }
+    return FALLBACK_REALTIME_PROVIDER_CONFIG;
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", onAbort);
+  }
+}
 
 /**
  * Create one native subscription-authenticated Codex GPT-Live V3 WebRTC call.
@@ -95,11 +201,27 @@ export async function createCodexRealtimeCall(
 ): Promise<CodexRealtimeCallResult> {
   validateRealtimeInput(input);
   const timeoutMs = options.timeoutMs ?? CODEX_REALTIME_CALL_TIMEOUT_MS;
+  const providerConfig = options.providerConfig ?? FALLBACK_REALTIME_PROVIDER_CONFIG;
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     throw new CodexRealtimeError("invalid_request", "Codex realtime timeout must be positive");
   }
   if (options.signal?.aborted) {
     throw new CodexRealtimeError("cancelled", "Codex realtime request cancelled");
+  }
+  if (providerConfig.version !== CODEX_REALTIME_VERSION) {
+    throw new CodexRealtimeError(
+      "incompatible",
+      `Codex realtime provider configuration requires ${providerConfig.version}`,
+    );
+  }
+  if (
+    !validProviderValue(providerConfig.architecture) ||
+    !validProviderValue(providerConfig.model)
+  ) {
+    throw new CodexRealtimeError(
+      "invalid_request",
+      "Codex realtime provider configuration is invalid",
+    );
   }
 
   const controller = new AbortController();
@@ -124,42 +246,45 @@ export async function createCodexRealtimeCall(
   });
 
   const request = (async (): Promise<CodexRealtimeCallResult> => {
-    const response = await fetchImpl(CODEX_REALTIME_CALL_URL, {
-      method: "POST",
-      headers: {
-        ...codexSubscriptionHeaders(auth),
-        "content-type": "application/json",
-        "openai-alpha": "quicksilver=v2",
-        "session-id": input.sessionId,
-        "thread-id": input.sessionId,
-      },
-      body: JSON.stringify({
-        sdp: input.sdp,
-        session: {
-          instructions: input.instructions ?? "",
-          audio: {
-            output: { voice: input.voice ?? CODEX_REALTIME_DEFAULT_VOICE },
-          },
-          delegation: { type: "client" },
-          model: CODEX_REALTIME_MODEL,
-          ...(input.initialItems?.length
-            ? {
-                initial_items: input.initialItems.map((item) => ({
-                  type: "message",
-                  role: item.role,
-                  content: [
-                    {
-                      type: item.role === "assistant" ? "output_text" : "input_text",
-                      text: item.text,
-                    },
-                  ],
-                })),
-              }
-            : {}),
+    const response = await fetchImpl(
+      `${CODEX_RESPONSES_BASE}/realtime/calls?intent=quicksilver&architecture=${encodeURIComponent(providerConfig.architecture)}`,
+      {
+        method: "POST",
+        headers: {
+          ...codexSubscriptionHeaders(auth),
+          "content-type": "application/json",
+          "openai-alpha": "quicksilver=v2",
+          "session-id": input.sessionId,
+          "thread-id": input.sessionId,
         },
-      }),
-      signal: controller.signal,
-    });
+        body: JSON.stringify({
+          sdp: input.sdp,
+          session: {
+            instructions: input.instructions ?? "",
+            audio: {
+              output: { voice: input.voice ?? CODEX_REALTIME_DEFAULT_VOICE },
+            },
+            delegation: { type: "client" },
+            model: providerConfig.model,
+            ...(input.initialItems?.length
+              ? {
+                  initial_items: input.initialItems.map((item) => ({
+                    type: "message",
+                    role: item.role,
+                    content: [
+                      {
+                        type: item.role === "assistant" ? "output_text" : "input_text",
+                        text: item.text,
+                      },
+                    ],
+                  })),
+                }
+              : {}),
+          },
+        }),
+        signal: controller.signal,
+      },
+    );
 
     if (!response.ok) {
       await response.body?.cancel().catch(() => undefined);
@@ -206,6 +331,14 @@ export async function createCodexRealtimeCall(
     if (timeout) clearTimeout(timeout);
     options.signal?.removeEventListener("abort", onAbort);
   }
+}
+
+function validProviderValue(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= MAX_REALTIME_PROVIDER_VALUE_LENGTH &&
+    REALTIME_PROVIDER_VALUE.test(value)
+  );
 }
 
 /** Shared pin→active selection for worker turns and direct realtime calls. */

--- a/packages/codex/test/realtime.test.ts
+++ b/packages/codex/test/realtime.test.ts
@@ -4,6 +4,7 @@ import {
   CODEX_REALTIME_VERSION,
   CodexRealtimeError,
   createCodexRealtimeCall,
+  fetchCodexRealtimeProviderConfig,
   selectCodexCredentialId,
 } from "../src";
 
@@ -67,7 +68,7 @@ describe("native Codex subscription realtime call", () => {
         instructions: "Help with the current OpenGeni session.",
         audio: { output: { voice: "juniper" } },
         delegation: { type: "client" },
-        model: "gpt-live-1-boulder-alpha",
+        model: "gpt-live-1-codex",
         initial_items: [
           {
             type: "message",
@@ -302,6 +303,77 @@ describe("native Codex subscription realtime call", () => {
     );
     await expect(pending).rejects.toMatchObject({ code: "timeout" });
     expect(calls).toBe(1);
+  });
+});
+
+describe("Codex realtime remote configuration", () => {
+  test("resolves the current V3 model and architecture from authenticated Statsig", async () => {
+    let captured: Request | null = null;
+    const config = await fetchCodexRealtimeProviderConfig(auth, async (input, init) => {
+      captured = new Request(input, init);
+      return Response.json({
+        statsigPayload: JSON.stringify({
+          dynamic_configs: {
+            "3566525122": {
+              value: {
+                architecture: "avas-next",
+                model: "gpt-live-1-codex",
+                version: "v3",
+              },
+            },
+          },
+        }),
+      });
+    });
+
+    expect(captured!.url).toBe("https://chatgpt.com/backend-api/wham/statsig/bootstrap");
+    expect(captured!.headers.get("authorization")).toBe("Bearer server-only-token");
+    expect(captured!.headers.get("chatgpt-account-id")).toBe("acct_bound");
+    expect(config).toEqual({
+      architecture: "avas-next",
+      model: "gpt-live-1-codex",
+      version: "v3",
+    });
+  });
+
+  test("never downgrades when the remote protocol is not V3", async () => {
+    await expect(
+      fetchCodexRealtimeProviderConfig(auth, async () =>
+        Response.json({
+          statsigPayload: JSON.stringify({
+            dynamic_configs: {
+              "3566525122": { value: { model: "legacy", version: "v2" } },
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "incompatible" });
+  });
+
+  test("uses the verified V3 fallback for transient or malformed config responses", async () => {
+    expect(
+      await fetchCodexRealtimeProviderConfig(
+        auth,
+        async () => new Response("unavailable", { status: 503 }),
+      ),
+    ).toEqual({
+      architecture: "avas",
+      model: "gpt-live-1-codex",
+      version: "v3",
+    });
+    expect(
+      await fetchCodexRealtimeProviderConfig(auth, async () => Response.json({ nope: true })),
+    ).toEqual({
+      architecture: "avas",
+      model: "gpt-live-1-codex",
+      version: "v3",
+    });
+  });
+
+  test("preserves an authentication rejection for the broker's one safe refresh", async () => {
+    await expect(
+      fetchCodexRealtimeProviderConfig(auth, async () => new Response(null, { status: 401 })),
+    ).rejects.toMatchObject({ code: "authentication", providerStatus: 401 });
   });
 });
 


### PR DESCRIPTION
## Root cause
ChatGPT rotated Codex Live V3 from `gpt-live-1-boulder-alpha` to `gpt-live-1-codex` through authenticated Statsig config version 73. OpenGeni hardcoded the retired provider model, so every call deterministically failed HTTP 400.

## Fix
- resolve the authenticated remote realtime model/architecture before call creation
- keep OpenGeni’s persisted selector stable
- require V3; never downgrade protocol
- retain a verified current V3 fallback for transient config lookup failures

## Verification
- live provider accepted the resolved model: HTTP 201 + valid audio SDP
- exact patched production broker returned a valid V3 audio answer
- 29 focused tests pass
- all 31 typecheck projects pass
- format and lint pass