### PR TITLE
fix(realtime): release expired browser owners

### DIFF
--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -6,6 +6,7 @@ import {
   type SessionRealtimeController,
   type SessionRealtimeControllerSnapshot,
   type CreateSessionRealtimeControllerOptions,
+  type SessionRealtimeLifecycleProjection,
   type SessionRealtimeModel,
   type WorkspaceRealtimeModelCatalogItem,
 } from "@opengeni/sdk/realtime";
@@ -280,7 +281,7 @@ export function useSessionRealtime(options: {
   const eventsReadyRef = useRef(options.eventsReady);
   lifecycleRef.current = lifecycle;
   eventsReadyRef.current = options.eventsReady;
-  const lifecycleActive = lifecycle?.state === "active";
+  const lifecycleActive = sessionRealtimeLifecycleIsActive(lifecycle);
 
   useEffect(() => {
     let disposed = false;
@@ -401,6 +402,14 @@ export function useSessionRealtime(options: {
   };
 }
 
+function sessionRealtimeLifecycleIsActive(
+  lifecycle: SessionRealtimeLifecycleProjection | null,
+): boolean {
+  if (lifecycle?.state !== "active") return false;
+  const leaseExpiresAt = Date.parse(lifecycle.leaseExpiresAt);
+  return !Number.isFinite(leaseExpiresAt) || leaseExpiresAt > Date.now();
+}
+
 export function SessionRealtimeControl(props: {
   client?: RealtimeControllerClient | undefined;
   workspaceId?: string | undefined;
@@ -429,11 +438,12 @@ export function SessionRealtimeControl(props: {
   controllerFactory?: SessionRealtimeControllerFactory | undefined;
 }) {
   const lifecycle = useMemo(() => projectSessionRealtimeLifecycle(props.events), [props.events]);
+  const lifecycleActive = sessionRealtimeLifecycleIsActive(lifecycle);
   const selection = useRealtimeModelSelection({
     client: props.client,
     workspaceId: props.workspaceId,
     codexConnected: props.codexConnected,
-    activeModel: lifecycle?.state === "active" ? lifecycle.model : null,
+    activeModel: lifecycleActive && lifecycle?.state === "active" ? lifecycle.model : null,
   });
   const selectedModel = selection.selectedModel;
   const realtime = useSessionRealtime({
@@ -457,7 +467,7 @@ export function SessionRealtimeControl(props: {
 
   useEffect(() => {
     const pending = autostartModelRef.current;
-    if (!pending || autostartStartedRef.current || lifecycle?.state === "active") return;
+    if (!pending || autostartStartedRef.current || lifecycleActive) return;
     const available = models.some((model) => model.id === pending && model.available);
     if (!available) return;
     if (selectedRealtimeModel.id !== pending) {
@@ -476,7 +486,7 @@ export function SessionRealtimeControl(props: {
       });
   }, [
     canStart,
-    lifecycle?.state,
+    lifecycleActive,
     models,
     props.sessionId,
     props.workspaceId,

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -174,7 +174,7 @@ describe("ordinary session Codex realtime control", () => {
         model: "gpt-live-1-boulder-alpha",
         version: 1,
         connectionEpoch: 1,
-        leaseExpiresAt: "2026-07-29T07:00:30.000Z",
+        leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
       },
       occurredAt: "2026-07-29T07:00:00.000Z",
     };
@@ -217,6 +217,56 @@ describe("ordinary session Codex realtime control", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  test("re-enables voice when the durable foreign-owner lease is already expired", async () => {
+    const started: SessionEvent = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      workspaceId: "11111111-1111-4111-8111-111111111111",
+      sessionId: "22222222-2222-4222-8222-222222222222",
+      sequence: 10,
+      type: "session.realtime.started",
+      payload: {
+        realtimeId: "33333333-3333-4333-8333-333333333333",
+        operationId: "44444444-4444-4444-8444-444444444444",
+        model: "gpt-live-1-boulder-alpha",
+        version: 1,
+        connectionEpoch: 1,
+        leaseExpiresAt: "2020-07-29T07:00:30.000Z",
+      },
+      occurredAt: "2020-07-29T07:00:00.000Z",
+    };
+    const client = {
+      beginSessionRealtime: async () => {
+        throw new Error("start was not requested");
+      },
+    } as unknown as OpenGeniClient;
+    const events = [started];
+
+    function Harness() {
+      const realtime = useSessionRealtime({
+        client,
+        workspaceId: started.workspaceId,
+        sessionId: started.sessionId,
+        sessionStatus: "idle",
+        effectiveControl,
+        events,
+        eventsReady: true,
+        codexConnected: true,
+      });
+      return (
+        <output data-status={realtime.snapshot.status} data-can-start={String(realtime.canStart)} />
+      );
+    }
+
+    await act(async () => root.render(<Harness />));
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+      if (container.querySelector("output")?.getAttribute("data-can-start") === "true") break;
+    }
+    const output = container.querySelector("output");
+    expect(output?.getAttribute("data-status")).toBe("idle");
+    expect(output?.getAttribute("data-can-start")).toBe("true");
   });
 
   test("keeps one controller while exposing the latest host model-context callback", async () => {

--- a/packages/sdk/src/codex-realtime-controller.ts
+++ b/packages/sdk/src/codex-realtime-controller.ts
@@ -50,6 +50,7 @@ export const CODEX_REALTIME_NEGOTIATION_TIMEOUT_MS = 20_000;
 // OpenGeni policy: rotate conservatively without asserting an upstream lifetime.
 const DEFAULT_CONNECTION_ROTATION_INTERVAL_MS = 15 * 60_000;
 const DEFAULT_RECONNECT_BACKOFF_MS = [250, 1_000, 2_000, 5_000] as const;
+const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 const OWNER_RECORD_VERSION = 1;
 const OWNER_DELEGATION_REPLAY_VERSION = 1;
 const OWNER_DELEGATION_REPLAY_MAX_CALLS = 4_096;
@@ -224,6 +225,7 @@ export type CreateCodexRealtimeControllerOptions = {
   createPeerConnection?: (() => RTCPeerConnection) | undefined;
   getUserMedia?: ((constraints: MediaStreamConstraints) => Promise<MediaStream>) | undefined;
   randomUUID?: (() => string) | undefined;
+  now?: (() => Date) | undefined;
   setInterval?: ((callback: () => void, delayMs: number) => unknown) | undefined;
   clearInterval?: ((handle: unknown) => void) | undefined;
   setTimeout?: ((callback: () => void, delayMs: number) => unknown) | undefined;
@@ -316,6 +318,7 @@ export function createCodexRealtimeController(
   );
   const model = options.model ?? "gpt-live-1-boulder-alpha";
   const randomUUID = options.randomUUID ?? defaultRandomUUID;
+  const now = options.now ?? (() => new Date());
   const scheduleInterval =
     options.setInterval ?? ((callback, delay) => globalThis.setInterval(callback, delay));
   const unscheduleInterval =
@@ -362,6 +365,7 @@ export function createCodexRealtimeController(
   let rotationTimer: unknown = null;
   let reconnectTimer: unknown = null;
   let negotiationTimer: unknown = null;
+  let lostOwnerExpiryTimer: unknown = null;
   let closed = false;
   let stopping = false;
   let generation = 0;
@@ -456,11 +460,13 @@ export function createCodexRealtimeController(
     if (rotationTimer !== null) unscheduleTimeout(rotationTimer);
     if (reconnectTimer !== null) unscheduleTimeout(reconnectTimer);
     if (negotiationTimer !== null) unscheduleTimeout(negotiationTimer);
+    if (lostOwnerExpiryTimer !== null) unscheduleTimeout(lostOwnerExpiryTimer);
     heartbeatTimer = null;
     syncTimer = null;
     rotationTimer = null;
     reconnectTimer = null;
     negotiationTimer = null;
+    lostOwnerExpiryTimer = null;
   };
 
   const stopNegotiationTimers = (): void => {
@@ -1255,6 +1261,12 @@ export function createCodexRealtimeController(
       if (!record || record.operationId !== lifecycle.operationId) {
         closeBrowserResources();
         owner = null;
+        const leaseExpiresAt = Date.parse(lifecycle.leaseExpiresAt);
+        const remainingLeaseMs = leaseExpiresAt - now().getTime();
+        if (Number.isFinite(remainingLeaseMs) && remainingLeaseMs <= 0) {
+          transitionEnded("Realtime lease expired");
+          return;
+        }
         const message =
           "Realtime is active in another browser owner. It can resume after that owner stops or its lease expires.";
         publish({
@@ -1265,6 +1277,15 @@ export function createCodexRealtimeController(
           diagnostic: diagnostic("lost_owner", message, false),
           error: message,
         });
+        if (Number.isFinite(remainingLeaseMs) && remainingLeaseMs <= MAX_BROWSER_TIMEOUT_MS) {
+          const observedRealtimeId = lifecycle.realtimeId;
+          lostOwnerExpiryTimer = scheduleTimeout(() => {
+            lostOwnerExpiryTimer = null;
+            if (state.status === "lost_owner" && state.realtimeId === observedRealtimeId) {
+              transitionEnded("Realtime lease expired");
+            }
+          }, remainingLeaseMs);
+        }
         return;
       }
       if (connectionTask || state.status === "starting") return;

--- a/packages/sdk/test/codex-realtime-controller.test.ts
+++ b/packages/sdk/test/codex-realtime-controller.test.ts
@@ -5,6 +5,7 @@ import {
   projectSessionRealtimeLifecycle,
 } from "../src/codex-realtime-controller";
 import { CODEX_REALTIME_V3_PENDING_MAX_BYTES } from "../src/codex-realtime-v3";
+import type { SessionRealtimeLifecycleProjection } from "../src/codex-realtime-lifecycle";
 import { OpenGeniApiError } from "../src/errors";
 import type {
   CodexRealtimeWebrtcRequest,
@@ -658,6 +659,7 @@ describe("Codex realtime browser controller", () => {
       workspaceId: WORKSPACE_ID,
       sessionId: SESSION_ID,
       storage: storageFixture(),
+      now: () => new Date("2026-07-29T07:00:00.000Z"),
       randomUUID: uuidSource(),
       ...noIntervals(),
       client: {
@@ -702,6 +704,57 @@ describe("Codex realtime browser controller", () => {
     ]);
     await controller.observeLifecycle(ended);
     expect(controller.snapshot().status).toBe("idle");
+  });
+
+  test("releases a foreign browser owner exactly when its lease expires", async () => {
+    const timers = timerFixture();
+    let beginCalls = 0;
+    const controller = createCodexRealtimeController({
+      workspaceId: WORKSPACE_ID,
+      sessionId: SESSION_ID,
+      storage: storageFixture(),
+      now: () => new Date("2026-07-29T07:00:00.000Z"),
+      randomUUID: uuidSource(),
+      ...timers,
+      client: {
+        beginSessionRealtime: async () => {
+          beginCalls += 1;
+          throw new Error("new owner began");
+        },
+        negotiateCodexRealtimeWebrtc: async () => {
+          throw new Error("must not negotiate");
+        },
+        activateCodexRealtimeConnection: async () => {
+          throw new Error("must not activate");
+        },
+        heartbeatSessionRealtime: async () => ({ mode: mode(), replay: true }),
+        syncSessionRealtimeLedger: async () => ({ accepted: [], outbound: [] }),
+        endSessionRealtime: async () => ({ mode: mode({ state: "ended" }), replay: true }),
+      },
+    });
+    const lifecycle: SessionRealtimeLifecycleProjection = {
+      state: "active",
+      realtimeId: REALTIME_ID,
+      operationId: "11111111-1111-4111-8111-111111111111",
+      model: "gpt-live-1-boulder-alpha",
+      version: 4,
+      connectionEpoch: 2,
+      leaseExpiresAt: "2026-07-29T07:00:30.000Z",
+    };
+
+    await controller.observeLifecycle(lifecycle);
+    expect(controller.snapshot().status).toBe("lost_owner");
+    expect(timers.timeoutDelays()).toContain(30_000);
+    timers.runTimeout(30_000);
+    expect(controller.snapshot()).toMatchObject({ status: "idle", realtimeId: null });
+    await expect(controller.start()).rejects.toThrow("new owner began");
+    expect(beginCalls).toBe(1);
+
+    await controller.observeLifecycle({
+      ...lifecycle,
+      leaseExpiresAt: "2026-07-29T06:59:59.000Z",
+    });
+    expect(controller.snapshot()).toMatchObject({ status: "idle", realtimeId: null });
   });
 
   test("replays persisted same-browser ownership and rotates the dead browser connection", async () => {


### PR DESCRIPTION
## Root cause
Durable `session.realtime.started` events outlive their 30-second lease. The browser controller treated any projected active event as a live foreign owner forever, even when `leaseExpiresAt` was hours old. The React admission layer independently made the same mistake, permanently disabling Start Voice.

## Fix
- Reconcile expired foreign-owner leases immediately.
- Arm a bounded browser timer for a still-live foreign lease, then return to idle at expiry.
- Make React admission/model/autostart state lease-aware.
- Preserve fail-closed behavior for malformed or implausibly distant lease timestamps.

## Verification
- 35 focused SDK/React tests pass.
- SDK and React typechecks pass.
- Formatting passes.
- Regression covers immediate stale recovery and exact future lease expiry.