### PR TITLE
fix(web): stabilize sandbox link bundle budget

### DIFF
--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -621,7 +621,7 @@ export function SessionRoute({
   const sandboxFileRequestSeq = useRef(0);
   const [sandboxFileRequest, setSandboxFileRequest] = useState<{
     path: string;
-    line: number | null;
+    line?: number;
     requestId: number;
   } | null>(null);
   useEffect(() => {
@@ -629,12 +629,11 @@ export function SessionRoute({
   }, [sessionId]);
   const setInspectorOpen = context.setInspectorOpen;
   const openSandboxFile = useCallback(
-    (path: string, line?: number | null) => {
-      sandboxFileRequestSeq.current += 1;
+    (path: string, line?: number) => {
       setSandboxFileRequest({
         path,
-        line: line != null && line > 0 ? line : null,
-        requestId: sandboxFileRequestSeq.current,
+        line,
+        requestId: ++sandboxFileRequestSeq.current,
       });
       setInspectorOpen(true);
     },
@@ -1003,7 +1002,7 @@ function SessionChatPane(props: {
   onReconnect: (item: AuthNeededItem) => void | Promise<void>;
   resolveProviderLogo: (providerDomain: string) => string | null;
   onReloadSession: () => Promise<void>;
-  onOpenSandboxFile: (path: string, line?: number | null) => void;
+  onOpenSandboxFile: (path: string, line?: number) => void;
 }) {
   const context = useAppContext();
   const modelCatalog = useWorkspaceModelCatalog(props.session.workspaceId);

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -1058,12 +1058,11 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
   const activeTabHint = selectedTab ?? initialTab ?? leadingTabs?.[0]?.id ?? null;
   const openFile = useCallback(
     (path: string, line?: number | null) => {
-      nextFileRequestId.current += 1;
       setRequestedFile({
         sessionId,
         path,
         line: line != null && line > 0 ? line : null,
-        requestId: nextFileRequestId.current,
+        requestId: ++nextFileRequestId.current,
       });
       setStoredSelection({ sessionId, tab: WORKBENCH_TAB_FILES });
       onActiveTabChange?.(WORKBENCH_TAB_FILES);
@@ -1077,7 +1076,7 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     if (!openFileRequest) return;
     if (handledOpenFileRequestId.current === openFileRequest.requestId) return;
     handledOpenFileRequestId.current = openFileRequest.requestId;
-    openFile(openFileRequest.path, openFileRequest.line ?? null);
+    openFile(openFileRequest.path, openFileRequest.line);
   }, [openFile, openFileRequest]);
   const openComputer = useCallback(
     (computerSessionId: string) => {


### PR DESCRIPTION
## Summary

- preserve exact sandbox Markdown file-open behavior while removing redundant request normalization
- retain positive-line validation at the Files workbench boundary
- restore the release-image web bundle budget after #1772 without increasing the budget

## Verification

- `bun run lint`
- `bun run typecheck` (31 projects)
- `bun test apps/web/src/session-control-surface.test.ts packages/react/test/markdown-sandbox-links.test.tsx packages/react/test/workbench-prewarm.test.tsx` (55 pass)
- `bun test packages/react/test` (1,407 pass)
- `bun run --cwd apps/web build`
- dual-architecture `linux/amd64,linux/arm64` web image build with the pinned Bun 1.3.14 Dockerfile (direct-session raw: 2,130,895 / 2,130,944 bytes)