### PR TITLE
fix(worker): isolate database readiness probes

### DIFF
--- a/apps/worker/src/http.ts
+++ b/apps/worker/src/http.ts
@@ -118,12 +118,22 @@ export function dbReadyCheck(
   db: Database,
   posture?: RuntimeDatabasePostureOptions,
 ): () => Promise<void> {
-  return async () => {
-    if (posture) {
-      await assertRuntimeDatabasePosture(db, posture);
-      return;
-    }
-    await db.execute(dbSql`select 1`);
+  let inFlight: Promise<void> | undefined;
+  return () => {
+    // The HTTP timeout cannot cancel a driver query. Reuse an outstanding
+    // attempt so repeated kubelet probes cannot queue an unbounded tail behind
+    // one slow or disconnected database connection.
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      if (posture) {
+        await assertRuntimeDatabasePosture(db, posture);
+        return;
+      }
+      await db.execute(dbSql`select 1`);
+    })().finally(() => {
+      inFlight = undefined;
+    });
+    return inFlight;
   };
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -742,8 +742,13 @@ export type OpenGeniWorkerServiceOptions = Omit<WorkerOptions, "activityDependen
    * in the same deployment owns them.
    */
   internalSchedules?: "role-default" | "none";
-  /** Set false only when the host exposes equivalent lifecycle endpoints itself. */
-  http?: false | { readinessTimeoutMs?: number };
+  /**
+   * Set false only when the host exposes equivalent lifecycle endpoints itself.
+   * A dedicated readiness database prevents ordinary activity-pool saturation
+   * from making an otherwise healthy Temporal worker fail Kubernetes readiness.
+   * The embedding host retains ownership of this handle.
+   */
+  http?: false | { readinessTimeoutMs?: number; readinessDb?: Database };
 };
 
 export type OpenGeniWorkerService = {
@@ -894,7 +899,10 @@ export async function createOpenGeniWorkerService(
         settings,
         observability,
         checks: {
-          db: dbReadyCheck(options.activityDependencies.db, options.databasePosture),
+          db: dbReadyCheck(
+            options.http?.readinessDb ?? options.activityDependencies.db,
+            options.databasePosture,
+          ),
           nats: natsReadyCheck(options.activityDependencies.bus),
           temporal: temporalReadyCheck(workerBundle.connection),
         },
@@ -1027,6 +1035,16 @@ export async function startWorker() {
     ...(searchPath ? { searchPath } : {}),
     rlsStrategy: settings.rlsStrategy,
   });
+  // Readiness must prove PostgreSQL independently of activity demand. Sharing
+  // the default application pool makes the probe wait behind live turns when
+  // all ten slots are occupied, even while PostgreSQL itself is healthy. Since
+  // Kubernetes readiness cannot stop Temporal polling, that false negative
+  // only wedges rollouts and service health; reserve one probe connection.
+  const readinessDbClient = createDb(settings.databaseUrl, {
+    ...(searchPath ? { searchPath } : {}),
+    rlsStrategy: settings.rlsStrategy,
+    max: 1,
+  });
   const databasePosture = {
     rlsStrategy: settings.rlsStrategy,
     expectedRole: settings.runtimeDatabaseRole,
@@ -1058,6 +1076,7 @@ export async function startWorker() {
       role,
       settings,
       databasePosture,
+      http: { readinessDb: readinessDbClient.db },
       activityDependencies: {
         observability,
         db: dbClient.db,
@@ -1065,7 +1084,7 @@ export async function startWorker() {
       },
     });
   } finally {
-    await Promise.allSettled([bus?.close(), dbClient.close()]);
+    await Promise.allSettled([bus?.close(), readinessDbClient.close(), dbClient.close()]);
   }
 }
 

--- a/apps/worker/test/embedded-lifecycle.test.ts
+++ b/apps/worker/test/embedded-lifecycle.test.ts
@@ -615,6 +615,32 @@ describe("embedded worker lifecycle contract", () => {
     await expect(dbReadyCheck(embeddedDb(false), options)()).resolves.toBeUndefined();
   });
 
+  test("database readiness coalesces overlapping probe attempts", async () => {
+    let executions = 0;
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const db = {
+      execute: async () => {
+        executions += 1;
+        if (executions === 1) await blocked;
+        return [];
+      },
+    } as unknown as Database;
+    const check = dbReadyCheck(db);
+
+    const first = check();
+    const second = check();
+    expect(first).toBe(second);
+    expect(executions).toBe(1);
+
+    release();
+    await Promise.all([first, second]);
+    await check();
+    expect(executions).toBe(2);
+  });
+
   test("readiness follows role lifecycle while health stays live during drain", async () => {
     const settings = testSettings();
     const observability = createObservability(settings, { component: "worker-test" });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1950,7 +1950,7 @@ and storage objects, so it proves deeper behavior but is not a liveness probe.
 Service endpoints:
 
 - API: `GET /metrics` and `GET /healthz` on `OPENGENI_API_PORT` (default `8000`); `GET /traffic-readyz` checks Postgres for traffic routing, while `GET /readyz` reports Postgres, NATS, and Temporal with bounded timeouts.
-- Worker: `GET /metrics`, `GET /healthz`, and `GET /readyz` on `OPENGENI_WORKER_HTTP_PORT` (default `8001`); readiness requires lifecycle state `ready` plus healthy Postgres, NATS, and Temporal checks. A draining worker stays live but becomes unready before polling stops.
+- Worker: `GET /metrics`, `GET /healthz`, and `GET /readyz` on `OPENGENI_WORKER_HTTP_PORT` (default `8001`); readiness requires lifecycle state `ready` plus healthy Postgres, NATS, and Temporal checks. The standalone worker reserves a one-connection Postgres probe pool so ordinary activity-pool saturation cannot create false readiness failures. A draining worker stays live but becomes unready before polling stops.
 - Relay: `GET /metrics` and `GET /healthz` on the relay port when the relay is enabled.
 
 Useful settings:


### PR DESCRIPTION
## Summary
- reserve a dedicated one-connection PostgreSQL readiness pool in standalone workers
- coalesce overlapping DB probes so timed-out HTTP requests cannot queue unbounded database checks
- preserve full posture, NATS, Temporal, and lifecycle readiness semantics

## Root cause
Turn activity occupied all 10 application-pool connections while PostgreSQL itself remained healthy. The Kubernetes probe borrowed that same pool, exceeded its 2s timeout, and marked the Temporal worker unready. Readiness cannot stop Temporal polling, so this only caused false service/rollout failure.

## Verification
- `bun run typecheck`
- `bun test --timeout 30000 apps/worker/test` (1,237 pass, 3 skip, 0 fail)
- `bun run check:public-hygiene`
- `bun x oxlint --deny-warnings apps/worker/src/index.ts apps/worker/src/http.ts apps/worker/test/embedded-lifecycle.test.ts`
- `bun x oxfmt --check apps/worker/src/index.ts apps/worker/src/http.ts apps/worker/test/embedded-lifecycle.test.ts docs/deployment.md`