### PR TITLE
fix(deploy): stop single-node from stacking turns on one event loop

### DIFF
--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -112,8 +112,8 @@ spec:
             )
         {{- end }}
         # Node-relative protection cannot rely on a container memory limit: the
-        # single-node profile intentionally leaves the resource-based turn worker
-        # unbounded so Temporal can tune concurrency against real headroom. These
+        # single-node profile omits per-pod memory partitions and uses several
+        # fixed-density turn workers instead of one host-tuned event loop. These
         # records map node-exporter instances onto Kubernetes nodes, then retain
         # alerts only for nodes currently hosting this OpenGeni release.
         - record: opengeni:workload_node:present

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -1,6 +1,8 @@
-# Supported non-HA, single-machine profile. Every process has one replica and
-# shares the host dynamically: no HPA, topology spreading, PDB, CPU quota, or
-# per-pod memory partition. Excess turns remain durable in Temporal.
+# Supported non-HA, single-machine profile. API, web, control, and deps stay
+# one replica. Turn workers are six replicas at a fixed 16 turns each so one
+# Bun event loop cannot admit host-wide concurrency. No HPA, topology
+# spreading, PDB, CPU quota, or per-pod memory partition. Excess turns remain
+# durable in Temporal.
 #
 # Bootstrap in two phases so Postgres/Temporal/NATS/Garage are healthy before the
 # pre-upgrade migration/role/posture gate runs. See docs/deployment.md.
@@ -36,7 +38,7 @@ worker:
     autoscaling:
       enabled: false
   turns:
-    replicaCount: 1
+    replicaCount: 6
     resources: null
     podDisruptionBudget:
       enabled: false
@@ -98,10 +100,10 @@ config:
   OPENGENI_STARTUP_DEPENDENCY_RETRY_ATTEMPTS: "30"
   OPENGENI_STARTUP_DEPENDENCY_RETRY_INITIAL_DELAY_MS: "1000"
   OPENGENI_STARTUP_DEPENDENCY_RETRY_MAX_DELAY_MS: "5000"
-  # One turn worker expands activity slots while total machine use stays below
-  # these targets. Temporal durably queues excess work above the safety ceiling.
-  OPENGENI_TURN_WORKER_CONCURRENCY_MODE: resource-based
-  OPENGENI_TURN_WORKER_MAX_CONCURRENT_TURNS: "256"
+  # Several turn-worker processes, each capped at the per-loop default. One
+  # Bun event loop cannot spend whole-machine CPU/RAM; Temporal queues the rest.
+  OPENGENI_TURN_WORKER_CONCURRENCY_MODE: fixed
+  OPENGENI_TURN_WORKER_MAX_CONCURRENT_TURNS: "16"
   OPENGENI_TURN_WORKER_TARGET_CPU_USAGE: "0.8"
   OPENGENI_TURN_WORKER_TARGET_MEMORY_USAGE: "0.75"
   # The tuner closes new admission at 75%. The distinct 90% threshold is an

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,10 +69,11 @@ persistent, non-HA profile for running the complete control plane on one
 machine. Kubernetes is used only as the process, restart, volume, and upgrade
 supervisor. It is not an autoscaling or failover layer in this profile.
 
-The profile renders one API, web, control worker, turn worker, relay, Postgres,
-Temporal, NATS, and Garage process. It disables HPAs, disruption budgets, and
-topology spreading. Container resource requests and limits are omitted, so a
-busy role may use otherwise-idle CPU and memory on the machine.
+The profile renders one API, web, control worker, relay, Postgres, Temporal,
+NATS, and Garage process, plus six turn-worker replicas. It disables HPAs,
+disruption budgets, and topology spreading. Container resource requests and
+limits are omitted, so a busy role may use otherwise-idle CPU and memory on
+the machine.
 
 The profile creates four non-preempting Pod priority tiers. Under
 kubelet-managed node pressure, presentation (web and relay) is evicted before
@@ -92,12 +93,14 @@ explicitly and recover after reconnect. `/readyz` remains the complete
 Postgres/NATS/Temporal dependency report, so the outage is still visible to
 operators. Losing Postgres fails both readiness paths.
 
-The one turn worker uses Temporal's resource-based slot tuner. It admits more
-agent turns while whole-machine CPU stays below 80% and memory stays below 75%,
-up to 256 active turns; excess work remains durable in Temporal. This is a
-safety ceiling, not a reservation or a promise that 256 heavy turns fit. The
-ordinary chart default remains a fixed 16 turns per worker so multi-worker
-deployments can scale replicas predictably. Fixed/HPA turn workers use a custom
+Turn workers use a fixed 16 concurrent `runAgentTurn` activities per process.
+A single Bun event loop cannot spend whole-machine CPU or RAM; host-level
+resource-based admission on one replica will pile tens of turns onto that
+loop until `/readyz` misses the kubelet timeout. The profile therefore runs
+six turn-worker replicas (96 host-wide turns, 16 per loop). Temporal load-
+balances `*-turns` across those pollers and durably queues the rest. The
+ordinary chart default for other profiles remains a fixed 16 turns per
+worker so multi-worker deployments can scale replicas predictably. Fixed/HPA turn workers use a custom
 Temporal slot supplier that reserves 100 MiB for the complete physical
 `runAgentTurn` promise lifetime, retains 512 MiB for runtime/native/GC headroom,
 and refuses another poll when either the startup-baseline or current-cgroup

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -165,8 +165,9 @@ describe("Helm database upgrade contract", () => {
     expect(values).toContain("resources: null");
     expect(values).toContain("priorityClasses:\n  enabled: true");
     expect(values).toContain("path: /traffic-readyz");
-    expect(values).toContain("OPENGENI_TURN_WORKER_CONCURRENCY_MODE: resource-based");
-    expect(values).toContain('OPENGENI_TURN_WORKER_MAX_CONCURRENT_TURNS: "256"');
+    expect(values).toContain("OPENGENI_TURN_WORKER_CONCURRENCY_MODE: fixed");
+    expect(values).toContain('OPENGENI_TURN_WORKER_MAX_CONCURRENT_TURNS: "16"');
+    expect(values).toMatch(/turns:\n    replicaCount: 6/);
     expect(values).toContain('OPENGENI_TURN_WORKER_EMERGENCY_MEMORY_USAGE: "0.9"');
     for (const tier of ["presentation", "execution", "control", "durable"]) {
       expect(defaults).toContain(`    ${tier}:`);


### PR DESCRIPTION
## Summary
- Single-node was `resource-based` / 256 on **one** turn worker. Temporal meters host CPU/RAM, not the Bun event loop, so one process admits tens of `runAgentTurn`s until `/readyz` misses kubelet (seen on Jorgebot: 44 inflight, 2–7s loop lag, 0/1 Ready).
- Profile is now **6 replicas × fixed 16** (96 host-wide, 16 per loop). Same density as the multi-worker default; Temporal still queues the rest.
- Docs and the Helm contract test follow.

## Test plan
- [x] `bun test scripts/helm-upgrade-contract.test.ts`
- [x] Jorgebot already running 6×16; `/readyz` 200, work spread across pollers


Made with [Cursor](https://cursor.com)