### PR TITLE
Fix stale Connected Machine browser and Desktop placement

### DIFF
--- a/.changeset/retire-stale-connected-interactions.md
+++ b/.changeset/retire-stale-connected-interactions.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+"@opengeni/react": patch
+---
+
+Retire Browser and Desktop resources when their source task leaves the Connected Machine that owns their controller, stop retrying the terminal placement conflict, and let Desktop create one replacement on the task's current placement.

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -133,6 +133,7 @@ import {
   touchBrowserSessionController,
   verifyAuthRun,
   settleBrowserDownloadSaveFailure,
+  terminalizeStaleConnectedInteractionPlacement,
   type BrowserSessionControlRecord,
   type BrowserPrivateCheckpointAuthority,
   type BrowserRevisionArtifactAuthority,
@@ -205,6 +206,7 @@ import {
 } from "../browser-auth-broker";
 import { managedNetworkRouteForPlacement } from "../browser-network-route";
 import { validateInteractionRequestOrigin } from "../http/cors";
+import { ApiHttpError } from "../http/api-error";
 import { interactionControlApiError } from "../http/interaction-control-error";
 import {
   createInteractionFrameProxyAttachment,
@@ -2780,8 +2782,10 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
             resolved.kind !== "selfhosted" ||
             resolved.sandboxId !== expectedPlacement.sandboxId
           ) {
-            throw new BrowserSessionStateError(
-              "BrowserSession Connected Machine is not the active placement",
+            return await throwBrowserSourcePlacementChanged(
+              grant,
+              sourceSession.id,
+              expectedPlacement.sandboxId,
             );
           }
           const placementInstanceId = resolved.providerInstanceId ?? expectedPlacement.sandboxId;
@@ -3023,6 +3027,17 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
         record.sourceSessionId,
         authorizationOperation,
       );
+      let sourceSession: Session | null = null;
+      if (record.session.placement?.kind === "connected_machine") {
+        sourceSession = await requireSourceSession(deps, workspaceId, record.sourceSessionId);
+        if (sourceSession.activeSandboxId !== record.session.placement.sandboxId) {
+          return await throwBrowserSourcePlacementChanged(
+            grant,
+            record.sourceSessionId,
+            record.session.placement.sandboxId,
+          );
+        }
+      }
       if (record.session.lifecycle !== "active" || !record.session.controller) {
         throw new BrowserSessionStateError("BrowserSession is not active");
       }
@@ -3107,7 +3122,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
         }
       }
 
-      const sourceSession = await requireSourceSession(deps, workspaceId, record.sourceSessionId);
+      sourceSession ??= await requireSourceSession(deps, workspaceId, record.sourceSessionId);
       return await withBrowserPlacement(
         sourceSession,
         grant,
@@ -3125,6 +3140,25 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
     } catch (error) {
       throw browserRouteError(error);
     }
+  }
+
+  async function throwBrowserSourcePlacementChanged(
+    grant: AccessGrant,
+    sourceSessionId: string,
+    connectedSandboxId: string,
+  ): Promise<never> {
+    const reconciliation = await terminalizeStaleConnectedInteractionPlacement(deps.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sourceSessionId,
+      connectedSandboxId,
+    });
+    if (reconciliation.sourcePlacementChanged) {
+      throw sourcePlacementChangedApiError("browser_session");
+    }
+    throw new BrowserSessionStateError(
+      "BrowserSession source placement changed during the request; retry",
+    );
   }
 
   async function recoverActiveBrowserController(
@@ -3225,6 +3259,21 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       record.controllerHostSandboxGroupId,
     );
   }
+}
+
+function sourcePlacementChangedApiError(interactionResource: "browser_session"): ApiHttpError {
+  return new ApiHttpError(409, {
+    code: "conflict",
+    message:
+      "This browser belonged to a previous task placement and was retired. Open a new browser.",
+    retryable: false,
+    outcomeUnknown: false,
+    details: {
+      interactionResource,
+      interactionFailureCode: "source_placement_changed",
+      interactionLifecycle: "lost",
+    },
+  });
 }
 
 function browserCreateInput(

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -46,6 +46,7 @@ import {
   releaseLeaseHolder,
   readLease,
   recordLeaseControllerDataPlaneUrl,
+  terminalizeStaleConnectedInteractionPlacement,
   touchComputerSessionController,
   type ComputerSessionControlRecord,
   type LeaseSnapshot,
@@ -94,6 +95,7 @@ import {
 } from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
 import { validateInteractionRequestOrigin } from "../http/cors";
+import { ApiHttpError } from "../http/api-error";
 import { interactionControlApiError } from "../http/interaction-control-error";
 import {
   createInteractionFrameProxyAttachment,
@@ -942,8 +944,10 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
             resolved.kind !== "selfhosted" ||
             resolved.sandboxId !== expectedPlacement.sandboxId
           ) {
-            throw new ComputerSessionStateError(
-              "ComputerSession Connected Machine is not the active placement",
+            return await throwComputerSourcePlacementChanged(
+              grant,
+              sourceSession.id,
+              expectedPlacement.sandboxId,
             );
           }
           const placementInstanceId = resolved.providerInstanceId ?? expectedPlacement.sandboxId;
@@ -1150,6 +1154,17 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
         computerSessionId,
       });
       await authorizeSourceSession(deps, grant, record.sourceSessionId, authorizationOperation);
+      let sourceSession: Session | null = null;
+      if (record.session.placement?.kind === "connected_machine") {
+        sourceSession = await requireSourceSession(deps, workspaceId, record.sourceSessionId);
+        if (sourceSession.activeSandboxId !== record.session.placement.sandboxId) {
+          return await throwComputerSourcePlacementChanged(
+            grant,
+            record.sourceSessionId,
+            record.session.placement.sandboxId,
+          );
+        }
+      }
       if (record.session.lifecycle !== "active" || !record.session.controller) {
         throw new ComputerSessionStateError("ComputerSession is not active");
       }
@@ -1230,7 +1245,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
         }
       }
 
-      const sourceSession = await requireSourceSession(deps, workspaceId, record.sourceSessionId);
+      sourceSession ??= await requireSourceSession(deps, workspaceId, record.sourceSessionId);
       return await withComputerPlacement(
         sourceSession,
         grant,
@@ -1248,6 +1263,25 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
     } catch (error) {
       throw computerRouteError(error);
     }
+  }
+
+  async function throwComputerSourcePlacementChanged(
+    grant: AccessGrant,
+    sourceSessionId: string,
+    connectedSandboxId: string,
+  ): Promise<never> {
+    const reconciliation = await terminalizeStaleConnectedInteractionPlacement(deps.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sourceSessionId,
+      connectedSandboxId,
+    });
+    if (reconciliation.sourcePlacementChanged) {
+      throw sourcePlacementChangedApiError("computer_session");
+    }
+    throw new ComputerSessionStateError(
+      "ComputerSession source placement changed during the request; retry",
+    );
   }
 
   async function ensureInteractionHolder(
@@ -1430,6 +1464,21 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       computerSessionId: requireUuidParam(context, "computerSessionId"),
     };
   }
+}
+
+function sourcePlacementChangedApiError(interactionResource: "computer_session"): ApiHttpError {
+  return new ApiHttpError(409, {
+    code: "conflict",
+    message:
+      "This Desktop belonged to a previous task placement and was retired. Open a new Desktop.",
+    retryable: false,
+    outcomeUnknown: false,
+    details: {
+      interactionResource,
+      interactionFailureCode: "source_placement_changed",
+      interactionLifecycle: "lost",
+    },
+  });
 }
 
 function computerCreateInput(

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -133,6 +133,26 @@ describe("BrowserSession route discipline", () => {
     expect(source).toContain('operation === "browser.end" && expectedPlacementInstanceId');
   });
 
+  test("retires a stale Connected Machine placement instead of advertising a retryable 409", async () => {
+    const source = await readFile(routeUrl, "utf8");
+    const placement = source.slice(
+      source.indexOf("async function withBrowserPlacement"),
+      source.indexOf("async function withActiveBrowserController"),
+    );
+    const active = source.slice(
+      source.indexOf("async function withActiveBrowserController"),
+      source.indexOf("async function recoverActiveBrowserController"),
+    );
+    expect(placement).toContain("throwBrowserSourcePlacementChanged");
+    expect(active).toContain("terminalizeStaleConnectedInteractionPlacement");
+    expect(active.indexOf("terminalizeStaleConnectedInteractionPlacement")).toBeLessThan(
+      active.indexOf('sourcePlacementChangedApiError("browser_session")'),
+    );
+    expect(source).toContain('interactionFailureCode: "source_placement_changed"');
+    expect(source).toContain('interactionLifecycle: "lost"');
+    expect(source).toContain("retryable: false");
+  });
+
   test("admits every controller call through the durable generation fence", async () => {
     const source = await readFile(routeUrl, "utf8");
     expect(source).toContain("touchBrowserSessionController(deps.db");

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -106,6 +106,26 @@ describe("ComputerSession route discipline", () => {
     expect(source).toContain('operation === "computer.end" && expectedPlacementInstanceId');
   });
 
+  test("retires a stale Connected Machine placement instead of advertising a retryable 409", async () => {
+    const source = await readFile(routeUrl, "utf8");
+    const placement = source.slice(
+      source.indexOf("async function withComputerPlacement"),
+      source.indexOf("async function withActiveComputerController"),
+    );
+    const active = source.slice(
+      source.indexOf("async function withActiveComputerController"),
+      source.indexOf("async function ensureInteractionHolder"),
+    );
+    expect(placement).toContain("throwComputerSourcePlacementChanged");
+    expect(active).toContain("terminalizeStaleConnectedInteractionPlacement");
+    expect(active.indexOf("terminalizeStaleConnectedInteractionPlacement")).toBeLessThan(
+      active.indexOf('sourcePlacementChangedApiError("computer_session")'),
+    );
+    expect(source).toContain('interactionFailureCode: "source_placement_changed"');
+    expect(source).toContain('interactionLifecycle: "lost"');
+    expect(source).toContain("retryable: false");
+  });
+
   test("dispatches lifecycle authority before physical mutation and preserves unknown outcomes", async () => {
     const source = await readFile(routeUrl, "utf8");
     const create = source.slice(

--- a/packages/db/drizzle/0326_interaction_operation_error_codes.sql
+++ b/packages/db/drizzle/0326_interaction_operation_error_codes.sql
@@ -1,0 +1,62 @@
+-- deployment-mode: maintenance
+-- Interaction operation receipts use the public controller-error enum. The
+-- durable resource keeps the exact internal loss reason; an ambiguous physical
+-- operation must expose the canonical `outcome_unknown` code so idempotent
+-- lifecycle replay remains parseable.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- `interaction_operations` is FORCE-RLS. Production migrations run as its
+-- NOSUPERUSER/NOBYPASSRLS owner without tenant GUCs, so the repair would
+-- otherwise see zero rows. This maintenance migration is one transaction;
+-- any failure rolls the temporary owner-only posture change back as well.
+ALTER TABLE "interaction_operations" NO FORCE ROW LEVEL SECURITY;
+
+DO $interaction_error_code_repair$
+DECLARE
+  data_schema text := current_schema();
+  reaper_definition text;
+  repaired_definition text;
+  repaired_rows integer := 0;
+BEGIN
+  SELECT pg_catalog.pg_get_functiondef(proc.oid)
+  INTO reaper_definition
+  FROM pg_catalog.pg_proc proc
+  JOIN pg_catalog.pg_namespace namespace ON namespace.oid = proc.pronamespace
+  WHERE namespace.nspname = 'opengeni_private'
+    AND proc.proname = 'reap_stale_interaction_transitions'
+    AND pg_catalog.pg_get_function_identity_arguments(proc.oid) = 'p_interaction_holder_ttl_ms bigint';
+
+  IF reaper_definition IS NULL THEN
+    RAISE EXCEPTION 'interaction transition reaper is missing';
+  END IF;
+
+  repaired_definition := pg_catalog.replace(
+    reaper_definition,
+    'error_code = ''controller_transition_expired''',
+    'error_code = ''outcome_unknown'''
+  );
+  IF repaired_definition = reaper_definition THEN
+    IF pg_catalog.strpos(reaper_definition, 'error_code = ''outcome_unknown''') = 0 THEN
+      RAISE EXCEPTION 'interaction transition reaper error-code contract is unrecognized';
+    END IF;
+  ELSE
+    EXECUTE repaired_definition;
+  END IF;
+
+  EXECUTE format($repair$
+    UPDATE %1$I.interaction_operations operation
+    SET error_code = 'outcome_unknown'
+    WHERE operation.state = 'outcome_unknown'
+      AND operation.error_code = 'controller_transition_expired'
+  $repair$, data_schema);
+  GET DIAGNOSTICS repaired_rows = ROW_COUNT;
+
+  RAISE NOTICE 'Repaired % interaction operation error-code receipt(s).', repaired_rows;
+END
+$interaction_error_code_repair$;
+
+ALTER TABLE "interaction_operations" FORCE ROW LEVEL SECURITY;
+
+RESET statement_timeout;
+RESET lock_timeout;

--- a/packages/db/src/attached-browser-devices.ts
+++ b/packages/db/src/attached-browser-devices.ts
@@ -386,7 +386,7 @@ async function terminalizeStaleAttachedDeviceSessions(
       .update(schema.interactionOperations)
       .set({
         state: "outcome_unknown",
-        errorCode: CONTROLLER_TRANSITION_EXPIRED,
+        errorCode: "outcome_unknown",
         errorMessage: "Attached Chrome connection generation changed",
         errorRetryable: false,
         errorDetails: { reason: "connection_generation_changed" },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -66059,6 +66059,7 @@ export * from "./browser-auth";
 export * from "./browser-downloads";
 export * from "./attached-browser-devices";
 export * from "./interaction-revisions";
+export * from "./interaction-placement-loss";
 export * from "./canonical-human-identities";
 export * from "./session-tenancy";
 export * from "./governed-learning-activation";

--- a/packages/db/src/interaction-placement-loss.ts
+++ b/packages/db/src/interaction-placement-loss.ts
@@ -1,0 +1,234 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { type Database, withRlsContext } from "./database";
+import {
+  advanceWorkspaceInteractionRevision,
+  readWorkspaceInteractionRevision,
+} from "./interaction-revisions";
+import * as schema from "./schema";
+
+export const SOURCE_PLACEMENT_CHANGED = "source_placement_changed";
+
+const CONNECTED_PLACEMENT_LIVE_LIFECYCLES = [
+  "starting",
+  "active",
+  "suspending",
+  "restoring",
+  "ending",
+] as const;
+
+export type TerminalizeStaleConnectedInteractionPlacementResult = {
+  sourcePlacementChanged: boolean;
+  changed: boolean;
+  browserSessionIds: string[];
+  computerSessionIds: string[];
+  revision: number;
+};
+
+/**
+ * Reconcile interaction resources after their source task moves away from a
+ * Connected Machine. The source row is the race fence: a stale route lookup
+ * may never retire resources while that machine is still the active placement.
+ * Browser and Desktop resources are settled together because headed browsers
+ * can share one physical controller with a linked Desktop.
+ */
+export async function terminalizeStaleConnectedInteractionPlacement(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sourceSessionId: string;
+    connectedSandboxId: string;
+  },
+): Promise<TerminalizeStaleConnectedInteractionPlacementResult> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) =>
+      await scopedDb.transaction(async (tx) => {
+        const [source] = await tx
+          .select({ activeSandboxId: schema.sessions.activeSandboxId })
+          .from(schema.sessions)
+          .where(
+            and(
+              eq(schema.sessions.accountId, input.accountId),
+              eq(schema.sessions.workspaceId, input.workspaceId),
+              eq(schema.sessions.id, input.sourceSessionId),
+            ),
+          )
+          .for("update")
+          .limit(1);
+
+        const sourcePlacementChanged =
+          source !== undefined && source.activeSandboxId !== input.connectedSandboxId;
+        if (!sourcePlacementChanged) {
+          return {
+            sourcePlacementChanged: false,
+            changed: false,
+            browserSessionIds: [],
+            computerSessionIds: [],
+            revision: await readWorkspaceInteractionRevision(tx, input.workspaceId),
+          };
+        }
+
+        const browserRows = await tx
+          .select({ id: schema.browserSessions.id })
+          .from(schema.browserSessions)
+          .innerJoin(
+            schema.browserSessionAssociations,
+            and(
+              eq(schema.browserSessionAssociations.browserSessionId, schema.browserSessions.id),
+              eq(schema.browserSessionAssociations.workspaceId, input.workspaceId),
+              eq(schema.browserSessionAssociations.sessionId, input.sourceSessionId),
+              eq(schema.browserSessionAssociations.relationship, "created"),
+            ),
+          )
+          .where(
+            and(
+              eq(schema.browserSessions.accountId, input.accountId),
+              eq(schema.browserSessions.workspaceId, input.workspaceId),
+              eq(schema.browserSessions.placementKind, "connected_machine"),
+              eq(schema.browserSessions.connectedSandboxId, input.connectedSandboxId),
+              inArray(schema.browserSessions.lifecycle, [...CONNECTED_PLACEMENT_LIVE_LIFECYCLES]),
+            ),
+          );
+        const computerRows = await tx
+          .select({ id: schema.computerSessions.id })
+          .from(schema.computerSessions)
+          .innerJoin(
+            schema.computerSessionAssociations,
+            and(
+              eq(schema.computerSessionAssociations.computerSessionId, schema.computerSessions.id),
+              eq(schema.computerSessionAssociations.workspaceId, input.workspaceId),
+              eq(schema.computerSessionAssociations.sessionId, input.sourceSessionId),
+              eq(schema.computerSessionAssociations.relationship, "created"),
+            ),
+          )
+          .where(
+            and(
+              eq(schema.computerSessions.accountId, input.accountId),
+              eq(schema.computerSessions.workspaceId, input.workspaceId),
+              eq(schema.computerSessions.placementKind, "connected_machine"),
+              eq(schema.computerSessions.connectedSandboxId, input.connectedSandboxId),
+              inArray(schema.computerSessions.lifecycle, [...CONNECTED_PLACEMENT_LIVE_LIFECYCLES]),
+            ),
+          );
+
+        const browserSessionIds = [...new Set(browserRows.map((row) => row.id))].sort();
+        const computerSessionIds = [...new Set(computerRows.map((row) => row.id))].sort();
+        const resourceIds = [...browserSessionIds, ...computerSessionIds];
+        if (resourceIds.length === 0) {
+          return {
+            sourcePlacementChanged: true,
+            changed: false,
+            browserSessionIds,
+            computerSessionIds,
+            revision: await readWorkspaceInteractionRevision(tx, input.workspaceId),
+          };
+        }
+
+        const operationRows = await tx
+          .select({ operationId: schema.interactionOperations.operationId })
+          .from(schema.interactionOperations)
+          .where(
+            and(
+              eq(schema.interactionOperations.accountId, input.accountId),
+              eq(schema.interactionOperations.workspaceId, input.workspaceId),
+              inArray(schema.interactionOperations.resourceId, resourceIds),
+              inArray(schema.interactionOperations.state, ["prepared", "dispatched"]),
+            ),
+          );
+        const operationIds = operationRows.map((row) => row.operationId).sort();
+
+        // Stable lock order matches the attached-device generation-loss path.
+        for (const operationId of operationIds) {
+          await tx.execute(sql`
+            select operation_id from interaction_operations
+            where workspace_id = ${input.workspaceId} and operation_id = ${operationId}
+            for update
+          `);
+        }
+        for (const browserSessionId of browserSessionIds) {
+          await tx.execute(sql`
+            select id from browser_sessions
+            where workspace_id = ${input.workspaceId} and id = ${browserSessionId}
+            for update
+          `);
+        }
+        for (const computerSessionId of computerSessionIds) {
+          await tx.execute(sql`
+            select id from computer_sessions
+            where workspace_id = ${input.workspaceId} and id = ${computerSessionId}
+            for update
+          `);
+        }
+
+        const now = new Date();
+        if (operationIds.length > 0) {
+          await tx
+            .update(schema.interactionOperations)
+            .set({
+              state: "outcome_unknown",
+              errorCode: "outcome_unknown",
+              errorMessage: "The source task moved to another placement",
+              errorRetryable: false,
+              errorDetails: { reason: SOURCE_PLACEMENT_CHANGED },
+              settledAt: now,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(schema.interactionOperations.workspaceId, input.workspaceId),
+                inArray(schema.interactionOperations.operationId, operationIds),
+                inArray(schema.interactionOperations.state, ["prepared", "dispatched"]),
+              ),
+            );
+        }
+        if (browserSessionIds.length > 0) {
+          await tx
+            .update(schema.browserSessions)
+            .set({
+              lifecycle: "lost",
+              failureCode: SOURCE_PLACEMENT_CHANGED,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(schema.browserSessions.workspaceId, input.workspaceId),
+                inArray(schema.browserSessions.id, browserSessionIds),
+                inArray(schema.browserSessions.lifecycle, [...CONNECTED_PLACEMENT_LIVE_LIFECYCLES]),
+              ),
+            );
+        }
+        if (computerSessionIds.length > 0) {
+          await tx
+            .update(schema.computerSessions)
+            .set({
+              lifecycle: "lost",
+              failureCode: SOURCE_PLACEMENT_CHANGED,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(schema.computerSessions.workspaceId, input.workspaceId),
+                inArray(schema.computerSessions.id, computerSessionIds),
+                inArray(schema.computerSessions.lifecycle, [
+                  ...CONNECTED_PLACEMENT_LIVE_LIFECYCLES,
+                ]),
+              ),
+            );
+        }
+        const revision = await advanceWorkspaceInteractionRevision(
+          tx,
+          input.accountId,
+          input.workspaceId,
+        );
+        return {
+          sourcePlacementChanged: true,
+          changed: true,
+          browserSessionIds,
+          computerSessionIds,
+          revision,
+        };
+      }),
+  );
+}

--- a/packages/db/test/attached-browser-devices.test.ts
+++ b/packages/db/test/attached-browser-devices.test.ts
@@ -463,9 +463,60 @@ describe("attached browser endpoint registry", () => {
       "extension-1",
       computer.computerSessionId,
     );
+    const pendingOperationId = crypto.randomUUID();
+    const pending = await prepareBrowserSessionCreate(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      operationId: pendingOperationId,
+      associatedSessionId: scope.sessionId,
+      actorSubjectId: scope.subjectId,
+      name: "Pending attached Chrome",
+      initialUrl: null,
+      placement: { kind: "attached_device", deviceId },
+      driverId: "opengeni.attached-chrome.v1",
+      engine: "chrome",
+      headless: false,
+      identityId: null,
+      baseRevisionId: null,
+      linkedComputerSessionId: null,
+      capabilities: ATTACHED_BROWSER_SESSION_CAPABILITIES,
+    });
+    await dispatchBrowserSessionOperation(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      operationId: pendingOperationId,
+      browserSessionId: pending.session.id,
+      controllerGeneration: crypto.randomUUID(),
+    });
 
     const rotated = await announceDevice(scope, deviceId, "extension-2", 2);
     expect(rotated).toMatchObject({ accepted: true, changed: true });
+
+    expect(
+      await prepareBrowserSessionCreate(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        operationId: pendingOperationId,
+        associatedSessionId: scope.sessionId,
+        actorSubjectId: scope.subjectId,
+        name: "Pending attached Chrome",
+        initialUrl: null,
+        placement: { kind: "attached_device", deviceId },
+        driverId: "opengeni.attached-chrome.v1",
+        engine: "chrome",
+        headless: false,
+        identityId: null,
+        baseRevisionId: null,
+        linkedComputerSessionId: null,
+        capabilities: ATTACHED_BROWSER_SESSION_CAPABILITIES,
+      }),
+    ).toMatchObject({
+      operation: {
+        state: "outcome_unknown",
+        replayed: true,
+        error: { code: "outcome_unknown", retryable: false },
+      },
+    });
 
     const lostBrowser = await getBrowserSession(client.db, {
       accountId: scope.accountId,

--- a/packages/db/test/browser-sessions.test.ts
+++ b/packages/db/test/browser-sessions.test.ts
@@ -1319,7 +1319,7 @@ describe("durable BrowserSession lifecycle", () => {
         and operation_id = ${abandonedOperationId}`;
     expect(settledOperation).toEqual({
       state: "outcome_unknown",
-      error_code: "controller_transition_expired",
+      error_code: "outcome_unknown",
       error_retryable: false,
     });
     const [abandonedHolderCount] = await shared!.admin<{ count: number }[]>`
@@ -1380,7 +1380,7 @@ describe("durable BrowserSession lifecycle", () => {
         and operation_id = ${computerOperationId}`;
     expect(computerOperation).toEqual({
       state: "outcome_unknown",
-      error_code: "controller_transition_expired",
+      error_code: "outcome_unknown",
       error_retryable: false,
     });
     const [computerHolderCount] = await shared!.admin<{ count: number }[]>`

--- a/packages/db/test/computer-sessions.test.ts
+++ b/packages/db/test/computer-sessions.test.ts
@@ -11,6 +11,8 @@ import {
   ComputerSessionOperationConflictError,
   ComputerSessionStateError,
   createDb,
+  createEnrollment,
+  createSandbox,
   createSession,
   dispatchBrowserSessionOperation,
   dispatchComputerSessionOperation,
@@ -27,6 +29,8 @@ import {
   prepareComputerSessionEnd,
   reapStaleLeaseHolders,
   safeDatabaseErrorFacts,
+  setActiveSandbox,
+  terminalizeStaleConnectedInteractionPlacement,
   touchComputerSessionController,
 } from "../src";
 
@@ -712,4 +716,182 @@ describe("durable ComputerSession lifecycle", () => {
       failureCode: "workspace_force_drained",
     });
   });
+
+  test("terminalizes a task's stale Connected Machine browser and Desktop as one fenced set", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const enrollment = await createEnrollment(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      pubkey: `ed25519:interaction-placement-${crypto.randomUUID()}`,
+      os: "macos",
+      arch: "arm64",
+    });
+    const machine = await createSandbox(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      kind: "selfhosted",
+      name: "Connected Mac",
+      enrollmentId: enrollment.id,
+    });
+    expect(
+      await setActiveSandbox(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        sessionId: scope.sessionId,
+        targetSandboxId: machine.id,
+        expectedEpoch: 0,
+      }),
+    ).toMatchObject({ swapped: true });
+
+    const computerOperationId = crypto.randomUUID();
+    const computer = await prepareComputerSessionCreate(client.db, {
+      ...createInput(scope, computerOperationId),
+      placement: { kind: "connected_machine", sandboxId: machine.id },
+    });
+    const computerController = {
+      controllerId: "interaction-controller:connected",
+      controllerGeneration: crypto.randomUUID(),
+      placementInstanceId: machine.id,
+    };
+    await dispatchComputerSessionOperation(client.db, {
+      ...scope,
+      operationId: computerOperationId,
+      computerSessionId: computer.session.id,
+      controllerGeneration: computerController.controllerGeneration,
+      controller: computerController,
+    });
+    await activateComputerSession(client.db, {
+      ...scope,
+      operationId: computerOperationId,
+      computerSessionId: computer.session.id,
+      controller: computerController,
+      platform: "macos",
+      adapter: "opengeni.macos.v1",
+      seatId: "seat:connected",
+      displayId: "display:connected",
+      capabilities,
+    });
+
+    const browserOperationId = crypto.randomUUID();
+    const browser = await prepareBrowserSessionCreate(client.db, {
+      ...scope,
+      operationId: browserOperationId,
+      associatedSessionId: scope.sessionId,
+      actorSubjectId: scope.subjectId,
+      name: "Connected browser",
+      initialUrl: "https://example.com/",
+      placement: { kind: "connected_machine", sandboxId: machine.id },
+      driverId: "opengeni.cdp.v1",
+      engine: "chrome",
+      headless: false,
+      identityId: null,
+      baseRevisionId: null,
+    });
+    const browserController = {
+      controllerId: "browserd:connected",
+      controllerGeneration: crypto.randomUUID(),
+      placementInstanceId: machine.id,
+    };
+    await dispatchBrowserSessionOperation(client.db, {
+      ...scope,
+      operationId: browserOperationId,
+      browserSessionId: browser.session.id,
+      controllerGeneration: browserController.controllerGeneration,
+    });
+    await activateBrowserSession(client.db, {
+      ...scope,
+      operationId: browserOperationId,
+      browserSessionId: browser.session.id,
+      controller: browserController,
+      engineVersion: "151.0.0",
+    });
+
+    const endOperationId = crypto.randomUUID();
+    expect(
+      (
+        await prepareComputerSessionEnd(client.db, {
+          ...scope,
+          computerSessionId: computer.session.id,
+          operationId: endOperationId,
+          actorSubjectId: scope.subjectId,
+        })
+      ).session.lifecycle,
+    ).toBe("ending");
+
+    const stillCurrent = await terminalizeStaleConnectedInteractionPlacement(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      sourceSessionId: scope.sessionId,
+      connectedSandboxId: machine.id,
+    });
+    expect(stillCurrent).toMatchObject({
+      sourcePlacementChanged: false,
+      changed: false,
+    });
+
+    expect(
+      await setActiveSandbox(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        sessionId: scope.sessionId,
+        targetSandboxId: null,
+        expectedEpoch: 1,
+      }),
+    ).toMatchObject({ swapped: true });
+    const reconciled = await terminalizeStaleConnectedInteractionPlacement(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      sourceSessionId: scope.sessionId,
+      connectedSandboxId: machine.id,
+    });
+    expect(reconciled).toMatchObject({
+      sourcePlacementChanged: true,
+      changed: true,
+      browserSessionIds: [browser.session.id],
+      computerSessionIds: [computer.session.id],
+    });
+    expect(
+      await getComputerSession(client.db, {
+        ...scope,
+        computerSessionId: computer.session.id,
+      }),
+    ).toMatchObject({
+      lifecycle: "lost",
+      failureCode: "source_placement_changed",
+    });
+    expect(
+      await prepareComputerSessionEnd(client.db, {
+        ...scope,
+        computerSessionId: computer.session.id,
+        operationId: endOperationId,
+        actorSubjectId: scope.subjectId,
+      }),
+    ).toMatchObject({
+      operation: {
+        state: "outcome_unknown",
+        error: {
+          code: "outcome_unknown",
+          retryable: false,
+        },
+      },
+    });
+    expect(
+      await getBrowserSession(client.db, {
+        ...scope,
+        browserSessionId: browser.session.id,
+      }),
+    ).toMatchObject({
+      lifecycle: "lost",
+      failureCode: "source_placement_changed",
+    });
+    expect(
+      await terminalizeStaleConnectedInteractionPlacement(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        sourceSessionId: scope.sessionId,
+        connectedSandboxId: machine.id,
+      }),
+    ).toMatchObject({ sourcePlacementChanged: true, changed: false });
+  }, 60_000);
 });

--- a/packages/db/test/migration-0326-interaction-operation-error-codes.test.ts
+++ b/packages/db/test/migration-0326-interaction-operation-error-codes.test.ts
@@ -1,0 +1,129 @@
+// Migration 0326 repairs an invalid historical interaction-operation receipt
+// under the same NOSUPERUSER/NOBYPASSRLS owner posture used in production.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { migrate } from "../src/migrate";
+
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
+const migrationUrl = new URL(
+  "../drizzle/0326_interaction_operation_error_codes.sql",
+  import.meta.url,
+);
+const REPAIR_MIGRATION = "0326_interaction_operation_error_codes.sql";
+const ACCOUNT = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE = "22222222-2222-4222-8222-222222222222";
+const OPERATION = "33333333-3333-4333-8333-333333333333";
+
+async function migrationFiles(): Promise<string[]> {
+  return (await readdir(migrationsDir)).filter((file) => file.endsWith(".sql")).sort();
+}
+
+async function applyBelow(url: string, upperBound: string): Promise<void> {
+  const deferred = (await migrationFiles()).filter((file) => file >= upperBound);
+  const ledger = postgres(url, { max: 1, onnotice: () => undefined });
+  try {
+    await ledger.unsafe(
+      `CREATE TABLE IF NOT EXISTS "schema_migrations" (
+        "name" text PRIMARY KEY,
+        "applied_at" timestamptz NOT NULL DEFAULT now()
+      )`,
+    );
+    for (const file of deferred) {
+      await ledger`insert into schema_migrations (name) values (${file}) on conflict do nothing`;
+    }
+    await migrate(url);
+    await ledger`delete from schema_migrations where name >= ${upperBound}`;
+  } finally {
+    await ledger.end({ timeout: 5 });
+  }
+}
+
+describe("migration 0326 interaction operation error codes", () => {
+  let owned: OwnerMigratedTestDatabase | null = null;
+
+  beforeAll(async () => {
+    owned = await acquireOwnerMigratedTestDatabase("migration-0326-interaction-error-codes");
+  }, 600_000);
+
+  afterAll(async () => {
+    await owned?.release();
+  }, 120_000);
+
+  test("declares and closes the FORCE-RLS owner repair window", async () => {
+    const sql = await readFile(migrationUrl, "utf8");
+    const noForce = 'ALTER TABLE "interaction_operations" NO FORCE ROW LEVEL SECURITY;';
+    const force = 'ALTER TABLE "interaction_operations" FORCE ROW LEVEL SECURITY;';
+    expect(sql.startsWith("-- deployment-mode: maintenance\n")).toBe(true);
+    expect(sql.indexOf(noForce)).toBeGreaterThanOrEqual(0);
+    expect(sql.indexOf(noForce)).toBeLessThan(sql.indexOf("UPDATE %1$I.interaction_operations"));
+    expect(sql.indexOf(force)).toBeGreaterThan(sql.indexOf("UPDATE %1$I.interaction_operations"));
+  });
+
+  test("repairs legacy receipts as the production migration owner and restores FORCE RLS", async () => {
+    if (!owned) return;
+    const { admin, ownerUrl, ownerRole } = owned;
+    await applyBelow(ownerUrl, REPAIR_MIGRATION);
+
+    const [identity] = await admin<Array<{ superuser: boolean; bypassRls: boolean }>>`
+      select rolsuper as "superuser", rolbypassrls as "bypassRls"
+      from pg_roles where rolname = ${ownerRole}`;
+    expect(identity).toEqual({ superuser: false, bypassRls: false });
+
+    await admin.unsafe(`
+      insert into managed_accounts (id, name)
+        values ('${ACCOUNT}', 'interaction-repair-account');
+      insert into workspaces (id, account_id, name)
+        values ('${WORKSPACE}', '${ACCOUNT}', 'interaction-repair-workspace');
+      insert into interaction_operations (
+        operation_id, account_id, workspace_id, resource_kind, resource_id,
+        kind, request_digest, state, error_code, error_message,
+        error_retryable, actor_subject_id, settled_at
+      ) values (
+        '${OPERATION}', '${ACCOUNT}', '${WORKSPACE}', 'browser_session',
+        '44444444-4444-4444-8444-444444444444', 'create', repeat('a', 64),
+        'outcome_unknown', 'controller_transition_expired', 'legacy receipt',
+        false, 'migration-test', now()
+      );
+    `);
+
+    const owner = postgres(ownerUrl, { max: 1, onnotice: () => undefined });
+    try {
+      const [visible] = await owner<Array<{ count: string }>>`
+        select count(*)::text as count from interaction_operations`;
+      expect(visible?.count).toBe("0");
+    } finally {
+      await owner.end({ timeout: 5 });
+    }
+
+    await migrate(ownerUrl);
+
+    const [operation] = await admin<Array<{ state: string; errorCode: string }>>`
+      select state, error_code as "errorCode"
+      from interaction_operations
+      where operation_id = ${OPERATION}`;
+    expect(operation).toEqual({ state: "outcome_unknown", errorCode: "outcome_unknown" });
+
+    const [posture] = await admin<Array<{ forced: boolean }>>`
+      select relforcerowsecurity as forced
+      from pg_class
+      where oid = 'interaction_operations'::regclass`;
+    expect(posture?.forced).toBe(true);
+
+    const [reaper] = await admin<Array<{ definition: string }>>`
+      select pg_get_functiondef(proc.oid) as definition
+      from pg_proc proc
+      join pg_namespace namespace on namespace.oid = proc.pronamespace
+      where namespace.nspname = 'opengeni_private'
+        and proc.proname = 'reap_stale_interaction_transitions'
+        and pg_get_function_identity_arguments(proc.oid) = 'p_interaction_holder_ttl_ms bigint'`;
+    expect(reaper?.definition).toContain("error_code = 'outcome_unknown'");
+    expect(reaper?.definition).not.toContain("error_code = 'controller_transition_expired'");
+  }, 900_000);
+});

--- a/packages/react/src/components/browser-viewer.tsx
+++ b/packages/react/src/components/browser-viewer.tsx
@@ -68,6 +68,7 @@ import { useSiteAuthConnections } from "../hooks/use-site-auth-connections";
 import { cn } from "../lib/cn";
 import { copyTextToClipboard } from "../lib/clipboard";
 import { formatBytes } from "../lib/format";
+import { isSourcePlacementChangedError } from "../lib/interaction-errors";
 import type { EmbeddedBrowserInteractionClientOverride } from "../session-context";
 import { browserKey, HUMAN_BROWSER_HOME_URL, normalizeBrowserAddress } from "./browser-input";
 import { InteractionInterventionBanner } from "./interaction-intervention-banner";
@@ -161,6 +162,7 @@ export function BrowserViewer({
     enabled: enabled && profiles.identities.length > 0,
   });
   const createRegistryBrowser = registry.create;
+  const refreshRegistry = registry.refresh;
   const loadProfileRevisions = profiles.revisions;
   const liveSessions = useMemo(
     () => registry.sessions.filter((session) => isLiveBrowser(session)),
@@ -347,6 +349,10 @@ export function BrowserViewer({
     browserSessionId: selection?.sessionId ?? null,
     enabled: enabled && selection !== null && controllerReady,
   });
+  useEffect(() => {
+    if (!isSourcePlacementChangedError(browser.error, "browser_session")) return;
+    void refreshRegistry();
+  }, [browser.error, refreshRegistry]);
   const downloads = useBrowserDownloads({
     ...override,
     browserSessionId: selection?.sessionId ?? null,

--- a/packages/react/src/components/computer-viewer.tsx
+++ b/packages/react/src/components/computer-viewer.tsx
@@ -45,6 +45,7 @@ import { useComputerSessions } from "../hooks/use-computer-sessions";
 import { useInteractionInterventions } from "../hooks/use-interaction-interventions";
 import { cn } from "../lib/cn";
 import { copyTextToClipboard } from "../lib/clipboard";
+import { isSourcePlacementChangedError } from "../lib/interaction-errors";
 import type { EmbeddedComputerInteractionClientOverride } from "../session-context";
 import { InteractionInterventionBanner } from "./interaction-intervention-banner";
 import { DesktopViewer } from "./desktop-viewer";
@@ -93,11 +94,26 @@ export function ComputerViewer({
     () => registry.relevantSessions.filter((session) => isLiveComputer(session)),
     [registry.relevantSessions],
   );
+  const connectedPlacementLoss = useMemo(
+    () =>
+      registry.relevantSessions.find(
+        (session) =>
+          session.lifecycle === "lost" &&
+          session.failureCode === "source_placement_changed" &&
+          session.placement.kind === "connected_machine",
+      ) ?? null,
+    [registry.relevantSessions],
+  );
   const recentRelevantFailure = useMemo(
     () =>
       liveRelevant.length === 0
-        ? (registry.relevantSessions.find((session) =>
-            ["failed", "lost"].includes(session.lifecycle),
+        ? (registry.relevantSessions.find(
+            (session) =>
+              ["failed", "lost"].includes(session.lifecycle) &&
+              !(
+                session.failureCode === "source_placement_changed" &&
+                session.placement.kind === "connected_machine"
+              ),
           ) ?? null)
         : null,
     [liveRelevant.length, registry.relevantSessions],
@@ -136,6 +152,7 @@ export function ComputerViewer({
   const autoCreateSessionRef = useRef<string | null>(null);
   const emptyCatalogConfirmationRef = useRef<string | null>(null);
   const endedGenerationLossRef = useRef(new Set<string>());
+  const recreatedPlacementLossRef = useRef(new Set<string>());
   const [suppressGenericCreate, setSuppressGenericCreate] = useState(false);
   const endStaleComputer = registry.end;
   useEffect(() => {
@@ -167,6 +184,7 @@ export function ComputerViewer({
     handledRequestRef.current = null;
     autoCreateSessionRef.current = null;
     emptyCatalogConfirmationRef.current = null;
+    recreatedPlacementLossRef.current.clear();
     setSuppressGenericCreate(false);
     setCreateError(null);
     setSelection(
@@ -235,6 +253,10 @@ export function ComputerViewer({
     computerSessionId: selection?.sessionId ?? null,
     enabled: enabled && selection !== null && controllerReady,
   });
+  useEffect(() => {
+    if (!isSourcePlacementChangedError(computer.error, "computer_session")) return;
+    void refreshRegistry();
+  }, [computer.error, refreshRegistry]);
   const act = computer.act;
   const actFromFrame = computer.actFromFrame;
   const refreshComputer = computer.refresh;
@@ -336,6 +358,31 @@ export function ComputerViewer({
         setCreating(false);
       });
   }, [createSession, notifyError, selectComputerSession, sessionId]);
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      registry.loading ||
+      registry.refreshing ||
+      liveRelevant.length > 0 ||
+      !connectedPlacementLoss ||
+      recreatedPlacementLossRef.current.has(connectedPlacementLoss.id)
+    ) {
+      return;
+    }
+    recreatedPlacementLossRef.current.add(connectedPlacementLoss.id);
+    autoCreateSessionRef.current = sessionId;
+    emptyCatalogConfirmationRef.current = null;
+    createComputer();
+  }, [
+    connectedPlacementLoss,
+    createComputer,
+    enabled,
+    liveRelevant.length,
+    registry.loading,
+    registry.refreshing,
+    sessionId,
+  ]);
 
   useEffect(() => {
     // Once this task's Desktop has been observed, a later transient empty

--- a/packages/react/src/hooks/use-browser-session.ts
+++ b/packages/react/src/hooks/use-browser-session.ts
@@ -16,6 +16,7 @@ import {
   type EmbeddedBrowserInteractionClientOverride,
   useEmbeddedBrowserInteraction,
 } from "../session-context";
+import { isNonRetryableInteractionError } from "../lib/interaction-errors";
 import { usePageLiveActivity } from "./internal";
 
 export type UseBrowserSessionOptions = EmbeddedBrowserInteractionClientOverride & {
@@ -71,6 +72,7 @@ export function useBrowserSession(options: UseBrowserSessionOptions): UseBrowser
   }>(() => emptyState(browserSessionId, enabled));
   const visible =
     state.browserSessionId === browserSessionId ? state : emptyState(browserSessionId, enabled);
+  const refreshBlocked = isNonRetryableInteractionError(visible.error);
   const selectedTargetIdRef = useRef<string | null>(visible.selectedTargetId);
   selectedTargetIdRef.current = visible.selectedTargetId;
   const observationRef = useRef<{
@@ -198,15 +200,15 @@ export function useBrowserSession(options: UseBrowserSessionOptions): UseBrowser
   }, [browserSessionId, enabled, invalidateRefresh, refresh]);
 
   useEffect(() => {
-    if (!enabled || !pageLive || visible.mutating) return;
+    if (!enabled || !pageLive || visible.mutating || refreshBlocked) return;
     const timer = setInterval(() => {
       if (!requestRef.current.controller) void refresh();
     }, pollIntervalMs);
     return () => clearInterval(timer);
-  }, [enabled, pageLive, pollIntervalMs, refresh, visible.mutating]);
+  }, [enabled, pageLive, pollIntervalMs, refresh, refreshBlocked, visible.mutating]);
 
   useEffect(() => {
-    if (!enabled || !browserSessionId || !pageLive) return;
+    if (!enabled || !browserSessionId || !pageLive || refreshBlocked) return;
     let disposed = false;
     const heartbeat = () => {
       void client.heartbeatBrowserSession(workspaceId, browserSessionId).catch(() => {
@@ -218,7 +220,7 @@ export function useBrowserSession(options: UseBrowserSessionOptions): UseBrowser
       disposed = true;
       clearInterval(timer);
     };
-  }, [browserSessionId, client, enabled, pageLive, refresh, workspaceId]);
+  }, [browserSessionId, client, enabled, pageLive, refresh, refreshBlocked, workspaceId]);
 
   const runMutation = useCallback(
     async <T>(scopeBrowserSessionId: string, operation: () => Promise<T>): Promise<T> => {

--- a/packages/react/src/hooks/use-computer-session.ts
+++ b/packages/react/src/hooks/use-computer-session.ts
@@ -8,6 +8,7 @@ import type {
   ComputerTarget,
 } from "@opengeni/sdk/interaction";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isNonRetryableInteractionError } from "../lib/interaction-errors";
 import {
   type EmbeddedComputerInteractionClientOverride,
   useEmbeddedComputerInteraction,
@@ -55,6 +56,7 @@ export function useComputerSession(options: UseComputerSessionOptions): UseCompu
   );
   const visible =
     state.computerSessionId === computerSessionId ? state : emptyState(computerSessionId, enabled);
+  const refreshBlocked = isNonRetryableInteractionError(visible.error);
   const selectedTargetIdRef = useRef<string | null>(visible.selectedTargetId);
   selectedTargetIdRef.current = visible.selectedTargetId;
   const targetsRef = useRef<{
@@ -173,15 +175,15 @@ export function useComputerSession(options: UseComputerSessionOptions): UseCompu
   }, [computerSessionId, enabled, invalidateRefresh, refresh]);
 
   useEffect(() => {
-    if (!enabled || !pageLive || visible.mutating) return;
+    if (!enabled || !pageLive || visible.mutating || refreshBlocked) return;
     const timer = setInterval(() => {
       if (!requestRef.current.controller) void refresh();
     }, pollIntervalMs);
     return () => clearInterval(timer);
-  }, [enabled, pageLive, pollIntervalMs, refresh, visible.mutating]);
+  }, [enabled, pageLive, pollIntervalMs, refresh, refreshBlocked, visible.mutating]);
 
   useEffect(() => {
-    if (!enabled || !computerSessionId || !pageLive) return;
+    if (!enabled || !computerSessionId || !pageLive || refreshBlocked) return;
     let disposed = false;
     const timer = setInterval(() => {
       void client.heartbeatComputerSession(workspaceId, computerSessionId).catch(() => {
@@ -192,7 +194,7 @@ export function useComputerSession(options: UseComputerSessionOptions): UseCompu
       disposed = true;
       clearInterval(timer);
     };
-  }, [client, computerSessionId, enabled, pageLive, refresh, workspaceId]);
+  }, [client, computerSessionId, enabled, pageLive, refresh, refreshBlocked, workspaceId]);
 
   const runMutation = useCallback(
     async <T>(scopeComputerSessionId: string, operation: () => Promise<T>): Promise<T> => {

--- a/packages/react/src/lib/interaction-errors.ts
+++ b/packages/react/src/lib/interaction-errors.ts
@@ -1,0 +1,18 @@
+import { OpenGeniApiError } from "@opengeni/sdk";
+
+export function isNonRetryableInteractionError(error: unknown): error is OpenGeniApiError {
+  return error instanceof OpenGeniApiError && error.retryable === false;
+}
+
+export function isSourcePlacementChangedError(
+  error: unknown,
+  resource: "browser_session" | "computer_session",
+): error is OpenGeniApiError {
+  return (
+    isNonRetryableInteractionError(error) &&
+    error.status === 409 &&
+    error.details?.interactionResource === resource &&
+    error.details?.interactionFailureCode === "source_placement_changed" &&
+    error.details?.interactionLifecycle === "lost"
+  );
+}

--- a/packages/react/test/browser-interaction.test.tsx
+++ b/packages/react/test/browser-interaction.test.tsx
@@ -171,6 +171,15 @@ function browserSession(
   };
 }
 
+function lostConnectedBrowser(): BrowserSession {
+  return {
+    ...browserSession(),
+    lifecycle: "lost",
+    failureCode: "source_placement_changed",
+    placement: { kind: "connected_machine", sandboxId: SANDBOX_GROUP_ID },
+  };
+}
+
 function browserIdentity(): BrowserIdentity {
   return {
     id: BROWSER_IDENTITY_ID,
@@ -1022,6 +1031,57 @@ describe("BrowserSession frame stream", () => {
 });
 
 describe("BrowserViewer", () => {
+  test("retires a stale Connected Machine browser and stops polling the permanent conflict", async () => {
+    const stale = {
+      ...browserSession(),
+      placement: {
+        kind: "connected_machine" as const,
+        sandboxId: SANDBOX_GROUP_ID,
+      },
+    };
+    const lost = lostConnectedBrowser();
+    let catalogCalls = 0;
+    let targetCalls = 0;
+    const client = fakeClient({
+      listBrowserSessions: async () => ({
+        revision: ++catalogCalls,
+        sessions: catalogCalls === 1 ? [stale] : [lost],
+      }),
+      getBrowserSession: async () => stale,
+      listBrowserTargets: async () => {
+        targetCalls += 1;
+        throw new OpenGeniApiError(
+          409,
+          JSON.stringify({
+            error: {
+              status: 409,
+              code: "conflict",
+              message: "This browser belonged to a previous task placement and was retired.",
+              retryable: false,
+              outcomeUnknown: false,
+              details: {
+                interactionResource: "browser_session",
+                interactionFailureCode: "source_placement_changed",
+                interactionLifecycle: "lost",
+              },
+            },
+          }),
+        );
+      },
+    });
+
+    const rendered = await renderComponent(
+      <BrowserViewer client={client} workspaceId={WORKSPACE_ID} sessionId={SESSION_ID} />,
+    );
+    await flush(120);
+    expect(catalogCalls).toBeGreaterThanOrEqual(2);
+    expect(targetCalls).toBe(1);
+    expect(rendered.container.textContent).toContain("No browser open");
+    await flush(900);
+    expect(targetCalls).toBe(1);
+    await rendered.unmount();
+  });
+
   test("restores the task's last selected BrowserSession", async () => {
     const current = browserSession();
     const peer = browserSession(PEER_BROWSER_SESSION_ID, PEER_SESSION_ID, "Peer browser");

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -99,6 +99,20 @@ function lostAttachedComputer(
   };
 }
 
+function lostConnectedComputer(
+  id = COMPUTER_SESSION_ID,
+  associationSessionId = SESSION_ID,
+): ComputerSession {
+  return {
+    ...computerSession(id, associationSessionId),
+    lifecycle: "lost",
+    failureCode: "source_placement_changed",
+    placement: { kind: "connected_machine", sandboxId: ATTACHED_DEVICE_ID },
+    platform: "macos",
+    adapter: "opengeni.macos.v1",
+  };
+}
+
 function startingComputerSession(
   id = COMPUTER_SESSION_ID,
   associationSessionId = SESSION_ID,
@@ -638,6 +652,81 @@ describe("ComputerSession frame stream", () => {
 });
 
 describe("ComputerViewer", () => {
+  test("retires a stale Connected Machine Desktop, stops polling, and recreates once", async () => {
+    const stale = {
+      ...computerSession(),
+      placement: {
+        kind: "connected_machine" as const,
+        sandboxId: ATTACHED_DEVICE_ID,
+      },
+      platform: "macos" as const,
+      adapter: "opengeni.macos.v1",
+    };
+    const lost = lostConnectedComputer();
+    const replacement = startingComputerSession(PEER_COMPUTER_SESSION_ID);
+    let catalogCalls = 0;
+    let targetCalls = 0;
+    let createCalls = 0;
+    const client = fakeClient({
+      listComputerSessions: async () => ({
+        revision: ++catalogCalls,
+        sessions: catalogCalls === 1 ? [stale] : createCalls === 0 ? [lost] : [lost, replacement],
+      }),
+      getComputerSession: async (_workspaceId, computerSessionId) =>
+        computerSessionId === replacement.id ? replacement : stale,
+      listComputerTargets: async (_workspaceId, computerSessionId) => {
+        if (computerSessionId === replacement.id) {
+          return {
+            computerSessionId,
+            controllerGeneration: "controller-2",
+            targets: [],
+          };
+        }
+        targetCalls += 1;
+        throw new OpenGeniApiError(
+          409,
+          JSON.stringify({
+            error: {
+              status: 409,
+              code: "conflict",
+              message: "This Desktop belonged to a previous task placement and was retired.",
+              retryable: false,
+              outcomeUnknown: false,
+              details: {
+                interactionResource: "computer_session",
+                interactionFailureCode: "source_placement_changed",
+                interactionLifecycle: "lost",
+              },
+            },
+          }),
+        );
+      },
+      createComputerSession: async () => {
+        createCalls += 1;
+        return mutation(replacement);
+      },
+    });
+
+    const rendered = await renderComponent(
+      <ComputerViewer client={client} workspaceId={WORKSPACE_ID} sessionId={SESSION_ID} />,
+    );
+    await flush(120);
+    expect(catalogCalls).toBeGreaterThanOrEqual(2);
+    expect(targetCalls).toBe(1);
+    expect(createCalls).toBe(1);
+    await flush(900);
+    expect(targetCalls).toBe(1);
+    expect(createCalls).toBe(1);
+    await rendered.unmount();
+
+    const remounted = await renderComponent(
+      <ComputerViewer client={client} workspaceId={WORKSPACE_ID} sessionId={SESSION_ID} />,
+    );
+    await flush(120);
+    expect(createCalls).toBe(1);
+    await remounted.unmount();
+  });
+
   test("restores the task's last selected Desktop session", async () => {
     const current = computerSession();
     const peer = computerSession(PEER_COMPUTER_SESSION_ID, PEER_SESSION_ID, "Peer Mac");

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -575,6 +575,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0326_interaction_operation_error_codes.sql")) {
+        return includesActivation
+          ? "c4ec5d41697c791e8083ae6285c7dd46b33d843b1ddf4024925d05fdceb5115c"
+          : "92906a57900983a7be80dd460e3fcc16e9f40da1441ae6be190fc088c168c1e9";
+      }
       if (migrations.has("0321_slack_bot_environment_display_name.sql")) {
         return includesActivation
           ? "3fa4d5e5322376e0f635e6d00f315a22013f4985c65b65cf10db16749391fc63"
@@ -1226,7 +1231,8 @@ describe("release schema contract", () => {
         (migrations.has("0308_session_archives.sql") ? 1 : 0) +
         (migrations.has("0309_channel_project_pins.sql") ? 1 : 0) +
         (migrations.has("0310_channel_project_order.sql") ? 1 : 0) +
-        (migrations.has("0321_slack_bot_environment_display_name.sql") ? 1 : 0),
+        (migrations.has("0321_slack_bot_environment_display_name.sql") ? 1 : 0) +
+        (migrations.has("0326_interaction_operation_error_codes.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1261,165 +1267,171 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0321_slack_bot_environment_display_name.sql")
-        ? "0321_slack_bot_environment_display_name.sql"
-        : migrations.has("0310_channel_project_order.sql")
-          ? "0310_channel_project_order.sql"
-          : migrations.has("0309_channel_project_pins.sql")
-            ? "0309_channel_project_pins.sql"
-            : migrations.has("0308_session_archives.sql")
-              ? "0308_session_archives.sql"
-              : migrations.has("0307_session_attention_state.sql")
-                ? "0307_session_attention_state.sql"
-                : migrations.has("0303_session_tenancy_product_activation.sql")
-                  ? "0303_session_tenancy_product_activation.sql"
-                  : migrations.has("0302_personal_workspace_session_ownership.sql")
-                    ? "0302_personal_workspace_session_ownership.sql"
-                    : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
-                      ? "0301_session_snapshot_and_pin_visibility.sql"
-                      : migrations.has("0300_tenancy_backfill_ledger.sql")
-                        ? "0300_tenancy_backfill_ledger.sql"
-                        : migrations.has("0299_organization_membership_lock_order.sql")
-                          ? "0299_organization_membership_lock_order.sql"
-                          : migrations.has("0298_organization_tenancy_parity.sql")
-                            ? "0298_organization_tenancy_parity.sql"
-                            : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
-                              ? "0295_retire_legacy_standing_memory_mode.sql"
-                              : migrations.has("0294_preference_activation_authority.sql")
-                                ? "0294_preference_activation_authority.sql"
-                                : migrations.has("0293_confirm_time_rule_rebaseline.sql")
-                                  ? "0293_confirm_time_rule_rebaseline.sql"
-                                  : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
-                                    ? "0292_truthful_tenancy_inventory_counters.sql"
-                                    : migrations.has(
-                                          "0291_resource_authority_classification_assertion.sql",
-                                        )
-                                      ? "0291_resource_authority_classification_assertion.sql"
-                                      : migrations.has("0290_organization_membership_backfill.sql")
-                                        ? "0290_organization_membership_backfill.sql"
+      migrations.has("0326_interaction_operation_error_codes.sql")
+        ? "0326_interaction_operation_error_codes.sql"
+        : migrations.has("0321_slack_bot_environment_display_name.sql")
+          ? "0321_slack_bot_environment_display_name.sql"
+          : migrations.has("0310_channel_project_order.sql")
+            ? "0310_channel_project_order.sql"
+            : migrations.has("0309_channel_project_pins.sql")
+              ? "0309_channel_project_pins.sql"
+              : migrations.has("0308_session_archives.sql")
+                ? "0308_session_archives.sql"
+                : migrations.has("0307_session_attention_state.sql")
+                  ? "0307_session_attention_state.sql"
+                  : migrations.has("0303_session_tenancy_product_activation.sql")
+                    ? "0303_session_tenancy_product_activation.sql"
+                    : migrations.has("0302_personal_workspace_session_ownership.sql")
+                      ? "0302_personal_workspace_session_ownership.sql"
+                      : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
+                        ? "0301_session_snapshot_and_pin_visibility.sql"
+                        : migrations.has("0300_tenancy_backfill_ledger.sql")
+                          ? "0300_tenancy_backfill_ledger.sql"
+                          : migrations.has("0299_organization_membership_lock_order.sql")
+                            ? "0299_organization_membership_lock_order.sql"
+                            : migrations.has("0298_organization_tenancy_parity.sql")
+                              ? "0298_organization_tenancy_parity.sql"
+                              : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
+                                ? "0295_retire_legacy_standing_memory_mode.sql"
+                                : migrations.has("0294_preference_activation_authority.sql")
+                                  ? "0294_preference_activation_authority.sql"
+                                  : migrations.has("0293_confirm_time_rule_rebaseline.sql")
+                                    ? "0293_confirm_time_rule_rebaseline.sql"
+                                    : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
+                                      ? "0292_truthful_tenancy_inventory_counters.sql"
+                                      : migrations.has(
+                                            "0291_resource_authority_classification_assertion.sql",
+                                          )
+                                        ? "0291_resource_authority_classification_assertion.sql"
                                         : migrations.has(
-                                              "0289_session_composer_policy_authority.sql",
+                                              "0290_organization_membership_backfill.sql",
                                             )
-                                          ? "0289_session_composer_policy_authority.sql"
-                                          : migrations.has("0288_attached_browser_reenrollment.sql")
-                                            ? "0288_attached_browser_reenrollment.sql"
+                                          ? "0290_organization_membership_backfill.sql"
+                                          : migrations.has(
+                                                "0289_session_composer_policy_authority.sql",
+                                              )
+                                            ? "0289_session_composer_policy_authority.sql"
                                             : migrations.has(
-                                                  "0287_open_suffix_pending_tool_calls.sql",
+                                                  "0288_attached_browser_reenrollment.sql",
                                                 )
-                                              ? "0287_open_suffix_pending_tool_calls.sql"
+                                              ? "0288_attached_browser_reenrollment.sql"
                                               : migrations.has(
-                                                    "0286_widen_task_note_expiry_ceiling.sql",
+                                                    "0287_open_suffix_pending_tool_calls.sql",
                                                   )
-                                                ? "0286_widen_task_note_expiry_ceiling.sql"
+                                                ? "0287_open_suffix_pending_tool_calls.sql"
                                                 : migrations.has(
-                                                      "0285_organization_tenancy_inventory.sql",
+                                                      "0286_widen_task_note_expiry_ceiling.sql",
                                                     )
-                                                  ? "0285_organization_tenancy_inventory.sql"
+                                                  ? "0286_widen_task_note_expiry_ceiling.sql"
                                                   : migrations.has(
-                                                        "0284_truthful_human_confirmed_review_reason.sql",
+                                                        "0285_organization_tenancy_inventory.sql",
                                                       )
-                                                    ? "0284_truthful_human_confirmed_review_reason.sql"
+                                                    ? "0285_organization_tenancy_inventory.sql"
                                                     : migrations.has(
-                                                          "0283_editable_spreadsheet_authored_state.sql",
+                                                          "0284_truthful_human_confirmed_review_reason.sql",
                                                         )
-                                                      ? "0283_editable_spreadsheet_authored_state.sql"
+                                                      ? "0284_truthful_human_confirmed_review_reason.sql"
                                                       : migrations.has(
-                                                            "0282_variable_set_session_attach_attribution.sql",
+                                                            "0283_editable_spreadsheet_authored_state.sql",
                                                           )
-                                                        ? "0282_variable_set_session_attach_attribution.sql"
+                                                        ? "0283_editable_spreadsheet_authored_state.sql"
                                                         : migrations.has(
-                                                              "0281_viewer_holder_authority_claims.sql",
+                                                              "0282_variable_set_session_attach_attribution.sql",
                                                             )
-                                                          ? "0281_viewer_holder_authority_claims.sql"
+                                                          ? "0282_variable_set_session_attach_attribution.sql"
                                                           : migrations.has(
-                                                                "0280_connection_and_variable_set_audit_attribution.sql",
+                                                                "0281_viewer_holder_authority_claims.sql",
                                                               )
-                                                            ? "0280_connection_and_variable_set_audit_attribution.sql"
+                                                            ? "0281_viewer_holder_authority_claims.sql"
                                                             : migrations.has(
-                                                                  "0279_workspace_connection_use_lane.sql",
+                                                                  "0280_connection_and_variable_set_audit_attribution.sql",
                                                                 )
-                                                              ? "0279_workspace_connection_use_lane.sql"
+                                                              ? "0280_connection_and_variable_set_audit_attribution.sql"
                                                               : migrations.has(
-                                                                    "0278_workspace_membership_removal_fencing.sql",
+                                                                    "0279_workspace_connection_use_lane.sql",
                                                                   )
-                                                                ? "0278_workspace_membership_removal_fencing.sql"
+                                                                ? "0279_workspace_connection_use_lane.sql"
                                                                 : migrations.has(
-                                                                      "0277_workspace_writer_authority_attribution.sql",
+                                                                      "0278_workspace_membership_removal_fencing.sql",
                                                                     )
-                                                                  ? "0277_workspace_writer_authority_attribution.sql"
+                                                                  ? "0278_workspace_membership_removal_fencing.sql"
                                                                   : migrations.has(
-                                                                        "0276_onboarding_proposal_initiating_human_guc.sql",
+                                                                        "0277_workspace_writer_authority_attribution.sql",
                                                                       )
-                                                                    ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                                                                    ? "0277_workspace_writer_authority_attribution.sql"
                                                                     : migrations.has(
-                                                                          "0275_scheduled_connection_authority.sql",
+                                                                          "0276_onboarding_proposal_initiating_human_guc.sql",
                                                                         )
-                                                                      ? "0275_scheduled_connection_authority.sql"
+                                                                      ? "0276_onboarding_proposal_initiating_human_guc.sql"
                                                                       : migrations.has(
-                                                                            "0274_human_confirmed_knowledge_review.sql",
+                                                                            "0275_scheduled_connection_authority.sql",
                                                                           )
-                                                                        ? "0274_human_confirmed_knowledge_review.sql"
+                                                                        ? "0275_scheduled_connection_authority.sql"
                                                                         : migrations.has(
-                                                                              "0272_human_confirmed_learning_activation.sql",
+                                                                              "0274_human_confirmed_knowledge_review.sql",
                                                                             )
-                                                                          ? "0272_human_confirmed_learning_activation.sql"
+                                                                          ? "0274_human_confirmed_knowledge_review.sql"
                                                                           : migrations.has(
-                                                                                "0271_company_brain_retrieval_only_default.sql",
+                                                                                "0272_human_confirmed_learning_activation.sql",
                                                                               )
-                                                                            ? "0271_company_brain_retrieval_only_default.sql"
+                                                                            ? "0272_human_confirmed_learning_activation.sql"
                                                                             : migrations.has(
-                                                                                  "0270_governed_learning_history_inspection.sql",
+                                                                                  "0271_company_brain_retrieval_only_default.sql",
                                                                                 )
-                                                                              ? "0270_governed_learning_history_inspection.sql"
+                                                                              ? "0271_company_brain_retrieval_only_default.sql"
                                                                               : migrations.has(
-                                                                                    "0269_governed_learning_activation_controller.sql",
+                                                                                    "0270_governed_learning_history_inspection.sql",
                                                                                   )
-                                                                                ? "0269_governed_learning_activation_controller.sql"
+                                                                                ? "0270_governed_learning_history_inspection.sql"
                                                                                 : migrations.has(
-                                                                                      "0268_governed_learning_decision_receipts.sql",
+                                                                                      "0269_governed_learning_activation_controller.sql",
                                                                                     )
-                                                                                  ? "0268_governed_learning_decision_receipts.sql"
+                                                                                  ? "0269_governed_learning_activation_controller.sql"
                                                                                   : migrations.has(
-                                                                                        "0266_company_brain_context_receipt_inspection.sql",
+                                                                                        "0268_governed_learning_decision_receipts.sql",
                                                                                       )
-                                                                                    ? "0266_company_brain_context_receipt_inspection.sql"
+                                                                                    ? "0268_governed_learning_decision_receipts.sql"
                                                                                     : migrations.has(
-                                                                                          "0261_preference_knowledge_proposal_actor_binding.sql",
+                                                                                          "0266_company_brain_context_receipt_inspection.sql",
                                                                                         )
-                                                                                      ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                                                                      ? "0266_company_brain_context_receipt_inspection.sql"
                                                                                       : migrations.has(
-                                                                                            "0260_task_note_knowledge_promotion.sql",
+                                                                                            "0261_preference_knowledge_proposal_actor_binding.sql",
                                                                                           )
-                                                                                        ? "0260_task_note_knowledge_promotion.sql"
+                                                                                        ? "0261_preference_knowledge_proposal_actor_binding.sql"
                                                                                         : migrations.has(
-                                                                                              "0259_company_brain_context_selection_receipts.sql",
+                                                                                              "0260_task_note_knowledge_promotion.sql",
                                                                                             )
-                                                                                          ? "0259_company_brain_context_selection_receipts.sql"
+                                                                                          ? "0260_task_note_knowledge_promotion.sql"
                                                                                           : migrations.has(
-                                                                                                "0258_three_scope_document_knowledge_authority.sql",
+                                                                                                "0259_company_brain_context_selection_receipts.sql",
                                                                                               )
-                                                                                            ? "0258_three_scope_document_knowledge_authority.sql"
+                                                                                            ? "0259_company_brain_context_selection_receipts.sql"
                                                                                             : migrations.has(
-                                                                                                  "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                                                                  "0258_three_scope_document_knowledge_authority.sql",
                                                                                                 )
-                                                                                              ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                                                                              ? "0258_three_scope_document_knowledge_authority.sql"
                                                                                               : migrations.has(
-                                                                                                    "0255_company_brain_governed_write_proposals.sql",
+                                                                                                    "0257_goal_revision_decisions_and_root_constraints.sql",
                                                                                                   )
-                                                                                                ? "0255_company_brain_governed_write_proposals.sql"
+                                                                                                ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                                                                                 : migrations.has(
-                                                                                                      "0248_terraform_stacks_component_resolution_fence.sql",
+                                                                                                      "0255_company_brain_governed_write_proposals.sql",
                                                                                                     )
-                                                                                                  ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                                                                  ? "0255_company_brain_governed_write_proposals.sql"
                                                                                                   : migrations.has(
-                                                                                                        "0247_terraform_stacks_provenance_repair.sql",
+                                                                                                        "0248_terraform_stacks_component_resolution_fence.sql",
                                                                                                       )
-                                                                                                    ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                    ? "0248_terraform_stacks_component_resolution_fence.sql"
                                                                                                     : migrations.has(
-                                                                                                          "0263_organization_membership_lifecycle.sql",
+                                                                                                          "0247_terraform_stacks_provenance_repair.sql",
                                                                                                         )
-                                                                                                      ? "0263_organization_membership_lifecycle.sql"
-                                                                                                      : latestCompatibleMigration,
+                                                                                                      ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                      : migrations.has(
+                                                                                                            "0263_organization_membership_lifecycle.sql",
+                                                                                                          )
+                                                                                                        ? "0263_organization_membership_lifecycle.sql"
+                                                                                                        : latestCompatibleMigration,
     );
     expect(migrations.get("0289_session_composer_policy_authority.sql")).toMatchObject({
       sha256: "478e7ba49b6940bdd849223a0965b7dcc20a0d4428f0fc85078961dbd3984285",


### PR DESCRIPTION
## What changed
- terminalize Browser/Desktop resources when their source task moves off the Connected Machine that owns them
- return a structured non-retryable 409 and stop client polling/heartbeat loops
- recreate exactly one task Desktop on the current placement; leave Browser identity selection explicit
- preserve canonical `outcome_unknown` operation receipts and repair invalid historical reaper receipts under FORCE-RLS migration posture

## Root cause
Interaction resources retained their old connected-machine route after `sessions.active_sandbox_id` changed. The API returned a generic retryable conflict forever, while the React viewer kept polling the permanently stale route.

## Verification
- 37 DB lifecycle tests
- migration 0326 production-owner FORCE-RLS regression test
- 28 API route tests
- 58 React interaction tests
- DB/API/React typechecks and builds
- targeted oxfmt/oxlint
- migration ordinal and FORCE-RLS guards