### PR TITLE
docs: require durable worktree checkpoints

### DIFF
--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -125,6 +125,21 @@ Do not rely on this skill for exact route lists, env var lists, event types, mod
 
 ## Code Change Workflow
 
+Preserve every material candidate before pausing or handing it off. Approval
+gates stop delivery, not checkpointing:
+
+- Use a durable worktree outside `/tmp` and `/private/tmp` for any task that may
+  survive the current turn.
+- Commit all intended changes locally before pausing, including tests, docs,
+  generated files, and visual-approval harnesses. Waiting for user approval is
+  not a reason to leave a dirty worktree.
+- Hand off the absolute worktree path, branch, and checkpoint SHA, and verify
+  `git status --porcelain` is empty.
+- Keep the branch and worktree until merge or explicit user-directed discard.
+
+If user-owned unrelated edits make a complete checkpoint unsafe, stop and ask
+for direction rather than leaving material work uncommitted.
+
 Before editing, identify which layer owns the behavior:
 
 - Public API or validation: routes, core domain helpers, contracts, tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,23 @@ This repository is a clean TypeScript/Bun stack. The public API is session-based
 
 > **Start here for orientation: [`docs/architecture.md`](docs/architecture.md).** It is the canonical whole-system map — what OpenGeni is, the load-bearing invariants, the full repo layout, per-component deep-dives, and a *"if you're changing X, read Y first"* decision table. Read it before navigating an unfamiliar area, and **keep it current**: if your change adds/removes/renames an app, package, or sandbox backend; alters an architectural invariant, the data-flow, or the session/turn lifecycle; or changes which file is canonical for a change area — update `docs/architecture.md` in the *same* change. A stale map is a bug. (This file, AGENTS.md, owns *how to run and operate* the stack; architecture.md owns *how the system is shaped*.)
 
+## Durable worktree checkpoints
+
+Never leave material source changes uncommitted when pausing, handing off, or
+ending work. An approval gate pauses delivery, not source durability.
+
+- Put worktrees that may outlive the current turn under a durable repository
+  sibling such as `../opengeni-wt/<task>`. Do not use `/tmp`, `/private/tmp`, or
+  another automatically cleaned location for retained work.
+- Before pausing or handing off, create a local checkpoint commit containing all
+  intended source, test, documentation, generated-file, and approval-harness
+  changes. The commit may remain unpushed while awaiting approval.
+- Leave the worktree clean and report its absolute path, branch, and checkpoint
+  SHA. Store approval boards and screenshots in a durable location as well.
+- Do not delete the worktree or branch until the change is merged or the user
+  explicitly asks to discard it. If unrelated user-owned changes prevent a
+  complete checkpoint, stop and ask instead of leaving a partially dirty tree.
+
 When the user says **"start the dev server"**, **"spin it up"**, or **"run the full stack"**, they mean the steps under **Full local stack**.
 
 ## Full Local Stack


### PR DESCRIPTION
## Summary

- require durable, non-temporary worktree locations for retained tasks
- require local checkpoint commits before approval pauses or handoffs
- require clean-tree handoff with path, branch, and SHA
- retain branches/worktrees until merge or explicit discard

## Verification

- `git diff --check`
- worktree clean at committed head
