### PR TITLE
fix(tenancy): keep resource discovery inert before activation

### DIFF
--- a/.changeset/tenancy-off-resource-discovery.md
+++ b/.changeset/tenancy-off-resource-discovery.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+Return empty personal-resource authority pages before session-tenancy activation while keeping mutations and runtime use activation-gated. Allow managed humans to read their personal Rig catalog without granting Rig administration.

--- a/apps/api/test/personal-workspace-session-surface.test.ts
+++ b/apps/api/test/personal-workspace-session-surface.test.ts
@@ -1285,6 +1285,49 @@ describe("the in-scope resolver refuses to be an arbitrary-subject oracle", () =
 });
 
 describe("managed personal-resource grant HTTP lifecycle", () => {
+  test("returns empty discovery pages before activation while mutation stays denied", async () => {
+    if (!shared || !client) return;
+    const human = await provisionManagedHuman();
+    const app = buildApp(undefined, true);
+    const headers = { cookie: human.cookie, "content-type": "application/json" };
+
+    for (const resourceKind of ["variable_set", "rig"] as const) {
+      const listResponse = await app.request(
+        `http://x/v1/workspaces/${human.personalWorkspaceId}/user-resource-authorities?scope=user&resourceKind=${resourceKind}`,
+        { headers },
+      );
+      expect(listResponse.status).toBe(200);
+      expect(await listResponse.json()).toEqual({
+        scope: "user",
+        authorities: [],
+        nextCursor: null,
+      });
+    }
+
+    const rigCatalogResponse = await app.request(
+      `http://x/v1/workspaces/${human.personalWorkspaceId}/rigs`,
+      { headers },
+    );
+    expect(rigCatalogResponse.status).toBe(200);
+    expect(await rigCatalogResponse.json()).toEqual([]);
+
+    const issueResponse = await app.request(
+      `http://x/v1/workspaces/${human.personalWorkspaceId}/user-resource-authorities/${crypto.randomUUID()}/grants`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          scope: "user",
+          resourceKind: "variable_set",
+          mode: "always",
+          context: "user_private",
+          workspaceSharedAcknowledged: false,
+        }),
+      },
+    );
+    expect(issueResponse.status).toBe(403);
+  }, 180_000);
+
   test("returns RFC3339 expiry/revoke times, reissues expiry, and revokes without connections:read", async () => {
     if (!shared || !client) return;
     const human = await provisionManagedHuman();

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -56,6 +56,14 @@ pages for one exact resource kind, include the opaque resource/origin identity,
 and return only grants targeting the route workspace. Resource kind derives the
 only accepted action (`connection.use`, `document.read`, `variable_set.use`,
 `rig.use`, or `connected_machine.use`) and its exact product permission gate.
+For a canonical managed human with that permission, an organization without
+the version-1 activation receipt has exactly zero usable personal authorities,
+so discovery returns an empty page. Issue, revoke, and runtime use remain
+activation-gated; the empty discovery answer does not activate the product or
+weaken any mutation fence.
+The managed personal-workspace projection includes `rigs:use`, allowing its
+owner to discover and propose changes to personal Rigs without granting the
+administrative `rigs:manage` capability.
 
 Public issuance supports `session` and `always`. Session grants are authorized
 through the ordinary session authorization seam after all target-free

--- a/packages/core/src/application/user-resource-grants.ts
+++ b/packages/core/src/application/user-resource-grants.ts
@@ -42,11 +42,19 @@ async function requireOwnerProductGate(
 ): Promise<void> {
   // Target-free gates must run before an optional target-session lookup or host
   // callback so rejected principals cannot use grant management as an oracle.
-  requireCanonicalManagedHuman(authorization, workspaceId);
-  for (const permission of permissions) requirePermission(authorization.grant, permission);
+  requireOwnerAuthority(authorization, workspaceId, permissions);
   if (!(await sessionTenancyProductActivated(deps.db, workspaceId))) {
     throw new SessionTenancyNotActivatedError();
   }
+}
+
+function requireOwnerAuthority(
+  authorization: AccessGrantAuthorization,
+  workspaceId: string,
+  permissions: readonly Permission[],
+): void {
+  requireCanonicalManagedHuman(authorization, workspaceId);
+  for (const permission of permissions) requirePermission(authorization.grant, permission);
 }
 
 export async function listManagedHumanUserResourceAuthorities(
@@ -55,12 +63,15 @@ export async function listManagedHumanUserResourceAuthorities(
   workspaceId: string,
   input: { resourceKind: UserResourceKind; cursor?: string | undefined; limit: number },
 ) {
-  await requireOwnerProductGate(
-    deps,
-    authorization,
-    workspaceId,
-    LIST_PERMISSIONS[input.resourceKind],
-  );
+  requireOwnerAuthority(authorization, workspaceId, LIST_PERMISSIONS[input.resourceKind]);
+  // Before activation there cannot be usable personal-resource authority in
+  // this organization. Discovery therefore has an exact empty answer; only
+  // issue/revoke and runtime use remain behind the forward-only product gate.
+  // This keeps ordinary workspace-owned Rig/Variable Set selection independent
+  // from an optional personal-resource product that is not enabled.
+  if (!(await sessionTenancyProductActivated(deps.db, workspaceId))) {
+    return { authorities: [], nextCursor: null };
+  }
   return await listSelfUserResourceAuthorities(deps.db, {
     accountId: authorization.grant.accountId,
     workspaceId,

--- a/packages/core/test/session-tenancy.test.ts
+++ b/packages/core/test/session-tenancy.test.ts
@@ -152,6 +152,94 @@ describe("managed-human session tenancy application service", () => {
     });
   }, 180_000);
 
+  test("returns empty personal-resource discovery before activation while mutations stay closed", async () => {
+    if (!shared || !client) return;
+    const userId = `core-personal-discovery-inactive-${crypto.randomUUID()}`;
+    const subjectId = `user:${userId}`;
+    const access = await ensureManagedAccessForUser(client.db, {
+      userId,
+      email: `${userId}@example.test`,
+      name: "Inactive personal-resource discovery",
+    });
+    const grant = access.workspaceGrants.find(
+      (candidate) => candidate.workspaceId === access.defaultWorkspaceId,
+    );
+    if (!grant) throw new Error("managed human has no shared workspace grant");
+    const authorization = {
+      grant: {
+        ...grant,
+        permissions: [...new Set([...grant.permissions, "rigs:use", "sessions:create"])],
+      },
+      accountGrant: access.accountGrants[0] ?? null,
+      authenticatedSubjectId: subjectId,
+      contextIntegrity: true,
+      canonicalManagedHumanSession: true,
+    } satisfies AccessGrantAuthorization;
+    const deps = {
+      db: client.db,
+      sessionAuthorization: {
+        authorizeSession: async () => {
+          throw new Error("host authorization must not run before activation");
+        },
+        resolveListScope: async () => ({ kind: "all" as const }),
+      },
+    };
+
+    await expect(
+      listManagedHumanUserResourceAuthorities(
+        deps,
+        { ...authorization, canonicalManagedHumanSession: false },
+        grant.workspaceId,
+        { resourceKind: "rig", limit: 100 },
+      ),
+    ).rejects.toBeInstanceOf(SessionTenancyManagedHumanRequiredError);
+    await expect(
+      listManagedHumanUserResourceAuthorities(
+        deps,
+        {
+          ...authorization,
+          grant: {
+            ...authorization.grant,
+            permissions: authorization.grant.permissions.filter(
+              (permission) => permission !== "rigs:use" && permission !== "workspace:admin",
+            ),
+          },
+        },
+        grant.workspaceId,
+        { resourceKind: "rig", limit: 100 },
+      ),
+    ).rejects.toMatchObject({ status: 403 } satisfies Partial<HTTPException>);
+    await expect(
+      listManagedHumanUserResourceAuthorities(deps, authorization, grant.workspaceId, {
+        resourceKind: "rig",
+        limit: 100,
+      }),
+    ).resolves.toEqual({ authorities: [], nextCursor: null });
+    await expect(
+      issueManagedHumanUserResourceGrant(
+        deps,
+        authorization,
+        grant.workspaceId,
+        crypto.randomUUID(),
+        {
+          scope: "user",
+          resourceKind: "rig",
+          mode: "always",
+          context: "user_private",
+          workspaceSharedAcknowledged: false,
+        },
+      ),
+    ).rejects.toBeInstanceOf(SessionTenancyNotActivatedError);
+    await expect(
+      revokeManagedHumanUserResourceGrant(
+        deps,
+        authorization,
+        grant.workspaceId,
+        crypto.randomUUID(),
+      ),
+    ).rejects.toBeInstanceOf(SessionTenancyNotActivatedError);
+  }, 180_000);
+
   test("lists, issues, reissues expired identities, and route-fences revocation", async () => {
     if (!shared || !client) return;
     const userId = `core-personal-grants-${crypto.randomUUID()}`;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1247,6 +1247,7 @@ export const managedPersonalWorkspacePermissions: Permission[] = [
   "goals:manage",
   "enrollments:read",
   "enrollments:manage",
+  "rigs:use",
   "artifacts:read",
   "artifacts:publish",
 ];

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -58,6 +58,7 @@ const expectedManagedPersonalWorkspacePermissions: Permission[] = [
   "goals:manage",
   "enrollments:read",
   "enrollments:manage",
+  "rigs:use",
   "artifacts:read",
   "artifacts:publish",
 ];
@@ -137,6 +138,7 @@ describe("migration 0219 managed-human organization provisioning", () => {
     expect(managedPersonalWorkspacePermissions).not.toContain("workspace:admin");
     expect(managedPersonalWorkspacePermissions).not.toContain("members:manage");
     expect(managedPersonalWorkspacePermissions).not.toContain("api_keys:manage");
+    expect(managedPersonalWorkspacePermissions).not.toContain("rigs:manage");
   });
 
   test("pins the rolling lifecycle capability, posture contract, and exact role grant", async () => {


### PR DESCRIPTION
## What
- return empty personal-resource authority pages before tenancy activation
- keep issue, revoke, and runtime paths activation-gated
- grant managed personal workspaces `rigs:use` so the catalog can load without Rig administration

## Verification
- 36 real-Postgres tests across core, DB migration, and API surface
- core, DB, and API-router typechecks
- oxfmt and diff checks