### PR TITLE
fix(release): select authoritative source push checks

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1635,16 +1635,39 @@ async function verifySuccessfulSourceChecks(api, checks, names, sha) {
     allIdentities.push(...identities);
   }
 
-  const runIds = new Set(allIdentities.map((identity) => identity.runId));
-  invariant(runIds.size === 1, "required source checks do not share one workflow run");
-  const checkSuiteIds = new Set(allIdentities.map((identity) => identity.checkSuiteId));
-  invariant(checkSuiteIds.size === 1, "required source checks do not share one check suite");
-  const runId = allIdentities[0].runId;
-  const checkSuiteId = allIdentities[0].checkSuiteId;
-  const run = record(
-    await api.get(repositoryPath(`/actions/runs/${runId}`)),
-    "required source workflow run",
+  // A main -> production PR may legitimately run the same aggregate check
+  // names against the exact source SHA. Treat those provider-owned checks as
+  // unrelated evidence: release admission is bound only to the unique CI run
+  // triggered by the source commit's push to protected main.
+  const observedRunIds = [...new Set(allIdentities.map((identity) => identity.runId))];
+  const observedRuns = await Promise.all(
+    observedRunIds.map(async (runId) => ({
+      runId,
+      run: record(
+        await api.get(repositoryPath(`/actions/runs/${runId}`)),
+        "observed source workflow run",
+      ),
+    })),
   );
+  const authoritativeRuns = observedRuns.filter(
+    ({ runId, run }) =>
+      run.id === runId &&
+      run.event === "push" &&
+      run.path === RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath &&
+      run.head_branch === RELEASE_AUTOMATION_CONTRACT.defaultBranch &&
+      run.head_sha === sha &&
+      run.repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository &&
+      run.head_repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+  );
+  invariant(
+    authoritativeRuns.length === 1,
+    "required source checks do not identify exactly one push CI workflow run",
+  );
+  const { runId, run } = authoritativeRuns[0];
+  const authoritativeIdentities = allIdentities.filter((identity) => identity.runId === runId);
+  const checkSuiteIds = new Set(authoritativeIdentities.map((identity) => identity.checkSuiteId));
+  invariant(checkSuiteIds.size === 1, "required source checks do not share one check suite");
+  const checkSuiteId = authoritativeIdentities[0].checkSuiteId;
   invariant(run.id === runId, "required source workflow run ID changed");
   invariant(
     run.check_suite_id === checkSuiteId,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -253,12 +253,7 @@ function dispatchFixture(
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({
-      method,
-      path: url.pathname,
-      query: url.searchParams,
-      body,
-    });
+    requests.push({ method, path: url.pathname, query: url.searchParams, body });
     const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
     if (method === "GET" && url.pathname === prefix) return response(repository());
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
@@ -935,7 +930,12 @@ function retainControllerFixture() {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    requests.push({
+      method,
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+    });
     if (method === "POST" && url.pathname === `${prefix}/git/refs`) {
       refRetained = true;
       return response({ ref: body?.ref, object: { type: "commit", sha: body?.sha } }, 201);
@@ -2265,6 +2265,7 @@ function approvalFixture(
     historicalHeadChecks?: Array<Record<string, unknown>>;
     historicalSourceChecks?: Array<Record<string, unknown>>;
     sourceRun?: Record<string, unknown>;
+    otherSourceRuns?: Record<string, Record<string, unknown>>;
     sourceAttemptJobs?: Array<Record<string, unknown>>;
     releaseHeadRefSha?: string | null;
     release?: Record<string, unknown> | null;
@@ -2580,6 +2581,13 @@ function approvalFixture(
           head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
         },
       );
+    const otherSourceRunMatch = url.pathname.match(
+      new RegExp(`^${prefix}/actions/runs/([1-9][0-9]*)$`),
+    );
+    if (method === "GET" && otherSourceRunMatch) {
+      const otherRun = options.otherSourceRuns?.[otherSourceRunMatch[1]];
+      if (otherRun) return response(otherRun);
+    }
     if (
       method === "GET" &&
       url.pathname === `${prefix}/actions/runs/${sourceCiRunId}/attempts/${sourceCiRunAttempt}/jobs`
@@ -3208,7 +3216,7 @@ describe("release approval provenance", () => {
     );
   });
 
-  test("rejects failed latest CI attempts and source checks from another workflow run", async () => {
+  test("rejects failed latest CI attempts", async () => {
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
@@ -3232,23 +3240,97 @@ describe("release approval provenance", () => {
         }).fetchImpl,
       }),
     ).rejects.toThrow("required source workflow did not complete successfully");
+  });
 
+  test("ignores same-name pull-request checks and binds the unique push CI run", async () => {
+    const pullRequestRunId = 999999;
+    const pullRequestCheckSuiteId = 999998;
+    const pullRequestChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map(
+      (name, index) => {
+        const jobId = 8050 + index;
+        return sourceCiCheck(name, 50 + index, {
+          id: jobId,
+          details_url:
+            `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+            `/actions/runs/${pullRequestRunId}/job/${jobId}`,
+          check_suite: { id: pullRequestCheckSuiteId },
+        });
+      },
+    );
+    const result = await verifyApprovedMerge({
+      env: approvalEnv(),
+      fetchImpl: approvalFixture({
+        historicalSourceChecks: pullRequestChecks,
+        otherSourceRuns: {
+          [pullRequestRunId]: {
+            id: pullRequestRunId,
+            run_attempt: 1,
+            status: "completed",
+            conclusion: "failure",
+            event: "pull_request",
+            path: RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+            head_sha: mergeSha,
+            head_branch: "main",
+            check_suite_id: pullRequestCheckSuiteId,
+            html_url:
+              `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+              `/actions/runs/${pullRequestRunId}`,
+            repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+            head_repository: {
+              full_name: RELEASE_AUTOMATION_CONTRACT.repository,
+            },
+          },
+        },
+      }).fetchImpl,
+      logger: { log() {} },
+    });
+
+    expect(
+      result.requiredSourceChecks.every((check) => check.workflowRunId === sourceCiRunId),
+    ).toBe(true);
+  });
+
+  test("rejects multiple push CI workflow runs on the source SHA", async () => {
+    const duplicateRunId = 999999;
+    const duplicateCheckSuiteId = 999998;
+    const duplicateChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) => {
+      const jobId = 8050 + index;
+      return sourceCiCheck(name, 50 + index, {
+        id: jobId,
+        details_url:
+          `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+          `/actions/runs/${duplicateRunId}/job/${jobId}`,
+        check_suite: { id: duplicateCheckSuiteId },
+      });
+    });
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
         fetchImpl: approvalFixture({
-          historicalSourceChecks: [
-            sourceCiCheck(RELEASE_AUTOMATION_CONTRACT.checks.requiredSource[0], 50, {
-              id: 8050,
-              details_url:
+          historicalSourceChecks: duplicateChecks,
+          otherSourceRuns: {
+            [duplicateRunId]: {
+              id: duplicateRunId,
+              run_attempt: 1,
+              status: "completed",
+              conclusion: "success",
+              event: "push",
+              path: RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+              head_sha: mergeSha,
+              head_branch: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+              check_suite_id: duplicateCheckSuiteId,
+              html_url:
                 `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
-                "/actions/runs/999999/job/8050",
-              check_suite: { id: 999999 },
-            }),
-          ],
+                `/actions/runs/${duplicateRunId}`,
+              repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+              head_repository: {
+                full_name: RELEASE_AUTOMATION_CONTRACT.repository,
+              },
+            },
+          },
         }).fetchImpl,
       }),
-    ).rejects.toThrow("required source checks do not share one workflow run");
+    ).rejects.toThrow("required source checks do not identify exactly one push CI workflow run");
   });
 
   test("requires the immutable reviewed-head evidence ref", async () => {


### PR DESCRIPTION
Fix ordinary-release source admission when a main-to-production PR ran same-name CI checks on the exact source SHA. The verifier now selects exactly one provider-verified protected-main push CI run before validating its suite/latest attempt/jobs; pull-request checks are unrelated evidence, while zero or multiple push runs still fail closed.\n\nVerification: bun test scripts/check-release-pr-automation.test.ts (83 pass, 470 assertions).