### PR TITLE
fix: execute PR review automation end to end

### DIFF
--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -315,7 +315,7 @@ export function registerAutomationRoutes(app: Hono, deps: ApiRouteDeps): void {
         message: "automation source is disabled",
       });
     }
-    const rawBody = await readBoundedBody(c.req.raw, AUTOMATION_WEBHOOK_MAX_BYTES);
+    const rawBody = await readAutomationWebhookBody(c.req.raw, AUTOMATION_WEBHOOK_MAX_BYTES);
     const adapter = requireAutomationAdapter(source.adapterId);
     const secret = decryptVariableSetValue(
       requireEncryptionKey(deps),
@@ -498,7 +498,10 @@ function requireEncryptionKey(deps: ApiRouteDeps): Uint8Array {
   return key;
 }
 
-async function readBoundedBody(request: Request, maxBytes: number): Promise<Uint8Array> {
+export async function readAutomationWebhookBody(
+  request: Request,
+  maxBytes: number,
+): Promise<Uint8Array> {
   const declared = Number(request.headers.get("content-length"));
   if (Number.isFinite(declared) && declared > maxBytes) {
     throw new HTTPException(413, {
@@ -509,21 +512,17 @@ async function readBoundedBody(request: Request, maxBytes: number): Promise<Uint
   const reader = request.body.getReader();
   const chunks: Uint8Array[] = [];
   let length = 0;
-  try {
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      length += value.byteLength;
-      if (length > maxBytes) {
-        await reader.cancel();
-        throw new HTTPException(413, {
-          message: "automation webhook payload is too large",
-        });
-      }
-      chunks.push(value);
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > maxBytes) {
+      await reader.cancel();
+      throw new HTTPException(413, {
+        message: "automation webhook payload is too large",
+      });
     }
-  } finally {
-    reader.releaseLock();
+    chunks.push(value);
   }
   const result = new Uint8Array(length);
   let offset = 0;

--- a/apps/api/test/automations-webhook-body.test.ts
+++ b/apps/api/test/automations-webhook-body.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { HTTPException } from "hono/http-exception";
+import { readAutomationWebhookBody } from "../src/routes/automations";
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+});
+
+function startBodyReader(maxBytes: number) {
+  const app = new Hono();
+  app.use("*", bodyLimit({ maxSize: 1024 * 1024 }));
+  app.post("/", async (context) => {
+    try {
+      const body = await readAutomationWebhookBody(context.req.raw, maxBytes);
+      return Response.json({ body: new TextDecoder().decode(body) });
+    } catch (error) {
+      const status = error instanceof HTTPException ? error.status : 500;
+      return Response.json(
+        { error: error instanceof Error ? error.message : String(error) },
+        {
+          status,
+        },
+      );
+    }
+  });
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: app.fetch,
+  });
+  servers.push(server);
+  return server;
+}
+
+describe("automation webhook body ingestion", () => {
+  test("reads a real Bun inbound request without assuming releaseLock exists", async () => {
+    const server = startBodyReader(1024);
+    const response = await fetch(`http://127.0.0.1:${server.port}`, {
+      method: "POST",
+      body: JSON.stringify({ action: "reopened" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ body: '{"action":"reopened"}' });
+  });
+
+  test("retains the route-specific streaming size fence", async () => {
+    const server = startBodyReader(4);
+    const response = await fetch(`http://127.0.0.1:${server.port}`, {
+      method: "POST",
+      body: "12345",
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "automation webhook payload is too large" });
+  });
+});

--- a/apps/worker/src/activities/agent-turn/file-resources.ts
+++ b/apps/worker/src/activities/agent-turn/file-resources.ts
@@ -6,7 +6,10 @@ import {
 import { type SandboxFileDownload, type SandboxFileDownloadFailure } from "@opengeni/runtime";
 import { type Settings } from "@opengeni/config";
 import { mergeResourceRefs } from "../common";
-import { gitHubTokenMintSelections } from "../environment";
+import {
+  gitHubTokenAuthorizationSelections,
+  type GitHubTokenMintAuthorization,
+} from "../environment";
 import type { TurnActivityServices as ActivityServices } from "../types";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
 import { CAPABILITY_DESCRIPTORS, resourceMountPath, type ResourceRef } from "@opengeni/contracts";
@@ -42,16 +45,21 @@ export async function assertGitHubResourcesRemainAuthorized(
   db: Parameters<typeof areGitHubRepositoriesAllowedForWorkspace>[0],
   workspaceId: string,
   resources: ResourceRef[],
+  authorize?: GitHubTokenMintAuthorization,
 ): Promise<void> {
   // Must check exactly what sandboxEnvironmentForRun would mint a token for,
   // so the selection is derived from the same extraction as the mint path.
-  for (const selection of gitHubTokenMintSelections(resources)) {
-    await assertGitHubTokenMintSelectionAuthorized(
-      db,
-      workspaceId,
-      selection.installationId,
-      selection.repositoryIds,
-    );
+  for (const selection of gitHubTokenAuthorizationSelections(resources)) {
+    if (authorize) {
+      await authorize(selection);
+    } else {
+      await assertGitHubTokenMintSelectionAuthorized(
+        db,
+        workspaceId,
+        selection.installationId,
+        selection.repositoryIds,
+      );
+    }
   }
 }
 

--- a/apps/worker/src/activities/agent-turn/run-credentials.ts
+++ b/apps/worker/src/activities/agent-turn/run-credentials.ts
@@ -1,4 +1,5 @@
-import { getSessionRootId } from "@opengeni/db";
+import { getSessionRootId, resolvePrReviewGitCredential } from "@opengeni/db";
+import { prReviewRegistrationIdFromCredentialBinding } from "@opengeni/core";
 import {
   materializeRunCredentials,
   clearRunCredentials,
@@ -198,6 +199,42 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
     ? runCredentialModelNote(initialRunCredentialMaterial)
     : undefined;
   throwIfTurnOperationCancelled(cancellationSignal);
+  const authorizeGitHubTokenMint: GitHubTokenMintAuthorization = async (selection) => {
+    const registrationId = prReviewRegistrationIdFromCredentialBinding(
+      selection.credentialBindingId,
+    );
+    if (registrationId) {
+      await resolvePrReviewGitCredential(db, {
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        registrationId,
+        provider: "github",
+        sessionId: input.sessionId,
+        rootSessionId: input.sessionId,
+        turnId: turn.id,
+        attemptId: input.attemptId,
+        executionGeneration: turn.executionGeneration,
+        repositoryRefs: selection.repositoryRefs.map((reference) => ({
+          uri: reference.uri,
+          ...(reference.expectedCommitSha !== undefined
+            ? { expectedCommitSha: reference.expectedCommitSha }
+            : {}),
+          ...(reference.repositoryId !== undefined ? { repositoryId: reference.repositoryId } : {}),
+          ...(reference.installationId !== undefined
+            ? { installationId: reference.installationId }
+            : {}),
+          ...(reference.projectId !== undefined ? { projectId: reference.projectId } : {}),
+        })),
+      });
+      return;
+    }
+    await assertGitHubTokenMintSelectionAuthorized(
+      db,
+      input.workspaceId,
+      selection.installationId,
+      selection.repositoryIds,
+    );
+  };
   await Promise.all([
     waitForTurnOperation(
       ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend),
@@ -205,7 +242,12 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
       undefined,
     ),
     activeSandboxBackend !== "selfhosted"
-      ? assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources)
+      ? assertGitHubResourcesRemainAuthorized(
+          db,
+          input.workspaceId,
+          turnResources,
+          authorizeGitHubTokenMint,
+        )
       : Promise.resolve(),
     assertFileResourcesRemainAuthorized(
       db,
@@ -234,14 +276,6 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
   // provider may supply it; unset still self-mints GitHub from settings.
   // gitToken/gitTokens are undefined on the selfhosted skip path (the machine
   // uses its own git creds).
-  const authorizeGitHubTokenMint: GitHubTokenMintAuthorization = async (selection) => {
-    await assertGitHubTokenMintSelectionAuthorized(
-      db,
-      input.workspaceId,
-      selection.installationId,
-      selection.repositoryIds,
-    );
-  };
   // Git and MCP credentials share one lineage snapshot for this turn. A
   // host that supplies both ports must never see two independently resolved
   // roots for the same execution merely because the call sites are far apart.

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -72,10 +72,13 @@ export type MintedRunGitCredentials = {
   expiresAt: GitTokenExpiries;
 };
 
-export type GitHubTokenMintAuthorization = (selection: {
+export type GitHubTokenMintSelection = {
+  credentialBindingId: string;
   installationId: number;
   repositoryIds: number[];
-}) => Promise<void>;
+  repositoryRefs: GitCredentialRepositoryRef[];
+};
+export type GitHubTokenMintAuthorization = (selection: GitHubTokenMintSelection) => Promise<void>;
 
 export {
   CODEMODE_TOKEN_TTL_SECONDS,
@@ -445,8 +448,10 @@ async function mintRunGitTokensWithIdentity(
       // the current workspace binding before every host-brokered or built-in
       // GitHub installation-token mint.
       await options.authorizeGitHubTokenMint?.({
+        credentialBindingId: selection.credentialBindingId,
         installationId: selection.installationId,
         repositoryIds: selection.repositoryIds,
+        repositoryRefs: selection.repositoryRefs,
       });
     }
     const gitCredentials = credentialsForSelection(options, selection);
@@ -775,6 +780,25 @@ export function gitHubTokenMintSelections(
     .map(({ installationId, repositoryIds }) => ({
       installationId,
       repositoryIds,
+    }));
+}
+
+/** Exact binding-aware selections used by authorization immediately before mint. */
+export function gitHubTokenAuthorizationSelections(
+  resources: ResourceRef[],
+): GitHubTokenMintSelection[] {
+  return gitCredentialSelections(resources)
+    .filter(
+      (candidate) =>
+        candidate.provider === "github" &&
+        candidate.installationId > 0 &&
+        candidate.repositoryIds.length > 0,
+    )
+    .map(({ credentialBindingId, installationId, repositoryIds, repositoryRefs }) => ({
+      credentialBindingId,
+      installationId,
+      repositoryIds,
+      repositoryRefs,
     }));
 }
 

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -2906,9 +2906,7 @@ describe("lazy sandbox provisioner single-flight", () => {
     const imageEnsure = credentialsSource.indexOf(
       "ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend)",
     );
-    const gitAssert = credentialsSource.indexOf(
-      "assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources)",
-    );
+    const gitAssert = credentialsSource.indexOf("assertGitHubResourcesRemainAuthorized(");
     expect(authorize).toBeGreaterThan(0);
     expect(overlappedReads).toBeGreaterThan(authorize);
     expect(packRead).toBeGreaterThan(overlappedReads);

--- a/apps/worker/test/git-credentials.test.ts
+++ b/apps/worker/test/git-credentials.test.ts
@@ -194,7 +194,20 @@ describe("sandbox git credentials", () => {
       authority,
       authorizeGitHubTokenMint: async (selection) => {
         events.push("authorize");
-        expect(selection).toEqual({ installationId: 123, repositoryIds: [456] });
+        expect(selection).toEqual({
+          credentialBindingId: "github-installation:123",
+          installationId: 123,
+          repositoryIds: [456],
+          repositoryRefs: [
+            {
+              uri: "https://github.com/acme/private.git",
+              ref: "main",
+              provider: "github",
+              repositoryId: 456,
+              installationId: 123,
+            },
+          ],
+        });
       },
       gitCredentials: async (input) => {
         events.push("mint");

--- a/apps/worker/test/github-mint-selection.test.ts
+++ b/apps/worker/test/github-mint-selection.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, test } from "bun:test";
 import type { ResourceRef } from "@opengeni/contracts";
-import { gitHubTokenMintSelection, gitHubTokenMintSelections } from "../src/activities/environment";
+import {
+  gitHubTokenAuthorizationSelections,
+  gitHubTokenMintSelection,
+  gitHubTokenMintSelections,
+} from "../src/activities/environment";
 
 const repo = (overrides: Record<string, unknown>): ResourceRef =>
   ({
@@ -81,5 +85,36 @@ describe("gitHubTokenMintSelection", () => {
         { ...bare, githubInstallationId: 123, githubRepositoryId: 456 } as ResourceRef,
       ]),
     ).toEqual([{ installationId: 123, repositoryIds: [456] }]);
+  });
+
+  test("preserves an explicit PR Review credential binding for authorization", () => {
+    expect(
+      gitHubTokenAuthorizationSelections([
+        repo({
+          provider: "github",
+          credentialBindingId: "pr-review:11111111-1111-4111-8111-111111111111",
+          installationId: "123",
+          repositoryId: "456",
+          expectedCommitSha: "a".repeat(40),
+        }),
+      ]),
+    ).toEqual([
+      {
+        credentialBindingId: "pr-review:11111111-1111-4111-8111-111111111111",
+        installationId: 123,
+        repositoryIds: [456],
+        repositoryRefs: [
+          {
+            uri: "https://github.com/acme/repo",
+            ref: "main",
+            provider: "github",
+            credentialBindingId: "pr-review:11111111-1111-4111-8111-111111111111",
+            expectedCommitSha: "a".repeat(40),
+            repositoryId: "456",
+            installationId: "123",
+          },
+        ],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- make automation webhook ingestion compatible with Bun/Hono inbound streams while preserving the route-specific byte limit
- authorize PR Review repository resources through their exact registration-bound credential authority instead of the generic workspace GitHub binding path
- retain the generic workspace authorization check for ordinary GitHub resources and recheck both paths immediately before token mint

## Verification

- 227 targeted tests passed across API, worker, core PR Review, and Postgres persistence suites
- all 31 TypeScript projects passed typecheck
- changed-file formatting and lint checks passed
- a real signed GitHub synchronize webhook created an automation run and agent session, cloned the exact PR head, completed review, and published five inline findings through the dedicated GitHub App

The intentionally vulnerable smoke fixture and its test PR are not included in this branch.