### PR TITLE
fix(web): scope personal resource access controls

### DIFF
--- a/apps/web/src/lib/use-personal-resource-attachment.test.tsx
+++ b/apps/web/src/lib/use-personal-resource-attachment.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { OpenGeniApiError } from "@opengeni/sdk";
+import { OpenGeniApiError, type ResourceAuthorityScope } from "@opengeni/sdk";
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
 import {
   actRun,
@@ -9,7 +9,10 @@ import {
 } from "../../../../packages/react/test/render-hook";
 
 import { managedSelfContextIdentity } from "./managed-self-context";
-import { usePersonalResourceAttachment } from "./use-personal-resource-attachment";
+import {
+  useFixedResourceScopes,
+  usePersonalResourceAttachment,
+} from "./use-personal-resource-attachment";
 
 registerDom();
 afterEach(() => document.body.replaceChildren());
@@ -18,7 +21,9 @@ const organizationId = "11111111-1111-4111-8111-111111111111";
 const workspaceId = "22222222-2222-4222-8222-222222222222";
 const personalWorkspaceId = "33333333-3333-4333-8333-333333333333";
 const variableSetId = "44444444-4444-4444-8444-444444444444";
+const rigId = "77777777-7777-4777-8777-777777777777";
 const workspace = { id: workspaceId, accountId: organizationId };
+type ResourceKind = "variable_set" | "rig";
 
 function identity(principal: string) {
   return {
@@ -56,26 +61,118 @@ function variableSet() {
   };
 }
 
-function authorityPage(active: boolean, kind: "variable_set" | "rig") {
+function rig() {
+  return {
+    id: rigId,
+    accountId: organizationId,
+    workspaceId: personalWorkspaceId,
+    scope: "user" as const,
+    generation: 1,
+    status: "active" as const,
+    name: "Private rig",
+    description: null,
+    createdBy: "user:owner",
+    activeVersion: null,
+    activeVersionHealth: null,
+    versionCount: 1,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function fixedResource(kind: ResourceKind, scope?: ResourceAuthorityScope | null) {
+  return kind === "variable_set"
+    ? { variableSetId, variableSetScope: scope, rigId: null }
+    : { variableSetId: null, rigId, rigScope: scope };
+}
+
+function authorityPage(active: boolean, kind: ResourceKind) {
   return {
     scope: "user" as const,
-    authorities:
-      active && kind === "variable_set"
-        ? [
-            {
-              authorityId: "55555555-5555-4555-8555-555555555555",
-              resourceKind: "variable_set" as const,
-              resourceId: variableSetId,
-              originWorkspaceId: personalWorkspaceId,
-              generation: 1,
-              status: "active" as const,
-              grants: [],
-            },
-          ]
-        : [],
+    authorities: active
+      ? [
+          {
+            authorityId: "55555555-5555-4555-8555-555555555555",
+            resourceKind: kind,
+            resourceId: kind === "variable_set" ? variableSetId : rigId,
+            originWorkspaceId: personalWorkspaceId,
+            generation: 1,
+            status: "active" as const,
+            grants: [],
+          },
+        ]
+      : [],
     nextCursor: null,
   };
 }
+
+function personalClient(input?: { active?: boolean; failure?: Error | null }): OpenGeniCoreClient {
+  return {
+    listVariableSets: async () => {
+      if (input?.failure) throw input.failure;
+      return input?.active === false ? [] : [variableSet()];
+    },
+    listRigs: async () => {
+      if (input?.failure) throw input.failure;
+      return input?.active === false ? [] : [rig()];
+    },
+    listUserResourceAuthorities: async (
+      _workspaceId: string,
+      options: { resourceKind: ResourceKind },
+    ) => {
+      if (input?.failure) throw input.failure;
+      return authorityPage(input?.active !== false, options.resourceKind);
+    },
+  } as unknown as OpenGeniCoreClient;
+}
+
+describe("useFixedResourceScopes", () => {
+  test("classifies both fixed resource kinds through exact ordinary catalog reads", async () => {
+    const requested: string[] = [];
+    const client = {
+      getVariableSet: async (requestedWorkspaceId: string, requestedId: string) => {
+        requested.push(`variable_set:${requestedWorkspaceId}:${requestedId}`);
+        return { ...variableSet(), scope: "organization" as const };
+      },
+      getRig: async (requestedWorkspaceId: string, requestedId: string) => {
+        requested.push(`rig:${requestedWorkspaceId}:${requestedId}`);
+        return { ...rig(), scope: "workspace" as const };
+      },
+    } as unknown as OpenGeniCoreClient;
+    const hook = await renderHook(
+      () => useFixedResourceScopes(client, workspaceId, variableSetId, rigId),
+      undefined,
+    );
+    await flush();
+    expect(requested).toEqual([
+      `variable_set:${workspaceId}:${variableSetId}`,
+      `rig:${workspaceId}:${rigId}`,
+    ]);
+    expect(hook.result.current).toEqual(["organization", "workspace"]);
+    await hook.unmount();
+  });
+
+  test("fails closed to unknown without retaining another route's classification", async () => {
+    const client = {
+      getVariableSet: async (requestedWorkspaceId: string) => {
+        if (requestedWorkspaceId !== workspaceId) throw new Error("ordinary catalog unavailable");
+        return { ...variableSet(), scope: "user" as const };
+      },
+    } as unknown as OpenGeniCoreClient;
+    const hook = await renderHook(
+      ({ routedWorkspaceId }: { routedWorkspaceId: string }) =>
+        useFixedResourceScopes(client, routedWorkspaceId, variableSetId, null),
+      { routedWorkspaceId: workspaceId },
+    );
+    await flush();
+    expect(hook.result.current[0]).toBe("user");
+    await hook.rerender({ routedWorkspaceId: personalWorkspaceId });
+    expect(hook.result.current[0]).toBeNull();
+    await flush();
+    expect(hook.result.current[0]).toBeNull();
+    await hook.unmount();
+  });
+});
 
 describe("usePersonalResourceAttachment", () => {
   test("discovers personal options without surfacing authority failure when nothing is selected", async () => {
@@ -266,18 +363,41 @@ describe("usePersonalResourceAttachment", () => {
     await hook.unmount();
   });
 
-  for (const [name, failure] of [
-    ["network failure", new TypeError("network unavailable")],
-    ["managed-session 401", new OpenGeniApiError(401, "unauthorized")],
-  ] as const) {
-    test(`${name} keeps a fixed personal-resource decision fenced with retry visible`, async () => {
-      const client = {
-        listVariableSets: async () => {
-          throw failure;
-        },
-        listRigs: async () => [],
-        listUserResourceAuthorities: async () => authorityPage(true, "variable_set"),
-      } as unknown as OpenGeniCoreClient;
+  for (const kind of ["variable_set", "rig"] as const) {
+    const label = kind === "variable_set" ? "Variable Set" : "Rig";
+
+    for (const scope of ["organization", "workspace"] as const) {
+      test(`${scope} ${label} never exposes a Personal catalog failure`, async () => {
+        const failure = new Error("personal catalog unavailable");
+        const client = personalClient({ failure });
+        const current = identity("owner");
+        const hook = await renderHook(
+          () =>
+            usePersonalResourceAttachment({
+              client,
+              authMode: "managedSession",
+              authSession: current.authSession,
+              accessSubjectId: "user:owner",
+              managedSelfContext: current.managedSelfContext,
+              workspace,
+              fixed: fixedResource(kind, scope),
+              personalWorkspaceTarget: false,
+            }),
+          undefined,
+        );
+        await flush();
+        expect(hook.result.current.eligible).toBe(true);
+        expect(hook.result.current.loading).toBe(false);
+        expect(hook.result.current.error).toBeNull();
+        expect(hook.result.current.selected.resourceCount).toBe(0);
+        expect(hook.result.current.requiresDecision).toBe(false);
+        expect(hook.result.current.intent).toBeUndefined();
+        await hook.unmount();
+      });
+    }
+
+    test(`personal ${label} positively identifies the selection and requires a decision`, async () => {
+      const client = personalClient();
       const current = identity("owner");
       const hook = await renderHook(
         () =>
@@ -288,49 +408,126 @@ describe("usePersonalResourceAttachment", () => {
             accessSubjectId: "user:owner",
             managedSelfContext: current.managedSelfContext,
             workspace,
-            fixed: { variableSetId, variableSetScope: "user", rigId: null },
+            fixed: fixedResource(kind, "user"),
             personalWorkspaceTarget: false,
           }),
         undefined,
       );
       await flush();
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.selected.resourceCount).toBe(1);
+      expect(hook.result.current.selected.personalResourceCount).toBe(1);
+      expect(hook.result.current.requiresDecision).toBe(true);
+      await hook.unmount();
+    });
+
+    test(`absent ${label} stays inert when neither catalog identifies it`, async () => {
+      const client = personalClient({ active: false });
+      const current = identity("owner");
+      const hook = await renderHook(
+        () =>
+          usePersonalResourceAttachment({
+            client,
+            authMode: "managedSession",
+            authSession: current.authSession,
+            accessSubjectId: "user:owner",
+            managedSelfContext: current.managedSelfContext,
+            workspace,
+            fixed: fixedResource(kind, null),
+            personalWorkspaceTarget: false,
+          }),
+        undefined,
+      );
+      await flush();
+      expect(hook.result.current.error).toBeNull();
       expect(hook.result.current.selected.resourceCount).toBe(0);
+      expect(hook.result.current.requiresDecision).toBe(false);
+      expect(hook.result.current.intent).toBeUndefined();
+      await hook.unmount();
+    });
+
+    test(`forbidden personal ${label} surfaces the retryable fence`, async () => {
+      const failure = new OpenGeniApiError(403, "forbidden");
+      const client = personalClient({ failure });
+      const current = identity("owner");
+      const hook = await renderHook(
+        () =>
+          usePersonalResourceAttachment({
+            client,
+            authMode: "managedSession",
+            authSession: current.authSession,
+            accessSubjectId: "user:owner",
+            managedSelfContext: current.managedSelfContext,
+            workspace,
+            fixed: fixedResource(kind, "user"),
+            personalWorkspaceTarget: false,
+          }),
+        undefined,
+      );
+      await flush();
       expect(hook.result.current.error).toBe(failure);
+      expect(hook.result.current.selected.resourceCount).toBe(0);
       expect(hook.result.current.requiresDecision).toBe(true);
       expect(hook.result.current.intent).toBeUndefined();
       await hook.unmount();
     });
-  }
 
-  for (const [name, fixed] of [
-    [
-      "organization Variable Set",
-      {
-        variableSetId,
-        variableSetScope: "organization" as const,
-        rigId: null,
-      },
-    ],
-    [
-      "workspace Rig",
-      {
-        variableSetId: null,
-        rigId: "77777777-7777-4777-8777-777777777777",
-        rigScope: "workspace" as const,
-      },
-    ],
-  ] as const) {
-    test(`${name} never exposes the Personal-resource access failure`, async () => {
-      const failure = new Error("personal catalog unavailable");
+    test(`pre-activation ${label} stays ineligible and performs no Personal lookup`, async () => {
+      let calls = 0;
+      const current = identity("owner");
       const client = {
         listVariableSets: async () => {
-          throw failure;
+          calls += 1;
+          throw new Error("must remain inert");
         },
         listRigs: async () => {
-          throw failure;
+          calls += 1;
+          throw new Error("must remain inert");
         },
         listUserResourceAuthorities: async () => {
-          throw failure;
+          calls += 1;
+          throw new Error("must remain inert");
+        },
+      } as unknown as OpenGeniCoreClient;
+      const hook = await renderHook(
+        () =>
+          usePersonalResourceAttachment({
+            client,
+            authMode: "managedSession",
+            authSession: current.authSession,
+            accessSubjectId: "user:owner",
+            managedSelfContext: { ...current.managedSelfContext, memberships: [] },
+            workspace,
+            fixed: fixedResource(kind, "user"),
+            personalWorkspaceTarget: false,
+          }),
+        undefined,
+      );
+      await flush();
+      expect(calls).toBe(0);
+      expect(hook.result.current.eligible).toBe(false);
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.requiresDecision).toBe(false);
+      await hook.unmount();
+    });
+
+    test(`personal ${label} refresh failure retains identity and fences submission`, async () => {
+      let failure: Error | null = null;
+      const client = {
+        listVariableSets: async () => {
+          if (failure) throw failure;
+          return [variableSet()];
+        },
+        listRigs: async () => {
+          if (failure) throw failure;
+          return [rig()];
+        },
+        listUserResourceAuthorities: async (
+          _workspaceId: string,
+          options: { resourceKind: ResourceKind },
+        ) => {
+          if (failure) throw failure;
+          return authorityPage(true, options.resourceKind);
         },
       } as unknown as OpenGeniCoreClient;
       const current = identity("owner");
@@ -343,17 +540,66 @@ describe("usePersonalResourceAttachment", () => {
             accessSubjectId: "user:owner",
             managedSelfContext: current.managedSelfContext,
             workspace,
-            fixed,
+            fixed: fixedResource(kind, "user"),
             personalWorkspaceTarget: false,
           }),
         undefined,
       );
       await flush();
-      expect(hook.result.current.eligible).toBe(true);
-      expect(hook.result.current.loading).toBe(false);
-      expect(hook.result.current.error).toBeNull();
-      expect(hook.result.current.requiresDecision).toBe(false);
+      expect(hook.result.current.selected.resourceCount).toBe(1);
+      failure = new Error("refresh unavailable");
+      await actRun(() => hook.result.current.refresh());
+      await flush();
+      expect(hook.result.current.error).toBe(failure);
+      expect(hook.result.current.selected.resourceCount).toBe(1);
+      expect(hook.result.current.requiresDecision).toBe(true);
       expect(hook.result.current.intent).toBeUndefined();
+      await hook.unmount();
+    });
+
+    test(`personal ${label} retry clears the failure and restores the decision`, async () => {
+      let failing = true;
+      const client = {
+        listVariableSets: async () => {
+          if (failing) throw new Error("initial failure");
+          return [variableSet()];
+        },
+        listRigs: async () => {
+          if (failing) throw new Error("initial failure");
+          return [rig()];
+        },
+        listUserResourceAuthorities: async (
+          _workspaceId: string,
+          options: { resourceKind: ResourceKind },
+        ) => {
+          if (failing) throw new Error("initial failure");
+          return authorityPage(true, options.resourceKind);
+        },
+      } as unknown as OpenGeniCoreClient;
+      const current = identity("owner");
+      const hook = await renderHook(
+        () =>
+          usePersonalResourceAttachment({
+            client,
+            authMode: "managedSession",
+            authSession: current.authSession,
+            accessSubjectId: "user:owner",
+            managedSelfContext: current.managedSelfContext,
+            workspace,
+            fixed: fixedResource(kind, "user"),
+            personalWorkspaceTarget: false,
+          }),
+        undefined,
+      );
+      await flush();
+      expect(hook.result.current.error).toBeInstanceOf(Error);
+      expect(hook.result.current.requiresDecision).toBe(true);
+      failing = false;
+      await actRun(() => hook.result.current.refresh());
+      await flush();
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.selected.resourceCount).toBe(1);
+      expect(hook.result.current.requiresDecision).toBe(true);
       await hook.unmount();
     });
   }

--- a/apps/web/src/lib/use-personal-resource-attachment.test.tsx
+++ b/apps/web/src/lib/use-personal-resource-attachment.test.tsx
@@ -288,7 +288,7 @@ describe("usePersonalResourceAttachment", () => {
             accessSubjectId: "user:owner",
             managedSelfContext: current.managedSelfContext,
             workspace,
-            fixed: { variableSetId, rigId: null },
+            fixed: { variableSetId, variableSetScope: "user", rigId: null },
             personalWorkspaceTarget: false,
           }),
         undefined,
@@ -297,6 +297,62 @@ describe("usePersonalResourceAttachment", () => {
       expect(hook.result.current.selected.resourceCount).toBe(0);
       expect(hook.result.current.error).toBe(failure);
       expect(hook.result.current.requiresDecision).toBe(true);
+      expect(hook.result.current.intent).toBeUndefined();
+      await hook.unmount();
+    });
+  }
+
+  for (const [name, fixed] of [
+    [
+      "organization Variable Set",
+      {
+        variableSetId,
+        variableSetScope: "organization" as const,
+        rigId: null,
+      },
+    ],
+    [
+      "workspace Rig",
+      {
+        variableSetId: null,
+        rigId: "77777777-7777-4777-8777-777777777777",
+        rigScope: "workspace" as const,
+      },
+    ],
+  ] as const) {
+    test(`${name} never exposes the Personal-resource access failure`, async () => {
+      const failure = new Error("personal catalog unavailable");
+      const client = {
+        listVariableSets: async () => {
+          throw failure;
+        },
+        listRigs: async () => {
+          throw failure;
+        },
+        listUserResourceAuthorities: async () => {
+          throw failure;
+        },
+      } as unknown as OpenGeniCoreClient;
+      const current = identity("owner");
+      const hook = await renderHook(
+        () =>
+          usePersonalResourceAttachment({
+            client,
+            authMode: "managedSession",
+            authSession: current.authSession,
+            accessSubjectId: "user:owner",
+            managedSelfContext: current.managedSelfContext,
+            workspace,
+            fixed,
+            personalWorkspaceTarget: false,
+          }),
+        undefined,
+      );
+      await flush();
+      expect(hook.result.current.eligible).toBe(true);
+      expect(hook.result.current.loading).toBe(false);
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.requiresDecision).toBe(false);
       expect(hook.result.current.intent).toBeUndefined();
       await hook.unmount();
     });

--- a/apps/web/src/lib/use-personal-resource-attachment.ts
+++ b/apps/web/src/lib/use-personal-resource-attachment.ts
@@ -1,6 +1,7 @@
 import {
   PERSONAL_RESOURCE_SHARED_OUTPUT_WARNING,
   type PersonalResourceAttachmentIntent,
+  type ResourceAuthorityScope,
   type SendMessageInput,
   type Session,
   type Workspace,
@@ -20,7 +21,12 @@ import {
   type PersonalResourceCatalog,
 } from "./personal-resource-attachments";
 
-type FixedPersonalResources = { variableSetId: string | null; rigId: string | null };
+type FixedPersonalResources = {
+  variableSetId: string | null;
+  variableSetScope?: ResourceAuthorityScope | null | undefined;
+  rigId: string | null;
+  rigScope?: ResourceAuthorityScope | null | undefined;
+};
 type PersonalResourceAttachmentAttempt = {
   personalResourceAttachment?: PersonalResourceAttachmentIntent | undefined;
 };
@@ -69,7 +75,6 @@ export function usePersonalResourceAttachment(input: {
   onReloadSession?: (() => Promise<void>) | undefined;
 }): PersonalResourceAttachmentController {
   const onReloadSession = input.onReloadSession;
-  const hasFixedResources = input.fixed.variableSetId !== null || input.fixed.rigId !== null;
   const resolvedScope =
     input.enabled === false
       ? null
@@ -142,7 +147,10 @@ export function usePersonalResourceAttachment(input: {
         setError(null);
       } catch (cause) {
         if (generation !== loadGeneration.current || acceptedScopeKey.current !== scopeKey) return;
-        setCatalog(null);
+        // Keep the last positively identified personal-resource catalog on a
+        // refresh failure. Clearing it would misclassify an outage as revoked
+        // authority and would make an unrelated workspace-scoped selection
+        // surface a Personal-resource error.
         setError(cause instanceof Error ? cause : new Error(String(cause)));
       } finally {
         if (generation === loadGeneration.current && acceptedScopeKey.current === scopeKey) {
@@ -171,7 +179,12 @@ export function usePersonalResourceAttachment(input: {
   // Eligibility is a synchronous fence. Do not wait for the transition effect
   // to clear prior owner state before hiding it from a connected-machine send.
   const selected = personalSelection(scope ? catalog : null, input.fixed);
-  const fixedIdentity = `${input.fixed.variableSetId ?? ""}:${input.fixed.rigId ?? ""}`;
+  const fixedIdentity = [
+    input.fixed.variableSetId ?? "",
+    input.fixed.variableSetScope ?? "unknown",
+    input.fixed.rigId ?? "",
+    input.fixed.rigScope ?? "unknown",
+  ].join(":");
   const selectedIdentity = `${fixedIdentity}:${selected.resourceCount}`;
   const priorSelectionIdentity = useRef(selectedIdentity);
   const priorFixedIdentity = useRef(fixedIdentity);
@@ -210,12 +223,17 @@ export function usePersonalResourceAttachment(input: {
   const expectedAuthorityEpoch = input.session?.tenancy?.authorityEpoch;
   const fixedResourceCount =
     Number(input.fixed.variableSetId !== null) + Number(input.fixed.rigId !== null);
+  const positivelyPersonal =
+    sourceLost ||
+    selected.personalResourceCount > 0 ||
+    (input.fixed.variableSetId !== null && input.fixed.variableSetScope === "user") ||
+    (input.fixed.rigId !== null && input.fixed.rigScope === "user");
   const closureError = selected.closureUnverified
     ? new Error(
         "The selected personal-resource authority closure could not be verified. Retry or choose a non-personal resource.",
       )
     : null;
-  const effectiveError = error ?? closureError;
+  const effectiveError = positivelyPersonal ? (error ?? closureError) : null;
   const intent = scope
     ? buildPersonalResourceAttachmentIntent({
         mode,
@@ -228,7 +246,9 @@ export function usePersonalResourceAttachment(input: {
   const requiresDecision =
     scope !== null &&
     (sourceLost ||
-      (fixedResourceCount > 0 && (loading || refreshing || effectiveError !== null)) ||
+      (positivelyPersonal &&
+        fixedResourceCount > 0 &&
+        (loading || refreshing || effectiveError !== null)) ||
       (selected.resourceCount > 0 &&
         (mode === null || (visibility === "workspace" && !acknowledged))));
 
@@ -276,12 +296,12 @@ export function usePersonalResourceAttachment(input: {
     // becomes submission UI only after the user has actually selected a fixed
     // personal resource; an unavailable optional catalog must not turn an
     // ordinary new-session composer into an error state.
-    loading: hasFixedResources && loading,
-    refreshing: hasFixedResources && refreshing,
-    error: hasFixedResources ? effectiveError : null,
+    loading: positivelyPersonal && fixedResourceCount > 0 && loading,
+    refreshing: positivelyPersonal && fixedResourceCount > 0 && refreshing,
+    error: positivelyPersonal && fixedResourceCount > 0 ? effectiveError : null,
     notice,
     sourceLost,
-    truncated: hasFixedResources && (catalog?.truncated ?? false),
+    truncated: positivelyPersonal && fixedResourceCount > 0 && (catalog?.truncated ?? false),
     catalog,
     selected,
     mode,

--- a/apps/web/src/lib/use-personal-resource-attachment.ts
+++ b/apps/web/src/lib/use-personal-resource-attachment.ts
@@ -60,6 +60,55 @@ export type PersonalResourceAttachmentController = Readonly<{
   ) => void;
 }>;
 
+/**
+ * Resolve the ordinary catalog scope for an already-fixed session resource
+ * without importing the broad @opengeni/react root into the direct-session
+ * route. Failure stays unknown: only a positive `user` classification may turn
+ * the optional Personal catalog into submission UI.
+ */
+export function useFixedResourceScopes(
+  client: OpenGeniCoreClient,
+  workspaceId: string | null,
+  variableSetId: string | null,
+  rigId: string | null,
+  enabled = true,
+): readonly [ResourceAuthorityScope | null, ResourceAuthorityScope | null] {
+  const identity =
+    !enabled || workspaceId === null || (variableSetId === null && rigId === null)
+      ? null
+      : [workspaceId, variableSetId ?? "", rigId ?? ""].join(":");
+  const [resolved, setResolved] = useState<
+    readonly [string, ResourceAuthorityScope | null, ResourceAuthorityScope | null] | null
+  >(null);
+
+  useEffect(() => {
+    if (identity === null || workspaceId === null) return;
+    let current = true;
+    void Promise.all([
+      variableSetId
+        ? client
+            .getVariableSet(workspaceId, variableSetId)
+            .then((resource) => resource.scope)
+            .catch(() => null)
+        : null,
+      rigId
+        ? client
+            .getRig(workspaceId, rigId)
+            .then((resource) => resource.scope)
+            .catch(() => null)
+        : null,
+    ]).then(([variableSetScope, rigScope]) => {
+      if (!current) return;
+      setResolved([identity, variableSetScope, rigScope]);
+    });
+    return () => {
+      current = false;
+    };
+  }, [client, identity, rigId, variableSetId, workspaceId]);
+
+  return resolved?.[0] === identity ? [resolved[1], resolved[2]] : [null, null];
+}
+
 export function usePersonalResourceAttachment(input: {
   client: OpenGeniCoreClient;
   authMode: string;

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -57,7 +57,7 @@ import { SessionWorkspace } from "@/components/session/sandbox-workspace";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Notice } from "@/components/ui/notice";
-import { useRigs, useVariableSets, type WorkspaceTab } from "@opengeni/react";
+import type { WorkspaceTab } from "@opengeni/react";
 import type { EditableArtifactResource } from "@opengeni/sdk/artifacts";
 import { useAppContext } from "@/context";
 import type {
@@ -119,7 +119,10 @@ import {
   toolsForPolicySelection,
 } from "@/lib/session-tools";
 import { useFollowUpRepositories } from "@/lib/use-follow-up-repositories";
-import { usePersonalResourceAttachment } from "@/lib/use-personal-resource-attachment";
+import {
+  useFixedResourceScopes,
+  usePersonalResourceAttachment,
+} from "@/lib/use-personal-resource-attachment";
 import { useWorkspaceModelCatalog } from "@/lib/use-workspace-model-catalog";
 import type { LineageNode, SessionRealtimeModel } from "@opengeni/sdk";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
@@ -1308,12 +1311,13 @@ function SessionChatPane(props: {
   const workspace =
     context.workspaces.find((candidate) => candidate.id === props.session.workspaceId) ?? null;
   const fixedResourceCatalogEnabled = props.session.sandboxBackend !== "selfhosted";
-  const variableSets = useVariableSets({ enabled: fixedResourceCatalogEnabled });
-  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled });
-  const selectedVariableSet = variableSets.variableSets.find(
-    (candidate) => candidate.id === props.session.variableSetId,
+  const [fixedVariableSetScope, fixedRigScope] = useFixedResourceScopes(
+    context.client,
+    workspace?.id ?? null,
+    props.session.variableSetId,
+    props.session.rigId,
+    fixedResourceCatalogEnabled,
   );
-  const selectedRig = rigs.rigs.find((candidate) => candidate.id === props.session.rigId);
   const personalAttachment = usePersonalResourceAttachment({
     client: context.client,
     authMode: context.clientConfig.auth.mode,
@@ -1325,9 +1329,9 @@ function SessionChatPane(props: {
     enabled: props.session.sandboxBackend !== "selfhosted",
     fixed: {
       variableSetId: props.session.variableSetId,
-      variableSetScope: selectedVariableSet?.scope ?? null,
+      variableSetScope: fixedVariableSetScope,
       rigId: props.session.rigId,
-      rigScope: selectedRig?.scope ?? null,
+      rigScope: fixedRigScope,
     },
     personalWorkspaceTarget: isPersonalWorkspace(workspace, context.managedSelfContext),
     onReloadSession: props.onReloadSession,

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -57,7 +57,7 @@ import { SessionWorkspace } from "@/components/session/sandbox-workspace";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Notice } from "@/components/ui/notice";
-import type { WorkspaceTab } from "@opengeni/react";
+import { useRigs, useVariableSets, type WorkspaceTab } from "@opengeni/react";
 import type { EditableArtifactResource } from "@opengeni/sdk/artifacts";
 import { useAppContext } from "@/context";
 import type {
@@ -1307,6 +1307,13 @@ function SessionChatPane(props: {
   const composerPolicyValidRef = useRef(false);
   const workspace =
     context.workspaces.find((candidate) => candidate.id === props.session.workspaceId) ?? null;
+  const fixedResourceCatalogEnabled = props.session.sandboxBackend !== "selfhosted";
+  const variableSets = useVariableSets({ enabled: fixedResourceCatalogEnabled });
+  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled });
+  const selectedVariableSet = variableSets.variableSets.find(
+    (candidate) => candidate.id === props.session.variableSetId,
+  );
+  const selectedRig = rigs.rigs.find((candidate) => candidate.id === props.session.rigId);
   const personalAttachment = usePersonalResourceAttachment({
     client: context.client,
     authMode: context.clientConfig.auth.mode,
@@ -1318,7 +1325,9 @@ function SessionChatPane(props: {
     enabled: props.session.sandboxBackend !== "selfhosted",
     fixed: {
       variableSetId: props.session.variableSetId,
+      variableSetScope: selectedVariableSet?.scope ?? null,
       rigId: props.session.rigId,
+      rigScope: selectedRig?.scope ?? null,
     },
     personalWorkspaceTarget: isPersonalWorkspace(workspace, context.managedSelfContext),
     onReloadSession: props.onReloadSession,

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -22,6 +22,8 @@ import {
   useVariableSets,
   useWorkspaceSessions,
   type ComposerState,
+  type UseRigsResult,
+  type UseVariableSetsResult,
 } from "@opengeni/react";
 import { MACHINES_COMPOSER_POLL_MS, useMachines, type MachineView } from "@opengeni/react/machines";
 import {
@@ -171,6 +173,13 @@ function SessionsIndexRouteContent({
   );
   const workspace = context.workspaces.find((candidate) => candidate.id === workspaceId) ?? null;
   const personalWorkspace = isPersonalWorkspace(workspace, context.managedSelfContext);
+  const fixedResourceCatalogEnabled = draft.compute.kind === "sandbox";
+  const variableSets = useVariableSets({ enabled: fixedResourceCatalogEnabled });
+  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled });
+  const selectedVariableSet = variableSets.variableSets.find(
+    (candidate) => candidate.id === draft.variableSetId,
+  );
+  const selectedRig = rigs.rigs.find((candidate) => candidate.id === draft.rigId);
   const [tenancyCapabilities, setTenancyCapabilities] = useState<{
     activated: boolean;
     canCreatePrivate: boolean;
@@ -221,7 +230,10 @@ function SessionsIndexRouteContent({
     enabled: draft.compute.kind === "sandbox",
     fixed: {
       variableSetId: draft.compute.kind === "sandbox" ? draft.variableSetId || null : null,
+      variableSetScope:
+        draft.compute.kind === "sandbox" ? (selectedVariableSet?.scope ?? null) : null,
       rigId: draft.compute.kind === "sandbox" ? draft.rigId || null : null,
+      rigScope: draft.compute.kind === "sandbox" ? (selectedRig?.scope ?? null) : null,
     },
     personalWorkspaceTarget: isPersonalWorkspace(workspace, context.managedSelfContext),
     createVisibility: personalWorkspace ? "private" : draft.visibility,
@@ -864,6 +876,8 @@ function SessionsIndexRouteContent({
             onChange={setDraft}
             disabled={busy || newSessionDraft.loading}
             personalAttachment={personalAttachment}
+            variableSets={variableSets}
+            rigs={rigs}
             selectedChannelId={selectedChannelId}
             selectionHistory={selectionHistory}
           />
@@ -1255,6 +1269,8 @@ function ComputeTargetControl(props: {
   onChange: (draft: SessionDraft) => void;
   disabled: boolean;
   personalAttachment: PersonalResourceAttachmentController;
+  variableSets: UseVariableSetsResult;
+  rigs: UseRigsResult;
   selectedChannelId: string | null;
   selectionHistory: NewSessionSelectionHistory;
 }) {
@@ -1397,6 +1413,8 @@ function ComputeTargetControl(props: {
             onChange={onChange}
             disabled={props.disabled}
             personalAttachment={props.personalAttachment}
+            variableSets={props.variableSets}
+            rigs={props.rigs}
           />
           <FleetErrorNotice onRetry={() => void fleet.refresh()} />
         </section>
@@ -1408,6 +1426,8 @@ function ComputeTargetControl(props: {
         onChange={onChange}
         disabled={props.disabled}
         personalAttachment={props.personalAttachment}
+        variableSets={props.variableSets}
+        rigs={props.rigs}
       />
     );
   }
@@ -1450,6 +1470,8 @@ function ComputeTargetControl(props: {
           onChange={onChange}
           disabled={props.disabled}
           personalAttachment={props.personalAttachment}
+          variableSets={props.variableSets}
+          rigs={props.rigs}
         />
       ) : (
         <ConnectedMachineFields
@@ -1525,16 +1547,16 @@ function ManagedSandboxFields(props: {
   onChange: (draft: SessionDraft) => void;
   disabled: boolean;
   personalAttachment: PersonalResourceAttachmentController;
+  variableSets: UseVariableSetsResult;
+  rigs: UseRigsResult;
 }) {
   const { draft, onChange } = props;
-  const variableSets = useVariableSets();
-  const rigs = useRigs();
   const personalRigs = props.personalAttachment.catalog?.rigs ?? [];
   const personalVariableSets = props.personalAttachment.catalog?.variableSets ?? [];
   const personalRigIds = new Set(personalRigs.map((resource) => resource.id));
   const personalVariableSetIds = new Set(personalVariableSets.map((resource) => resource.id));
-  const workspaceRigs = rigs.rigs.filter((resource) => !personalRigIds.has(resource.id));
-  const workspaceVariableSets = variableSets.variableSets.filter(
+  const workspaceRigs = props.rigs.rigs.filter((resource) => !personalRigIds.has(resource.id));
+  const workspaceVariableSets = props.variableSets.variableSets.filter(
     (resource) => !personalVariableSetIds.has(resource.id),
   );
   const showRigs = workspaceRigs.length > 0 || personalRigs.length > 0;

--- a/docs/variable-sets.md
+++ b/docs/variable-sets.md
@@ -111,6 +111,11 @@ Attachment points:
   worker and provide the exact old/new runtime login list through
   `OPENGENI_MIGRATION_APPLICATION_DATABASE_ROLES`; never restart a pre-0306
   image after it commits.
+  The browser uses the ordinary scoped resource metadata to classify a fixed
+  selection before presenting this delegation choice. Organization- and
+  workspace-scoped Variable Sets and Rigs never render the **Your resource
+  access** control or surface Personal-catalog failures; that UI is reserved
+  for selections positively identified as user-scoped.
 - `POST`/`PATCH /v1/workspaces/:id/scheduled-tasks` accept `variableSetId` (null detaches on update). Setting or changing a non-null attachment requires both permissions; detaching requires `variable-sets:attach`. Changing the attachment of a task with a live reusable session returns 409 — the session keeps its creation-time attachment, so recreate the task instead.
 - Organization- and workspace-scoped Variable Sets on scheduled runs materialize under the exact fenced service turn (`scheduler`) and do not invent an initiating human. User-scoped Variable Sets remain different: they require the frozen causal human and exact personal-resource grant described next. This distinction applies identically to standalone database decryption and a host-provided `sandboxSecrets` credential boundary.
 - When the selected Variable Set, Rig, or one of the Rig version's defaults is personal, scheduled-task acceptance freezes the causal human plus exact membership/resource/grant generations. Each occurrence revalidates and copies that immutable authority before dispatch; task edits, current Rig defaults, the current API user, and workspace defaults are never fallback authority. `once` grants belong to one admitted occurrence across recovery attempts. A rolling upgrade pauses legacy tasks that lack this ledger, and an explicit resume converts them before dispatch; old-writer authority-free runs are rejected in PostgreSQL. Only identifiers and generations are stored in this ledger; plaintext still crosses only the ordinary materialization/read boundaries described above.


### PR DESCRIPTION
## Summary
- classify selected Rigs and Variable Sets from ordinary scoped resource metadata
- render Personal-resource delegation state only for positively user-scoped selections
- suppress Personal-catalog errors for organization/workspace selections while preserving fail-closed personal retry behavior
- retain the last positive Personal classification across refresh outages

## Verification
- bun test apps/web/src/lib/use-personal-resource-attachment.test.tsx apps/web/src/lib/personal-resource-attachments.test.ts
- bun test apps/web/src/App.test.ts apps/web/src/lib/session-create-request.test.ts
- bun run --cwd apps/web typecheck
- bun run lint
- bun run format:check

Linear: OPE-338