### PR TITLE
fix(codex): explain reset credit ownership recovery

### DIFF
--- a/.changeset/quiet-reset-owners.md
+++ b/.changeset/quiet-reset-owners.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": minor
+"@opengeni/sdk": minor
+---
+
+Codex reset-credit overview responses now explain whether redemption belongs to the current managed human, an unowned legacy connection, another human, or an unavailable managed identity. Eligible admins can follow an explicit same-account reconnect path that claims only a null owner; existing ownership remains non-transferable without disconnect.

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -386,10 +386,46 @@ function createProviderCallLimiter(limit: number): CodexProviderCall {
   };
 }
 
+type CodexRedemptionAccess = {
+  ownership: "current_human" | "unowned" | "different_human" | "managed_human_unavailable";
+  canClaimUnownedViaReconnect: boolean;
+};
+
+function codexRedemptionAccess(input: {
+  connectedBySubjectId: string | null;
+  grantSubjectId: string;
+  managedHumanSubjectId: string | null;
+  canManage: boolean;
+}): CodexRedemptionAccess {
+  if (
+    input.managedHumanSubjectId === null ||
+    input.managedHumanSubjectId !== input.grantSubjectId
+  ) {
+    return {
+      ownership: "managed_human_unavailable",
+      canClaimUnownedViaReconnect: false,
+    };
+  }
+  if (input.connectedBySubjectId === null) {
+    return {
+      ownership: "unowned",
+      canClaimUnownedViaReconnect: input.canManage,
+    };
+  }
+  return {
+    ownership:
+      input.connectedBySubjectId === input.managedHumanSubjectId
+        ? "current_human"
+        : "different_human",
+    canClaimUnownedViaReconnect: false,
+  };
+}
+
 async function fetchCodexAccountOverview(
   deps: ApiRouteDeps,
   workspaceId: string,
   row: CodexAccountStatus,
+  redemptionAccess: CodexRedemptionAccess,
   canRedeem: boolean,
   canResumeRedemption: boolean,
   redemptions: Awaited<ReturnType<typeof listCodexResetRedemptionRecoveries>> = [],
@@ -496,6 +532,7 @@ async function fetchCodexAccountOverview(
       })),
     },
     canRedeem,
+    redemptionAccess,
     canResumeRedemption,
     redemptions: redemptions.map((redemption) => ({
       attemptId: redemption.attemptId,
@@ -1166,10 +1203,17 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
           hasPermission(grant.permissions, "workspace:admin"),
         );
         const canRedeem = canResumeRedemption && account.status === "active";
+        const redemptionAccess = codexRedemptionAccess({
+          connectedBySubjectId: account.connectedBySubjectId,
+          grantSubjectId: grant.subjectId,
+          managedHumanSubjectId: human?.subjectId ?? null,
+          canManage: hasPermission(grant.permissions, "workspace:admin"),
+        });
         overview[account.id] = await fetchCodexAccountOverview(
           deps,
           workspaceId,
           account,
+          redemptionAccess,
           canRedeem,
           canResumeRedemption,
           canResumeRedemption
@@ -1216,6 +1260,12 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
               deps,
               workspaceId,
               account,
+              codexRedemptionAccess({
+                connectedBySubjectId: account.connectedBySubjectId,
+                grantSubjectId: grant.subjectId,
+                managedHumanSubjectId: human?.subjectId ?? null,
+                canManage: hasPermission(grant.permissions, "workspace:admin"),
+              }),
               false,
               canResumeRedemption,
               canResumeRedemption

--- a/apps/api/test/codex-redemption-routes.test.ts
+++ b/apps/api/test/codex-redemption-routes.test.ts
@@ -670,6 +670,10 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
     expect(overview.status).toBe(200);
     const overviewBody = (await overview.json()) as any;
     expect(overviewBody.accounts[connected.id].canRedeem).toBe(true);
+    expect(overviewBody.accounts[connected.id].redemptionAccess).toEqual({
+      ownership: "current_human",
+      canClaimUnownedViaReconnect: false,
+    });
     expect(overviewBody.accounts[connected.id].resetCredits).toMatchObject({
       detailState: "detailed",
       detailsComplete: true,
@@ -688,6 +692,70 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
       { status: "available", actionable: true },
     ]);
     expect(provider.consumeBodies).toHaveLength(0);
+
+    const unownedProviderAccountId = `legacy-unowned-${crypto.randomUUID()}`;
+    const unowned = await upsertCodexSubscriptionCredential(client.db, {
+      accountId,
+      workspaceId,
+      credentialEncrypted: encryptEnvironmentValue(
+        key,
+        JSON.stringify({
+          access_token: "legacy-token",
+          refresh_token: "legacy-refresh",
+          id_token: "legacy-id",
+        }),
+      ),
+      chatgptAccountId: unownedProviderAccountId,
+      scopes: null,
+      planType: "pro",
+      isFedramp: false,
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      lastRefreshAt: new Date(),
+      connectedBySubjectId: null,
+    });
+    const unownedOverview = await api.request(`/v1/workspaces/${workspaceId}/codex/overview`, {
+      headers: { cookie: OWNER_COOKIE },
+    });
+    expect(unownedOverview.status).toBe(200);
+    expect(((await unownedOverview.json()) as any).accounts[unowned.id]).toMatchObject({
+      canRedeem: false,
+      canResumeRedemption: false,
+      redemptionAccess: {
+        ownership: "unowned",
+        canClaimUnownedViaReconnect: true,
+      },
+    });
+    const claimed = await upsertCodexSubscriptionCredential(client.db, {
+      accountId,
+      workspaceId,
+      credentialEncrypted: encryptEnvironmentValue(
+        key,
+        JSON.stringify({
+          access_token: "claimed-token",
+          refresh_token: "claimed-refresh",
+          id_token: "claimed-id",
+        }),
+      ),
+      chatgptAccountId: unownedProviderAccountId,
+      scopes: null,
+      planType: "pro",
+      isFedramp: false,
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      lastRefreshAt: new Date(),
+      connectedBySubjectId: `user:${OWNER_USER_ID}`,
+    });
+    expect(claimed).toMatchObject({ kind: "upserted", id: unowned.id, isNew: false });
+    const claimedOverview = await api.request(`/v1/workspaces/${workspaceId}/codex/overview`, {
+      headers: { cookie: OWNER_COOKIE },
+    });
+    expect(claimedOverview.status).toBe(200);
+    expect(((await claimedOverview.json()) as any).accounts[unowned.id]).toMatchObject({
+      canRedeem: true,
+      redemptionAccess: {
+        ownership: "current_human",
+        canClaimUnownedViaReconnect: false,
+      },
+    });
 
     const unhealthy = await upsertCodexSubscriptionCredential(client.db, {
       accountId,
@@ -765,7 +833,13 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
       headers: { cookie: OTHER_COOKIE },
     });
     expect(otherOverview.status).toBe(200);
-    expect(((await otherOverview.json()) as any).accounts[connected.id].canRedeem).toBe(false);
+    expect(((await otherOverview.json()) as any).accounts[connected.id]).toMatchObject({
+      canRedeem: false,
+      redemptionAccess: {
+        ownership: "different_human",
+        canClaimUnownedViaReconnect: false,
+      },
+    });
     const otherPrepared = await prepare(
       api,
       workspaceId,

--- a/apps/api/test/codex-redemption-routes.test.ts
+++ b/apps/api/test/codex-redemption-routes.test.ts
@@ -894,6 +894,24 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
     });
     expect(keyResponse.status).toBe(201);
     const productToken = ((await keyResponse.json()) as any).token as string;
+    const productOverview = await api.request(`/v1/workspaces/${workspaceId}/codex/overview`, {
+      headers: { authorization: `Bearer ${productToken}` },
+    });
+    expect(productOverview.status).toBe(200);
+    const productAccount = ((await productOverview.json()) as any).accounts[connected.id];
+    expect(productAccount).toMatchObject({
+      canRedeem: false,
+      canResumeRedemption: false,
+      redemptionAccess: {
+        ownership: "managed_human_unavailable",
+        canClaimUnownedViaReconnect: false,
+      },
+    });
+    expect(
+      productAccount.resetCredits.credits.every(
+        (credit: { actionable: boolean }) => !credit.actionable,
+      ),
+    ).toBe(true);
     const productKeyAttempt = await prepare(
       api,
       workspaceId,

--- a/apps/web/src/components/codex-connection.test.tsx
+++ b/apps/web/src/components/codex-connection.test.tsx
@@ -1,10 +1,11 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { copyTextToClipboard } from "@opengeni/react/clipboard";
+import type { CodexAccountOverview } from "@opengeni/sdk";
 import { act, type ComponentProps } from "react";
 import { createRoot } from "react-dom/client";
 
-import { CodexDeviceCodePanel } from "./codex-connection";
+import { CodexDeviceCodePanel, ResetCreditInventory } from "./codex-connection";
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -229,5 +230,81 @@ describe("CodexDeviceCodePanel", () => {
 
     expect(writes).toEqual([]);
     container.remove();
+  });
+});
+
+describe("ResetCreditInventory", () => {
+  test("explains unavailable managed-human authority without offering ownership recovery", async () => {
+    const overview: CodexAccountOverview = {
+      accountId: "account-unavailable",
+      usage: {
+        source: "none",
+        fetchedAt: null,
+        stale: false,
+        error: null,
+        value: null,
+      },
+      resetCredits: {
+        source: "provider",
+        fetchedAt: null,
+        stale: false,
+        error: null,
+        detailState: "detailed",
+        detailsComplete: true,
+        availableCount: 1,
+        credits: [
+          {
+            id: "credit-view-only",
+            resetType: "codexRateLimits",
+            status: "available",
+            grantedAt: 1,
+            expiresAt: null,
+            title: "Full reset",
+            description: null,
+            actionable: false,
+          },
+        ],
+      },
+      canRedeem: false,
+      redemptionAccess: {
+        ownership: "managed_human_unavailable",
+        canClaimUnownedViaReconnect: false,
+      },
+      canResumeRedemption: false,
+      redemptions: [],
+    };
+    let reconnectCalls = 0;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <ResetCreditInventory
+            overview={overview}
+            now={0}
+            busy={false}
+            recoveryAttempts={[]}
+            onRedeem={() => undefined}
+            onReconnectSameAccount={() => {
+              reconnectCalls += 1;
+            }}
+          />,
+        );
+      });
+
+      expect(container.textContent).toContain(
+        "OpenGeni could not verify a managed human for this browser session.",
+      );
+      expect(container.textContent).toContain(
+        "Reset credits are view only, and ownership cannot be claimed or changed here.",
+      );
+      expect(container.querySelectorAll("button")).toHaveLength(0);
+      expect(reconnectCalls).toBe(0);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
   });
 });

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -422,7 +422,7 @@ function AccountUsageMeta({
   );
 }
 
-function ResetCreditInventory({
+export function ResetCreditInventory({
   overview,
   now,
   busy,
@@ -499,6 +499,14 @@ function ResetCreditInventory({
             </Button>
           ) : null}
         </div>
+      ) : viewOnlyOwnership === "managed_human_unavailable" ? (
+        <p
+          className="rounded border border-border/70 bg-surface-2/50 p-2 text-2xs text-fg-muted"
+          role="status"
+        >
+          OpenGeni could not verify a managed human for this browser session. Reset credits are view
+          only, and ownership cannot be claimed or changed here.
+        </p>
       ) : viewOnlyOwnership === "different_human" ? (
         <p
           className="rounded border border-border/70 bg-surface-2/50 p-2 text-2xs text-fg-muted"

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -428,12 +428,14 @@ function ResetCreditInventory({
   busy,
   recoveryAttempts,
   onRedeem,
+  onReconnectSameAccount,
 }: {
   overview: CodexAccountOverview | undefined;
   now: number;
   busy: boolean;
   recoveryAttempts: RedemptionAttemptView[];
   onRedeem: (credit: CodexResetCredit, recovery?: RedemptionAttemptView) => void;
+  onReconnectSameAccount: () => void;
 }) {
   if (!overview) return null;
   const reset = overview.resetCredits;
@@ -450,6 +452,8 @@ function ResetCreditInventory({
   const hiddenRecoveries = recoveryAttempts.filter(
     (attempt) => !visibleCreditIds.has(attempt.creditId),
   );
+  const viewOnlyOwnership =
+    count !== null && count > 0 && !overview.canRedeem ? overview.redemptionAccess.ownership : null;
   return (
     <div className="grid min-w-0 gap-2 rounded-md border border-border/70 bg-surface/60 p-2.5">
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
@@ -473,6 +477,37 @@ function ResetCreditInventory({
           ? ` Checked ${absoluteTimestamp(reset.fetchedAt)} (${relativeTimestamp(reset.fetchedAt, now)}).`
           : ""}
       </p>
+      {viewOnlyOwnership === "unowned" ? (
+        <div
+          className="flex min-w-0 flex-wrap items-center justify-between gap-2 rounded border border-status-waiting/30 bg-status-waiting/10 p-2"
+          role="status"
+        >
+          <p className="min-w-0 flex-1 text-2xs text-fg-muted">
+            This legacy connection has no recorded human owner, so its resets are view only.
+            Reconnect the same ChatGPT account while signed in as yourself to claim it safely.
+          </p>
+          {overview.redemptionAccess.canClaimUnownedViaReconnect ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              className="min-h-11 shrink-0"
+              disabled={busy}
+              onClick={onReconnectSameAccount}
+            >
+              <RefreshCwIcon className="size-3.5" /> Reconnect same account
+            </Button>
+          ) : null}
+        </div>
+      ) : viewOnlyOwnership === "different_human" ? (
+        <p
+          className="rounded border border-border/70 bg-surface-2/50 p-2 text-2xs text-fg-muted"
+          role="status"
+        >
+          This connection belongs to another person. Only that person can redeem its resets;
+          disconnecting it is the explicit ownership-reset boundary.
+        </p>
+      ) : null}
       {reset.credits.length > 0 ? (
         <div className="grid min-w-0 gap-1.5">
           {reset.credits.map((credit) => {
@@ -905,7 +940,7 @@ export function CodexSubscriptionsCard({
           if (!cancelled.current) {
             setPending(null);
             toast.success(`Codex connected${result.plan ? ` (${result.plan} plan)` : ""}`);
-            await refreshAccounts();
+            await refreshUsage();
           }
           return;
         }
@@ -925,7 +960,7 @@ export function CodexSubscriptionsCard({
     } finally {
       setBusy(false);
     }
-  }, [client, workspaceId, refreshAccounts]);
+  }, [client, workspaceId, refreshUsage]);
 
   const activate = useCallback(
     async (accountId: string) => {
@@ -1490,6 +1525,7 @@ export function CodexSubscriptionsCard({
                       onRedeem={(credit, recovery) =>
                         void beginRedemption(account.id, credit, recovery)
                       }
+                      onReconnectSameAccount={() => void connect()}
                     />
                     {canManage ? (
                       <div className="flex flex-wrap items-center gap-2">

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -138,8 +138,10 @@ Codex quota adds three deliberately separate product seams:
   managed-cookie admin to reconnect the same ChatGPT account; that row-locked
   same-provider upsert may fill only a NULL owner. A different existing owner
   is never transferred by reconnect, and disconnect remains the explicit
-  ownership-reset boundary. The browser refreshes the full overview after a
-  successful reconnect so an exact claim immediately exposes Redeem.
+  ownership-reset boundary. When no matching managed human can be verified, the
+  browser renders a closed view-only explanation with no reclaim action. The
+  browser refreshes the full overview after a successful reconnect so an exact
+  claim immediately exposes Redeem.
 
 The durable redemption attempt separates `processing` (fresh exact actionable
 detail still owed) from `provider_started` (the consume POST may have begun).

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -133,6 +133,13 @@ Codex quota adds three deliberately separate product seams:
   session-bound HMAC confirmation. The deployment must configure
   `publicBaseUrl`; the route never derives a trusted origin from request
   `Host`/URL headers. Legacy/nonhuman-connected rows are view-only.
+  The overview returns only a closed, secret-free ownership reason. A legacy
+  row with no recorded human owner explicitly tells an eligible direct
+  managed-cookie admin to reconnect the same ChatGPT account; that row-locked
+  same-provider upsert may fill only a NULL owner. A different existing owner
+  is never transferred by reconnect, and disconnect remains the explicit
+  ownership-reset boundary. The browser refreshes the full overview after a
+  successful reconnect so an exact claim immediately exposes Redeem.
 
 The durable redemption attempt separates `processing` (fresh exact actionable
 detail still owed) from `provider_started` (the consume POST may have begun).

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3204,6 +3204,12 @@ export type CodexAccountOverview = {
     credits: CodexResetCredit[];
   };
   canRedeem: boolean;
+  /** Secret-free reason redemption is owner-actionable or view-only. */
+  redemptionAccess: {
+    ownership: "current_human" | "unowned" | "different_human" | "managed_human_unavailable";
+    /** A direct managed-cookie admin may claim only an unowned same-provider row by reconnecting. */
+    canClaimUnownedViaReconnect: boolean;
+  };
   /** Owning managed-cookie human may replay durable completion without a healthy provider token. */
   canResumeRedemption: boolean;
   /** Durable owner-scoped ambiguity/completion discovery; never redemption authority for agents. */

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -432,6 +432,7 @@ beforeAll(async () => {
     ["unsupported", "Unsupported account"],
     ["error", "Error account"],
     ["cached", "Cached account"],
+    ["unowned", "Unowned account"],
   ] as const) {
     const connected = await upsertCodexSubscriptionCredential(client.db, {
       accountId,
@@ -450,7 +451,7 @@ beforeAll(async () => {
       isFedramp: false,
       expiresAt: new Date(Date.now() + 60 * 60_000),
       lastRefreshAt: new Date(),
-      connectedBySubjectId: `user:${OWNER_USER_ID}`,
+      connectedBySubjectId: externalId === "unowned" ? null : `user:${OWNER_USER_ID}`,
       label,
     });
     if (externalId === "detailed") detailedCredentialId = connected.id;
@@ -566,6 +567,16 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await accountCard("Cached account")
       .getByText(/OpenGeni cache · stale/)
       .waitFor();
+    await expandAccount("Unowned account");
+    const unownedCard = accountCard("Unowned account");
+    await unownedCard
+      .getByText(/no recorded human owner.+view only.+Reconnect the same ChatGPT account/s)
+      .waitFor();
+    expect(await unownedCard.getByRole("button", { name: /^Redeem / }).count()).toBe(0);
+    const reconnectSameAccount = unownedCard.getByRole("button", {
+      name: "Reconnect same account",
+    });
+    expect((await reconnectSameAccount.boundingBox())?.height ?? 0).toBeGreaterThanOrEqual(44);
     expect(provider.maxActiveOverviewCalls).toBeLessThanOrEqual(4);
     await expandAccount("Detailed account");
     expect(await page.getByRole("button", { name: /^Redeem / }).count()).toBe(1);
@@ -615,6 +626,15 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
       .count();
     releaseMobileAccountList();
     expect(initialMobileAccountCount).toBe(0);
+    const mobileUnowned = await expandAccountDetails(mobile, "Unowned account", "tap");
+    await mobileUnowned
+      .getByText(/no recorded human owner.+view only.+Reconnect the same ChatGPT account/s)
+      .waitFor();
+    expect(await mobileUnowned.getByRole("button", { name: /^Redeem / }).count()).toBe(0);
+    expect(
+      (await mobileUnowned.getByRole("button", { name: "Reconnect same account" }).boundingBox())
+        ?.height ?? 0,
+    ).toBeGreaterThanOrEqual(44);
     const mobileDetailed = await expandAccountDetails(mobile, "Detailed account", "tap");
     await mobileDetailed.getByRole("button", { name: "Redeem Full reset" }).waitFor();
     expect(


### PR DESCRIPTION
## Summary
- expose a secret-free ownership reason for reset-credit redemption
- guide eligible admins to reclaim only null-owner legacy rows by reconnecting the same ChatGPT account
- explain non-transferable ownership and refresh the full overview after reconnect
- prove null-owner claim and non-transfer in real PostgreSQL API tests and desktop/mobile browser coverage

## Verification
- bun run typecheck:api
- bun run typecheck:web
- bun run typecheck:sdk
- bun run lint
- bun run format:check
- bun test ./apps/api/test/codex-redemption-routes.test.ts (9 pass)
- bun test ./test/e2e/codex-overview.e2e.ts (1 pass, real browser/API/PostgreSQL)
- git diff --check

Linear: OPE-177