### PR TITLE
fix(sessions): keep prompt placement truthful

### DIFF
--- a/.changeset/calm-session-queue-truth.md
+++ b/.changeset/calm-session-queue-truth.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+"@opengeni/observability": patch
+"@opengeni/react": patch
+---
+
+Separate worker-claim queue state from prompts genuinely waiting behind work, keep rapid sends on stable chat and queue surfaces, and make local development fail fast when schema or aggregate runtime readiness is lost.

--- a/apps/api/test/session-authorization-routes.test.ts
+++ b/apps/api/test/session-authorization-routes.test.ts
@@ -18,6 +18,8 @@ import {
   applySessionTurnSettlement,
   getSessionHumanInputRequest,
   mutateSessionControlInTransaction,
+  submitHumanPromptInTransaction,
+  withWorkspaceSubjectSessionActivityRls,
   withWorkspaceSessionActivityRls,
   type DbClient,
 } from "@opengeni/db";
@@ -540,6 +542,38 @@ describe("embedding host session authorization routes", () => {
     const turns = (await turnsResponse.json()) as Array<Record<string, unknown>>;
     expect(turns).toHaveLength(1);
     expect(turns[0]).not.toHaveProperty("modelContext");
+
+    const acceptedQueueResponse = await app.request(`${base}/queue`, { headers });
+    expect(acceptedQueueResponse.status).toBe(200);
+    const acceptedQueue = (await acceptedQueueResponse.json()) as {
+      items: Array<Record<string, unknown>>;
+    };
+    expect(acceptedQueue.items).toHaveLength(0);
+
+    const queuedSubmission = await withWorkspaceSubjectSessionActivityRls(
+      client.db,
+      value.grant.workspaceId,
+      value.grant.subjectId,
+      (db) =>
+        submitHumanPromptInTransaction(db, {
+          accountId: value.grant.accountId,
+          workspaceId: value.grant.workspaceId,
+          sessionId: value.child.id,
+          subjectId: value.grant.subjectId,
+          actor: { type: "human", subjectId: value.grant.subjectId },
+          operationKey: crypto.randomUUID(),
+          delivery: "send",
+          text: "queued projection probe",
+          modelContext: "queued host-only context",
+          resources: [],
+          model: "test-model",
+          reasoningEffort: "medium",
+          latencyMode: "standard",
+          reasoningEffortFallback: "low",
+          source: "user",
+        }),
+    );
+    expect(queuedSubmission.routing).toBe("queued_for_execution");
 
     const queueResponse = await app.request(`${base}/queue`, { headers });
     expect(queueResponse.status).toBe(200);

--- a/apps/api/test/session-queue-delete.test.ts
+++ b/apps/api/test/session-queue-delete.test.ts
@@ -300,6 +300,19 @@ describe("session queue delete lookup", () => {
       sandboxBackend: "none",
     });
     const authorization = await bearer(owner.accountId, owner.workspaceId);
+    const accepted = await app.request(
+      `http://x/v1/workspaces/${owner.workspaceId}/sessions/${session.id}/events`,
+      {
+        method: "POST",
+        headers: { authorization, "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "user.message",
+          clientEventId: crypto.randomUUID(),
+          payload: { text: "run first" },
+        }),
+      },
+    );
+    expect(accepted.status).toBe(202);
     const submitted = await app.request(
       `http://x/v1/workspaces/${owner.workspaceId}/sessions/${session.id}/events`,
       {

--- a/apps/web/src/components/ui/status-dot.tsx
+++ b/apps/web/src/components/ui/status-dot.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 export type StatusTone = "queued" | "running" | "waiting" | "idle" | "failed" | "cancelled";
 
 export const STATUS_META: Record<StatusTone, { dot: string; text: string; label: string }> = {
-  queued: { dot: "bg-status-queued", text: "text-status-queued", label: "Queued" },
+  queued: { dot: "bg-status-queued", text: "text-status-queued", label: "Starting" },
   running: { dot: "bg-status-running", text: "text-status-running", label: "Running" },
   waiting: { dot: "bg-status-waiting", text: "text-status-waiting", label: "Waiting on you" },
   idle: { dot: "bg-status-idle", text: "text-status-idle", label: "Idle" },

--- a/apps/web/src/lib/session-empty-state.test.ts
+++ b/apps/web/src/lib/session-empty-state.test.ts
@@ -3,7 +3,10 @@ import { sessionTimelineEmptyStateCopy } from "./session-empty-state";
 
 describe("sessionTimelineEmptyStateCopy", () => {
   test("reports the actual zero-step lifecycle", () => {
-    expect(sessionTimelineEmptyStateCopy("queued", false).title).toBe("Queued to start");
+    expect(sessionTimelineEmptyStateCopy("queued", false)).toEqual({
+      title: "Starting the agent",
+      description: "Your prompt is in the conversation while the agent starts.",
+    });
     expect(sessionTimelineEmptyStateCopy("running", false).title).toBe("Starting the agent");
     expect(sessionTimelineEmptyStateCopy("recovering", false).title).toBe("Restoring this session");
     expect(sessionTimelineEmptyStateCopy("waiting_capacity", false).title).toBe(

--- a/apps/web/src/lib/session-empty-state.ts
+++ b/apps/web/src/lib/session-empty-state.ts
@@ -19,8 +19,8 @@ export function sessionTimelineEmptyStateCopy(
   switch (status) {
     case "queued":
       return {
-        title: "Queued to start",
-        description: "Your prompt is saved and will start when this session is admitted.",
+        title: "Starting the agent",
+        description: "Your prompt is in the conversation while the agent starts.",
       };
     case "running":
       return {

--- a/apps/web/src/lib/session-rail.ts
+++ b/apps/web/src/lib/session-rail.ts
@@ -14,7 +14,7 @@ export function sessionStatusLabel(status: Session["status"]): string {
     case "running":
       return "Running";
     case "queued":
-      return "Queued";
+      return "Starting";
     case "failed":
       return "Failed";
     case "cancelled":

--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -54,10 +54,13 @@ describe("managed self-context surfaces", () => {
   });
 
   test("separates organization administration from Personal content", () => {
+    expect(organizationAdminSource).toContain("Personal content stays personal");
     expect(organizationAdminSource).toContain(
-      "Personal workspaces and their content are\n            never included.",
+      "Organization administration never grants access to another member&apos;s Personal",
     );
-    expect(organizationAdminSource).toContain("Every shared workspace in this organization.");
+    expect(organizationAdminSource).toContain(
+      "Create shared workspaces, then choose which organization members can use each one.",
+    );
     expect(organizationSource).toContain("<OrganizationPeopleSection");
     expect(organizationSource).toContain("<OrganizationRetentionSection");
   });

--- a/apps/web/src/routes/agents.tsx
+++ b/apps/web/src/routes/agents.tsx
@@ -374,7 +374,7 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
       >
         <TopologyMetric label="Active" value={summary.active} icon={ActivityIcon} tone="running" />
         <TopologyMetric label="Running" value={summary.running} icon={BotIcon} tone="running" />
-        <TopologyMetric label="Queued" value={summary.queued} icon={Clock3Icon} tone="queued" />
+        <TopologyMetric label="Starting" value={summary.queued} icon={Clock3Icon} tone="queued" />
         <TopologyMetric
           label="Needs you"
           value={summary.attention}
@@ -944,7 +944,7 @@ function agentStatus(session: AgentTopologySession): {
   }
   if (session.status === "queued") {
     return {
-      label: "Queued",
+      label: "Starting",
       tone: "queued",
       pulse: false,
       textClass: "text-status-queued",
@@ -1039,7 +1039,7 @@ export function AgentTopologyPreviewRoute() {
             tone="running"
           />
           <TopologyMetric label="Running" value={summary.running} icon={BotIcon} tone="running" />
-          <TopologyMetric label="Queued" value={summary.queued} icon={Clock3Icon} tone="queued" />
+          <TopologyMetric label="Starting" value={summary.queued} icon={Clock3Icon} tone="queued" />
           <TopologyMetric
             label="Needs you"
             value={summary.attention}

--- a/apps/web/src/routes/variable-sets.test.tsx
+++ b/apps/web/src/routes/variable-sets.test.tsx
@@ -277,7 +277,9 @@ describe("Variable Sets credential-autofill boundaries", () => {
   });
 
   test("keeps the managed sign-in fields on their credential autocomplete tokens", async () => {
-    const authSource = await Bun.file(`${import.meta.dir}/../context.tsx`).text();
+    const authSource = await Bun.file(
+      `${import.meta.dir}/../components/managed-auth-panel.tsx`,
+    ).text();
 
     expect(authSource).toContain('autoComplete="email"');
     expect(authSource).toContain(

--- a/apps/web/src/routes/workspace-settings.test.tsx
+++ b/apps/web/src/routes/workspace-settings.test.tsx
@@ -1,5 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterContextProvider,
+} from "@tanstack/react-router";
 import { act, type ReactNode, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -67,6 +73,14 @@ mock.module("@/components/ui/confirm-dialog", () => ({
 }));
 
 const { MembersSection } = await import("./workspace-settings");
+const testRouter = createRouter({
+  routeTree: createRootRoute(),
+  history: createMemoryHistory({ initialEntries: ["/"] }),
+});
+
+function withTestRouter(children: ReactNode) {
+  return <RouterContextProvider router={testRouter}>{children}</RouterContextProvider>;
+}
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -104,7 +118,9 @@ async function renderMembers(canManage: boolean, workspaceId = workspaceA) {
 
   async function render(nextWorkspaceId: string, nextCanManage: boolean) {
     await act(async () => {
-      root.render(<MembersSection workspaceId={nextWorkspaceId} canManage={nextCanManage} />);
+      root.render(
+        withTestRouter(<MembersSection workspaceId={nextWorkspaceId} canManage={nextCanManage} />),
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
   }
@@ -366,11 +382,13 @@ describe("workspace members loading", () => {
     try {
       await act(async () => {
         root.render(
-          <MembersBoundaryProbe
-            workspaceId={workspaceA}
-            canManage={true}
-            onBoundaryLayout={captureBoundaryLayout}
-          />,
+          withTestRouter(
+            <MembersBoundaryProbe
+              workspaceId={workspaceA}
+              canManage={true}
+              onBoundaryLayout={captureBoundaryLayout}
+            />,
+          ),
         );
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
@@ -398,11 +416,13 @@ describe("workspace members loading", () => {
 
       act(() => {
         root.render(
-          <MembersBoundaryProbe
-            workspaceId={workspaceB}
-            canManage={true}
-            onBoundaryLayout={captureBoundaryLayout}
-          />,
+          withTestRouter(
+            <MembersBoundaryProbe
+              workspaceId={workspaceB}
+              canManage={true}
+              onBoundaryLayout={captureBoundaryLayout}
+            />,
+          ),
         );
       });
 

--- a/apps/worker/test/retained-process-reconciliation.test.ts
+++ b/apps/worker/test/retained-process-reconciliation.test.ts
@@ -1103,6 +1103,7 @@ describe("retained-process terminal-owner reconciliation", () => {
         ) attempt on true`;
       await tx`set local enable_bitmapscan = off`;
       await tx`set local enable_sort = off`;
+      await tx`set local enable_incremental_sort = off`;
       const retainedInventory = await tx`
         explain (format json, costs off)
         select process.owner_actor_kind, process.workspace_id,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,10 @@ on every native target and WASM and aggregation rejects any digest mismatch.
   The committed response includes the command receipt and admission routing. The
   same immutable decision is stored as `session_turns.prompt_routing`; physical
   `status = 'queued'` means only that the worker has not claimed the row and is
-  never itself user-visible queue authority. The browser therefore shows an idle
+  never itself user-visible queue authority. Both durable `user.message` and
+  `turn.queued` projections repeat that routing fact, so a partial stream or
+  fresh reload places the prompt correctly without a transient chat/queue flash.
+  The browser therefore shows an idle
   Send in chat, a busy or paused Send in the queue, and Steer in chat without
   guessing from a later event. A `queued_for_execution` `user.message` stays out
   of the chat timeline until its turn is claimed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,9 +91,12 @@ on every native target and WASM and aggregation rejects any digest mismatch.
   path likewise acknowledges locally with one `clientEventId`, renders a bounded
   optimistic message, and reconciles it against the authoritative event stream.
   The committed response includes the command receipt and admission routing. The
-  browser therefore shows an idle Send in chat, a busy or paused Send in the queue,
-  and Steer in chat without guessing from a later event. A queued `user.message`
-  stays out of the chat timeline until its turn leaves the authoritative queue.
+  same immutable decision is stored as `session_turns.prompt_routing`; physical
+  `status = 'queued'` means only that the worker has not claimed the row and is
+  never itself user-visible queue authority. The browser therefore shows an idle
+  Send in chat, a busy or paused Send in the queue, and Steer in chat without
+  guessing from a later event. A `queued_for_execution` `user.message` stays out
+  of the chat timeline until its turn is claimed.
   Queue-row Steer bridges that existing prompt into chat immediately and dedupes
   it by trigger event when durable stream history catches up, so missed live
   fanout cannot make an accepted direction change disappear.
@@ -874,7 +877,7 @@ stateDiagram-v2
 
 Key transitions (canonical: `apps/worker/src/workflows/session.ts`):
 
-- **Only human/API prompts are reorderable queue rows.** The one compact queue surface also projects canonical pending machine inputs directly from `session_system_updates`: attached to the eligible human prompt they will join, or grouped as standalone incoming updates. Events only invalidate that projection. The current inference, same-turn recovery, and compaction are not queue work.
+- **Only human/API prompts admitted as `queued_for_execution` are reorderable queue rows.** Physical unclaimed rows also include idle Send and Steer admissions whose immutable `prompt_routing` keeps them in chat; nullable rolling/legacy rows project conservatively into the visible queue. The one compact queue surface also projects canonical pending machine inputs directly from `session_system_updates`: attached to the eligible human prompt they will join, or grouped as standalone incoming updates. Events only invalidate that projection. The current inference, same-turn recovery, and compaction are not queue work.
 - **Machine-input batching preserves executable authority.** Ordinary notices may coalesce only when their frozen personal-MCP delegation snapshots are identical; differing snapshots form separate turns. Agent Steer remains authoritative over ordinary notices that join it. The active-turn and queued-turn surfaces disclose only server/provider summaries, never credential or owner identifiers.
 - **Structured human input is not an approval or a queue prompt.** When workspace setting `agentHumanInputEnabled` is not false, `request_human_input` freezes the current SDK tool call; answer, allowed skip, expiry, or cancellation is injected as structured output into that same call. Disabled workspaces omit the tool and reject stale/forged structured-input boundaries before `requires_action`. The request row, open suffix, events, and `requires_action` status are installed atomically. See [`human-input.md`](human-input.md).
 - **Every requires-action boundary admits one resume event.** Ordinary approval decisions and structured-input responses share the same durable gate, so parallel or mixed interruptions advance and re-freeze serially instead of settling two tool calls against one trigger.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -25,10 +25,13 @@ needs.
 Ordinary Send acknowledges locally before transport completion. The composer
 freezes the exact text, annotations, resources, settings, and one
 `clientEventId`, clears the visible draft immediately, and renders that snapshot
-as `Sending`, `Queued`, or `Not sent`. Rapid distinct sends keep distinct keys
-and preserve order. An outcome-unknown retry first reconciles and reuses the
-same key; a definite rejection retry receives a fresh key. Newer edits are a
-separate draft shadow and survive the in-flight operation and remount. The
+directly in chat when admitted toward execution, in the prompt queue when it
+must wait behind work, or as `Not sent` after a definite rejection. Rapid
+distinct sends keep distinct keys and preserve order: while the first admission
+is unsettled, the next Send is provisionally placed in the queue and never
+bounces between surfaces. An outcome-unknown retry first reconciles and reuses
+the same key; a definite rejection retry receives a fresh key. Newer edits are
+a separate draft shadow and survive the in-flight operation and remount. The
 optimistic row disappears when the authoritative `user.message` arrives, so
 HTTP-first, SSE-first, reconnect, and remount paths cannot create duplicate
 visible messages.
@@ -46,9 +49,10 @@ session fork copies the source session's exact typed reasoning and latency; it
 does not invent defaults or consult either composer.
 
 On the server, prompt acceptance remains one canonical Postgres transaction:
-the user event, queued turn, session/queue state, optional realtime mirror,
-audit receipt, `agent_run.created` usage fact, and workflow-wake outbox revision
-commit together. The response is built from those returned committed rows.
+the user event, physically queued turn, immutable admission routing,
+session/queue state, optional realtime mirror, audit receipt,
+`agent_run.created` usage fact, and workflow-wake outbox revision commit
+together. The response is built from those returned committed rows.
 NATS and workspace-control fanout plus the immediate Temporal wake attempt are
 scheduled only after commit and are not response-holding; durable event replay
 and the wake outbox recover their failures.
@@ -244,12 +248,17 @@ them. A Codex-subscription manager therefore keeps its external billing path for
 workers by default instead of falling back to the deployment's OpenGeni-credit
 model.
 
-The prompt queue is not worker backlog. In particular, human prompts preserved
-behind paused session/workspace gates are intentionally ineligible and do not
-schedule an activity. Fleet pressure comes from Temporal's dedicated
-`runAgentTurn` activity queue (`approximateBacklogCount` and oldest backlog
-age), together with the turn workers' used/memory-safe slots. Each turn worker
-must obtain a cgroup-aware slot before polling. Admission is capped at the
+The prompt queue is not worker backlog. `session_turns.status = 'queued'` means
+the worker has not claimed the physical row; it does not decide whether the user
+sees a queued prompt. Immutable `session_turns.prompt_routing` records that
+admission decision: `accepted_for_execution` and `accepted_for_steering` stay in
+chat, while only `queued_for_execution` appears in the prompt queue. Null remains
+a conservative visible-queue fallback for rolling/legacy writers. In particular,
+human prompts preserved behind paused session/workspace gates are intentionally
+ineligible and do not schedule an activity. Fleet pressure comes from Temporal's
+dedicated `runAgentTurn` activity queue (`approximateBacklogCount` and oldest
+backlog age), together with the turn workers' used/memory-safe slots. Each turn
+worker must obtain a cgroup-aware slot before polling. Admission is capped at the
 measured density of 16 and reserves a hard 100 MiB per turn plus 512 MiB of
 runtime/native headroom; a finite container that cannot safely admit one turn
 does not start. The invariant is checked both before and after Temporal's native

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -253,7 +253,10 @@ the worker has not claimed the physical row; it does not decide whether the user
 sees a queued prompt. Immutable `session_turns.prompt_routing` records that
 admission decision: `accepted_for_execution` and `accepted_for_steering` stay in
 chat, while only `queued_for_execution` appears in the prompt queue. Null remains
-a conservative visible-queue fallback for rolling/legacy writers. In particular,
+a conservative visible-queue fallback for rolling/legacy writers. New durable
+`user.message` and `turn.queued` events repeat the same routing fact so live
+streaming and reload reconstruction cannot briefly place a prompt on the wrong
+surface. In particular,
 human prompts preserved behind paused session/workspace gates are intentionally
 ineligible and do not schedule an activity. Fleet pressure comes from Temporal's
 dedicated `runAgentTurn` activity queue (`approximateBacklogCount` and oldest

--- a/packages/db/drizzle/0333_session_turn_prompt_routing.sql
+++ b/packages/db/drizzle/0333_session_turn_prompt_routing.sql
@@ -1,0 +1,45 @@
+-- deployment-mode: rolling
+-- A physically queued turn is not necessarily part of the operator-visible
+-- prompt queue: an idle Send and a Steer are accepted immediately, then wait
+-- only for the worker claim boundary. Persist that admission decision so UI
+-- projections never infer product semantics from worker implementation state.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE session_turns
+  ADD COLUMN prompt_routing text;
+
+ALTER TABLE session_turns
+  ADD CONSTRAINT session_turns_prompt_routing_check CHECK (
+    prompt_routing IS NULL OR prompt_routing IN (
+      'accepted_for_execution',
+      'queued_for_execution',
+      'accepted_for_steering'
+    )
+  ) NOT VALID;
+
+ALTER TABLE session_turns
+  VALIDATE CONSTRAINT session_turns_prompt_routing_check;
+
+CREATE FUNCTION opengeni_private.reject_session_turn_prompt_routing_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.prompt_routing IS DISTINCT FROM OLD.prompt_routing THEN
+    RAISE EXCEPTION 'turn prompt routing is immutable after admission'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION opengeni_private.reject_session_turn_prompt_routing_mutation() FROM PUBLIC;
+
+CREATE TRIGGER session_turns_prompt_routing_immutable
+  BEFORE UPDATE OF prompt_routing ON session_turns
+  FOR EACH ROW EXECUTE FUNCTION opengeni_private.reject_session_turn_prompt_routing_mutation();
+
+COMMENT ON COLUMN session_turns.prompt_routing IS
+  'Immutable admission intent for human/API prompts. Null is rolling/legacy compatibility; status remains physical execution state.';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -54227,6 +54227,7 @@ export async function initializeSessionStartAtomically(
                   temporalWorkflowId,
                   status: "queued",
                   source: "user",
+                  promptRouting: runnable ? "accepted_for_execution" : "queued_for_execution",
                   position: queueTailPosition,
                   prompt: canonicalInitialMessage,
                   modelContext: session.initialModelContext ?? null,
@@ -54533,6 +54534,7 @@ export async function enqueueSessionTurn(
                 temporalWorkflowId: input.temporalWorkflowId,
                 status: "queued",
                 source: input.source,
+                promptRouting: "queued_for_execution",
                 position,
                 prompt: input.prompt,
                 modelContext: input.modelContext ?? null,
@@ -62178,13 +62180,20 @@ export async function getSessionQueueSnapshot(
         asc(schema.sessionSystemUpdates.createdAt),
         asc(schema.sessionSystemUpdates.id),
       );
-    const items = rows.map(mapSessionTurn);
+    // `status=queued` is the physical worker-claim queue. Only an explicit
+    // queued_for_execution admission belongs in the operator-visible queue.
+    // Null remains visible during rolling deploys and for legacy rows so a
+    // prompt written by an older process can never disappear from the UI.
+    const physicalItems = rows.map(mapSessionTurn);
+    const items = rows
+      .filter((row) => row.promptRouting === null || row.promptRouting === "queued_for_execution")
+      .map(mapSessionTurn);
     const latestInterruption = await latestSessionAttemptInterruption(
       scopedDb,
       workspaceId,
       sessionId,
     );
-    const queuedSteerPredecessorIds = items
+    const queuedSteerPredecessorIds = physicalItems
       .map((turn) => queuedSteerReplacementAttemptId(turn.metadata))
       .filter((attemptId): attemptId is string => attemptId !== null);
     const stoppingPreviousAttempt =
@@ -62202,8 +62211,8 @@ export async function getSessionQueueSnapshot(
       (update) => update.kind === "agent_steer_instruction",
     );
     const attachmentTurn = hasPendingAgentSteer
-      ? items.find((turn) => turn.metadata.delivery === "steer")
-      : items[0];
+      ? physicalItems.find((turn) => turn.metadata.delivery === "steer")
+      : physicalItems[0];
     return {
       version: session.queueVersion,
       effectiveControl: serializeEffectiveSessionControl(effectiveControl),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -54128,6 +54128,7 @@ export async function initializeSessionStartAtomically(
                       ...(session.initialModelContext
                         ? { modelContext: session.initialModelContext }
                         : {}),
+                      routing: runnable ? "accepted_for_execution" : "queued_for_execution",
                       initiator: creator.initiator,
                     },
                     clientEventId: input.clientEventId ?? `session-initial:${session.id}`,
@@ -54367,6 +54368,7 @@ export async function initializeSessionStartAtomically(
                     turnId: turn.id,
                     triggerEventId: userEvent.id,
                     source: turn.source,
+                    ...(turn.promptRouting ? { routing: turn.promptRouting } : {}),
                     initiator: creator.initiator,
                   },
                 },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5474,6 +5474,12 @@ export const sessionTurns = pgTable(
     temporalWorkflowId: text("temporal_workflow_id").notNull(),
     status: text("status").notNull(),
     source: text("source").notNull().default("user"),
+    // Immutable user-facing admission intent. Physical execution still uses
+    // status=queued until a worker claims the row; this field keeps that
+    // implementation queue distinct from prompts genuinely waiting behind
+    // other work. Null is reserved for rolling/legacy writers and non-human
+    // turns, and is projected conservatively as visible queue work.
+    promptRouting: text("prompt_routing"),
     position: bigint("position", { mode: "number" }).notNull(),
     prompt: losslessText("prompt").notNull(),
     promptCodecVersion: losslessCodecVersion("prompt_codec_version"),

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -1914,6 +1914,13 @@ export async function submitHumanPromptInTransaction(
     editedSourceModelContext !== undefined
       ? editedSourceModelContext
       : (input.modelContext ?? null);
+  const existingQueued = await loadQueuedTurns(db, input.workspaceId, input.sessionId, true);
+  const routing: SessionPromptRouting =
+    input.delivery === "steer"
+      ? "accepted_for_steering"
+      : before.state === "paused" || session.activeTurnId || existingQueued.length > 0
+        ? "queued_for_execution"
+        : "accepted_for_execution";
   let sequence = session.lastSequence;
   const eventValues: SessionEventInsertWithPayload[] = [
     {
@@ -1941,18 +1948,12 @@ export async function submitHumanPromptInTransaction(
         ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
         ...(input.latencyMode ? { latencyMode: input.latencyMode } : {}),
         delivery: input.delivery,
+        routing,
         initiator: frozenInitiator.initiator,
       },
       occurredAt: now,
     },
   ];
-  const existingQueued = await loadQueuedTurns(db, input.workspaceId, input.sessionId, true);
-  const routing: SessionPromptRouting =
-    input.delivery === "steer"
-      ? "accepted_for_steering"
-      : before.state === "paused" || session.activeTurnId || existingQueued.length > 0
-        ? "queued_for_execution"
-        : "accepted_for_execution";
   const [turn] = await db
     .insert(schema.sessionTurns)
     .values(
@@ -2052,6 +2053,7 @@ export async function submitHumanPromptInTransaction(
       turnId,
       triggerEventId: acceptedEventId,
       source: input.source,
+      routing,
       initiator: frozenInitiator.initiator,
     },
     occurredAt: now,

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -1966,6 +1966,7 @@ export async function submitHumanPromptInTransaction(
           temporalWorkflowId: workflowId,
           status: "queued",
           source: input.source,
+          promptRouting: routing,
           position: input.delivery === "steer" ? 0 : existingQueued.length + 1,
           prompt: input.text,
           annotations,

--- a/packages/db/test/migration-0333-session-turn-prompt-routing.test.ts
+++ b/packages/db/test/migration-0333-session-turn-prompt-routing.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+
+const migrationUrl = new URL("../drizzle/0333_session_turn_prompt_routing.sql", import.meta.url);
+
+let shared: SharedTestDatabase | null = null;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("migration-0333-session-turn-prompt-routing");
+});
+
+afterAll(async () => {
+  await shared?.release();
+});
+
+describe("migration 0333 session turn prompt routing", () => {
+  test("is a rolling additive change with no historical queue rewrite", async () => {
+    const sql = await readFile(migrationUrl, "utf8");
+    expect(sql.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+    expect(sql).toContain("ADD COLUMN prompt_routing text");
+    expect(sql).toContain("session_turns_prompt_routing_check");
+    expect(sql).toContain("session_turns_prompt_routing_immutable");
+    expect(sql).not.toMatch(/\bUPDATE\s+session_turns/iu);
+    expect(sql).not.toMatch(/\bDELETE\s+FROM/iu);
+  });
+
+  test("installs the nullable rolling column and closed routing vocabulary", async () => {
+    if (!shared) return;
+    const [column] = await shared.admin<
+      Array<{ data_type: string; is_nullable: string; column_default: string | null }>
+    >`
+      select data_type, is_nullable, column_default
+      from information_schema.columns
+      where table_schema = current_schema()
+        and table_name = 'session_turns'
+        and column_name = 'prompt_routing'`;
+    expect({ ...column! }).toEqual({
+      data_type: "text",
+      is_nullable: "YES",
+      column_default: null,
+    });
+
+    const [constraint] = await shared.admin<Array<{ definition: string }>>`
+      select pg_get_constraintdef(oid) as definition
+      from pg_constraint
+      where conrelid = 'session_turns'::regclass
+        and conname = 'session_turns_prompt_routing_check'`;
+    expect(constraint?.definition).toContain("accepted_for_execution");
+    expect(constraint?.definition).toContain("queued_for_execution");
+    expect(constraint?.definition).toContain("accepted_for_steering");
+
+    const [trigger] = await shared.admin<Array<{ enabled: string }>>`
+      select tgenabled as enabled
+      from pg_trigger
+      where tgrelid = 'session_turns'::regclass
+        and tgname = 'session_turns_prompt_routing_immutable'
+        and not tgisinternal`;
+    expect(trigger?.enabled).toBe("O");
+  });
+});

--- a/packages/db/test/queue-mutations.test.ts
+++ b/packages/db/test/queue-mutations.test.ts
@@ -70,28 +70,32 @@ async function fixture(count = 3) {
     sandboxBackend: "none",
   });
   const turns = await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
-    const rows = await db
-      .insert(schema.sessionTurns)
-      .values(
-        Array.from({ length: count }, (_, index) => ({
-          accountId: grant.accountId,
-          workspaceId: grant.workspaceId!,
-          sessionId: session.id,
-          triggerEventId: crypto.randomUUID(),
-          temporalWorkflowId: `session-${session.id}`,
-          status: "queued",
-          source: "user",
-          position: index + 1,
-          prompt: `prompt ${index + 1}`,
-          resources: index === 1 ? [{ kind: "file" as const, id: crypto.randomUUID() }] : [],
-          tools: [],
-          model: `model-${index + 1}`,
-          reasoningEffort: index === 1 ? "high" : "low",
-          sandboxBackend: "none",
-          metadata: {},
-        })),
-      )
-      .returning();
+    const rows =
+      count === 0
+        ? []
+        : await db
+            .insert(schema.sessionTurns)
+            .values(
+              Array.from({ length: count }, (_, index) => ({
+                accountId: grant.accountId,
+                workspaceId: grant.workspaceId!,
+                sessionId: session.id,
+                triggerEventId: crypto.randomUUID(),
+                temporalWorkflowId: `session-${session.id}`,
+                status: "queued",
+                source: "user",
+                promptRouting: "queued_for_execution",
+                position: index + 1,
+                prompt: `prompt ${index + 1}`,
+                resources: index === 1 ? [{ kind: "file" as const, id: crypto.randomUUID() }] : [],
+                tools: [],
+                model: `model-${index + 1}`,
+                reasoningEffort: index === 1 ? "high" : "low",
+                sandboxBackend: "none",
+                metadata: {},
+              })),
+            )
+            .returning();
     await db
       .update(schema.sessions)
       .set({ queueVersion: 1, queueHeadPosition: 0, queueTailPosition: count, status: "queued" })
@@ -132,6 +136,65 @@ async function storedEvents(workspaceId: string, eventIds: string[]) {
 }
 
 describe("canonical queue commands", () => {
+  test("projects only prompts admitted to wait behind work into the visible queue", async () => {
+    const value = await fixture(0);
+    const submit = async (text: string, delivery: "send" | "steer") =>
+      await withWorkspaceSubjectRls(
+        client.db,
+        value.grant.workspaceId!,
+        value.grant.subjectId,
+        (db) =>
+          db.transaction((tx) =>
+            submitHumanPromptInTransaction(tx as unknown as typeof db, {
+              accountId: value.grant.accountId,
+              workspaceId: value.grant.workspaceId!,
+              sessionId: value.session.id,
+              subjectId: value.grant.subjectId,
+              actor: value.actor,
+              operationKey: crypto.randomUUID(),
+              delivery,
+              text,
+              resources: [],
+              model: "scripted-model",
+              reasoningEffort: "medium",
+              latencyMode: "standard",
+              reasoningEffortFallback: "medium",
+              source: "user",
+            }),
+          ),
+      );
+
+    const direct = await submit("start now", "send");
+    expect(direct.routing).toBe("accepted_for_execution");
+    expect(
+      await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
+        db
+          .select({ promptRouting: schema.sessionTurns.promptRouting })
+          .from(schema.sessionTurns)
+          .where(eq(schema.sessionTurns.id, direct.turnId)),
+      ),
+    ).toEqual([{ promptRouting: "accepted_for_execution" }]);
+    expect(
+      (await getSessionQueueSnapshot(client.db, value.grant.workspaceId!, value.session.id))?.items,
+    ).toEqual([]);
+
+    const waiting = await submit("run second", "send");
+    expect(waiting.routing).toBe("queued_for_execution");
+    expect(
+      (
+        await getSessionQueueSnapshot(client.db, value.grant.workspaceId!, value.session.id)
+      )?.items.map((turn) => turn.id),
+    ).toEqual([waiting.turnId]);
+
+    const steer = await submit("change direction", "steer");
+    expect(steer.routing).toBe("accepted_for_steering");
+    expect(
+      (
+        await getSessionQueueSnapshot(client.db, value.grant.workspaceId!, value.session.id)
+      )?.items.map((turn) => turn.id),
+    ).toEqual([waiting.turnId]);
+  });
+
   test("Move rewrites one authoritative order and an exact retry replays", async () => {
     const value = await fixture();
     const operationKey = crypto.randomUUID();

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -3207,15 +3207,38 @@ describe("clean session control plane", () => {
     expect(steeredResult).not.toHaveProperty("status");
   });
 
-  test("Send appends, Steer head-inserts, and the snapshot is server order", async () => {
+  test("accepted Send and Steer stay out of the waiting queue", async () => {
     const { grant, session } = await fixture();
-    await send(grant, session.id, "first");
-    await send(grant, session.id, "second");
-    await send(grant, session.id, "urgent", "steer");
+    const first = await send(grant, session.id, "first");
+    const second = await send(grant, session.id, "second");
+    const urgent = await send(grant, session.id, "urgent", "steer");
+
+    expect(first.routing).toBe("accepted_for_execution");
+    expect(second.routing).toBe("queued_for_execution");
+    expect(urgent.routing).toBe("accepted_for_steering");
 
     const queue = await getSessionQueueSnapshot(client.db, grant.workspaceId!, session.id);
-    expect(queue?.items.map((turn) => turn.prompt)).toEqual(["urgent", "first", "second"]);
+    expect(queue?.items.map((turn) => turn.prompt)).toEqual(["second"]);
     expect(queue?.items.every((turn) => ["user", "api"].includes(turn.source))).toBe(true);
+    const routedEvents = await listSessionEvents(client.db, grant.workspaceId!, session.id);
+    const routingByTurnId = new Map(
+      routedEvents
+        .filter((event) => event.type === "turn.queued" && event.turnId)
+        .map(
+          (event) => [event.turnId!, (event.payload as Record<string, unknown>).routing] as const,
+        ),
+    );
+    expect(routingByTurnId.get(first.turn.id)).toBe("accepted_for_execution");
+    expect(routingByTurnId.get(second.turn.id)).toBe("queued_for_execution");
+    expect(routingByTurnId.get(urgent.turn.id)).toBe("accepted_for_steering");
+    const routingByMessageId = new Map(
+      routedEvents
+        .filter((event) => event.type === "user.message")
+        .map((event) => [event.id, (event.payload as Record<string, unknown>).routing] as const),
+    );
+    expect(routingByMessageId.get(first.acceptedEventId)).toBe("accepted_for_execution");
+    expect(routingByMessageId.get(second.acceptedEventId)).toBe("queued_for_execution");
+    expect(routingByMessageId.get(urgent.acceptedEventId)).toBe("accepted_for_steering");
   });
 
   test("workflow enrollment never marks a queued prompt running before turn capacity accepts it", async () => {
@@ -4098,9 +4121,11 @@ describe("clean session control plane", () => {
 
     const steered = await send(grant, session.id, "use this instead", "steer");
     expect(steered.interruptionCount).toBe(1);
+    expect(steered.routing).toBe("accepted_for_steering");
     const stopping = await getSessionQueueSnapshot(client.db, grant.workspaceId!, session.id);
     expect(stopping?.stoppingPreviousAttempt).toBe(true);
-    expect(stopping?.items[0]).toMatchObject({
+    expect(stopping?.items).toHaveLength(0);
+    expect(steered.turn).toMatchObject({
       id: steered.turn.id,
       metadata: {
         delivery: "steer",

--- a/packages/db/test/session-realtime-ledger.test.ts
+++ b/packages/db/test/session-realtime-ledger.test.ts
@@ -1333,6 +1333,7 @@ describe("session realtime ledger", () => {
       reasoningEffort: "high",
       latencyMode: "fast",
       delivery: "steer",
+      routing: "accepted_for_steering",
       initiator: expect.any(Object),
     });
     expect(persisted.calls[0]!.turnId).toBe(persisted.turns[0]!.id);

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -235,6 +235,17 @@ const INTERACTION_INTERVENTION_OUTCOMES = new Set([
   "expired",
   "cancelled",
 ]);
+const PUBLIC_STARTUP_DEPENDENCIES = new Set([
+  "Modal private-registry image",
+  "NATS",
+  "PostgreSQL runtime posture",
+  "Temporal",
+  "Temporal client",
+  "Temporal schedule (file upload reaper)",
+  "Temporal schedule (sandbox reaper)",
+  "Temporal schedule (session-workflow wake dispatcher)",
+  "Temporal schedule (site auth maintenance)",
+]);
 
 /**
  * External logs and OTLP are public/third-party projections, not canonical
@@ -1065,15 +1076,19 @@ export function logStartupDependencyRetry(
   observability: Observability,
   event: StartupDependencyRetryEvent,
 ): void {
-  observability.warn("Startup dependency connection failed; retrying", {
-    dependency: event.label,
-    attempt: event.attempt,
-    attempts: event.attempts,
-    delayMs: event.delayMs,
-    errorClass: "StartupDependencyError",
-    errorCode: "startup_dependency_retry",
-    origin: "observability",
-  });
+  const dependency = PUBLIC_STARTUP_DEPENDENCIES.has(event.label) ? event.label : "Dependency";
+  observability.warn(
+    `Startup dependency ${dependency} connection failed; retrying (${event.attempt}/${event.attempts} in ${event.delayMs}ms)`,
+    {
+      dependency,
+      attempt: event.attempt,
+      attempts: event.attempts,
+      delayMs: event.delayMs,
+      errorClass: "StartupDependencyError",
+      errorCode: "startup_dependency_retry",
+      origin: "observability",
+    },
+  );
 }
 
 function normalizeLabels(labels: MetricLabels = {}): Record<string, string> {
@@ -1098,6 +1113,7 @@ function cleanAttributes(attributes: Attributes): Record<string, string | number
 function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
   if ("errorClass" in attributes || "errorCode" in attributes) {
     return {
+      ...projectStartupDependencyAttributes(attributes),
       ...projectPublicChannelADiagnosticAttributes(attributes),
       ...projectPublicDiagnosticAttributes(attributes),
     };
@@ -1110,6 +1126,29 @@ function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
       return typeof value === "string" && pattern?.test(value) === true;
     }),
   );
+}
+
+function projectStartupDependencyAttributes(attributes: Attributes): Attributes {
+  if (
+    attributes.errorClass !== "StartupDependencyError" ||
+    attributes.errorCode !== "startup_dependency_retry"
+  ) {
+    return {};
+  }
+  const dependency = attributes.dependency;
+  const attempt = attributes.attempt;
+  const attempts = attributes.attempts;
+  const delayMs = attributes.delayMs;
+  return {
+    ...(typeof dependency === "string" && PUBLIC_STARTUP_DEPENDENCIES.has(dependency)
+      ? { dependency }
+      : {}),
+    ...(typeof attempt === "number" && Number.isInteger(attempt) && attempt > 0 ? { attempt } : {}),
+    ...(typeof attempts === "number" && Number.isInteger(attempts) && attempts > 0
+      ? { attempts }
+      : {}),
+    ...(typeof delayMs === "number" && Number.isFinite(delayMs) && delayMs >= 0 ? { delayMs } : {}),
+  };
 }
 
 function projectPublicChannelADiagnosticAttributes(attributes: Attributes): Attributes {

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -425,7 +425,43 @@ describe("observability", () => {
       console.warn = originalWarn;
     }
 
-    expect(observed).toEqual(["Startup dependency connection failed; retrying"]);
+    expect(observed).toEqual([
+      "Startup dependency Temporal connection failed; retrying (1/3 in 100ms)",
+    ]);
+  });
+
+  test("keeps safe retry context in structured startup logs", () => {
+    const observed: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      observed.push(String(message));
+    };
+    try {
+      const obs = createObservability(
+        { ...settings, observabilityStructuredLogs: true },
+        { component: "worker" },
+      );
+      logStartupDependencyRetry(obs, {
+        label: "PostgreSQL runtime posture",
+        attempt: 2,
+        attempts: 5,
+        delayMs: 250,
+        error: new Error("must remain private"),
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(JSON.parse(observed[0]!)).toMatchObject({
+      dependency: "PostgreSQL runtime posture",
+      attempt: 2,
+      attempts: 5,
+      delayMs: 250,
+      errorClass: "StartupDependencyError",
+      errorCode: "startup_dependency_retry",
+      origin: "observability",
+    });
+    expect(observed[0]).not.toContain("must remain private");
   });
 
   test("public structured logs omit identifiers and arbitrary source fields", () => {

--- a/packages/react/src/components/session-status.tsx
+++ b/packages/react/src/components/session-status.tsx
@@ -12,7 +12,7 @@ export type SessionStatusMeta = {
 
 export const SESSION_STATUS_META: Record<SessionStatusValue, SessionStatusMeta> = {
   queued: {
-    label: "Queued",
+    label: "Starting",
     dotClassName: "bg-og-status-queued",
     badgeClassName: "text-og-fg-muted border-og-border bg-og-status-queued/10",
     pulse: true,

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -208,6 +208,15 @@ function rememberOptimisticSendOperations(
         hasMcpCredentialUpdates: input.mcpCredentialUpdates !== undefined,
       } satisfies StoredOptimisticSendOperation;
     });
+  if (stored.length === 0) {
+    optimisticSendOperations.delete(key);
+    try {
+      pendingComposerStorage()?.removeItem(optimisticSendStorageKey(key));
+    } catch {
+      // Best effort; the in-memory entry is already gone.
+    }
+    return;
+  }
   optimisticSendOperations.set(key, stored);
   try {
     pendingComposerStorage()?.setItem(optimisticSendStorageKey(key), JSON.stringify(stored));
@@ -1950,11 +1959,14 @@ export function useComposer(
         annotations: annotationsAtSend,
       });
       const currentPayload = currentDraftPayload();
+      const hasEarlierUnsettledSend = optimisticSendsRef.current.some(
+        (candidate) => candidate.state !== "failed" || candidate.outcomeUnknown === true,
+      );
       const operation: OptimisticSendOperation = {
         clientEventId,
         delivery: "send",
         destination:
-          effectiveControl?.state === "paused"
+          effectiveControl?.state === "paused" || hasEarlierUnsettledSend
             ? "queue"
             : (sendDestinationRef.current?.() ?? "chat"),
         text: sendText,

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1357,6 +1357,7 @@ type TurnAnchorPrescan = {
   startSeqByTrigger: Map<string, number>;
   cancelledBeforeStartTriggers: Set<string>;
   directChatSequenceByTrigger: Map<string, number>;
+  explicitQueuedTriggers: Set<string>;
   startedTurnIds: Set<string>;
 };
 
@@ -1368,12 +1369,25 @@ function prescanTurnAnchors(events: SessionEvent[]): TurnAnchorPrescan {
   const withdrawnTurnIds = new Set<string>();
   const fallbackSeqByTurn = new Map<string, number>();
   const directChatSequenceByTrigger = new Map<string, number>();
+  const explicitQueuedTriggers = new Set<string>();
   const queueSteerSequenceByTurn = new Map<string, number>();
   const startedTurnIds = new Set<string>();
+  const userMessageSequenceById = new Map<string, number>();
 
   for (const event of ordered) {
     const payload = asRecord(event.payload);
     const turnId = event.turnId ?? null;
+    if (event.type === "user.message") {
+      userMessageSequenceById.set(event.id, event.sequence);
+      if (payload.routing === "queued_for_execution") {
+        explicitQueuedTriggers.add(event.id);
+      } else if (
+        payload.routing === "accepted_for_execution" ||
+        payload.routing === "accepted_for_steering"
+      ) {
+        directChatSequenceByTrigger.set(event.id, event.sequence);
+      }
+    }
     if (event.type === "user.message" && payload.delivery === "steer") {
       directChatSequenceByTrigger.set(event.id, event.sequence);
     }
@@ -1397,6 +1411,16 @@ function prescanTurnAnchors(events: SessionEvent[]): TurnAnchorPrescan {
       const queuedTurnId = typeof payload.turnId === "string" ? payload.turnId : turnId;
       if (triggerEventId && queuedTurnId) {
         queuedTurnByTrigger.set(triggerEventId, queuedTurnId);
+        if (
+          (payload.routing === "accepted_for_execution" ||
+            payload.routing === "accepted_for_steering") &&
+          !directChatSequenceByTrigger.has(triggerEventId)
+        ) {
+          directChatSequenceByTrigger.set(
+            triggerEventId,
+            userMessageSequenceById.get(triggerEventId) ?? event.sequence,
+          );
+        }
       }
       continue;
     }
@@ -1453,6 +1477,7 @@ function prescanTurnAnchors(events: SessionEvent[]): TurnAnchorPrescan {
     startSeqByTrigger,
     cancelledBeforeStartTriggers,
     directChatSequenceByTrigger,
+    explicitQueuedTriggers,
     startedTurnIds,
   };
 }
@@ -1474,6 +1499,13 @@ function orderTimelineEvents(events: SessionEvent[], prescan: TurnAnchorPrescan)
     }
     const queuedTurnId = prescan.queuedTurnByTrigger.get(event.id);
     if (!queuedTurnId) {
+      if (prescan.explicitQueuedTriggers.has(event.id)) {
+        const startSeq = prescan.startSeqByTrigger.get(event.id);
+        if (startSeq !== undefined) {
+          pushInsertion(insertions, startSeq, event);
+        }
+        continue;
+      }
       pushInsertion(insertions, event.sequence, event);
       continue;
     }

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1899,6 +1899,72 @@ describe("useComposer queue-vs-steer", () => {
     await hook.unmount();
   });
 
+  test("keeps rapid first and second Sends on stable chat and queue surfaces", async () => {
+    const resolvers: Array<(event: SessionEvent) => void> = [];
+    const inputs: SendMessageInput[] = [];
+    const client = fakeClient({
+      sendMessage: async (_workspaceId, _sessionId, input) => {
+        const typed = typeof input === "string" ? { text: input } : input;
+        inputs.push(typed);
+        return await new Promise<SessionEvent>((resolve) => resolvers.push(resolve));
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          draftPersistence: "disabled",
+          initialPolicy: INITIAL_COMPOSER_POLICY,
+          events: [],
+          sendDestination: () => "chat",
+        }),
+      undefined,
+    );
+
+    await flushing(async () => {
+      expect(await hook.result.current.send("first now")).toBe(true);
+      expect(await hook.result.current.send("second later")).toBe(true);
+    });
+    expect(
+      hook.result.current.optimisticMessages?.map(({ text, destination }) => ({
+        text,
+        destination,
+      })),
+    ).toEqual([
+      { text: "first now", destination: "chat" },
+      { text: "second later", destination: "queue" },
+    ]);
+    expect(inputs).toHaveLength(1);
+
+    await flushing(() =>
+      resolvers[0]?.({
+        ...makeEvent(10, "user.message"),
+        clientEventId: inputs[0]?.clientEventId ?? null,
+      }),
+    );
+    await flush();
+    expect(inputs).toHaveLength(2);
+    expect(
+      hook.result.current.optimisticMessages?.map(({ text, destination }) => ({
+        text,
+        destination,
+      })),
+    ).toEqual([
+      { text: "first now", destination: "chat" },
+      { text: "second later", destination: "queue" },
+    ]);
+
+    await flushing(() =>
+      resolvers[1]?.({
+        ...makeEvent(11, "user.message"),
+        clientEventId: inputs[1]?.clientEventId ?? null,
+      }),
+    );
+    await flush();
+    await hook.unmount();
+  });
+
   test("keeps an admitted chat bubble until execution starts even when the HTTP response is lost", async () => {
     let rejectSend!: (cause: unknown) => void;
     const pendingSend = new Promise<SessionEvent>((_resolve, reject) => {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -717,6 +717,55 @@ describe("buildTimeline", () => {
     expect(turnBIndex).toBeGreaterThan(followUpIndex);
   });
 
+  test("an accepted Send stays directly in chat before start and across reconstruction", () => {
+    const items = buildTimeline([
+      eventAt(16, "user.message", { text: "Run this now" }, { turnId: null }),
+      eventAt(
+        17,
+        "turn.queued",
+        {
+          turnId: "turn-accepted",
+          triggerEventId: "evt-16",
+          source: "user",
+          routing: "accepted_for_execution",
+        },
+        { turnId: "turn-accepted" },
+      ),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: "user-message",
+        id: "evt-16",
+        text: "Run this now",
+      }),
+    ]);
+  });
+
+  test("an explicitly queued Send never flashes into chat before its turn event arrives", () => {
+    const waiting = eventAt(
+      16,
+      "user.message",
+      { text: "Wait behind current work", routing: "queued_for_execution" },
+      { turnId: null },
+    );
+    expect(buildTimeline([waiting])).toEqual([]);
+
+    const started = buildTimeline([
+      waiting,
+      eventAt(
+        20,
+        "turn.started",
+        { triggerEventId: "evt-16" },
+        { turnId: "turn-with-partial-history" },
+      ),
+    ]);
+    expect(started[0]).toMatchObject({
+      kind: "user-message",
+      text: "Wait behind current work",
+    });
+  });
+
   test("an accepted Steer stays directly in chat before start and across reconstruction", () => {
     const items = buildTimeline([
       eventAt(

--- a/scripts/dev-stack-readiness.test.ts
+++ b/scripts/dev-stack-readiness.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const scriptUrl = new URL("./dev-stack.sh", import.meta.url);
+
+describe("development stack supervision", () => {
+  test("requires aggregate readiness and stops on schema or child-process failure", async () => {
+    const source = await readFile(scriptUrl, "utf8");
+    expect(source).toContain("wait_for_stack_readiness");
+    expect(source).toContain("monitor_dev_stack");
+    expect(source).toContain("dev_processes_running");
+    expect(source).toContain("signal_process_tree");
+    expect(source).toContain("signal_process_tree KILL");
+    expect(source).toContain('if [ "$unhealthy_checks" -ge 2 ]');
+    expect(source).toContain("sleep 5");
+    expect(source).toContain('bun scripts/watch-development-schema.ts "$(pwd)"');
+    for (const path of [
+      "${OPENGENI_API_PORT}/healthz",
+      "${OPENGENI_WORKER_HTTP_PORT}/healthz",
+      "${OPENGENI_TURN_WORKER_HTTP_PORT}/healthz",
+      "${OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT}/healthz",
+      "${OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT}/healthz",
+      "${OPENGENI_WEB_PORT}/",
+    ]) {
+      expect(source).toContain(path);
+    }
+    expect(source).not.toMatch(/^wait$/mu);
+  });
+});

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -431,12 +431,123 @@ if [ "${OPENGENI_SANDBOX_SELFHOSTED_ENABLED:-false}" = "true" ]; then
 fi
 
 pids=()
+pid_labels=()
+failed_process_status=1
+
+register_process() {
+  pids+=("$1")
+  pid_labels+=("$2")
+}
+
+signal_process_tree() {
+  local signal="$1"
+  local pid="$2"
+  local child
+  while read -r child; do
+    if [ -n "$child" ]; then
+      signal_process_tree "$signal" "$child"
+    fi
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+  kill "-$signal" "$pid" >/dev/null 2>&1 || true
+}
+
 cleanup() {
-  if [ "${#pids[@]}" -gt 0 ]; then
-    kill "${pids[@]}" >/dev/null 2>&1 || true
+  if [ "${#pids[@]}" -eq 0 ]; then
+    return
   fi
+  local deadline=$((SECONDS + 5))
+  local pid running
+  for pid in "${pids[@]}"; do
+    signal_process_tree TERM "$pid"
+  done
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    running=0
+    for pid in "${pids[@]}"; do
+      if kill -0 "$pid" >/dev/null 2>&1; then
+        running=1
+        break
+      fi
+    done
+    if [ "$running" -eq 0 ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  for pid in "${pids[@]}"; do
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      signal_process_tree KILL "$pid"
+    fi
+  done
+  for pid in "${pids[@]}"; do
+    wait "$pid" >/dev/null 2>&1 || true
+  done
 }
 trap cleanup EXIT INT TERM
+
+dev_processes_running() {
+  local index pid label status
+  for ((index = 0; index < ${#pids[@]}; index++)); do
+    pid="${pids[$index]}"
+    label="${pid_labels[$index]}"
+    if ! kill -0 "$pid" >/dev/null 2>&1; then
+      if wait "$pid"; then
+        status=0
+      else
+        status=$?
+      fi
+      failed_process_status="$status"
+      if [ "$failed_process_status" -eq 0 ]; then
+        failed_process_status=1
+      fi
+      echo "OpenGeni dev process exited: ${label} (status ${status}). Stopping the stack." >&2
+      return 1
+    fi
+  done
+  return 0
+}
+
+stack_http_ready() {
+  curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_API_PORT}/healthz" >/dev/null 2>&1 &&
+    curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_WORKER_HTTP_PORT}/healthz" >/dev/null 2>&1 &&
+    curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_TURN_WORKER_HTTP_PORT}/healthz" >/dev/null 2>&1 &&
+    curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT}/healthz" >/dev/null 2>&1 &&
+    curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT}/healthz" >/dev/null 2>&1 &&
+    curl -fsS -m 1 "http://127.0.0.1:${OPENGENI_WEB_PORT}/" >/dev/null 2>&1
+}
+
+wait_for_stack_readiness() {
+  local deadline=$((SECONDS + 60))
+  while ! stack_http_ready; do
+    if ! dev_processes_running; then
+      return 1
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "OpenGeni dev stack did not become ready within 60 seconds. Stopping all processes." >&2
+      failed_process_status=1
+      return 1
+    fi
+    sleep 0.1
+  done
+  echo "OpenGeni dev stack ready: API, workers, artifact services, and web are reachable."
+}
+
+monitor_dev_stack() {
+  local unhealthy_checks=0
+  while dev_processes_running; do
+    if stack_http_ready; then
+      unhealthy_checks=0
+    else
+      unhealthy_checks=$((unhealthy_checks + 1))
+      if [ "$unhealthy_checks" -ge 2 ]; then
+        echo "OpenGeni dev stack lost aggregate readiness. Stopping instead of leaving a partial stack running." >&2
+        failed_process_status=1
+        return 1
+      fi
+    fi
+    sleep 5
+  done
+  return 1
+}
 
 default_database_url="postgres://opengeni_app:opengeni_app@127.0.0.1:5432/opengeni"
 if [ -z "${OPENGENI_DATABASE_URL:-}" ] || [ "${OPENGENI_DATABASE_URL}" = "$default_database_url" ]; then
@@ -1037,24 +1148,24 @@ fi
 if [ "$start_local_relay" = "1" ]; then
   env "${relay_cargo_env[@]+"${relay_cargo_env[@]}"}" \
     bash scripts/run-development-relay.sh &
-  pids+=("$!")
+  register_process "$!" "connected-machine relay"
 fi
 
 (cd apps/api && bun run dev) &
-pids+=("$!")
+register_process "$!" "API"
 
 (cd apps/worker && OPENGENI_WORKER_ROLE=control bun run dev:watch) &
-pids+=("$!")
+register_process "$!" "control worker"
 
 (cd apps/worker && OPENGENI_WORKER_ROLE=turn \
   OPENGENI_WORKER_HTTP_PORT="${OPENGENI_TURN_WORKER_HTTP_PORT}" bun run dev:watch) &
-pids+=("$!")
+register_process "$!" "turn worker"
 
 (cd apps/worker && bun run start:artifact-materializer) &
-pids+=("$!")
+register_process "$!" "artifact materializer"
 
 (cd apps/worker && bun run start:artifact-outbox) &
-pids+=("$!")
+register_process "$!" "artifact outbox"
 
 # The web setup surface serves the unpacked Chrome bridge archive directly from
 # apps/browser-extension/dist. Starting Vite without the package build leaves a
@@ -1064,9 +1175,14 @@ pids+=("$!")
 # the deterministic extension artifact cannot be produced.
 bun run --cwd apps/browser-extension build
 (cd apps/web && bun x vite dev --port "${OPENGENI_WEB_PORT}" --host 0.0.0.0) &
-pids+=("$!")
+register_process "$!" "web"
 
-wait
-exit_code=$?
-cleanup
-exit "$exit_code"
+bun scripts/watch-development-schema.ts "$(pwd)" &
+register_process "$!" "database schema guard"
+
+if ! wait_for_stack_readiness; then
+  exit "$failed_process_status"
+fi
+if ! monitor_dev_stack; then
+  exit "$failed_process_status"
+fi

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -579,6 +579,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0333_session_turn_prompt_routing.sql")) {
+        return includesActivation
+          ? "9dc02f21cc037d92b17716abdf3bb45a9b15c8100f72a9da70fc2e9e00c11d57"
+          : "05cb061cd55087923fcc8664b3697527da678806aa3b450c21a217ef1203b99b";
+      }
       if (migrations.has("0326_interaction_operation_error_codes.sql")) {
         return includesActivation
           ? "c4ec5d41697c791e8083ae6285c7dd46b33d843b1ddf4024925d05fdceb5115c"
@@ -1236,7 +1241,10 @@ describe("release schema contract", () => {
         (migrations.has("0309_channel_project_pins.sql") ? 1 : 0) +
         (migrations.has("0310_channel_project_order.sql") ? 1 : 0) +
         (migrations.has("0321_slack_bot_environment_display_name.sql") ? 1 : 0) +
-        (migrations.has("0326_interaction_operation_error_codes.sql") ? 1 : 0),
+        (migrations.has("0326_interaction_operation_error_codes.sql") ? 1 : 0) +
+        (migrations.has("0331_managed_organization_creation.sql") ? 1 : 0) +
+        (migrations.has("0332_organization_shared_workspace_control_plane.sql") ? 1 : 0) +
+        (migrations.has("0333_session_turn_prompt_routing.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1271,171 +1279,179 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0326_interaction_operation_error_codes.sql")
-        ? "0326_interaction_operation_error_codes.sql"
-        : migrations.has("0321_slack_bot_environment_display_name.sql")
-          ? "0321_slack_bot_environment_display_name.sql"
-          : migrations.has("0310_channel_project_order.sql")
-            ? "0310_channel_project_order.sql"
-            : migrations.has("0309_channel_project_pins.sql")
-              ? "0309_channel_project_pins.sql"
-              : migrations.has("0308_session_archives.sql")
-                ? "0308_session_archives.sql"
-                : migrations.has("0307_session_attention_state.sql")
-                  ? "0307_session_attention_state.sql"
-                  : migrations.has("0303_session_tenancy_product_activation.sql")
-                    ? "0303_session_tenancy_product_activation.sql"
-                    : migrations.has("0302_personal_workspace_session_ownership.sql")
-                      ? "0302_personal_workspace_session_ownership.sql"
-                      : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
-                        ? "0301_session_snapshot_and_pin_visibility.sql"
-                        : migrations.has("0300_tenancy_backfill_ledger.sql")
-                          ? "0300_tenancy_backfill_ledger.sql"
-                          : migrations.has("0299_organization_membership_lock_order.sql")
-                            ? "0299_organization_membership_lock_order.sql"
-                            : migrations.has("0298_organization_tenancy_parity.sql")
-                              ? "0298_organization_tenancy_parity.sql"
-                              : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
-                                ? "0295_retire_legacy_standing_memory_mode.sql"
-                                : migrations.has("0294_preference_activation_authority.sql")
-                                  ? "0294_preference_activation_authority.sql"
-                                  : migrations.has("0293_confirm_time_rule_rebaseline.sql")
-                                    ? "0293_confirm_time_rule_rebaseline.sql"
-                                    : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
-                                      ? "0292_truthful_tenancy_inventory_counters.sql"
-                                      : migrations.has(
-                                            "0291_resource_authority_classification_assertion.sql",
-                                          )
-                                        ? "0291_resource_authority_classification_assertion.sql"
-                                        : migrations.has(
-                                              "0290_organization_membership_backfill.sql",
-                                            )
-                                          ? "0290_organization_membership_backfill.sql"
+      migrations.has("0333_session_turn_prompt_routing.sql")
+        ? "0333_session_turn_prompt_routing.sql"
+        : migrations.has("0332_organization_shared_workspace_control_plane.sql")
+          ? "0332_organization_shared_workspace_control_plane.sql"
+          : migrations.has("0331_managed_organization_creation.sql")
+            ? "0331_managed_organization_creation.sql"
+            : migrations.has("0326_interaction_operation_error_codes.sql")
+              ? "0326_interaction_operation_error_codes.sql"
+              : migrations.has("0321_slack_bot_environment_display_name.sql")
+                ? "0321_slack_bot_environment_display_name.sql"
+                : migrations.has("0310_channel_project_order.sql")
+                  ? "0310_channel_project_order.sql"
+                  : migrations.has("0309_channel_project_pins.sql")
+                    ? "0309_channel_project_pins.sql"
+                    : migrations.has("0308_session_archives.sql")
+                      ? "0308_session_archives.sql"
+                      : migrations.has("0307_session_attention_state.sql")
+                        ? "0307_session_attention_state.sql"
+                        : migrations.has("0303_session_tenancy_product_activation.sql")
+                          ? "0303_session_tenancy_product_activation.sql"
+                          : migrations.has("0302_personal_workspace_session_ownership.sql")
+                            ? "0302_personal_workspace_session_ownership.sql"
+                            : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
+                              ? "0301_session_snapshot_and_pin_visibility.sql"
+                              : migrations.has("0300_tenancy_backfill_ledger.sql")
+                                ? "0300_tenancy_backfill_ledger.sql"
+                                : migrations.has("0299_organization_membership_lock_order.sql")
+                                  ? "0299_organization_membership_lock_order.sql"
+                                  : migrations.has("0298_organization_tenancy_parity.sql")
+                                    ? "0298_organization_tenancy_parity.sql"
+                                    : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
+                                      ? "0295_retire_legacy_standing_memory_mode.sql"
+                                      : migrations.has("0294_preference_activation_authority.sql")
+                                        ? "0294_preference_activation_authority.sql"
+                                        : migrations.has("0293_confirm_time_rule_rebaseline.sql")
+                                          ? "0293_confirm_time_rule_rebaseline.sql"
                                           : migrations.has(
-                                                "0289_session_composer_policy_authority.sql",
+                                                "0292_truthful_tenancy_inventory_counters.sql",
                                               )
-                                            ? "0289_session_composer_policy_authority.sql"
+                                            ? "0292_truthful_tenancy_inventory_counters.sql"
                                             : migrations.has(
-                                                  "0288_attached_browser_reenrollment.sql",
+                                                  "0291_resource_authority_classification_assertion.sql",
                                                 )
-                                              ? "0288_attached_browser_reenrollment.sql"
+                                              ? "0291_resource_authority_classification_assertion.sql"
                                               : migrations.has(
-                                                    "0287_open_suffix_pending_tool_calls.sql",
+                                                    "0290_organization_membership_backfill.sql",
                                                   )
-                                                ? "0287_open_suffix_pending_tool_calls.sql"
+                                                ? "0290_organization_membership_backfill.sql"
                                                 : migrations.has(
-                                                      "0286_widen_task_note_expiry_ceiling.sql",
+                                                      "0289_session_composer_policy_authority.sql",
                                                     )
-                                                  ? "0286_widen_task_note_expiry_ceiling.sql"
+                                                  ? "0289_session_composer_policy_authority.sql"
                                                   : migrations.has(
-                                                        "0285_organization_tenancy_inventory.sql",
+                                                        "0288_attached_browser_reenrollment.sql",
                                                       )
-                                                    ? "0285_organization_tenancy_inventory.sql"
+                                                    ? "0288_attached_browser_reenrollment.sql"
                                                     : migrations.has(
-                                                          "0284_truthful_human_confirmed_review_reason.sql",
+                                                          "0287_open_suffix_pending_tool_calls.sql",
                                                         )
-                                                      ? "0284_truthful_human_confirmed_review_reason.sql"
+                                                      ? "0287_open_suffix_pending_tool_calls.sql"
                                                       : migrations.has(
-                                                            "0283_editable_spreadsheet_authored_state.sql",
+                                                            "0286_widen_task_note_expiry_ceiling.sql",
                                                           )
-                                                        ? "0283_editable_spreadsheet_authored_state.sql"
+                                                        ? "0286_widen_task_note_expiry_ceiling.sql"
                                                         : migrations.has(
-                                                              "0282_variable_set_session_attach_attribution.sql",
+                                                              "0285_organization_tenancy_inventory.sql",
                                                             )
-                                                          ? "0282_variable_set_session_attach_attribution.sql"
+                                                          ? "0285_organization_tenancy_inventory.sql"
                                                           : migrations.has(
-                                                                "0281_viewer_holder_authority_claims.sql",
+                                                                "0284_truthful_human_confirmed_review_reason.sql",
                                                               )
-                                                            ? "0281_viewer_holder_authority_claims.sql"
+                                                            ? "0284_truthful_human_confirmed_review_reason.sql"
                                                             : migrations.has(
-                                                                  "0280_connection_and_variable_set_audit_attribution.sql",
+                                                                  "0283_editable_spreadsheet_authored_state.sql",
                                                                 )
-                                                              ? "0280_connection_and_variable_set_audit_attribution.sql"
+                                                              ? "0283_editable_spreadsheet_authored_state.sql"
                                                               : migrations.has(
-                                                                    "0279_workspace_connection_use_lane.sql",
+                                                                    "0282_variable_set_session_attach_attribution.sql",
                                                                   )
-                                                                ? "0279_workspace_connection_use_lane.sql"
+                                                                ? "0282_variable_set_session_attach_attribution.sql"
                                                                 : migrations.has(
-                                                                      "0278_workspace_membership_removal_fencing.sql",
+                                                                      "0281_viewer_holder_authority_claims.sql",
                                                                     )
-                                                                  ? "0278_workspace_membership_removal_fencing.sql"
+                                                                  ? "0281_viewer_holder_authority_claims.sql"
                                                                   : migrations.has(
-                                                                        "0277_workspace_writer_authority_attribution.sql",
+                                                                        "0280_connection_and_variable_set_audit_attribution.sql",
                                                                       )
-                                                                    ? "0277_workspace_writer_authority_attribution.sql"
+                                                                    ? "0280_connection_and_variable_set_audit_attribution.sql"
                                                                     : migrations.has(
-                                                                          "0276_onboarding_proposal_initiating_human_guc.sql",
+                                                                          "0279_workspace_connection_use_lane.sql",
                                                                         )
-                                                                      ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                                                                      ? "0279_workspace_connection_use_lane.sql"
                                                                       : migrations.has(
-                                                                            "0275_scheduled_connection_authority.sql",
+                                                                            "0278_workspace_membership_removal_fencing.sql",
                                                                           )
-                                                                        ? "0275_scheduled_connection_authority.sql"
+                                                                        ? "0278_workspace_membership_removal_fencing.sql"
                                                                         : migrations.has(
-                                                                              "0274_human_confirmed_knowledge_review.sql",
+                                                                              "0277_workspace_writer_authority_attribution.sql",
                                                                             )
-                                                                          ? "0274_human_confirmed_knowledge_review.sql"
+                                                                          ? "0277_workspace_writer_authority_attribution.sql"
                                                                           : migrations.has(
-                                                                                "0272_human_confirmed_learning_activation.sql",
+                                                                                "0276_onboarding_proposal_initiating_human_guc.sql",
                                                                               )
-                                                                            ? "0272_human_confirmed_learning_activation.sql"
+                                                                            ? "0276_onboarding_proposal_initiating_human_guc.sql"
                                                                             : migrations.has(
-                                                                                  "0271_company_brain_retrieval_only_default.sql",
+                                                                                  "0275_scheduled_connection_authority.sql",
                                                                                 )
-                                                                              ? "0271_company_brain_retrieval_only_default.sql"
+                                                                              ? "0275_scheduled_connection_authority.sql"
                                                                               : migrations.has(
-                                                                                    "0270_governed_learning_history_inspection.sql",
+                                                                                    "0274_human_confirmed_knowledge_review.sql",
                                                                                   )
-                                                                                ? "0270_governed_learning_history_inspection.sql"
+                                                                                ? "0274_human_confirmed_knowledge_review.sql"
                                                                                 : migrations.has(
-                                                                                      "0269_governed_learning_activation_controller.sql",
+                                                                                      "0272_human_confirmed_learning_activation.sql",
                                                                                     )
-                                                                                  ? "0269_governed_learning_activation_controller.sql"
+                                                                                  ? "0272_human_confirmed_learning_activation.sql"
                                                                                   : migrations.has(
-                                                                                        "0268_governed_learning_decision_receipts.sql",
+                                                                                        "0271_company_brain_retrieval_only_default.sql",
                                                                                       )
-                                                                                    ? "0268_governed_learning_decision_receipts.sql"
+                                                                                    ? "0271_company_brain_retrieval_only_default.sql"
                                                                                     : migrations.has(
-                                                                                          "0266_company_brain_context_receipt_inspection.sql",
+                                                                                          "0270_governed_learning_history_inspection.sql",
                                                                                         )
-                                                                                      ? "0266_company_brain_context_receipt_inspection.sql"
+                                                                                      ? "0270_governed_learning_history_inspection.sql"
                                                                                       : migrations.has(
-                                                                                            "0261_preference_knowledge_proposal_actor_binding.sql",
+                                                                                            "0269_governed_learning_activation_controller.sql",
                                                                                           )
-                                                                                        ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                                                                        ? "0269_governed_learning_activation_controller.sql"
                                                                                         : migrations.has(
-                                                                                              "0260_task_note_knowledge_promotion.sql",
+                                                                                              "0268_governed_learning_decision_receipts.sql",
                                                                                             )
-                                                                                          ? "0260_task_note_knowledge_promotion.sql"
+                                                                                          ? "0268_governed_learning_decision_receipts.sql"
                                                                                           : migrations.has(
-                                                                                                "0259_company_brain_context_selection_receipts.sql",
+                                                                                                "0266_company_brain_context_receipt_inspection.sql",
                                                                                               )
-                                                                                            ? "0259_company_brain_context_selection_receipts.sql"
+                                                                                            ? "0266_company_brain_context_receipt_inspection.sql"
                                                                                             : migrations.has(
-                                                                                                  "0258_three_scope_document_knowledge_authority.sql",
+                                                                                                  "0261_preference_knowledge_proposal_actor_binding.sql",
                                                                                                 )
-                                                                                              ? "0258_three_scope_document_knowledge_authority.sql"
+                                                                                              ? "0261_preference_knowledge_proposal_actor_binding.sql"
                                                                                               : migrations.has(
-                                                                                                    "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                                                                    "0260_task_note_knowledge_promotion.sql",
                                                                                                   )
-                                                                                                ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                                                                                ? "0260_task_note_knowledge_promotion.sql"
                                                                                                 : migrations.has(
-                                                                                                      "0255_company_brain_governed_write_proposals.sql",
+                                                                                                      "0259_company_brain_context_selection_receipts.sql",
                                                                                                     )
-                                                                                                  ? "0255_company_brain_governed_write_proposals.sql"
+                                                                                                  ? "0259_company_brain_context_selection_receipts.sql"
                                                                                                   : migrations.has(
-                                                                                                        "0248_terraform_stacks_component_resolution_fence.sql",
+                                                                                                        "0258_three_scope_document_knowledge_authority.sql",
                                                                                                       )
-                                                                                                    ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                                                                    ? "0258_three_scope_document_knowledge_authority.sql"
                                                                                                     : migrations.has(
-                                                                                                          "0247_terraform_stacks_provenance_repair.sql",
+                                                                                                          "0257_goal_revision_decisions_and_root_constraints.sql",
                                                                                                         )
-                                                                                                      ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                      ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                                                                                       : migrations.has(
-                                                                                                            "0263_organization_membership_lifecycle.sql",
+                                                                                                            "0255_company_brain_governed_write_proposals.sql",
                                                                                                           )
-                                                                                                        ? "0263_organization_membership_lifecycle.sql"
-                                                                                                        : latestCompatibleMigration,
+                                                                                                        ? "0255_company_brain_governed_write_proposals.sql"
+                                                                                                        : migrations.has(
+                                                                                                              "0248_terraform_stacks_component_resolution_fence.sql",
+                                                                                                            )
+                                                                                                          ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                                                                          : migrations.has(
+                                                                                                                "0247_terraform_stacks_provenance_repair.sql",
+                                                                                                              )
+                                                                                                            ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                                                            : migrations.has(
+                                                                                                                  "0263_organization_membership_lifecycle.sql",
+                                                                                                                )
+                                                                                                              ? "0263_organization_membership_lifecycle.sql"
+                                                                                                              : latestCompatibleMigration,
     );
     expect(migrations.get("0289_session_composer_policy_authority.sql")).toMatchObject({
       sha256: "478e7ba49b6940bdd849223a0965b7dcc20a0d4428f0fc85078961dbd3984285",

--- a/scripts/watch-development-schema.test.ts
+++ b/scripts/watch-development-schema.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { developmentSchemaFingerprint, watchDevelopmentSchema } from "./watch-development-schema";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "opengeni-schema-watch-"));
+  roots.push(root);
+  await mkdir(join(root, "packages/db/drizzle"), { recursive: true });
+  await writeFile(join(root, "packages/db/drizzle/0001_first.sql"), "select 1;\n");
+  return root;
+}
+
+describe("development schema watcher", () => {
+  test("fingerprint is stable across directory ordering and changes with SQL", async () => {
+    const root = await fixture();
+    const first = await developmentSchemaFingerprint(root);
+    await writeFile(join(root, "packages/db/drizzle/readme.txt"), "ignored\n");
+    expect(await developmentSchemaFingerprint(root)).toBe(first);
+    await writeFile(join(root, "packages/db/drizzle/0001_first.sql"), "select 2;\n");
+    expect(await developmentSchemaFingerprint(root)).not.toBe(first);
+  });
+
+  test("settles when a migration is added after startup", async () => {
+    const root = await fixture();
+    const watching = watchDevelopmentSchema(root, { intervalMs: 5 });
+    await Bun.sleep(10);
+    await writeFile(join(root, "packages/db/drizzle/0002_second.sql"), "select 2;\n");
+    expect(await watching).toBe("changed");
+  });
+});

--- a/scripts/watch-development-schema.ts
+++ b/scripts/watch-development-schema.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function developmentSchemaFingerprint(repositoryRoot: string): Promise<string> {
+  const directory = join(repositoryRoot, "packages/db/drizzle");
+  const files = (await readdir(directory)).filter((file) => file.endsWith(".sql")).sort();
+  const hash = createHash("sha256");
+  for (const file of files) {
+    hash.update(file);
+    hash.update("\0");
+    hash.update(await readFile(join(directory, file)));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export async function watchDevelopmentSchema(
+  repositoryRoot: string,
+  options: { intervalMs?: number; signal?: AbortSignal } = {},
+): Promise<"changed" | "aborted"> {
+  const initial = await developmentSchemaFingerprint(repositoryRoot);
+  const intervalMs = options.intervalMs ?? 500;
+  for (;;) {
+    if (options.signal?.aborted) return "aborted";
+    await Bun.sleep(intervalMs);
+    if (options.signal?.aborted) return "aborted";
+    if ((await developmentSchemaFingerprint(repositoryRoot)) !== initial) return "changed";
+  }
+}
+
+if (import.meta.main) {
+  const repositoryRoot = process.argv[2] ?? process.cwd();
+  const outcome = await watchDevelopmentSchema(repositoryRoot);
+  if (outcome === "changed") {
+    console.error(
+      "Database migrations changed while the dev stack was running; stopping before watched code can use a stale schema. Restart bun run dev.",
+    );
+    process.exit(78);
+  }
+}

--- a/test/e2e/browser.e2e.ts
+++ b/test/e2e/browser.e2e.ts
@@ -171,7 +171,12 @@ describe("browser e2e", () => {
     const secondPage = await context.newPage();
     const diagnostics = observePageFailures(page);
     let coordinates: BrowserSessionCoordinates | null = null;
+    let turnWorkerSuspended = false;
     try {
+      if (process.platform !== "win32") {
+        turnWorkerSuspended = worker.turns.proc.kill("SIGSTOP");
+        expect(turnWorkerSuspended).toBe(true);
+      }
       const response = await page.goto(`http://127.0.0.1:${webPort}`);
       expect(response?.ok()).toBe(true);
       await page.evaluate(() => {
@@ -219,6 +224,15 @@ describe("browser e2e", () => {
       const queueChip = page.getByTestId("session-chrome-queue");
 
       await timeline.getByText("E2E HOLD INITIAL DIRECTION", { exact: true }).waitFor();
+      if (turnWorkerSuspended) {
+        expect((await browserQueueSnapshot(page, apiPort, coordinates)).items).toEqual([]);
+        expect(await queueChip.getByText(/queued prompt/).count()).toBe(0);
+        expect(
+          await timeline.getByText("E2E HOLD INITIAL DIRECTION", { exact: true }).count(),
+        ).toBe(1);
+        expect(worker.turns.proc.kill("SIGCONT")).toBe(true);
+        turnWorkerSuspended = false;
+      }
       const firstSendFailures = await page.evaluate(() => {
         const browserWindow = window as typeof window & {
           __opengeniFirstSendTrace?: {
@@ -489,6 +503,7 @@ describe("browser e2e", () => {
         { cause: error },
       );
     } finally {
+      if (turnWorkerSuspended) worker.turns.proc.kill("SIGCONT");
       diagnostics.stop();
       await context.close();
     }

--- a/test/e2e/personal-workspace-accessibility.browser.e2e.ts
+++ b/test/e2e/personal-workspace-accessibility.browser.e2e.ts
@@ -186,10 +186,8 @@ describe("Personal workspace accessibility in Chromium", () => {
     expect(await sessions.textContent()).toContain("Only you can open this session.");
 
     const inactive = page.locator("#inactive-session-visibility-picker");
-    expect(await inactive.getByRole("radio", { name: /Only me/ }).isDisabled()).toBe(true);
-    expect(await inactive.textContent()).toContain(
-      "Private sessions are not enabled for this organization yet.",
-    );
+    expect(await inactive.getByRole("radio").count()).toBe(0);
+    expect(await inactive.textContent()).toBe("");
 
     expect(
       await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -988,7 +988,11 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       const goalChip = desktopPage.getByTestId("session-chrome-goal");
       const agentsChip = desktopPage.getByTestId("session-chrome-agents");
       const composer = desktopPage.getByLabel("Message the agent");
-      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
+      const timeline = desktopPage.getByTestId("session-timeline");
+      await timeline
+        .getByText("Inspect the full session-control surface", { exact: true })
+        .waitFor();
+      expect(await queueChip.count()).toBe(0);
       await goalChip.waitFor();
       await agentsChip.waitFor();
       await composer.waitFor();
@@ -1005,9 +1009,18 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         Math.abs((chromeBounds?.width ?? 0) - (composerBounds?.width ?? 0)),
       ).toBeLessThanOrEqual(1);
 
-      // Enter appends an ordinary human prompt to the one visible queue. The
-      // inert workflow client keeps both rows waiting so the browser can inspect
-      // the exact server-authoritative order.
+      // The initial prompt is already in chat, never presented as queued. Later
+      // sends wait in the one visible queue because the inert workflow client
+      // deliberately leaves the accepted initial turn pending.
+      await composer.fill("A first prompt queued from the composer");
+      await submitQueuedComposerPrompt(
+        desktopPage,
+        apiBaseUrl,
+        workspaceId,
+        manager.id,
+        "A first prompt queued from the composer",
+      );
+      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor({ timeout: 20_000 });
       await composer.fill("A second prompt queued from the composer");
       await submitQueuedComposerPrompt(
         desktopPage,
@@ -1033,7 +1046,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       const queuedRows = chrome.getByRole("list", { name: "Queued prompts" }).getByRole("listitem");
       expect(await queuedRows.count()).toBe(2);
       expect(await queuedRows.nth(0).innerText()).toContain(
-        "Inspect the full session-control surface",
+        "A first prompt queued from the composer",
       );
       expect(await queuedRows.nth(1).innerText()).toContain(
         "A second prompt queued from the composer",
@@ -1057,7 +1070,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await chrome.getByRole("button", { name: "Move queued prompt 2 up" }).click();
       await expectRowPrompt(queuedRows, 0, "A second prompt queued from the composer");
       await chrome.getByRole("button", { name: "Move queued prompt 1 down" }).click();
-      await expectRowPrompt(queuedRows, 0, "Inspect the full session-control surface");
+      await expectRowPrompt(queuedRows, 0, "A first prompt queued from the composer");
 
       // Edit is a checkout: it removes the exact queue row and restores the
       // complete durable prompt into the composer, where Enter submits it again.
@@ -1105,7 +1118,6 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await desktopPage.getByRole("button", { name: "Resume this workstream" }).waitFor();
       await chrome.getByRole("button", { name: "Steer queued prompt 2" }).click();
       await desktopPage.getByRole("button", { name: "Pause this workstream" }).waitFor();
-      const timeline = desktopPage.getByTestId("session-timeline");
       try {
         await timeline
           .getByText("A second prompt queued from the composer (edited)", { exact: true })
@@ -1123,7 +1135,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       }
       expect(await chrome.getByText("Changing direction…", { exact: true }).count()).toBe(0);
       await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
-      await expectRowPrompt(queuedRows, 0, "Inspect the full session-control surface");
+      await expectRowPrompt(queuedRows, 0, "A first prompt queued from the composer");
 
       // Remove deletes only the selected waiting prompt. Add one final prompt so
       // the queue surface can still be exercised in the mobile pass.
@@ -1138,7 +1150,11 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         "A replacement prompt after delete",
       );
       await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
-      expect(await timeline.getByText("Inspect the full session-control surface").count()).toBe(0);
+      expect(
+        await timeline
+          .getByText("Inspect the full session-control surface", { exact: true })
+          .count(),
+      ).toBe(1);
       const withdrawnPromptCount = await timeline
         .getByText("A second prompt queued from the composer", { exact: true })
         .count();

--- a/test/e2e/slack-access-link.browser.e2e.ts
+++ b/test/e2e/slack-access-link.browser.e2e.ts
@@ -235,7 +235,7 @@ describe("Slack access-link browser acceptance", () => {
       await page.getByLabel("Email").fill("slack-link@example.test");
       await page.getByLabel("Password").fill("correct-horse-battery-staple");
       await page.locator('form button[type="submit"]').click();
-      await expectText(page.locator("body"), "Sign in failed");
+      await expectText(page.locator("body"), "Couldn't sign in");
       await expectSingleMainWithoutRail(page);
       expect(state.prepareBodies).toEqual([]);
 
@@ -285,7 +285,7 @@ describe("Slack access-link browser acceptance", () => {
       expect(state.requestStatus).toBe("cancelled");
       expect(new URL(page.url()).hash).toBe("");
       await page.reload({ waitUntil: "networkidle" });
-      await expectText(page.locator("main"), "No workspace access");
+      await expectText(page.locator("main"), "Set up your OpenGeni workspace");
       await expectSingleMainWithoutRail(page);
       expect(state.prepareBodies).toHaveLength(1);
       expect(await page.getByRole("button", { name: "Cancel" }).count()).toBe(0);

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -198,9 +198,15 @@ describe("API component integration", () => {
       "session.status.changed",
       "turn.queued",
     ]);
-    // The initial prompt is still waiting, so it exists only in the compact
-    // prompt queue. Timeline projection begins it when the turn actually starts.
-    expect(buildTimeline(events).map((item) => item.kind)).toEqual([]);
+    // Admission accepted the initial prompt directly. It belongs in chat even
+    // while the physical turn row waits for a worker claim.
+    expect(buildTimeline(events).map((item) => item.kind)).toEqual(["user-message"]);
+    expect(events.find((event) => event.type === "user.message")?.payload).toMatchObject({
+      routing: "accepted_for_execution",
+    });
+    expect(events.find((event) => event.type === "turn.queued")?.payload).toMatchObject({
+      routing: "accepted_for_execution",
+    });
 
     const listed = await app.request(workspacePath(workspaceId, "/sessions?limit=10"));
     expect(listed.status).toBe(200);
@@ -2484,6 +2490,7 @@ describe("API component integration", () => {
       model: "gpt-5.6-sol",
       reasoningEffort: "xhigh",
       delivery: "send",
+      routing: "queued_for_execution",
       initiator: { kind: "subject", subjectId: "dev", label: "Local dev" },
     });
     const turns = await listSessionTurns(dbClient.db, workspaceId, session.id);


### PR DESCRIPTION
## What changed
- persist immutable prompt admission routing so worker backlog never masquerades as the user queue
- keep first/rapid Send and Steer placement stable across optimistic, committed, reload, and lost-response paths
- simplify lifecycle copy: session startup is Starting; only real waiting prompts are Queued
- fail the local stack fast on schema drift, dead services, or hung child trees; retain safe startup retry context
- document the execution-admission boundary

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:docs-refs`
- focused regression pack: 187 pass; migration invariant rerun alone: 2 pass
- `bun scripts/run-browser-e2e.ts ./test/e2e/browser.e2e.ts`: 3 pass
- live browser: Azure Sol, Terra, Luna each direct-to-chat, zero queue chip, one completion
- durable facts: all three `accepted_for_execution`, `azure`, `responses`, `opengeni_credits`
- supervisor failure drill: all six services and the parent exited in 5s; clean restart returned six HTTP 200 health gates