### PR TITLE
fix(ci): repair main

### DIFF
--- a/apps/web/src/managed-self-context-surface.test.ts
+++ b/apps/web/src/managed-self-context-surface.test.ts
@@ -55,9 +55,9 @@ describe("managed self-context surfaces", () => {
 
   test("separates organization administration from Personal content", () => {
     expect(organizationAdminSource).toContain(
-      "Personal workspaces and their content are\n            never included.",
+      "Create shared workspaces, then choose which organization members can use each one.",
     );
-    expect(organizationAdminSource).toContain("Every shared workspace in this organization.");
+    expect(organizationAdminSource).toContain("Personal workspaces stay private.");
     expect(organizationSource).toContain("<OrganizationPeopleSection");
     expect(organizationSource).toContain("<OrganizationRetentionSection");
   });

--- a/apps/web/src/routes/variable-sets.test.tsx
+++ b/apps/web/src/routes/variable-sets.test.tsx
@@ -277,7 +277,9 @@ describe("Variable Sets credential-autofill boundaries", () => {
   });
 
   test("keeps the managed sign-in fields on their credential autocomplete tokens", async () => {
-    const authSource = await Bun.file(`${import.meta.dir}/../context.tsx`).text();
+    const authSource = await Bun.file(
+      `${import.meta.dir}/../components/managed-auth-panel.tsx`,
+    ).text();
 
     expect(authSource).toContain('autoComplete="email"');
     expect(authSource).toContain(

--- a/apps/web/src/routes/workspace-settings.test.tsx
+++ b/apps/web/src/routes/workspace-settings.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import * as RouterPackage from "@tanstack/react-router";
 import { act, type ReactNode, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -64,6 +65,14 @@ mock.module("@/context", () => ({
 mock.module("@/components/ui/confirm-dialog", () => ({
   ConfirmDialog: ({ open, title }: { open: boolean; title: ReactNode }) =>
     open ? <div data-testid="confirm-dialog">{title}</div> : null,
+}));
+
+// The manager view links to organization workspace access, and a real
+// `<Link>` needs a router this roster-focused render deliberately does not
+// mount.
+mock.module("@tanstack/react-router", () => ({
+  ...RouterPackage,
+  Link: ({ children }: { children: ReactNode }) => <a href="#organization">{children}</a>,
 }));
 
 const { MembersSection } = await import("./workspace-settings");

--- a/test/e2e/personal-workspace-accessibility.browser.e2e.ts
+++ b/test/e2e/personal-workspace-accessibility.browser.e2e.ts
@@ -185,11 +185,12 @@ describe("Personal workspace accessibility in Chromium", () => {
     expect(await sessions.getByRole("radio", { name: /Only me/ }).isEnabled()).toBe(true);
     expect(await sessions.textContent()).toContain("Only you can open this session.");
 
+    // An organization that has not activated private sessions gets no chooser at
+    // all rather than a disabled one: Workspace is the only valid value, so there
+    // is no decision to present.
     const inactive = page.locator("#inactive-session-visibility-picker");
-    expect(await inactive.getByRole("radio", { name: /Only me/ }).isDisabled()).toBe(true);
-    expect(await inactive.textContent()).toContain(
-      "Private sessions are not enabled for this organization yet.",
-    );
+    expect(await inactive.getByRole("radio").count()).toBe(0);
+    expect((await inactive.textContent()) ?? "").toBe("");
 
     expect(
       await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),

--- a/test/e2e/slack-access-link.browser.e2e.ts
+++ b/test/e2e/slack-access-link.browser.e2e.ts
@@ -235,7 +235,9 @@ describe("Slack access-link browser acceptance", () => {
       await page.getByLabel("Email").fill("slack-link@example.test");
       await page.getByLabel("Password").fill("correct-horse-battery-staple");
       await page.locator('form button[type="submit"]').click();
-      await expectText(page.locator("body"), "Sign in failed");
+      // The managed panel keeps a failed attempt inline on the form instead of
+      // in a toast, so the failure is part of the sign-in surface itself.
+      await expectText(page.locator("body"), "Couldn't sign in");
       await expectSingleMainWithoutRail(page);
       expect(state.prepareBodies).toEqual([]);
 
@@ -285,7 +287,9 @@ describe("Slack access-link browser acceptance", () => {
       expect(state.requestStatus).toBe("cancelled");
       expect(new URL(page.url()).hash).toBe("");
       await page.reload({ waitUntil: "networkidle" });
-      await expectText(page.locator("main"), "No workspace access");
+      // A managed principal with no workspace access lands on organization
+      // onboarding; the bare "No workspace access" panel is the unmanaged path.
+      await expectText(page.locator("main"), "Set up your OpenGeni workspace");
       await expectSingleMainWithoutRail(page);
       expect(state.prepareBodies).toHaveLength(1);
       expect(await page.getByRole("button", { name: "Cancel" }).count()).toBe(0);
@@ -589,6 +593,9 @@ async function installAccessApi(page: Page, state: AccessUiState): Promise<void>
         state.linkedWorkspaceAuthorized = true;
       }
       return json(accessRequest(state));
+    }
+    if (url.pathname === "/v1/organization-invitations") {
+      return json({ invitations: [], nextCursor: null });
     }
     if (url.pathname.endsWith("/sessions")) {
       return json({ sessions: [], pinned: [], pinnedTruncated: false, nextCursor: null });


### PR DESCRIPTION
`main` has been red on its own push CI since 0cece4b9f. Commit 0d75b4c69 (PR #1793, "feat(organizations): complete managed tenancy UX") changed five web surfaces without updating the tests that pin them. This PR repairs exactly those tests. No product code changes, and no feature is reverted.

## Root causes

**1. `apps/web/src/routes/workspace-settings.test.tsx` (11 of 12 tests)**

`MembersSectionContent` replaced its inline add-member form with a `Notice` containing a TanStack `<Link>` to organization workspace access (`apps/web/src/routes/workspace-settings.tsx:975`). The test renders `MembersSection` directly with no `RouterProvider`, so `useLinkProps` hit `router.isServer` on `null` and threw for every `canManage: true` case. The one passing test was the `canManage: false` case, which never reaches the `<Link>`.

Fix: mock `Link` the way `apps/web/src/routes/org-settings-strict-mode.test.tsx:100` already does, spreading the real package so `useNavigate` is untouched.

**2. `apps/web/src/managed-self-context-surface.test.ts:57`**

The org-admin "Workspace access" section became "Workspaces &amp; access" with new copy (`apps/web/src/components/organization-admin.tsx:832`). The old exact-source strings `"Personal workspaces and their content are\n            never included."` and `"Every shared workspace in this organization."` no longer exist.

Fix: pin the current strings. They still carry both original intents, that the section is about shared workspaces and that Personal content is excluded.

**3. `apps/web/src/routes/variable-sets.test.tsx:280`**

The managed sign-in fields moved out of `context.tsx` into the new `apps/web/src/components/managed-auth-panel.tsx`, keeping their `autoComplete` tokens intact (lines 180 and 203). The guard was still reading `context.tsx`.

Fix: read the file that now owns those fields. The credential-autofill boundary itself is unchanged.

**4. `test/e2e/personal-workspace-accessibility.browser.e2e.ts:189`**

`SessionVisibilityPicker` now returns `null` when `capabilities.canCreatePrivate !== true` (`apps/web/src/components/session-visibility-picker.tsx:36`), so the `not_activated` fixture renders nothing and the test timed out waiting 5s for a disabled radio. This is deliberate: the same commit added `apps/web/src/components/session-visibility-picker.test.tsx:41`, "omits a redundant chooser when workspace visibility is the only option", asserting empty output. The string the E2E waited on, "Private sessions are not enabled for this organization yet.", now exists nowhere but that assertion.

Fix: assert the chooser is absent rather than disabled, keeping the fixture case as a regression guard.

**5. `test/e2e/slack-access-link.browser.e2e.ts:238` and `:288`**

Two failures, hidden on the latest `main` run because fail-fast cancelled E2E shard 1.

- A failed managed sign-in used to be a `toast.error("Sign in failed", ...)` in `context.tsx`. It is now an inline form error in `managed-auth-panel.tsx:223`, titled "Couldn't sign in".
- A managed principal with no workspace access now lands on `ManagedWorkspaceOnboardingPanel` (`apps/web/src/context.tsx:2068`); the bare "No workspace access" panel is the unmanaged branch only.

That onboarding panel also calls `GET /v1/organization-invitations`, which the route stub did not answer. The catch-all `json({})` made `page.invitations.filter(...)` throw, so the panel rendered its "Couldn't load invitations" error state. Fix: answer that endpoint with an empty page and assert against the surfaces that now exist.

## Deliberately not fixed here

`scripts/release-schema-contract.test.ts:964` fails on `main` with `Expected c4ec5d41... Received d4944e04...` because migrations `0331_managed_organization_creation.sql` and `0332_organization_shared_workspace_control_plane.sql` landed in 0d75b4c69 without being added to `appendedMigrationPaths`.

PR #1796 already registers exactly those two plus its own `0333`. I verified locally that adding only 0331 and 0332 restores the pinned `c4ec5d41...` hash and the whole file passes, and #1796's extra `0333` entry is inert on `main` because the list is filtered against migrations that actually exist. So #1796's registration is correct and complete for this failure, and duplicating it here would only create a conflict.

The two failures #1796 still has of its own, `Unit tests (shard 4/6)` and `Impacted E2E shard 3/4`, are exactly the `workspace-settings.test.tsx` and `personal-workspace-accessibility` failures this PR repairs.

## Verification

- `bun run typecheck` clean
- `bun run check:public-hygiene` clean
- `bun run format:check` and `bun run lint` clean
- `bun test apps/web/` 937 pass, 0 fail (was 924 pass, 13 fail)
- `bun test ./test/e2e/personal-workspace-accessibility.browser.e2e.ts` 6 pass, 0 fail
- `bun test ./test/e2e/slack-access-link.browser.e2e.ts` 6 pass, 0 fail (was 4 pass, 2 fail; runtime dropped from 59s to 21s once the 15s waits stopped timing out)

The impacted-E2E lane is plain `bun test` plus Playwright Chromium, so both E2E files ran locally exactly as CI runs them.

Test-only changes to `opengeni-web` and the root E2E suite, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
