### PR TITLE
fix(ci): finish main contract repair

### DIFF
--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -164,6 +164,8 @@ describe("release schema contract", () => {
       "0328_session_background_commands.sql",
       "0329_slack_orchestration_delivery_events.sql",
       "0330_api_key_descriptions.sql",
+      "0331_managed_organization_creation.sql",
+      "0332_organization_shared_workspace_control_plane.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -183,6 +185,22 @@ describe("release schema contract", () => {
         (migration) => migration.path === "0314_unregistered_organization_invitations.sql",
       ),
     ).toMatchObject({ deploymentMode: "maintenance" });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0331_managed_organization_creation.sql",
+      ),
+    ).toMatchObject({
+      sha256: "62912af210c1db18c7b58de8ad2c233f2fc6759a6ef4509c8e6352d75dd0641f",
+      deploymentMode: "rolling",
+    });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0332_organization_shared_workspace_control_plane.sql",
+      ),
+    ).toMatchObject({
+      sha256: "6de1a4fc6f0dc0e67852cef996b6d0e01326d180c67d188cb7fcb9c704bc5cdd",
+      deploymentMode: "rolling",
+    });
     expect(
       completeSourceContract.migrations.find(
         (migration) => migration.path === "0238_supergrok_realtime_model.sql",

--- a/test/e2e/slack-access-link.browser.e2e.ts
+++ b/test/e2e/slack-access-link.browser.e2e.ts
@@ -238,6 +238,7 @@ describe("Slack access-link browser acceptance", () => {
       // The managed panel keeps a failed attempt inline on the form instead of
       // in a toast, so the failure is part of the sign-in surface itself.
       await expectText(page.locator("body"), "Couldn't sign in");
+      await expectText(page.locator("body"), "Email or password is incorrect.");
       await expectSingleMainWithoutRail(page);
       expect(state.prepareBodies).toEqual([]);
 
@@ -265,6 +266,7 @@ describe("Slack access-link browser acceptance", () => {
         `${webBaseUrl}/workspaces/${workspaceId}/capabilities#slack_link=${encodeURIComponent(signedLink)}`,
         { waitUntil: "networkidle" },
       );
+      await expectVisible(page.getByRole("button", { name: "Cancel" }));
       expect(new URL(page.url()).searchParams.has("slack_link")).toBe(false);
       expect(new URL(page.url()).hash).toBe("");
       expect(
@@ -273,7 +275,6 @@ describe("Slack access-link browser acceptance", () => {
           session: Object.values(sessionStorage),
         })),
       ).toEqual({ local: [], session: [] });
-      await expectVisible(page.getByRole("button", { name: "Cancel" }));
       await expectSingleMainWithoutRail(page);
       await page.getByRole("button", { name: "Cancel" }).click();
       await expectSingleMainWithoutRail(page);
@@ -436,7 +437,13 @@ async function installAccessApi(page: Page, state: AccessUiState): Promise<void>
       state.signInBodies.push((request.postDataJSON() ?? {}) as Record<string, unknown>);
       if (state.signInFailuresRemaining > 0) {
         state.signInFailuresRemaining -= 1;
-        return json({ message: "Invalid credentials" }, 401);
+        return json(
+          {
+            code: "INVALID_EMAIL_OR_PASSWORD",
+            message: "Invalid email or password",
+          },
+          401,
+        );
       }
       state.signedIn = true;
       return json({ user: { id: "browser-user" } });


### PR DESCRIPTION
## Why

PR #1800 repaired the stale managed-tenancy web assertions, but current main still has two confirmed CI defects:

- migrations 0331 and 0332 remain in the published host-export source hash because they were not registered as forward migrations
- the Slack access-link cancel acceptance can assert URL scrubbing before the signed-in continuation UI has mounted

## What changed

- register migrations 0331 and 0332 in the forward contract and pin their exact SHA-256 plus rolling deployment mode
- use the real Better Auth `INVALID_EMAIL_OR_PASSWORD` fixture shape and assert its inline message
- wait for the visible Cancel affordance before asserting the one-shot fragment has been scrubbed

## Verification

- `bun test scripts/release-schema-contract.test.ts` — 6 pass
- `bun scripts/run-browser-e2e.ts ./test/e2e/slack-access-link.browser.e2e.ts` — 6 pass
- `bun run format:check`
- `bun run check:public-hygiene`
- `git diff --check`

No changeset: this is test/contract registration only.