### PR TITLE
fix(release): register migration 0333 in the schema contract

### DIFF
--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -166,6 +166,7 @@ describe("release schema contract", () => {
       "0330_api_key_descriptions.sql",
       "0331_managed_organization_creation.sql",
       "0332_organization_shared_workspace_control_plane.sql",
+      "0333_session_turn_prompt_routing.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -199,6 +200,14 @@ describe("release schema contract", () => {
       ),
     ).toMatchObject({
       sha256: "6de1a4fc6f0dc0e67852cef996b6d0e01326d180c67d188cb7fcb9c704bc5cdd",
+      deploymentMode: "rolling",
+    });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0333_session_turn_prompt_routing.sql",
+      ),
+    ).toMatchObject({
+      sha256: "3eab54938c65c4db7af9ae3421045e6f44af01a27b06129093a58f1ae22ea05c",
       deploymentMode: "rolling",
     });
     expect(


### PR DESCRIPTION
`main` is red again on the same gate. Commit `4d833689a` (#1798) added `packages/db/drizzle/0333_session_turn_prompt_routing.sql` without adding it to the forward-migration list in `scripts/release-schema-contract.test.ts`, so the governed checkpoint input still frames that file:

```
release schema contract > preserves published host-export history and appends the forward repair
Expected: 9dc02f21cc037d92b17716abdf3bb45a9b15c8100f72a9da70fc2e9e00c11d57
Received: 81a28040b800ad49a3c49e1d9bec22303884646b16afbfb9cf0f9e8f470c52ff
```

This is the third instance of this exact failure in a day (`0331`/`0332` were #1803). Registering `0333` as a forward addition and pinning its bytes restores the pinned checkpoint.

- sha256 `3eab54938c65c4db7af9ae3421045e6f44af01a27b06129093a58f1ae22ea05c`, verified byte-exact with `sha256sum`
- `-- deployment-mode: rolling`, read from the first line of the migration

No migration bytes, schema generator, or generated artifact changes.

## Verification

- `bun test scripts/release-schema-contract.test.ts`: 6 pass, 0 fail (was 5 pass, 1 fail on `main`)
- `bun run check:migration-ordinals`: ok, next free ordinal `0334`
- `bunx oxfmt` and `bun run check:public-hygiene`: clean

Test-only change, so no changeset.

Worth a follow-up: this gate has now broken `main` three times because nothing forces a new migration to be registered in the same change. A CI guard that fails when a top-level `packages/db/drizzle/*.sql` file is unregistered would turn it into a PR-time failure instead of a main-is-red failure.