### PR TITLE
test(release): re-pin the schema ladder for 0334

### DIFF
--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -608,8 +608,8 @@ describe("release schema contract", () => {
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
       if (migrations.has("0334_connected_machine_workspace_root.sql")) {
         return includesActivation
-          ? "34e6f107db58c27e56d14558a98aa178e081753d1fa6f1c8547cd71947f82ca2"
-          : "12b765b2e7c99d847a85c67ea3a37fd0a5bdbd5cb1af5789120f1d7edb535331";
+          ? "3d058b3b8c05d2ebf84de1b1024c995ec131c3c4dcb973a0c42014bca1046e3f"
+          : "eab718bef0df92dd9c78feb9639c0098ec0bbce267de79146315091ce8289d98";
       }
       if (migrations.has("0333_session_turn_prompt_routing.sql")) {
         return includesActivation


### PR DESCRIPTION
## Protected `main` is red

`Unit tests (shard 3/6)` fails `scripts/release-schema-contract.test.ts` > *"preserves published host-export history and appends the forward repair"* at `ca8aad33d` and at the current tip `ca04e4acc`.

Reproduced on a pristine `origin/main` worktree, so it is not a PR-local effect:

```
Expected: "34e6f107db58c27e56d14558a98aa178e081753d1fa6f1c8547cd71947f82ca2"
Received: "3d058b3b8c05d2ebf84de1b1024c995ec131c3c4dcb973a0c42014bca1046e3f"
5 pass / 1 fail
```

## Cause

#1799 pinned its ladder hashes against a tree that did not yet contain #1805's reconciliation. Each PR was green at its own head; the combination is not.

This is the **second occurrence of the same class in a row** — #1805 repaired the previous one (#1798 vs #1803). The aggregate hash covers the whole *filtered migration set*, not just the one file a PR adds, so any ladder pin goes stale the moment a different migration merges first. Worth a follow-up on the mechanism (OPE-347 tracks the area); this PR only unblocks `main`.

## Fix

Recomputed from `origin/main` using the test's own `companyBrainMigrationPaths` + `appendedMigrationPaths` exclusion and `buildSchemaContract` directly:

| | value |
|---|---|
| `includesActivation = true` | `3d058b3b8c05d2ebf84de1b1024c995ec131c3c4dcb973a0c42014bca1046e3f` |
| `includesActivation = false` | `eab718bef0df92dd9c78feb9639c0098ec0bbce267de79146315091ce8289d98` |

No migration bytes change; this only re-pins the two expected values.

## Verification

- `bun test scripts/release-schema-contract.test.ts` — **6 pass / 0 fail**, 219 assertions
- `bun run typecheck` — all 31 projects clean
- `bun run lint` — clean
- `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4t3ZQpeVxFa6WZJ5C6pba