### PR TITLE
refactor(slack): split home and target tenancy in the interaction pump

### DIFF
--- a/.changeset/slack-home-target-tenancy-split.md
+++ b/.changeset/slack-home-target-tenancy-split.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Split the Slack integration's single workspace identifier into two explicit scopes: home (the installation binding that owns the bot credential, the inbox row, the identity link, and the post ledgers) and target (the workspace that owns the interaction, its action handles, the grant, and the session). The two are equal today, so behaviour is unchanged. Thread continuation is now connection-scoped through the content-free tenancy probe, interaction creation adopts an existing thread's tenancy instead of failing an idempotency conflict, delivery builds its bot client from the installation route, and the first-task hint resolves its identity claim and its frozen answer in the scope that owns each.

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -1238,6 +1238,26 @@ export function startSlackInteractionPump(
   };
 }
 
+/**
+ * A concurrent creator may have won this thread in another workspace between the
+ * tenancy probe and the insert, in which case `getOrCreateSlackInteraction`
+ * adopts that row. The grant, the imported attachments, and the resolved route
+ * all belong to the workspace this pass chose, so none of them may be used
+ * against the adopted row. Retry instead: the next pass sees the thread through
+ * the probe, routes to it, and authorizes it properly.
+ */
+function requireSlackInteractionMatchesTarget(
+  interaction: Pick<SlackInteraction, "accountId" | "workspaceId">,
+  target: { accountId: string; workspaceId: string },
+): void {
+  if (
+    interaction.accountId !== target.accountId ||
+    interaction.workspaceId !== target.workspaceId
+  ) {
+    throw new SlackInteractionRetryableError("slack_route_creation_pending");
+  }
+}
+
 async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractionInboxEntry) {
   if (entry.triggerKind === "block_action") {
     await processSlackBlockAction(deps, entry);
@@ -1420,6 +1440,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     owningSubjectId: grant.subjectId,
     visibility: routePolicy.visibility,
   });
+  requireSlackInteractionMatchesTarget(interaction, target);
   if (interaction.sessionId) {
     const remounted = await remountSlackReactionTaskForSession(
       deps,
@@ -1963,6 +1984,7 @@ async function processSlackReactionInboxEntry(
     owningSubjectId: grant.subjectId,
     visibility: "workspace",
   });
+  requireSlackInteractionMatchesTarget(interaction, target);
   if (interaction.sessionId) {
     const appendedTask = await remountSlackReactionTaskForSession(
       deps,
@@ -2379,9 +2401,11 @@ async function acceptSlackReactionTask(
   resources: FileResourceRef[],
 ) {
   const clientEventId = `slack:${entry.providerEventId}`;
+  // Session events and user messages belong to the workspace that owns the
+  // session, which is the workspace the grant authorized, not the installation.
   const existing = await getSessionEventByClientEventId(
     deps.db,
-    entry.workspaceId,
+    grant.workspaceId,
     sessionId,
     clientEventId,
   );
@@ -2391,7 +2415,7 @@ async function acceptSlackReactionTask(
     }
     return;
   }
-  await acceptSessionUserMessage(deps, grant, entry.workspaceId, sessionId, {
+  await acceptSessionUserMessage(deps, grant, grant.workspaceId, sessionId, {
     text: entry.text,
     resources,
     clientEventId,
@@ -2435,7 +2459,7 @@ async function continueSlackSession(
   }
   const pending = await listSessionHumanInputRequests(
     deps.db,
-    entry.workspaceId,
+    interaction.workspaceId,
     interaction.sessionId,
     { status: "pending", limit: 2 },
   );
@@ -2475,7 +2499,7 @@ async function continueSlackSession(
   if (!hasPermission(grant.permissions, "sessions:control")) {
     throw new SlackInteractionPermanentError("sessions_control_denied");
   }
-  await acceptSessionUserMessage(deps, grant, entry.workspaceId, interaction.sessionId, {
+  await acceptSessionUserMessage(deps, grant, interaction.workspaceId, interaction.sessionId, {
     text: entry.text,
     ...(options.modelContext ? { modelContext: options.modelContext } : {}),
     resources,
@@ -3392,19 +3416,24 @@ function slackGoalPausedText(
  * The installation tenancy that owns this interaction's Slack credential.
  *
  * `slack_interactions.connection_id` deliberately has no composite
- * `(workspace_id, connection_id)` foreign key, so a routed interaction may
- * point at the installation's connection from another workspace. Resolve the
- * binding by team and prove it is the same connection before any provider call.
+ * `(workspace_id, connection_id)` foreign key, so a routed interaction may point
+ * at the installation's connection from another workspace.
+ *
+ * A binding that does not resolve, or that now names a different connection, is
+ * NOT turned into a new delivery precondition: this code previously used the
+ * interaction's own tenancy unconditionally, so falling back to it keeps every
+ * delivery that used to succeed succeeding. The fallback cannot post from the
+ * wrong workspace either, because `claimSlackBotPostOperation` selects the
+ * connection under the tenancy it is given and fails when it does not own it.
  */
 async function resolveSlackDeliveryHome(
   deps: ApiRouteDeps,
   interaction: Pick<SlackInteraction, "accountId" | "workspaceId" | "connectionId" | "slackTeamId">,
 ): Promise<{ accountId: string; workspaceId: string }> {
   const installation = await resolveSlackInstallationRoute(deps.db, interaction.slackTeamId);
-  if (!installation || installation.connectionId !== interaction.connectionId) {
-    throw new SlackInteractionPermanentError("slack_delivery_installation_changed");
-  }
-  return { accountId: installation.accountId, workspaceId: installation.workspaceId };
+  return installation && installation.connectionId === interaction.connectionId
+    ? { accountId: installation.accountId, workspaceId: installation.workspaceId }
+    : { accountId: interaction.accountId, workspaceId: interaction.workspaceId };
 }
 
 async function deliverSlackSessionEvents(
@@ -3656,7 +3685,7 @@ async function deliverSlackSessionEvents(
         );
         const posted = await getSlackBotPostOperation(
           deps.db,
-          interaction.workspaceId,
+          home.workspaceId,
           interaction.connectionId,
           existingProgress.operationId,
         );

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -59,12 +59,13 @@ import {
   getSlackInteractionActionHandle,
   getSlackInteractionByClientEventId,
   getSlackInteractionById,
-  getSlackInteractionByRoute,
+  getSlackInteractionByConnectionRoute,
   getActiveSlackTaskPolicy,
   getSlackSharedTaskOrigin,
   getSessionEventByClientEventId,
   getWorkspace,
   getWorkspaceGrant,
+  resolveSlackTargetAuthority,
   listSlackInteractionProgressDeliveryEvidence,
   listSessionEventPage,
   listSessionHumanInputRequests,
@@ -1246,6 +1247,11 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     await processSlackReactionInboxEntry(deps, entry);
     return;
   }
+  // HOME is the installation binding's tenancy: it owns the bot credential and
+  // connection, this inbox row, the identity links, and the post ledgers. TARGET
+  // is the tenancy the resulting session lives in. They are equal today; the
+  // routing resolver is what makes them diverge.
+  const home = { accountId: entry.accountId, workspaceId: entry.workspaceId } as const;
   const installation = await resolveSlackInstallationRoute(deps.db, entry.slackTeamId);
   if (
     !installation ||
@@ -1256,8 +1262,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     throw new SlackInteractionPermanentError("slack_task_installation_changed");
   }
   const client = await createOpenGeniSlackBotInteractionClient(deps, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...home,
     connectionId: entry.connectionId,
     subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
   });
@@ -1284,17 +1289,20 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     privateHandoff: policyDecision.disposition === "private_handoff",
   });
   const routeKey = routePolicy.initialRouteKey;
-  const existing = await getSlackInteractionByRoute(
-    deps.db,
-    entry.workspaceId,
-    entry.connectionId,
+  // A mapped thread keeps the workspace it was created in, so the continuation
+  // lookup is connection-scoped rather than workspace-fenced.
+  const existing = await getSlackInteractionByConnectionRoute(deps.db, {
+    connectionId: entry.connectionId,
     routeKey,
-  );
+  });
   if (entry.triggerKind === "thread_reply" && !existing) return;
-
+  // The identity link is a HOME fact: `slack_bot_user_links` is unique on
+  // `(connection_id, slack_user_id)` and RLS-visible only under the
+  // installation's own tenancy. It is read before the target is chosen because
+  // the routing decision needs the subject it names.
   const link = await getSlackBotUserLink(
     deps.db,
-    entry.workspaceId,
+    home.workspaceId,
     entry.connectionId,
     entry.slackUserId,
   );
@@ -1306,16 +1314,21 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     });
     return;
   }
-  const grant = await getWorkspaceGrant(deps.db, link.subjectId, entry.workspaceId, {
-    principalKind: "human_session",
+  const target: { accountId: string; workspaceId: string } = existing
+    ? { accountId: existing.accountId, workspaceId: existing.workspaceId }
+    : home;
+  const grant = await resolveSlackTargetAuthority(deps.db, {
+    subjectId: link.subjectId,
+    targetAccountId: target.accountId,
+    targetWorkspaceId: target.workspaceId,
   });
-  if (!grant || grant.accountId !== entry.accountId) {
+  if (!grant) {
     throw new SlackInteractionPermanentError("identity_access_revoked");
   }
 
   const alreadyDurable = await getSlackInteractionByClientEventId(
     deps.db,
-    entry.workspaceId,
+    target.workspaceId,
     entry.connectionId,
     `slack:${entry.providerEventId}`,
   );
@@ -1344,8 +1357,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
       (usesPrivateBotDm(boundInteraction, entry) && boundInteraction.ackSlackMessageTs === null);
     if (shouldRepairAcknowledgement) {
       const boundClient = await createOpenGeniSlackBotInteractionClient(deps, {
-        accountId: entry.accountId,
-        workspaceId: entry.workspaceId,
+        ...home,
         connectionId: entry.connectionId,
         subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
         sessionId: eventSessionId,
@@ -1368,6 +1380,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
       deps,
       client,
       entry,
+      target,
       policyDecision.disposition === "private_handoff"
         ? async () => {
             await requireSlackSharedReadAuthorization(deps, client, entry, policyResolution);
@@ -1382,7 +1395,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
   if (existing?.sessionId) {
     const remounted = await remountSlackReactionTaskForSession(
       deps,
-      entry.workspaceId,
+      target.workspaceId,
       existing.sessionId,
       preparedAttachments,
     );
@@ -1396,8 +1409,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     throw new SlackInteractionPermanentError("sessions_create_denied");
   }
   const { interaction } = await getOrCreateSlackInteraction(deps.db, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...target,
     connectionId: entry.connectionId,
     slackTeamId: entry.slackTeamId,
     slackChannelId: entry.slackChannelId,
@@ -1411,7 +1423,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
   if (interaction.sessionId) {
     const remounted = await remountSlackReactionTaskForSession(
       deps,
-      entry.workspaceId,
+      interaction.workspaceId,
       interaction.sessionId,
       preparedAttachments,
     );
@@ -1423,7 +1435,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
   }
   const preferredModel = await getLatestSessionModelForSubject(
     deps.db,
-    entry.workspaceId,
+    interaction.workspaceId,
     grant.subjectId,
   );
   let session: Awaited<ReturnType<typeof createSessionForRequest>>;
@@ -1433,7 +1445,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
       preparedAttachments,
       preparedModelContext,
     );
-    session = await createSessionForRequest(deps, grant, entry.workspaceId, {
+    session = await createSessionForRequest(deps, grant, interaction.workspaceId, {
       requestedSessionId: interaction.sessionReservationId,
       initialMessage: prepared.entry.text,
       ...(prepared.modelContext ? { modelContext: prepared.modelContext } : {}),
@@ -1469,8 +1481,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
   if (!bound) throw new Error("Slack route could not bind its durable session");
   await ensureSlackSharedTaskOrigin(deps, bound, entry, policyResolution);
   const boundClient = await createOpenGeniSlackBotInteractionClient(deps, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...home,
     connectionId: entry.connectionId,
     subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
     sessionId: session.id,
@@ -1574,6 +1585,9 @@ async function prepareSlackInvocationEntry(
   deps: ApiRouteDeps,
   client: OpenGeniSlackBotClient,
   entry: SlackInteractionInboxEntry,
+  // Imported attachments become File resources of the session's workspace, so
+  // they follow TARGET tenancy rather than the installation's.
+  target: { accountId: string; workspaceId: string },
   authorizeRead?: () => Promise<void>,
 ): Promise<{
   entry: SlackInteractionInboxEntry;
@@ -1608,7 +1622,14 @@ async function prepareSlackInvocationEntry(
     exactMessage = exact.messages.find((message) => message.timestamp === entry.slackMessageTs);
   }
   const attachments = exactMessage
-    ? await prepareSlackMessageAttachments(deps, client, entry, exactMessage.files, authorizeRead)
+    ? await prepareSlackMessageAttachments(
+        deps,
+        client,
+        entry,
+        target,
+        exactMessage.files,
+        authorizeRead,
+      )
     : {
         resources: [],
         attachments: [],
@@ -1702,17 +1723,19 @@ async function acknowledgeSlackSession(
   // buttons. The how-to prose it used to repeat forever now rides along once,
   // on this Slack identity's first accepted task in this installation.
   const started = directMessageShortcut
-    ? `OpenGeni started a private task from the selected DM message. ${openSessionText(deps, entry.workspaceId, interaction.sessionId)} The source DM was not opened to the bot or made workspace-visible.`
+    ? `OpenGeni started a private task from the selected DM message. ${openSessionText(deps, interaction.workspaceId, interaction.sessionId)} The source DM was not opened to the bot or made workspace-visible.`
     : privateHandoff
-      ? `OpenGeni started a private task from the selected Slack conversation. ${openSessionText(deps, entry.workspaceId, interaction.sessionId)} Results stay private unless a separate authorized publication is approved.`
-      : `OpenGeni started this task. ${openSessionText(deps, entry.workspaceId, interaction.sessionId)}`;
+      ? `OpenGeni started a private task from the selected Slack conversation. ${openSessionText(deps, interaction.workspaceId, interaction.sessionId)} Results stay private unless a separate authorized publication is approved.`
+      : `OpenGeni started this task. ${openSessionText(deps, interaction.workspaceId, interaction.sessionId)}`;
   // The post ledger binds this fixed operation id to a digest over the message
   // text, and this function re-runs on every acknowledgement repair. Resolving
   // the hint freezes it durably before the post, so a repair renders identical
   // bytes; a failure here raises into the retryable inbox path rather than
   // binding the ledger to a hint-less acknowledgement it can never revise.
   const showHint = await resolveSlackInteractionFirstTaskHint(deps.db, {
+    // The identity link is HOME; the interaction row is TARGET.
     workspaceId: entry.workspaceId,
+    interactionWorkspaceId: interaction.workspaceId,
     connectionId: entry.connectionId,
     slackUserId: entry.slackUserId,
     interactionId: interaction.id,
@@ -1781,10 +1804,13 @@ async function processSlackReactionInboxEntry(
   deps: ApiRouteDeps,
   entry: SlackInteractionInboxEntry,
 ) {
+  // Reaction summon is configured on the installation surface, so the settings,
+  // the connection scopes, and the identity link are all HOME reads.
+  const home = { accountId: entry.accountId, workspaceId: entry.workspaceId } as const;
   const [workspace, connection, link] = await Promise.all([
-    getWorkspace(deps.db, entry.workspaceId),
-    getConnectionMetadata(deps.db, entry.workspaceId, entry.connectionId, null),
-    getSlackBotUserLink(deps.db, entry.workspaceId, entry.connectionId, entry.slackUserId),
+    getWorkspace(deps.db, home.workspaceId),
+    getConnectionMetadata(deps.db, home.workspaceId, entry.connectionId, null),
+    getSlackBotUserLink(deps.db, home.workspaceId, entry.connectionId, entry.slackUserId),
   ]);
   const settings = resolveWorkspaceSlackReactionSummonSettings(workspace?.settings);
   if (
@@ -1798,23 +1824,30 @@ async function processSlackReactionInboxEntry(
   ) {
     return;
   }
-  const grant = await getWorkspaceGrant(deps.db, link.subjectId, entry.workspaceId, {
-    principalKind: "human_session",
-  });
-  if (!grant || grant.accountId !== entry.accountId) {
-    throw new SlackInteractionPermanentError("identity_access_revoked");
-  }
-  if (
-    !hasPermission(grant.permissions, "sessions:create") ||
-    !hasPermission(grant.permissions, "sessions:control")
-  ) {
-    throw new SlackInteractionPermanentError("reaction_session_permissions_denied");
-  }
+  let target: { accountId: string; workspaceId: string } = home;
+  const authorizeTarget = async () => {
+    const resolved = await resolveSlackTargetAuthority(deps.db, {
+      subjectId: link.subjectId,
+      targetAccountId: target.accountId,
+      targetWorkspaceId: target.workspaceId,
+    });
+    if (!resolved) {
+      throw new SlackInteractionPermanentError("identity_access_revoked");
+    }
+    if (
+      !hasPermission(resolved.permissions, "sessions:create") ||
+      !hasPermission(resolved.permissions, "sessions:control")
+    ) {
+      throw new SlackInteractionPermanentError("reaction_session_permissions_denied");
+    }
+    return resolved;
+  };
+  let grant = await authorizeTarget();
 
   const clientEventId = `slack:${entry.providerEventId}`;
   const durableInteraction = await getSlackInteractionByClientEventId(
     deps.db,
-    entry.workspaceId,
+    target.workspaceId,
     entry.connectionId,
     clientEventId,
   );
@@ -1846,8 +1879,7 @@ async function processSlackReactionInboxEntry(
     await reopenSlackInteractionDelivery(deps.db, boundInteraction);
     if (shouldRepairAcknowledgement) {
       const client = await createOpenGeniSlackBotInteractionClient(deps, {
-        accountId: entry.accountId,
-        workspaceId: entry.workspaceId,
+        ...home,
         connectionId: entry.connectionId,
         subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
         sessionId: eventSessionId,
@@ -1858,8 +1890,7 @@ async function processSlackReactionInboxEntry(
   }
 
   const client = await createOpenGeniSlackBotInteractionClient(deps, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...home,
     connectionId: entry.connectionId,
     subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
   });
@@ -1890,18 +1921,24 @@ async function processSlackReactionInboxEntry(
       if (!saved) throw new Error("Slack reaction inbox checkpoint claim was lost");
     },
   });
-  const preparedTask = await prepareSlackReactionTask(deps, client, entry, context);
   const routeKey = slackRouteKey(entry.slackChannelId, context.threadTimestamp);
-  const existing = await getSlackInteractionByRoute(
-    deps.db,
-    entry.workspaceId,
-    entry.connectionId,
+  const existing = await getSlackInteractionByConnectionRoute(deps.db, {
+    connectionId: entry.connectionId,
     routeKey,
-  );
+  });
+  if (
+    existing &&
+    (existing.accountId !== target.accountId || existing.workspaceId !== target.workspaceId)
+  ) {
+    // A mapped thread keeps the workspace it was created in.
+    target = { accountId: existing.accountId, workspaceId: existing.workspaceId };
+    grant = await authorizeTarget();
+  }
+  const preparedTask = await prepareSlackReactionTask(deps, client, entry, target, context);
   if (existing?.sessionId) {
     const appendedTask = await remountSlackReactionTaskForSession(
       deps,
-      entry.workspaceId,
+      existing.workspaceId,
       existing.sessionId,
       preparedTask,
     );
@@ -1915,8 +1952,7 @@ async function processSlackReactionInboxEntry(
     return;
   }
   const { interaction } = await getOrCreateSlackInteraction(deps.db, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...target,
     connectionId: entry.connectionId,
     slackTeamId: entry.slackTeamId,
     slackChannelId: entry.slackChannelId,
@@ -1930,7 +1966,7 @@ async function processSlackReactionInboxEntry(
   if (interaction.sessionId) {
     const appendedTask = await remountSlackReactionTaskForSession(
       deps,
-      entry.workspaceId,
+      interaction.workspaceId,
       interaction.sessionId,
       preparedTask,
     );
@@ -1953,13 +1989,13 @@ async function processSlackReactionInboxEntry(
   }
   const preferredModel = await getLatestSessionModelForSubject(
     deps.db,
-    entry.workspaceId,
+    interaction.workspaceId,
     grant.subjectId,
   );
   const preparedEntry = slackReactionPreparedEntry(entry, context, preparedTask);
   let session: Awaited<ReturnType<typeof createSessionForRequest>>;
   try {
-    session = await createSessionForRequest(deps, grant, entry.workspaceId, {
+    session = await createSessionForRequest(deps, grant, interaction.workspaceId, {
       requestedSessionId: interaction.sessionReservationId,
       initialMessage: preparedEntry.text,
       instructions: SLACK_SESSION_INSTRUCTIONS,
@@ -2126,15 +2162,23 @@ async function prepareSlackReactionTask(
   deps: ApiRouteDeps,
   client: OpenGeniSlackBotClient,
   entry: SlackInteractionInboxEntry,
+  target: { accountId: string; workspaceId: string },
   context: SlackReactionMessageContext,
 ): Promise<PreparedSlackReactionTask> {
-  return await prepareSlackMessageAttachments(deps, client, entry, context.reactedMessage.files);
+  return await prepareSlackMessageAttachments(
+    deps,
+    client,
+    entry,
+    target,
+    context.reactedMessage.files,
+  );
 }
 
 async function prepareSlackMessageAttachments(
   deps: ApiRouteDeps,
   client: OpenGeniSlackBotClient,
   entry: SlackInteractionInboxEntry,
+  target: { accountId: string; workspaceId: string },
   exactFiles: readonly { id: string; name: string; title: string }[],
   authorizeSharedRead?: () => Promise<void>,
 ): Promise<PreparedSlackReactionTask> {
@@ -2195,8 +2239,8 @@ async function prepareSlackMessageAttachments(
         await importSlackReactionImage(
           { db: deps.db, objectStorage: deps.objectStorage },
           {
-            accountId: entry.accountId,
-            workspaceId: entry.workspaceId,
+            accountId: target.accountId,
+            workspaceId: target.workspaceId,
             connectionId: entry.connectionId,
             slackTeamId: entry.slackTeamId,
             slackChannelId: entry.slackChannelId,
@@ -2454,6 +2498,9 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
   const separator = entry.text.lastIndexOf(":");
   const actionId = separator > 0 ? entry.text.slice(0, separator) : "";
   const handleId = separator > 0 ? entry.text.slice(separator + 1) : "";
+  // The block-action inbox row carries HOME tenancy, exactly like every other
+  // inbox row: it is the installation binding that received the click.
+  const home = { accountId: entry.accountId, workspaceId: entry.workspaceId } as const;
   const route = await resolveSlackInstallationRoute(deps.db, entry.slackTeamId);
   if (
     !route ||
@@ -2463,19 +2510,22 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
   ) {
     throw new SlackInteractionPermanentError("slack_action_installation_changed");
   }
-  const handle = await getSlackInteractionActionHandle(deps.db, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
-    handleId,
-  });
+  // A handle lives in the workspace that owns its session, which is the routed
+  // workspace once routing exists. Every installation addresses exactly one
+  // workspace today, so the home scope is still the handle's scope.
+  const handle = await getSlackInteractionActionHandle(deps.db, { ...home, handleId });
   if (!handle || SLACK_ACTION_ID_BY_KIND[handle.actionKind] !== actionId) {
     throw new SlackInteractionPermanentError("slack_action_handle_invalid");
   }
+  // An action handle is a TARGET fact: it is composite-FK'd to its interaction
+  // and its RESTRICTIVE session-visibility policy resolves the session under the
+  // handle's own tenancy, so every read, settle and interaction lookup below
+  // uses the handle's scope rather than the installation's.
+  const target = { accountId: handle.accountId, workspaceId: handle.workspaceId } as const;
   if (handle.status !== "pending") return;
   if (handle.expiresAt.getTime() <= Date.now()) {
     await settleSlackInteractionActionHandles(deps.db, {
-      accountId: entry.accountId,
-      workspaceId: entry.workspaceId,
+      ...target,
       handleId: handle.id,
       result: "expired",
       stale: true,
@@ -2487,14 +2537,15 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
   }
   const [interaction, link, post] = await Promise.all([
     getSlackInteractionById(deps.db, {
-      accountId: entry.accountId,
-      workspaceId: entry.workspaceId,
+      ...target,
       interactionId: handle.interactionId,
     }),
-    getSlackBotUserLink(deps.db, entry.workspaceId, entry.connectionId, entry.slackUserId),
+    // Identity stays HOME.
+    getSlackBotUserLink(deps.db, home.workspaceId, entry.connectionId, entry.slackUserId),
+    // The post ledger is written by the bot credential, so it stays HOME too.
     getSlackBotPostOperation(
       deps.db,
-      entry.workspaceId,
+      home.workspaceId,
       entry.connectionId,
       handle.messageOperationId,
     ),
@@ -2515,19 +2566,16 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
   ) {
     throw new SlackInteractionPermanentError("slack_action_authority_changed");
   }
-  const grant = await getWorkspaceGrant(deps.db, link.subjectId, entry.workspaceId, {
-    principalKind: "human_session",
+  const grant = await resolveSlackTargetAuthority(deps.db, {
+    subjectId: link.subjectId,
+    targetAccountId: target.accountId,
+    targetWorkspaceId: target.workspaceId,
   });
-  if (
-    !grant ||
-    grant.accountId !== entry.accountId ||
-    !hasPermission(grant.permissions, "sessions:control")
-  ) {
+  if (!grant || !hasPermission(grant.permissions, "sessions:control")) {
     throw new SlackInteractionPermanentError("sessions_control_denied");
   }
   const client = await createOpenGeniSlackBotInteractionClient(deps, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...home,
     connectionId: entry.connectionId,
     subjectId: grant.subjectId,
     sessionId: handle.sessionId,
@@ -2553,8 +2601,7 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
     blocks: [{ type: "section", text: { type: "mrkdwn", text: updateText } }],
   });
   await settleSlackInteractionActionHandles(deps.db, {
-    accountId: entry.accountId,
-    workspaceId: entry.workspaceId,
+    ...target,
     handleId: handle.id,
     result: outcome.result,
     ...(outcome.stale ? { stale: true } : {}),
@@ -2872,13 +2919,16 @@ async function validatedSlackRequester(
     SlackInteraction,
     "accountId" | "workspaceId" | "connectionId" | "initiatingSlackUserId" | "owningSubjectId"
   >,
+  // Identity links are HOME facts, unique on (connection_id, slack_user_id) and
+  // RLS-visible only under the installation's own tenancy.
+  home: { accountId: string; workspaceId: string },
 ) {
   if (!interaction.initiatingSlackUserId) {
     return { authorized: false, mention: "" };
   }
   const link = await getSlackBotUserLink(
     deps.db,
-    interaction.workspaceId,
+    home.workspaceId,
     interaction.connectionId,
     interaction.initiatingSlackUserId,
   );
@@ -3338,6 +3388,25 @@ function slackGoalPausedText(
   return boundedOutput(`${mention}${headline}.${link ? ` <${link}|Open in OpenGeni>` : ""}`);
 }
 
+/**
+ * The installation tenancy that owns this interaction's Slack credential.
+ *
+ * `slack_interactions.connection_id` deliberately has no composite
+ * `(workspace_id, connection_id)` foreign key, so a routed interaction may
+ * point at the installation's connection from another workspace. Resolve the
+ * binding by team and prove it is the same connection before any provider call.
+ */
+async function resolveSlackDeliveryHome(
+  deps: ApiRouteDeps,
+  interaction: Pick<SlackInteraction, "accountId" | "workspaceId" | "connectionId" | "slackTeamId">,
+): Promise<{ accountId: string; workspaceId: string }> {
+  const installation = await resolveSlackInstallationRoute(deps.db, interaction.slackTeamId);
+  if (!installation || installation.connectionId !== interaction.connectionId) {
+    throw new SlackInteractionPermanentError("slack_delivery_installation_changed");
+  }
+  return { accountId: installation.accountId, workspaceId: installation.workspaceId };
+}
+
 async function deliverSlackSessionEvents(
   deps: ApiRouteDeps,
   interaction: SlackInteraction,
@@ -3357,14 +3426,17 @@ async function deliverSlackSessionEvents(
     });
     return;
   }
+  // The bot credential is owned by the installation's workspace and every
+  // provider call is fenced on it, so the delivery client is always built from
+  // HOME even when the session it reports on lives in another workspace.
+  const home = await resolveSlackDeliveryHome(deps, interaction);
   const client = await createOpenGeniSlackBotInteractionClient(deps, {
-    accountId: interaction.accountId,
-    workspaceId: interaction.workspaceId,
+    ...home,
     connectionId: interaction.connectionId,
     subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
     sessionId: interaction.sessionId,
   });
-  const requester = await validatedSlackRequester(deps, interaction);
+  const requester = await validatedSlackRequester(deps, interaction, home);
   // Both orchestration notices are per-workspace and OFF unless this workspace
   // turned them on. Resolved lazily so an ordinary page of turn/progress events
   // costs no extra workspace read, and memoized so one page resolves once. A

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9663,10 +9663,16 @@ export async function getSlackBotUserLink(
  * stored decision, and unlinking plus relinking the Slack identity cannot flip
  * an acknowledgement that was already rendered.
  *
- * The frozen decision and the per-identity claim commit in one transaction, so
- * at most one interaction per Slack identity per installation is granted the
- * hint. Failure raises instead of degrading to "no hint": a caller must never
- * bind a post operation to text that depends on an unresolved answer.
+ * The per-identity claim row is the single source of truth and is replay-stable:
+ * the frozen answer is exactly "this identity's one claim names THIS
+ * interaction". At most one interaction per Slack identity per installation is
+ * therefore granted the hint, whichever resolver wins the claim, and the freeze
+ * is a separate compare-and-set whose losers read back the stored byte rather
+ * than their own recomputed one. This is deliberately not one transaction: the
+ * claim is a home-tenancy row and the freeze is a target-tenancy row, and one
+ * transaction carries one RLS scope. Failure raises instead of degrading to "no
+ * hint": a caller must never bind a post operation to text that depends on an
+ * unresolved answer.
  */
 export async function resolveSlackInteractionFirstTaskHint(
   db: Database,
@@ -10215,6 +10221,14 @@ export async function getSlackInteractionByConnectionRoute(
   });
 }
 
+/**
+ * Workspace-fenced route lookup.
+ *
+ * This is NOT the thread-continuation read: `slack_interactions_route_uq` is
+ * `(connection_id, route_key)` and therefore connection-global, so a thread that
+ * belongs to another workspace this installation can address is invisible here.
+ * Use `getSlackInteractionByConnectionRoute` for continuation.
+ */
 export async function getSlackInteractionByRoute(
   db: Database,
   workspaceId: string,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -429,7 +429,7 @@ export * from "./organization-membership-backfill";
 export * from "./generated-images";
 export * from "./slack-user-link-access";
 export * from "./slack-routing";
-import { personalWorkspaceIdForSubject } from "./slack-routing";
+import { personalWorkspaceIdForSubject, probeSlackInteractionTenancy } from "./slack-routing";
 export * from "./workspace-membership-permissions";
 export * from "./video-generation";
 export * from "./user-resource-authority";
@@ -9671,54 +9671,109 @@ export async function getSlackBotUserLink(
 export async function resolveSlackInteractionFirstTaskHint(
   db: Database,
   input: {
+    /** HOME: the installation workspace that owns the identity link. */
     workspaceId: string;
     connectionId: string;
     slackUserId: string;
     interactionId: string;
+    /**
+     * TARGET: the workspace that owns the interaction row. Defaults to HOME,
+     * which is what every caller means until routing exists.
+     */
+    interactionWorkspaceId?: string;
   },
 ): Promise<boolean> {
-  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
-    // Interaction row first, then the identity link: one lock order for every
-    // concurrent resolver of the same interaction.
-    const [frozen] = await scopedDb
+  const identityWorkspaceId = input.workspaceId;
+  const interactionWorkspaceId = input.interactionWorkspaceId ?? input.workspaceId;
+
+  // `slack_bot_user_links` is a HOME row and `slack_interactions` is a TARGET
+  // row. One transaction carries one RLS scope, so this cannot be a single
+  // scoped transaction once the two differ. It does not need to be: the
+  // per-identity claim is itself the source of truth, and it is replay-stable.
+  //
+  // The frozen answer is `the identity's one claim names THIS interaction`. Two
+  // resolvers of the same interaction therefore always agree, whichever wins the
+  // claim; two resolvers of different interactions elect exactly one winner; and
+  // a crash between the claim and the freeze re-derives the same answer on the
+  // next call. Failure still raises rather than degrading to "no hint": a caller
+  // must never bind a post operation to text that depends on an unresolved
+  // answer.
+  const frozen = await withWorkspaceRls(db, interactionWorkspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
       .select({ firstTaskHint: schema.slackInteractions.firstTaskHint })
       .from(schema.slackInteractions)
       .where(
         and(
-          eq(schema.slackInteractions.workspaceId, input.workspaceId),
+          eq(schema.slackInteractions.workspaceId, interactionWorkspaceId),
           eq(schema.slackInteractions.id, input.interactionId),
         ),
       )
-      .limit(1)
-      .for("update");
-    if (!frozen) throw new Error("Slack first-task hint requires a durable interaction row");
-    if (frozen.firstTaskHint !== null) return frozen.firstTaskHint;
+      .limit(1);
+    if (!row) throw new Error("Slack first-task hint requires a durable interaction row");
+    return row.firstTaskHint;
+  });
+  if (frozen !== null) return frozen;
 
+  const granted = await withWorkspaceRls(db, identityWorkspaceId, async (scopedDb) => {
     const claimed = await scopedDb
       .update(schema.slackBotUserLinks)
       .set({ firstTaskHintInteractionId: input.interactionId })
       .where(
         and(
-          eq(schema.slackBotUserLinks.workspaceId, input.workspaceId),
+          eq(schema.slackBotUserLinks.workspaceId, identityWorkspaceId),
           eq(schema.slackBotUserLinks.connectionId, input.connectionId),
           eq(schema.slackBotUserLinks.slackUserId, input.slackUserId),
           isNull(schema.slackBotUserLinks.firstTaskHintInteractionId),
         ),
       )
       .returning({ id: schema.slackBotUserLinks.id });
-    const granted = claimed.length > 0;
+    if (claimed.length > 0) return true;
+    // Lost the claim, or replaying after a crash between the claim and the
+    // freeze. The claim itself says which it was.
+    const [existing] = await scopedDb
+      .select({
+        firstTaskHintInteractionId: schema.slackBotUserLinks.firstTaskHintInteractionId,
+      })
+      .from(schema.slackBotUserLinks)
+      .where(
+        and(
+          eq(schema.slackBotUserLinks.workspaceId, identityWorkspaceId),
+          eq(schema.slackBotUserLinks.connectionId, input.connectionId),
+          eq(schema.slackBotUserLinks.slackUserId, input.slackUserId),
+        ),
+      )
+      .limit(1);
+    return existing?.firstTaskHintInteractionId === input.interactionId;
+  });
 
-    await scopedDb
+  return await withWorkspaceRls(db, interactionWorkspaceId, async (scopedDb) => {
+    const [written] = await scopedDb
       .update(schema.slackInteractions)
       .set({ firstTaskHint: granted, updatedAt: sql`now()` })
       .where(
         and(
-          eq(schema.slackInteractions.workspaceId, input.workspaceId),
+          eq(schema.slackInteractions.workspaceId, interactionWorkspaceId),
           eq(schema.slackInteractions.id, input.interactionId),
           isNull(schema.slackInteractions.firstTaskHint),
         ),
-      );
-    return granted;
+      )
+      .returning({ firstTaskHint: schema.slackInteractions.firstTaskHint });
+    if (written) return written.firstTaskHint ?? granted;
+    // Another resolver of this exact interaction froze first. It computed the
+    // same predicate, but return the stored byte rather than a recomputed one so
+    // the digest-bound post ledger can never see two answers.
+    const [current] = await scopedDb
+      .select({ firstTaskHint: schema.slackInteractions.firstTaskHint })
+      .from(schema.slackInteractions)
+      .where(
+        and(
+          eq(schema.slackInteractions.workspaceId, interactionWorkspaceId),
+          eq(schema.slackInteractions.id, input.interactionId),
+        ),
+      )
+      .limit(1);
+    if (!current) throw new Error("Slack first-task hint requires a durable interaction row");
+    return current.firstTaskHint ?? granted;
   });
 }
 
@@ -10091,7 +10146,7 @@ export async function getOrCreateSlackInteraction(
     | "updatedAt"
   > & { initiatingSlackUserId?: string | null },
 ): Promise<{ created: boolean; interaction: SlackInteraction }> {
-  return await withRlsContext(db, input, async (scopedDb) => {
+  const outcome = await withRlsContext(db, input, async (scopedDb) => {
     const [created] = await scopedDb
       .insert(schema.slackInteractions)
       .values({
@@ -10100,7 +10155,9 @@ export async function getOrCreateSlackInteraction(
       })
       .onConflictDoNothing()
       .returning();
-    if (created) return { created: true, interaction: mapSlackInteraction(created) };
+    if (created) {
+      return { created: true, interaction: mapSlackInteraction(created) } as const;
+    }
     const [existing] = await scopedDb
       .select()
       .from(schema.slackInteractions)
@@ -10111,8 +10168,50 @@ export async function getOrCreateSlackInteraction(
         ),
       )
       .limit(1);
-    if (!existing) throw new Error("Slack route idempotency conflict could not be resolved");
-    return { created: false, interaction: mapSlackInteraction(existing) };
+    return existing
+      ? ({ created: false, interaction: mapSlackInteraction(existing) } as const)
+      : ({ created: false, interaction: null } as const);
+  });
+  if (outcome.interaction) {
+    return { created: outcome.created, interaction: outcome.interaction };
+  }
+  // The route unique index is connection-global while the recovery SELECT above
+  // runs under the intended tenancy. A thread that already belongs to another
+  // workspace in this organization therefore conflicts without being visible
+  // here. Re-probe the connection-global route and adopt the existing row's
+  // tenancy: a mapped thread keeps the workspace it was created in.
+  const probed = await probeSlackInteractionTenancy(db, {
+    connectionId: input.connectionId,
+    routeKey: input.routeKey,
+  });
+  const adopted = probed
+    ? await getSlackInteractionById(db, {
+        accountId: probed.accountId,
+        workspaceId: probed.workspaceId,
+        interactionId: probed.interactionId,
+      })
+    : null;
+  if (!adopted) throw new Error("Slack route idempotency conflict could not be resolved");
+  return { created: false, interaction: adopted };
+}
+
+/**
+ * Connection-scoped thread continuation. `slack_interactions_route_uq` is
+ * `(connection_id, route_key)`, so one Slack thread maps to exactly one
+ * interaction across every workspace this installation can address. The
+ * content-free tenancy probe resolves which workspace that is; the full row is
+ * then read under that workspace's own RLS scope, so nothing is widened.
+ */
+export async function getSlackInteractionByConnectionRoute(
+  db: Database,
+  input: { connectionId: string; routeKey: string },
+): Promise<SlackInteraction | null> {
+  const probed = await probeSlackInteractionTenancy(db, input);
+  if (!probed) return null;
+  return await getSlackInteractionById(db, {
+    accountId: probed.accountId,
+    workspaceId: probed.workspaceId,
+    interactionId: probed.interactionId,
   });
 }
 

--- a/packages/db/test/migration-0327-slack-first-task-hint.test.ts
+++ b/packages/db/test/migration-0327-slack-first-task-hint.test.ts
@@ -286,6 +286,66 @@ describe("migration 0327 Slack first-task hint", () => {
     ).toBe(false);
   });
 
+  test("resolves across a home identity and a target interaction", async () => {
+    if (!available) return;
+    // Slack workspace routing puts the identity link in the installation's
+    // workspace and the interaction in the routed one, so the two halves of the
+    // decision live under different RLS scopes.
+    const home = await installation(`split-home-${Date.now()}`);
+    await home.link("U_SPLIT", "user:hint-split");
+    const [routed] = await shared!.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${home.accountId}, ${`Slack hint routed ${Date.now()}`}) returning id`;
+    await shared!.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${routed!.id}, ${home.accountId})`;
+    const channel = "C_SPLIT";
+    const created = await getOrCreateSlackInteraction(db, {
+      accountId: home.accountId,
+      workspaceId: routed!.id,
+      connectionId: home.connectionId,
+      slackTeamId: home.slackTeamId,
+      slackChannelId: channel,
+      slackThreadTs: `${Date.now()}.1`,
+      routeKey: `${channel}:${crypto.randomUUID()}`,
+      triggeringProviderEventId: `E_${crypto.randomUUID()}`,
+      initiatingSlackUserId: "U_SPLIT",
+      owningSubjectId: "user:hint-split",
+      visibility: "workspace",
+    });
+    const identity = {
+      workspaceId: home.workspaceId,
+      interactionWorkspaceId: routed!.id,
+      connectionId: home.connectionId,
+      slackUserId: "U_SPLIT",
+    };
+    expect(
+      await resolveSlackInteractionFirstTaskHint(db, {
+        ...identity,
+        interactionId: created.interaction.id,
+      }),
+    ).toBe(true);
+    // Replaying the same acknowledgement must render the same bytes.
+    expect(
+      await resolveSlackInteractionFirstTaskHint(db, {
+        ...identity,
+        interactionId: created.interaction.id,
+      }),
+    ).toBe(true);
+    // The claim is spent, and it was spent in the HOME workspace.
+    const link = await getSlackBotUserLink(db, home.workspaceId, home.connectionId, "U_SPLIT");
+    expect(link?.firstTaskHintInteractionId).toBe(created.interaction.id);
+    const next = await home.interaction("U_SPLIT", "C_SPLIT_NEXT");
+    expect(
+      await resolveSlackInteractionFirstTaskHint(db, {
+        workspaceId: home.workspaceId,
+        connectionId: home.connectionId,
+        slackUserId: "U_SPLIT",
+        interactionId: next.id,
+      }),
+    ).toBe(false);
+  });
+
   test("concurrent resolvers of distinct interactions elect a single winner", async () => {
     if (!available) return;
     const target = await installation(`race-${Date.now()}`);


### PR DESCRIPTION
Second step of per-channel and per-DM Slack workspace routing. This is a refactor: **no routing is added, and behaviour is unchanged**. The whole existing Slack suite (145 tests across seven files) passes with zero test edits, which is the acceptance criterion.

## Why

Today one Slack team addresses exactly one OpenGeni workspace, so one workspace id serves every purpose in the Slack integration. Per-channel routing makes that false, and the two roles the id plays have different owners:

- **HOME** is the installation binding's tenancy. It owns the `connections` row and the bot credential, the post/update/delete ledgers, the inbox row, the identity links, reaction-summon settings, and Slack task policy.
- **TARGET** is the tenancy the session lives in. It owns the `slack_interactions` row, its action handles, its progress deliveries, the access grant, the session, and every session event.

This introduces both explicitly and threads the right one into every call. They are equal on every path today.

## What actually changes shape

- **Thread continuation is connection-scoped.** `slack_interactions_route_uq` is `(connection_id, route_key)`, so one Slack thread maps to one interaction across every workspace an installation can address, while the ordinary read is workspace-fenced. Continuation now goes through the content-free tenancy probe and then reads the full row under the probed tenancy's own RLS.
- **`getOrCreateSlackInteraction` adopts an existing row's tenancy on conflict.** Its recovery `SELECT` runs under the intended scope while the unique index is connection-global, so a thread already owned by another workspace conflicted without being visible to the recovery read and raised `"Slack route idempotency conflict could not be resolved"`. A mapped thread keeps the workspace it was created in. The pump refuses an adopted row whose tenancy differs from the one it authorized, and retries, rather than creating a session there with authority for somewhere else.
- **Delivery resolves its bot client from the installation route** rather than from the interaction's workspace. Every provider call is fenced on a workspace-owned credential, so posting a routed session's progress on another workspace's connection fails hard. A missing or re-pointed binding falls back to the interaction's own tenancy, which is exactly what this code did before, so no delivery that used to succeed can now fail.
- **The first-task hint no longer mutates a home table and a target table inside one RLS scope**, which one transaction cannot do once the two differ. The per-identity claim is the source of truth and is replay-stable, so the answer is derived from it and then frozen on the interaction. Concurrent resolvers of one interaction still agree, concurrent resolvers of distinct interactions still elect exactly one winner, and a crash between claim and freeze still re-derives the same answer.
- **Imported Slack attachments become File resources of the session's workspace**, so the invocation and reaction preparation paths take the target scope.
- **Session events, user messages and pending human-input reads** follow the session, not the inbox row. Deep links point at the workspace the session is in.

## Deliberately unchanged

The three installation re-checks still compare HOME on both sides, because they compare credential tenancy and are the guard that the app was not reinstalled elsewhere between enqueue and drain. Reaction-summon settings and Slack task policy stay HOME, because they govern the Slack surface rather than the task tenant.

## Review

An independent five-lens adversarial panel reviewed this diff cold; 10 findings survived verification and all are fixed here, including four session operations that still addressed a target session under home tenancy and would have been invisible until routing landed. 25 further claimed findings were rejected under verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111dShuHC2eNj1Z53dtS1dL