### PR TITLE
Fix production source-admission controller context

### DIFF
--- a/.github/workflows/source-admission.yml
+++ b/.github/workflows/source-admission.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       OPENGENI_SOURCE_ADMISSION_ACTION: verify_immutable_pr_head
+      ADMISSION_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       ADMISSION_HELPER_SHA256: d7a5619c88a0118348ee923b862ecac6ad9608c696494f42252f89455b5fe55a
     steps:
       - name: Execute the exact base-owned admission verifier
@@ -38,23 +39,44 @@ jobs:
           [[ "$GITHUB_API_URL" == "https://api.github.com" ]]
           [[ "$GITHUB_REPOSITORY" == "Cloudgeni-ai/opengeni" ]]
           [[ "$GITHUB_EVENT_NAME" == "pull_request_target" ]]
-          [[ "$GITHUB_REF" == "refs/heads/production" ]]
+          [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$GITHUB_BASE_REF" == "production" ]]
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$GITHUB_WORKFLOW_SHA" == "$GITHUB_SHA" ]]
+          [[ "$GITHUB_WORKFLOW_REF" == "$GITHUB_REPOSITORY/.github/workflows/source-admission.yml@refs/heads/main" ]]
+          [[ "$ADMISSION_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
 
-          # The workflow file is the base-owned trust anchor. Fetch the helper
-          # from that same immutable commit and verify its exact reviewed bytes.
+          # pull_request_target loads this controller from protected main even
+          # when the PR base is production. Keep the verifier base-owned: fetch
+          # it from the immutable production event-base SHA, verify its reviewed
+          # bytes, then supply that exact base identity to its context checker.
           helper="$RUNNER_TEMP/source-admission.mjs"
           curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.raw+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/Cloudgeni-ai/opengeni/contents/scripts/check-source-admission.mjs?ref=$GITHUB_WORKFLOW_SHA" \
+            "https://api.github.com/repos/Cloudgeni-ai/opengeni/contents/scripts/check-source-admission.mjs?ref=$ADMISSION_BASE_SHA" \
             --output "$helper"
           actual_sha256="$(sha256sum "$helper" | awk '{print $1}')"
           [[ "$actual_sha256" == "$ADMISSION_HELPER_SHA256" ]]
-          node "$helper"
+          ADMISSION_HELPER_PATH="$helper" node --input-type=module <<'NODE'
+          import { pathToFileURL } from "node:url";
+
+          const helperPath = process.env.ADMISSION_HELPER_PATH;
+          if (!helperPath) throw new Error("ADMISSION_HELPER_PATH is missing");
+          const { verifySourceAdmission } = await import(pathToFileURL(helperPath).href);
+          await verifySourceAdmission({
+            env: {
+              ...process.env,
+              GITHUB_REF: `refs/heads/${process.env.GITHUB_BASE_REF}`,
+              GITHUB_SHA: process.env.ADMISSION_BASE_SHA,
+              GITHUB_WORKFLOW_REF:
+                `${process.env.GITHUB_REPOSITORY}/.github/workflows/source-admission.yml` +
+                `@refs/heads/${process.env.GITHUB_BASE_REF}`,
+              GITHUB_WORKFLOW_SHA: process.env.ADMISSION_BASE_SHA,
+            },
+          });
+          NODE
 
   report:
     name: Current-base source admission

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1002,11 +1002,16 @@ The exact reviewed head must still resolve directly from its canonical
 `Current-base source admission` check. Version PRs receive that named check
 from trusted `ci.yml` dispatch. The `source-admission.yml` workflow is
 hotfix-into-production only; its required-check name stays on a skip-success
-report job so promote PRs from live `main` remain mergeable. The check admits
-the immutable provider event head against the PR's provider merge-base tree; it
-does not require the event base to equal continuously moving `main`. The
-base-owned workflow/helper SHA must remain in protected `production` ancestry
-for hotfix admission, and the provider base/head/repository,
+report job so promote PRs from live `main` remain mergeable. GitHub loads a
+`pull_request_target` workflow from protected default-branch `main`, even when
+the PR base is `production`. That controller therefore validates its real
+default-branch workflow identity, reads the production base SHA from the exact
+pull-request event, fetches and hash-pins the verifier from that immutable event
+base, and invokes it with an explicit base-owned workflow context. The check
+admits the immutable provider event head against
+the PR's provider merge-base tree; it does not require the event base to equal
+continuously moving `main`. The base-owned helper SHA must remain in protected
+`production` ancestry for hotfix admission, and the provider base/head/repository,
 direct tree manifest, file projection, helper digest, read-only permissions,
 and terminal head identity remain fail-closed. The merge authority separately performs the fresh latest-main
 conflict, canonical patch-equivalence, protected-path, generated/migration,

--- a/scripts/check-source-admission.test.ts
+++ b/scripts/check-source-admission.test.ts
@@ -487,7 +487,7 @@ describe("source admission", () => {
     ).rejects.toThrow("pull-request head repository changed");
   });
 
-  test("workflow is base-owned, read-only, action-free, and helper-hash pinned", () => {
+  test("workflow uses a trusted main controller with a base-owned pinned helper", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     const helper = readFileSync(helperPath);
     const helperSha256 = createHash("sha256").update(helper).digest("hex");
@@ -501,14 +501,23 @@ describe("source admission", () => {
     expect(workflow).not.toMatch(/^\s+uses:/m);
     expect(workflow).not.toContain("secrets.");
     expect(workflow).not.toContain("--location");
-    expect(workflow).toContain("base-owned trust anchor");
+    expect(workflow).toContain("pull_request_target loads this controller from protected main");
+    expect(workflow).toContain(
+      '[[ "$GITHUB_WORKFLOW_REF" == "$GITHUB_REPOSITORY/.github/workflows/source-admission.yml@refs/heads/main" ]]',
+    );
+    expect(workflow).toContain('[[ "$GITHUB_REF" == "refs/heads/main" ]]');
+    expect(workflow).toContain("ADMISSION_BASE_SHA: ${{ github.event.pull_request.base.sha }}");
     expect(workflow).toContain("name: Verify hotfix freeze-head");
     expect(workflow).toContain("name: Current-base source admission");
     expect(workflow).toContain("if: ${{ always() }}");
     expect(workflow).toContain("VERIFY_RESULT");
     expect(workflow).toContain(`ADMISSION_HELPER_SHA256: ${helperSha256}`);
-    expect(workflow).toContain("ref=$GITHUB_WORKFLOW_SHA");
-    expect(workflow).toContain('node "$helper"');
+    expect(workflow).toContain("ref=$ADMISSION_BASE_SHA");
+    expect(workflow).toContain('ADMISSION_HELPER_PATH="$helper" node --input-type=module');
+    expect(workflow).toContain("GITHUB_REF: `refs/heads/${process.env.GITHUB_BASE_REF}`");
+    expect(workflow).toContain("GITHUB_SHA: process.env.ADMISSION_BASE_SHA");
+    expect(workflow).toContain("GITHUB_WORKFLOW_SHA: process.env.ADMISSION_BASE_SHA");
+    expect(workflow).toContain("@refs/heads/${process.env.GITHUB_BASE_REF}");
   });
 
   test("repository skill requires leaf-cause triage and immutable-head delivery", () => {

--- a/scripts/staging-production-split-contract.test.ts
+++ b/scripts/staging-production-split-contract.test.ts
@@ -56,5 +56,8 @@ describe("staging / production split workflows", () => {
     expect(source).toContain("name: Verify hotfix freeze-head");
     expect(source).toContain("name: Current-base source admission");
     expect(source).toContain("if: ${{ always() }}");
+    expect(source).toContain("ref=$ADMISSION_BASE_SHA");
+    expect(source).toContain("ADMISSION_BASE_SHA: ${{ github.event.pull_request.base.sha }}");
+    expect(source).toContain("pull_request_target loads this controller from protected main");
   });
 });

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -78,7 +78,7 @@
     },
     {
       "path": ".github/workflows/source-admission.yml",
-      "sha256": "f18606d2da2fef8dc7726958e5fbe753b4567a7df043f5549f650ef491310673"
+      "sha256": "dff0ac659656f7158bad6936bcc1fdee321beccfdf134944f087612efef37a3f"
     },
     {
       "path": ".github/workflows/staging-canary-dispatch.yml",
@@ -1291,7 +1291,7 @@
       "workflow": ".github/workflows/source-admission.yml",
       "job": "verify",
       "step": "Execute the exact base-owned admission verifier",
-      "sha256": "48befe1e1f09b43c7f5951b3a31776fe7d28ac20945291a2afe7e8beaa10abdf"
+      "sha256": "1fea293d52d68f63debb78965e555985a4383b85ac96726f688d9ae62d800bb0"
     },
     {
       "workflow": ".github/workflows/staging-canary-dispatch.yml",


### PR DESCRIPTION
## Summary

- treat `pull_request_target` as a protected-default-branch controller instead of conflating its SHA/ref with the PR base
- read the immutable production base SHA from the exact pull-request event
- fetch and hash-pin the verifier from that base, then invoke it with the explicit base-owned context it already validates
- update the workflow execution manifest and delivery documentation

## Verification

- source-admission, staging/production split, and delivery-process tests: 27 passed
- exact live verifier simulation against an open production hotfix: passed with an 18-path manifest
- `bun run check:workflow-graph`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:public-hygiene`