### PR TITLE
fix(slack): fence the routing probes and the membership authority arm

### DIFF
--- a/.changeset/slack-routing-authority-fences.md
+++ b/.changeset/slack-routing-authority-fences.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Fence both Slack routing tenancy probes on the organization the caller is acting for, and apply the canonical live-authority rule to the membership arm of `resolveSlackTargetAuthority`, so a suspended organization member holding a stale `workspace_memberships` row is no longer granted. The two arbitrary-subject Slack resolvers are renamed to the repository's `namedSubject*` convention and carry the oracle banner.

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -63,7 +63,7 @@ import {
   probeSlackActionHandleTenancy,
   getSlackChannelRoute,
   getSlackUserDmRoute,
-  listSlackRoutableWorkspacesForSubject,
+  listNamedSubjectSlackRoutableWorkspaces,
   getActiveSlackTaskPolicy,
   getSlackSharedTaskOrigin,
   getSessionEventByClientEventId,
@@ -1318,7 +1318,7 @@ async function resolveSlackRouteForEntry(
           slackUserId: entry.slackUserId,
         })
       : Promise.resolve(null),
-    listSlackRoutableWorkspacesForSubject(deps.db, { accountId: home.accountId, subjectId }),
+    listNamedSubjectSlackRoutableWorkspaces(deps.db, { accountId: home.accountId, subjectId }),
   ]);
   return resolveSlackWorkspaceRoute({
     ...base,
@@ -1423,6 +1423,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
   // A mapped thread keeps the workspace it was created in, so the continuation
   // lookup is connection-scoped rather than workspace-fenced.
   const existing = await getSlackInteractionByConnectionRoute(deps.db, {
+    accountId: home.accountId,
     connectionId: entry.connectionId,
     routeKey,
   });
@@ -2123,6 +2124,7 @@ async function processSlackReactionInboxEntry(
   });
   const routeKey = slackRouteKey(entry.slackChannelId, context.threadTimestamp);
   const existing = await getSlackInteractionByConnectionRoute(deps.db, {
+    accountId: home.accountId,
     connectionId: entry.connectionId,
     routeKey,
   });
@@ -2719,6 +2721,7 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
   // check below is unchanged and still runs in the handle's own tenancy.
   const handleTenancy =
     (await probeSlackActionHandleTenancy(deps.db, {
+      accountId: home.accountId,
       connectionId: entry.connectionId,
       handleId,
     })) ?? home;

--- a/packages/db/drizzle/0341_slack_routing_probe_organization_fence.sql
+++ b/packages/db/drizzle/0341_slack_routing_probe_organization_fence.sql
@@ -1,0 +1,109 @@
+-- deployment-mode: rolling
+-- Fence both Slack routing tenancy probes on the organization the caller is
+-- acting for.
+--
+-- Neither probe carried an account predicate. Both are SECURITY DEFINER and
+-- both return tenancy ids, so a caller holding another organization's
+-- connection UUID plus a route key or a handle id learned that organization's
+-- account, workspace and interaction ids. Exploitability is low today, because
+-- connection ids are never caller-supplied and the Slack signature check
+-- already fences the team, but the predicate is one line and every sibling
+-- authority routine carries it.
+--
+-- Rolling by expand-and-contract: the fenced three-argument routines are added
+-- alongside the existing two-argument ones rather than replacing them, so an
+-- old image keeps resolving thread continuation and button clicks through the
+-- signature it knows. A later migration drops the unfenced pair once the fleet
+-- is on an image that calls the fenced one; dropping them here would break
+-- every running old worker the moment this commits.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+DO $slack_fenced_interaction_probe$
+DECLARE data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE FUNCTION opengeni_private.resolve_slack_interaction_tenancy(
+      p_account_id uuid,
+      p_connection_id uuid,
+      p_route_key text
+    )
+    RETURNS TABLE (account_id uuid, workspace_id uuid, interaction_id uuid)
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = %1$I, pg_catalog
+    AS $body$
+    BEGIN
+      IF p_account_id IS NULL OR p_connection_id IS NULL OR p_route_key IS NULL THEN
+        RETURN;
+      END IF;
+      INSERT INTO opengeni_private.slack_routing_runtime_capabilities (
+        backend_pid, transaction_id, capability_kind
+      ) VALUES (
+        pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'interaction_tenancy'
+      ) ON CONFLICT DO NOTHING;
+      BEGIN
+        RETURN QUERY
+          SELECT I.account_id, I.workspace_id, I.id
+          FROM slack_interactions I
+          WHERE I.account_id = p_account_id
+            AND I.connection_id = p_connection_id
+            AND I.route_key = p_route_key
+          LIMIT 1;
+        DELETE FROM opengeni_private.slack_routing_runtime_capabilities
+        WHERE backend_pid = pg_catalog.pg_backend_pid()
+          AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+          AND capability_kind = 'interaction_tenancy';
+        RETURN;
+      EXCEPTION WHEN OTHERS THEN
+        DELETE FROM opengeni_private.slack_routing_runtime_capabilities
+        WHERE backend_pid = pg_catalog.pg_backend_pid()
+          AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+          AND capability_kind = 'interaction_tenancy';
+        RAISE;
+      END;
+    END;
+    $body$
+  $ddl$, data_schema);
+END
+$slack_fenced_interaction_probe$;
+
+REVOKE ALL ON FUNCTION opengeni_private.resolve_slack_interaction_tenancy(uuid, uuid, text)
+  FROM PUBLIC;
+
+CREATE FUNCTION opengeni_private.resolve_slack_action_handle_tenancy(
+  p_account_id uuid,
+  p_connection_id uuid,
+  p_handle_id uuid
+)
+RETURNS TABLE (account_id uuid, workspace_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = opengeni_private, pg_catalog
+AS $$
+  SELECT T.account_id, T.workspace_id
+  FROM slack_action_handle_tenancy T
+  WHERE T.account_id = p_account_id
+    AND T.handle_id = p_handle_id
+    AND T.connection_id = p_connection_id
+  LIMIT 1
+$$;
+
+REVOKE ALL ON FUNCTION
+  opengeni_private.resolve_slack_action_handle_tenancy(uuid, uuid, uuid) FROM PUBLIC;
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION
+      opengeni_private.resolve_slack_interaction_tenancy(uuid, uuid, text) TO opengeni_app;
+    GRANT EXECUTE ON FUNCTION
+      opengeni_private.resolve_slack_action_handle_tenancy(uuid, uuid, uuid) TO opengeni_app;
+  END IF;
+END
+$grants$;
+
+RESET statement_timeout;
+RESET lock_timeout;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -432,7 +432,7 @@ export * from "./slack-user-link-access";
 export * from "./slack-routing";
 export * from "./slack-routing-personal-workspace";
 import { probeSlackInteractionTenancy } from "./slack-routing";
-import { personalWorkspaceIdForSubject } from "./slack-routing-personal-workspace";
+import { namedSubjectPersonalWorkspaceId } from "./slack-routing-personal-workspace";
 export * from "./workspace-membership-permissions";
 export * from "./video-generation";
 export * from "./user-resource-authority";
@@ -10190,6 +10190,7 @@ export async function getOrCreateSlackInteraction(
   // here. Re-probe the connection-global route and adopt the existing row's
   // tenancy: a mapped thread keeps the workspace it was created in.
   const probed = await probeSlackInteractionTenancy(db, {
+    accountId: input.accountId,
     connectionId: input.connectionId,
     routeKey: input.routeKey,
   });
@@ -10210,10 +10211,14 @@ export async function getOrCreateSlackInteraction(
  * interaction across every workspace this installation can address. The
  * content-free tenancy probe resolves which workspace that is; the full row is
  * then read under that workspace's own RLS scope, so nothing is widened.
+ *
+ * `accountId` is the organization the caller is acting for, and the probe is
+ * fenced on it: crossing workspaces within one organization is the whole point,
+ * crossing organizations never is.
  */
 export async function getSlackInteractionByConnectionRoute(
   db: Database,
-  input: { connectionId: string; routeKey: string },
+  input: { accountId: string; connectionId: string; routeKey: string },
 ): Promise<SlackInteraction | null> {
   const probed = await probeSlackInteractionTenancy(db, input);
   if (!probed) return null;
@@ -18627,13 +18632,22 @@ export async function resolveSlackTargetAuthority(
   const grant = await getWorkspaceGrant(db, input.subjectId, input.targetWorkspaceId, {
     principalKind: "human_session",
   });
-  if (grant && grant.accountId === input.targetAccountId) return grant;
+  const membershipGrant = grant && grant.accountId === input.targetAccountId ? grant : null;
 
-  const personalWorkspaceId = await personalWorkspaceIdForSubject(db, {
-    accountId: input.targetAccountId,
-    subjectId: input.subjectId,
-  });
-  if (!personalWorkspaceId || personalWorkspaceId !== input.targetWorkspaceId) return null;
+  // Both arms answer to the same rule. `getWorkspaceGrant` is a bare membership
+  // join: it cannot see that the organization membership behind that row was
+  // suspended or offboarded, so returning it verbatim would keep serving a
+  // person the organization has already removed. `namedSubjectHasLiveWorkspaceAuthority`
+  // is the canonical implementation of "does this subject hold authority here",
+  // and it covers both a persisted membership row and the personal-workspace
+  // pointer, so it is applied before either grant shape is returned.
+  const personalWorkspaceId = membershipGrant
+    ? null
+    : await namedSubjectPersonalWorkspaceId(db, {
+        accountId: input.targetAccountId,
+        subjectId: input.subjectId,
+      });
+  if (!membershipGrant && personalWorkspaceId !== input.targetWorkspaceId) return null;
 
   const live = await namedSubjectHasLiveWorkspaceAuthority(db, {
     accountId: input.targetAccountId,
@@ -18641,6 +18655,7 @@ export async function resolveSlackTargetAuthority(
     subjectId: input.subjectId,
   });
   if (!live) return null;
+  if (membershipGrant) return membershipGrant;
 
   return {
     workspaceId: input.targetWorkspaceId,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1980,10 +1980,20 @@ export const slackUserDmRoutes = pgTable(
  * own `block_action` inbox row - so this column is provenance, not a live edge.
  *
  * `requestText` mirrors the inbox's exact 12000 byte bound so a prompt can
- * always carry the originating row's text losslessly, and `providerEventId` is
- * the ORIGINAL event so the answer can re-materialize it under the inbox's own
- * `(connection_id, provider_event_id)` dedupe unique. That is also what makes a
- * double-click unable to create two sessions.
+ * always carry the originating row's text losslessly.
+ *
+ * `providerEventId` is the ORIGINAL event, and it is PROVENANCE, not the id the
+ * answer re-materializes under. Migration 0335's comment claims the answer can
+ * re-insert the original event id under the inbox's own
+ * `(connection_id, provider_event_id)` dedupe unique; that is wrong, and the
+ * migration's bytes are frozen so the claim is corrected here instead. The
+ * original inbox row still exists and is settled `processed`, so re-inserting
+ * its id conflicts and does nothing, and the chosen workspace would never start
+ * any work at all. The answer must enqueue a DERIVED id -
+ * `<originalProviderEventId>:route:<promptId>` - which is unique per prompt and
+ * still idempotent, so a double-click cannot create two sessions. The
+ * `(connection_id, provider_event_id)` unique on this table is what makes
+ * Slack's retries of the same event unable to post a second picker.
  */
 export const slackRoutePrompts = pgTable(
   "slack_route_prompts",

--- a/packages/db/src/slack-routing-personal-workspace.ts
+++ b/packages/db/src/slack-routing-personal-workspace.ts
@@ -19,8 +19,14 @@ import { rlsSubjectIdOrEmpty } from "./workspace-authority";
  * local principals) can never own an organization membership, so they
  * short-circuit rather than tripping `list_self_organization_memberships`'
  * `42501` guard.
+ *
+ * ORACLE, NOT AN AUTHORIZATION. This answers "which workspace is this named
+ * subject's own" for whatever subject it is handed; it does not establish that
+ * the caller IS that subject. Pass only a subject authenticated out of band -
+ * for Slack, one named by a durable `slack_bot_user_links` row. Never pass a
+ * subject taken from a request payload.
  */
-export async function personalWorkspaceIdForSubject(
+export async function namedSubjectPersonalWorkspaceId(
   db: Database,
   input: { accountId: string; subjectId: string },
 ): Promise<string | null> {

--- a/packages/db/src/slack-routing.ts
+++ b/packages/db/src/slack-routing.ts
@@ -24,7 +24,7 @@
 import { and, eq, sql } from "drizzle-orm";
 
 import { rawRows, withRlsContext, type Database } from "./database";
-import { personalWorkspaceIdForSubject } from "./slack-routing-personal-workspace";
+import { namedSubjectPersonalWorkspaceId } from "./slack-routing-personal-workspace";
 import * as schema from "./schema";
 import { workspaceMembershipPermissionsAllowSlackLink } from "./slack-user-link-access";
 
@@ -139,7 +139,7 @@ function mapUserDmRoute(row: typeof schema.slackUserDmRoutes.$inferSelect): Slac
  */
 export async function probeSlackInteractionTenancy(
   db: Database,
-  input: { connectionId: string; routeKey: string },
+  input: { accountId: string; connectionId: string; routeKey: string },
 ): Promise<SlackInteractionTenancy | null> {
   const rows = await rawRows<{
     account_id: string;
@@ -149,6 +149,7 @@ export async function probeSlackInteractionTenancy(
     db,
     sql`select account_id, workspace_id, interaction_id
       from opengeni_private.resolve_slack_interaction_tenancy(
+        ${input.accountId}::uuid,
         ${input.connectionId}::uuid,
         ${input.routeKey}
       )`,
@@ -174,12 +175,13 @@ export async function probeSlackInteractionTenancy(
  */
 export async function probeSlackActionHandleTenancy(
   db: Database,
-  input: { connectionId: string; handleId: string },
+  input: { accountId: string; connectionId: string; handleId: string },
 ): Promise<SlackRouteHome | null> {
   const rows = await rawRows<{ account_id: string; workspace_id: string }>(
     db,
     sql`select account_id, workspace_id
       from opengeni_private.resolve_slack_action_handle_tenancy(
+        ${input.accountId}::uuid,
         ${input.connectionId}::uuid,
         ${input.handleId}::uuid
       )`,
@@ -390,8 +392,14 @@ export async function deleteSlackUserDmRoute(
  *
  * Ordered stably by label then workspace id, with plain code-unit comparison so
  * two hosts with different ICU data cannot render a picker differently.
+ *
+ * ORACLE, NOT AN AUTHORIZATION. This answers "what could this named subject use"
+ * for whatever subject it is handed; it does not establish that the caller IS
+ * that subject. Pass only a subject authenticated out of band - for Slack, one
+ * named by a durable `slack_bot_user_links` row. Never pass a subject taken
+ * from a request payload.
  */
-export async function listSlackRoutableWorkspacesForSubject(
+export async function listNamedSubjectSlackRoutableWorkspaces(
   db: Database,
   input: { accountId: string; subjectId: string },
 ): Promise<SlackRoutableWorkspace[]> {
@@ -422,7 +430,7 @@ export async function listSlackRoutableWorkspacesForSubject(
     });
   }
 
-  const personalWorkspaceId = await personalWorkspaceIdForSubject(db, input);
+  const personalWorkspaceId = await namedSubjectPersonalWorkspaceId(db, input);
   if (personalWorkspaceId) {
     const [row] = await db
       .select({

--- a/packages/db/src/slack-user-link-access.ts
+++ b/packages/db/src/slack-user-link-access.ts
@@ -9,7 +9,7 @@ import {
 import { and, asc, eq, gt, inArray, ne } from "drizzle-orm";
 
 import { type Database, withWorkspaceRls } from "./database";
-import { personalWorkspaceIdForSubject } from "./slack-routing-personal-workspace";
+import { namedSubjectPersonalWorkspaceId } from "./slack-routing-personal-workspace";
 import { withLosslessContentWriteVersion } from "./lossless-json";
 import * as schema from "./schema";
 import { normalizeWorkspaceMembershipPermissions } from "./workspace-membership-permissions";
@@ -571,7 +571,7 @@ async function membershipAllowsSlackLink(database: Database, row: RequestRow) {
   // Once a Slack direct message can land there, that would tell people to
   // request access to their own workspace. The pointer is DERIVED from an
   // active organization membership; it is never accepted from the request row.
-  const personalWorkspaceId = await personalWorkspaceIdForSubject(database, {
+  const personalWorkspaceId = await namedSubjectPersonalWorkspaceId(database, {
     accountId: row.accountId,
     subjectId: row.subjectId,
   });

--- a/packages/db/test/migration-0341-slack-routing-probe-organization-fence.test.ts
+++ b/packages/db/test/migration-0341-slack-routing-probe-organization-fence.test.ts
@@ -1,0 +1,125 @@
+// Migration 0341 fences both Slack routing tenancy probes on the organization
+// the caller is acting for. Crossing workspaces inside one organization is what
+// routing is; crossing organizations never is.
+//
+// Driven through `acquireOwnerMigratedTestDatabase` because the shared harness
+// hands out the container superuser, for whom FORCE ROW LEVEL SECURITY never
+// engages, and the owner posture is exactly what a definer probe has to survive.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { migrate } from "../src/migrate";
+
+const migrationUrl = new URL(
+  "../drizzle/0341_slack_routing_probe_organization_fence.sql",
+  import.meta.url,
+);
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+const ACCOUNT = "aaaaaaaa-0341-4341-8341-aaaaaaaaaaaa";
+const OTHER_ACCOUNT = "bbbbbbbb-0341-4341-8341-bbbbbbbbbbbb";
+const HOME_WORKSPACE = "11111111-0341-4341-8341-111111111111";
+const TARGET_WORKSPACE = "22222222-0341-4341-8341-222222222222";
+const CONNECTION = "33333333-0341-4341-8341-333333333333";
+const INTERACTION = "44444444-0341-4341-8341-444444444444";
+const ROUTE_KEY = "C0341:1700000000.0001";
+
+let owned: OwnerMigratedTestDatabase | null = null;
+
+describe("migration 0341 organization-fenced Slack routing probes", () => {
+  beforeAll(async () => {
+    owned = await acquireOwnerMigratedTestDatabase("slack-probe-fence");
+    if (!owned) {
+      if (requireRealDatabase) {
+        throw new Error("OPENGENI_REQUIRE_REAL_DB=1 but no owner-migrated database was available");
+      }
+      return;
+    }
+    await migrate(owned.ownerUrl);
+    await owned.admin.unsafe(`
+      insert into managed_accounts (id, name) values
+        ('${ACCOUNT}', 'fence'), ('${OTHER_ACCOUNT}', 'other');
+      insert into workspaces (id, account_id, name) values
+        ('${HOME_WORKSPACE}', '${ACCOUNT}', 'Home'),
+        ('${TARGET_WORKSPACE}', '${ACCOUNT}', 'Target');
+      insert into connections
+        (id, account_id, workspace_id, provider_domain, kind, status, credential_encrypted)
+        values ('${CONNECTION}', '${ACCOUNT}', '${HOME_WORKSPACE}', 'slack.com', 'app_install',
+                'active', '\\x00'::bytea);
+      insert into slack_interactions
+        (id, account_id, workspace_id, connection_id, slack_team_id, slack_channel_id,
+         slack_thread_ts, route_key, triggering_provider_event_id, owning_subject_id, visibility)
+        values ('${INTERACTION}', '${ACCOUNT}', '${TARGET_WORKSPACE}', '${CONNECTION}', 'T0341',
+                'C0341', '1700000000.0001', '${ROUTE_KEY}', 'Ev0341', 'user:fence', 'workspace');
+    `);
+  }, 900_000);
+
+  afterAll(async () => {
+    await owned?.release();
+  });
+
+  test("adds the fenced routines without dropping the ones an old image calls", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.startsWith("-- deployment-mode: rolling")).toBe(true);
+    expect(source).toContain("SET search_path");
+    expect(source).toContain("REVOKE ALL ON FUNCTION");
+    // Expand-and-contract: dropping the unfenced pair here would break every
+    // running old worker the moment this commits.
+    expect(source).not.toMatch(/DROP\s+FUNCTION/u);
+    expect(source).not.toContain("resolve_slack_installation");
+  });
+
+  test("resolves inside the organization and refuses across organizations", async () => {
+    if (!owned) return;
+    const rows = await owned.admin<Array<{ account_id: string; workspace_id: string }>>`
+      select account_id, workspace_id
+      from opengeni_private.resolve_slack_interaction_tenancy(
+        ${ACCOUNT}::uuid, ${CONNECTION}::uuid, ${ROUTE_KEY})`;
+    expect([...rows]).toEqual([{ account_id: ACCOUNT, workspace_id: TARGET_WORKSPACE }]);
+
+    // The same connection and route key, named by another organization, learns
+    // nothing at all - not even that the interaction exists.
+    const foreign = await owned.admin<Array<Record<string, unknown>>>`
+      select account_id, workspace_id
+      from opengeni_private.resolve_slack_interaction_tenancy(
+        ${OTHER_ACCOUNT}::uuid, ${CONNECTION}::uuid, ${ROUTE_KEY})`;
+    expect([...foreign]).toEqual([]);
+
+    const missing = await owned.admin<Array<Record<string, unknown>>>`
+      select account_id, workspace_id
+      from opengeni_private.resolve_slack_interaction_tenancy(
+        null::uuid, ${CONNECTION}::uuid, ${ROUTE_KEY})`;
+    expect([...missing]).toEqual([]);
+  }, 120_000);
+
+  test("fences the action-handle probe the same way", async () => {
+    if (!owned) return;
+    const [privileges] = await owned.admin<Array<{ fenced: boolean; unfenced: boolean }>>`
+      select
+        has_function_privilege(
+          'opengeni_app',
+          'opengeni_private.resolve_slack_action_handle_tenancy(uuid, uuid, uuid)',
+          'EXECUTE') as fenced,
+        has_function_privilege(
+          'opengeni_app',
+          'opengeni_private.resolve_slack_action_handle_tenancy(uuid, uuid)',
+          'EXECUTE') as unfenced`;
+    // Both are executable during the rolling window; the fenced one is what the
+    // new image calls.
+    expect(privileges).toEqual({ fenced: true, unfenced: true });
+
+    const [definer] = await owned.admin<Array<{ security: string; config: string[] | null }>>`
+      select case when p.prosecdef then 'definer' else 'invoker' end as security,
+             p.proconfig as config
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'opengeni_private'
+        and p.proname = 'resolve_slack_action_handle_tenancy'
+        and p.pronargs = 3`;
+    expect(definer?.security).toBe("definer");
+    expect(definer?.config).toContain("search_path=opengeni_private, pg_catalog");
+  }, 120_000);
+});

--- a/packages/db/test/slack-routing.test.ts
+++ b/packages/db/test/slack-routing.test.ts
@@ -16,9 +16,9 @@ import {
   getSlackChannelRoute,
   getSlackUserDmRoute,
   grantWorkspaceAccess,
-  listSlackRoutableWorkspacesForSubject,
+  listNamedSubjectSlackRoutableWorkspaces,
   managedPersonalWorkspacePermissions,
-  personalWorkspaceIdForSubject,
+  namedSubjectPersonalWorkspaceId,
   probeSlackInteractionTenancy,
   resolveSlackTargetAuthority,
   upsertSlackChannelRoute,
@@ -92,7 +92,7 @@ afterAll(async () => {
   await shared?.release();
 }, 180_000);
 
-describe("listSlackRoutableWorkspacesForSubject", () => {
+describe("listNamedSubjectSlackRoutableWorkspaces", () => {
   test("offers writable memberships plus the subject's own personal workspace", async () => {
     if (!client) return;
     const human = await provisionHuman("candidates");
@@ -127,7 +127,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
       name: "Unrelated",
     });
 
-    const candidates = await listSlackRoutableWorkspacesForSubject(client.db, {
+    const candidates = await listNamedSubjectSlackRoutableWorkspaces(client.db, {
       accountId: human.accountId,
       subjectId: human.subjectId,
     });
@@ -151,7 +151,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
     const human = await provisionHuman("scoped");
     const stranger = await provisionHuman("stranger");
 
-    const candidates = await listSlackRoutableWorkspacesForSubject(client.db, {
+    const candidates = await listNamedSubjectSlackRoutableWorkspaces(client.db, {
       accountId: human.accountId,
       subjectId: human.subjectId,
     });
@@ -161,7 +161,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
 
     // Asking about an organization the subject does not belong to yields nothing.
     await expect(
-      listSlackRoutableWorkspacesForSubject(client.db, {
+      listNamedSubjectSlackRoutableWorkspaces(client.db, {
         accountId: stranger.accountId,
         subjectId: human.subjectId,
       }),
@@ -183,7 +183,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
         permissions: ["sessions:create"],
       });
     }
-    const candidates = await listSlackRoutableWorkspacesForSubject(client.db, {
+    const candidates = await listNamedSubjectSlackRoutableWorkspaces(client.db, {
       accountId: human.accountId,
       subjectId: human.subjectId,
     });
@@ -205,7 +205,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
                    set_config('opengeni.workspace_id', ${human.sharedWorkspaceId}, true),
                    set_config('opengeni.subject_id', ${human.subjectId}, true)`,
       );
-      await personalWorkspaceIdForSubject(tx, {
+      await namedSubjectPersonalWorkspaceId(tx, {
         accountId: other.accountId,
         subjectId: other.subjectId,
       });
@@ -221,7 +221,7 @@ describe("listSlackRoutableWorkspacesForSubject", () => {
     if (!client) return;
     const human = await provisionHuman("machine");
     await expect(
-      listSlackRoutableWorkspacesForSubject(client.db, {
+      listNamedSubjectSlackRoutableWorkspaces(client.db, {
         accountId: human.accountId,
         subjectId: `api_key:${crypto.randomUUID()}`,
       }),
@@ -245,6 +245,43 @@ describe("resolveSlackTargetAuthority", () => {
       principalKind: "human_session",
     });
     expect(grant?.permissions).toContain("sessions:create");
+  });
+
+  test("refuses a suspended organization member holding a stale membership row", async () => {
+    if (!client) return;
+    // `getWorkspaceGrant` is a bare membership join: it cannot see that the
+    // organization membership behind the row was suspended. Returning it
+    // verbatim would keep serving someone the organization has removed, and
+    // Slack is the one surface where that person still has a live credential
+    // pointed at the workspace.
+    const human = await provisionHuman("suspended-member");
+    await expect(
+      resolveSlackTargetAuthority(client.db, {
+        subjectId: human.subjectId,
+        targetAccountId: human.accountId,
+        targetWorkspaceId: human.sharedWorkspaceId,
+      }),
+    ).resolves.not.toBeNull();
+
+    await shared!.admin`
+      update organization_memberships set status = 'suspended'
+      where id = ${human.membershipId}::uuid`;
+
+    await expect(
+      resolveSlackTargetAuthority(client.db, {
+        subjectId: human.subjectId,
+        targetAccountId: human.accountId,
+        targetWorkspaceId: human.sharedWorkspaceId,
+      }),
+    ).resolves.toBeNull();
+    // The personal-workspace arm was already fenced and stays fenced.
+    await expect(
+      resolveSlackTargetAuthority(client.db, {
+        subjectId: human.subjectId,
+        targetAccountId: human.accountId,
+        targetWorkspaceId: human.personalWorkspaceId,
+      }),
+    ).resolves.toBeNull();
   });
 
   test("mints the personal-workspace grant only for its own owner", async () => {
@@ -362,7 +399,11 @@ describe("probeSlackInteractionTenancy", () => {
 
     // The caller here is scoped nowhere near the target workspace; the probe is
     // what makes thread continuation work across a routed workspace at all.
-    const probed = await probeSlackInteractionTenancy(client.db, { connectionId, routeKey });
+    const probed = await probeSlackInteractionTenancy(client.db, {
+      accountId: human.accountId,
+      connectionId,
+      routeKey,
+    });
     expect(probed).toEqual({
       accountId: human.accountId,
       workspaceId: target.id,
@@ -372,7 +413,22 @@ describe("probeSlackInteractionTenancy", () => {
     expect(Object.keys(probed ?? {}).sort()).toEqual(["accountId", "interactionId", "workspaceId"]);
 
     await expect(
-      probeSlackInteractionTenancy(client.db, { connectionId, routeKey: "absent" }),
+      probeSlackInteractionTenancy(client.db, {
+        accountId: human.accountId,
+        connectionId,
+        routeKey: "absent",
+      }),
+    ).resolves.toBeNull();
+
+    // Crossing workspaces inside one organization is the point. Crossing
+    // organizations never is, so another organization's id resolves nothing
+    // even with the right connection and route key.
+    await expect(
+      probeSlackInteractionTenancy(client.db, {
+        accountId: crypto.randomUUID(),
+        connectionId,
+        routeKey,
+      }),
     ).resolves.toBeNull();
   });
 });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -174,6 +174,7 @@ describe("release schema contract", () => {
       "0338_atomic_connected_machine_attachments.sql",
       "0339_document_authority_reclassification.sql",
       "0340_tenancy_backfill_activation_evidence.sql",
+      "0341_slack_routing_probe_organization_fence.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -192,20 +193,27 @@ describe("release schema contract", () => {
     const tenancyBackfillActivationEvidence = completeSourceContract.migrations.some(
       (migration) => migration.path === "0340_tenancy_backfill_activation_evidence.sql",
     );
+
+    const slackRoutingProbeFence = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0341_slack_routing_probe_organization_fence.sql",
+    );
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
         (documentAuthorityReclassification ? 1 : 0) +
-        (tenancyBackfillActivationEvidence ? 1 : 0),
-      latestMigration: tenancyBackfillActivationEvidence
-        ? "0340_tenancy_backfill_activation_evidence.sql"
-        : documentAuthorityReclassification
-          ? "0339_document_authority_reclassification.sql"
-          : atomicConnectedMachineAttachments
-            ? "0338_atomic_connected_machine_attachments.sql"
-            : routedSlackHandles
-              ? "0337_slack_routed_action_handles.sql"
-              : "0336_atomic_session_fork_visibility.sql",
+        (tenancyBackfillActivationEvidence ? 1 : 0) +
+        (slackRoutingProbeFence ? 1 : 0),
+      latestMigration: slackRoutingProbeFence
+        ? "0341_slack_routing_probe_organization_fence.sql"
+        : tenancyBackfillActivationEvidence
+          ? "0340_tenancy_backfill_activation_evidence.sql"
+          : documentAuthorityReclassification
+            ? "0339_document_authority_reclassification.sql"
+            : atomicConnectedMachineAttachments
+              ? "0338_atomic_connected_machine_attachments.sql"
+              : routedSlackHandles
+                ? "0337_slack_routed_action_handles.sql"
+                : "0336_atomic_session_fork_visibility.sql",
     });
     expect(
       completeSourceContract.migrations.find(


### PR DESCRIPTION
Follow-up to the merged Slack workspace routing work (#1796, #1813, #1816), from a second independent review panel. Eight findings were reported as still standing; I verified each against current `main`. **Five stand and are fixed here**, three were already fixed on `main` by the first panel's pass.

## The two that matter

**Neither tenancy probe carried an account predicate.** `resolve_slack_interaction_tenancy` and `resolve_slack_action_handle_tenancy` are both `SECURITY DEFINER` and both return tenancy ids, so a caller holding another organization's connection UUID plus a route key or a handle id learned that organization's account, workspace and interaction ids. Exploitability is low today, because connection ids are never caller-supplied and the Slack signature check already fences the team, but the predicate is one line and every sibling authority routine carries it. Crossing workspaces inside one organization is what routing *is*; crossing organizations never is.

Migration 0341 is rolling by expand-and-contract: the fenced three-argument routines are added *alongside* the two-argument ones rather than replacing them, so an old image keeps resolving thread continuation and button clicks through the signature it knows. Dropping the unfenced pair here would break every running old worker the moment it commits; a later migration can drop them once the fleet has moved.

**`resolveSlackTargetAuthority` returned `getWorkspaceGrant` verbatim** whenever a `workspace_memberships` row existed, applying the organization-membership fence only on the personal-workspace arm. `getWorkspaceGrant` is a bare membership join, so it cannot see that the organization membership behind that row was suspended or offboarded, and Slack is the one surface where such a person still has a live credential pointed at the workspace. Both arms now go through `namedSubjectHasLiveWorkspaceAuthority`, which is the canonical implementation of that rule and already covers a persisted membership row and the personal pointer alike. **The new test fails without the fix** (verified by reverting).

## Also fixed

- `personalWorkspaceIdForSubject` and `listSlackRoutableWorkspacesForSubject` are arbitrary-subject oracles exported from the package root with no warning. Renamed to the repository's `namedSubject*` convention and given the `ORACLE, NOT AN AUTHORIZATION` banner, so a future caller does not hand either one a request-derived subject.
- Migration 0335's comment claims the picker answer re-materializes the ORIGINAL provider event id under the inbox's own dedupe unique. That cannot work: the original inbox row still exists and is settled `processed`, so the insert conflicts and the chosen workspace never starts any work at all. Migration bytes are frozen, so the correction lands on the schema definition instead, naming the derived id (`<originalProviderEventId>:route:<promptId>`) the answer must actually use.

## Verified already fixed on main

The inbox same-organization fence, the `opengeni.subject_id` leak out of `personalWorkspaceIdForSubject`, and the owner-migrated probe test that establishes a conflicting tenant scope and asserts the direct RLS-scoped read returns nothing. The ordinal and schema-contract findings were moot.

## Deliberately not fixed

Concurrent pending route prompts. The finding is real, but `slack_route_prompts` has no rows and no writer: the picker does not exist yet. A uniqueness constraint belongs with the code that has to handle its conflict, and adding it now is no cheaper than adding it then.

## Verification

New coverage: the fence resolves inside the organization, returns nothing for another organization's id with the *same* connection and route key, and returns nothing for a null account; the fenced handle probe is `SECURITY DEFINER` with a pinned `search_path`; and the suspended-member case on both authority arms. Local: 177 Slack API tests, 58 db tests, schema contract, lint, format, typecheck and all four repo guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111dShuHC2eNj1Z53dtS1dL