### PR TITLE
Backport pinned dual-stack MCP transport

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -445,7 +445,20 @@ export async function resolvePinnedDestination(
       `${label} may not target a private or special-use network address`,
     );
   }
-  return { url, hostname, addresses: normalizedAddresses };
+  return { url, hostname, addresses: preferIpv4Addresses(normalizedAddresses) };
+}
+
+/**
+ * Keep every vetted resolver answer pinned, but prefer IPv4 when both public
+ * families are available. Docker hosts commonly advertise public IPv6 DNS
+ * without an IPv6 egress route; selecting that answer first turns a healthy
+ * dual-stack destination into a deterministic connection failure.
+ */
+function preferIpv4Addresses(addresses: readonly DnsAddress[]): DnsAddress[] {
+  return [
+    ...addresses.filter((entry) => entry.family === 4),
+    ...addresses.filter((entry) => entry.family === 6),
+  ];
 }
 
 /**

--- a/packages/network/test/index.test.ts
+++ b/packages/network/test/index.test.ts
@@ -184,6 +184,33 @@ describe("DNS-pinned outbound transport", () => {
     expect(addresses).toEqual([[{ address: "127.0.0.1", family: 4 }]]);
   });
 
+  test("prefers IPv4 while retaining the complete vetted dual-stack answer", async () => {
+    const pinned: DnsAddress[][] = [];
+    const response = await pinnedFetch("https://dual-stack.example.test/mcp", undefined, production, {
+      dnsLookup: async () => [
+        { address: "2606:4700:3032::6815:3c7a", family: 6 },
+        { address: "104.21.60.122", family: 4 },
+        { address: "2606:4700:3035::ac43:c447", family: 6 },
+        { address: "172.67.196.71", family: 4 },
+      ],
+      agentFactory: (addresses) => {
+        pinned.push([...addresses]);
+        return fakeDispatcher();
+      },
+      fetchImpl: async () => new Response("connected"),
+    });
+
+    expect(await response.text()).toBe("connected");
+    expect(pinned).toEqual([
+      [
+        { address: "104.21.60.122", family: 4 },
+        { address: "172.67.196.71", family: 4 },
+        { address: "2606:4700:3032::6815:3c7a", family: 6 },
+        { address: "2606:4700:3035::ac43:c447", family: 6 },
+      ],
+    ]);
+  });
+
   test("re-pins each redirect hop independently", async () => {
     const lookedUp: string[] = [];
     const pinned: string[][] = [];

--- a/packages/network/test/index.test.ts
+++ b/packages/network/test/index.test.ts
@@ -186,19 +186,24 @@ describe("DNS-pinned outbound transport", () => {
 
   test("prefers IPv4 while retaining the complete vetted dual-stack answer", async () => {
     const pinned: DnsAddress[][] = [];
-    const response = await pinnedFetch("https://dual-stack.example.test/mcp", undefined, production, {
-      dnsLookup: async () => [
-        { address: "2606:4700:3032::6815:3c7a", family: 6 },
-        { address: "104.21.60.122", family: 4 },
-        { address: "2606:4700:3035::ac43:c447", family: 6 },
-        { address: "172.67.196.71", family: 4 },
-      ],
-      agentFactory: (addresses) => {
-        pinned.push([...addresses]);
-        return fakeDispatcher();
+    const response = await pinnedFetch(
+      "https://dual-stack.example.test/mcp",
+      undefined,
+      production,
+      {
+        dnsLookup: async () => [
+          { address: "2606:4700:3032::6815:3c7a", family: 6 },
+          { address: "104.21.60.122", family: 4 },
+          { address: "2606:4700:3035::ac43:c447", family: 6 },
+          { address: "172.67.196.71", family: 4 },
+        ],
+        agentFactory: (addresses) => {
+          pinned.push([...addresses]);
+          return fakeDispatcher();
+        },
+        fetchImpl: async () => new Response("connected"),
       },
-      fetchImpl: async () => new Response("connected"),
-    });
+    );
 
     expect(await response.text()).toBe("connected");
     expect(pinned).toEqual([

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3494,10 +3494,9 @@ export async function prepareAgentTools(
   const registry = new Map(settings.mcpServers.map((server) => [server.id, server]));
   const localRegistry = localMcpServerRegistry(options.localMcpServers ?? [], registry);
   const aggregateToolBudget = new McpAggregateToolListBudget();
-  // npm Undici's dispatcher transport can hang indefinitely under Bun even
-  // after an AbortSignal fires. Bun's native fetch is the supported runtime
-  // transport there; destination policy validation still runs before every
-  // credential-bearing MCP request.
+  // Codex Apps retains its sanitizer-specific Bun fetch path. Ordinary MCP
+  // traffic uses @opengeni/network's explicit undici.request() adapter under
+  // Bun so the vetted DNS answer remains the actual connection destination.
   const useBunNativeFetch = options.mcpFetchImpl === undefined && !!process.versions.bun;
   const mcpFetchImpl =
     options.mcpFetchImpl ?? (useBunNativeFetch ? globalThis.fetch.bind(globalThis) : undiciFetch);
@@ -3558,7 +3557,11 @@ export async function prepareAgentTools(
           baseFetch,
           {
             ...(firstParty ? { requireHttpsOutsideLocalTest: false } : {}),
-            ...(useBunNativeFetch ? { pinResolvedDestination: false } : {}),
+            ...(useBunNativeFetch && !isCodexAppsMcpServer(config)
+              ? { usePinnedRequestTransport: true }
+              : useBunNativeFetch
+                ? { pinResolvedDestination: false }
+                : {}),
           },
         );
         const optional = tool.optional === true;

--- a/packages/runtime/src/mcp-network.ts
+++ b/packages/runtime/src/mcp-network.ts
@@ -573,6 +573,7 @@ export function guardedMcpFetch<TInput extends string | URL | Request>(
     dnsLookup?: DnsLookup;
     pinResolvedDestination?: boolean;
     requireHttpsOutsideLocalTest?: boolean;
+    usePinnedRequestTransport?: boolean;
   } = {},
 ): (input: TInput, init?: RequestInit) => Promise<Response> {
   return async (input: TInput, init?: RequestInit) => {
@@ -592,7 +593,7 @@ export function guardedMcpFetch<TInput extends string | URL | Request>(
         response = await fetchImpl(input, { ...init, redirect: "manual" });
       } else {
         response = await pinnedFetch(input, init, settings, {
-          fetchImpl: fetchImpl as FetchLike,
+          ...(options.usePinnedRequestTransport ? {} : { fetchImpl: fetchImpl as FetchLike }),
           ...destinationOptions,
         });
       }


### PR DESCRIPTION
Backports the reviewed network and runtime transport fixes from main onto the production line.

- prefer vetted IPv4 answers before IPv6 while retaining the complete DNS set
- keep ordinary Bun MCP traffic on the explicitly pinned request transport
- retain the sanitizer-specific native Fetch path for Codex Apps

Focused verification:
- 45 network/runtime tests pass under the repository-pinned Bun 1.3.14
- network and runtime package typechecks pass
- affected-file formatting passes