### PR TITLE
feat(slack): ask once where an unconfigured conversation should work

### DIFF
--- a/.changeset/slack-route-picker.md
+++ b/.changeset/slack-route-picker.md
@@ -1,5 +1,6 @@
 ---
-"@opengeni/db": patch
+"@opengeni/db": minor
+"@opengeni/api-router": minor
 ---
 
-Ask once where an unconfigured Slack conversation should work, remember the answer, and re-queue the request that was interrupted by the question. One live card per conversation is enforced by a partial unique index, and the answer commits the choice, the remembered route and the re-queued request together.
+Ask once where an unconfigured Slack conversation should work, remember the answer, and re-queue the request that was interrupted by the question. One live card per person per conversation is enforced by a partial unique index, an aged-out card is settled by the writer rather than holding the slot, and the answer commits the choice, the remembered route and the re-queued request together.

--- a/.changeset/slack-route-picker.md
+++ b/.changeset/slack-route-picker.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Ask once where an unconfigured Slack conversation should work, remember the answer, and re-queue the request that was interrupted by the question. One live card per conversation is enforced by a partial unique index, and the answer commits the choice, the remembered route and the re-queued request together.

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -1374,6 +1374,24 @@ async function postSlackRouteRefusal(
   });
 }
 
+/**
+ * A workspace name as a Slack button label.
+ *
+ * Slack renders a button label as plain text and the stored option snapshot caps
+ * it at 128 bytes, so bound it once at the boundary: the button, the row and
+ * every outcome card then agree. Counted in UTF-8 bytes, because that is what
+ * the CHECK counts.
+ */
+function boundedSlackRouteLabel(label: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(label).length <= 72) return label;
+  let bounded = label;
+  while (bounded.length > 0 && encoder.encode(`${bounded}...`).length > 72) {
+    bounded = bounded.slice(0, -1);
+  }
+  return `${bounded}...`;
+}
+
 /** How long a first-use picker stays answerable. */
 const SLACK_ROUTE_PROMPT_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -1399,6 +1417,13 @@ async function askSlackRouteChoice(
   candidates: readonly SlackRoutableWorkspace[],
 ): Promise<void> {
   const offered = candidates.slice(0, MAX_SLACK_ROUTE_PROMPT_BUTTONS);
+  // Slack renders a button label as plain text and the stored snapshot caps it
+  // at 128 bytes, so bound it once here: the button, the stored row and every
+  // outcome card then agree, and the full name still shows in OpenGeni.
+  const bounded = offered.map((candidate) => ({
+    ...candidate,
+    label: boundedSlackRouteLabel(candidate.label),
+  }));
   const opened = await openSlackRoutePrompt(deps.db, home, {
     connectionId: entry.connectionId,
     inboxId: entry.id,
@@ -1413,15 +1438,18 @@ async function askSlackRouteChoice(
     slackThreadTs: entry.slackThreadTs,
     messageOperationId: deterministicUuid(`slack-route-prompt:${entry.id}`),
     expiresAt: new Date(Date.now() + SLACK_ROUTE_PROMPT_TTL_MS),
-    candidates: offered,
+    candidates: bounded,
   });
-  // Someone is already being asked this exact question in this conversation.
-  // Asking again would put two live cards in front of one person.
-  if (!opened || !opened.opened) return;
-
-  const where = entry.slackChannelId.startsWith("D")
+  if (!opened) return;
+  // The prompt commits before the card is posted, so a transient Slack failure
+  // would otherwise leave a pending row with no card in front of anybody and
+  // silently deaden the conversation. Post unconditionally instead: the
+  // operation id is persisted on the prompt and the card is rendered from the
+  // prompt's own stored options, so a replay reproduces identical bytes and the
+  // post ledger returns the completed original rather than posting twice.
+  const where = opened.prompt.slackChannelId.startsWith("D")
     ? "your messages with OpenGeni"
-    : `<#${entry.slackChannelId}>`;
+    : `<#${opened.prompt.slackChannelId}>`;
   const blocks: SlackMessageBlock[] = [
     {
       type: "section",
@@ -1449,21 +1477,22 @@ async function askSlackRouteChoice(
       ],
     },
   ];
-  if (candidates.length > offered.length) {
-    const url = slackWorkspaceUrl(deps, home.workspaceId);
-    blocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: url
-          ? `More workspaces: <${url}|Choose in OpenGeni>`
-          : "More workspaces are available in OpenGeni under Capabilities, then Slack.",
-      },
-    });
-  }
+  // Deliberately unconditional rather than derived from the live candidate
+  // count: a replay must render identical bytes, and membership can change
+  // between attempts.
+  const url = slackWorkspaceUrl(deps, home.workspaceId);
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: url
+        ? `You can change this later in <${url}|OpenGeni>, under Capabilities, then Slack.`
+        : "You can change this later in OpenGeni, under Capabilities, then Slack.",
+    },
+  });
   await client.postMessage({
     operationId: opened.prompt.messageOperationId,
-    userId: entry.slackUserId,
+    userId: opened.prompt.slackUserId,
     text: boundedOutput(
       `OpenGeni can start this task in more than one workspace. Pick where ${where} should work.`,
     ),
@@ -1485,6 +1514,12 @@ async function handleSlackRouteChoice(
   actionId: string,
   optionId: string,
 ): Promise<void> {
+  if (!deps.settings.slackWorkspaceRoutingEnabled) {
+    // A card can outlive the flag being turned back off. Honouring the click
+    // would write a route row and start work through a path the operator has
+    // disabled.
+    throw new SlackInteractionPermanentError("slack_route_choice_unavailable");
+  }
   const found = await getSlackRoutePromptByOption(deps.db, home, optionId);
   if (!found) throw new SlackInteractionPermanentError("slack_route_prompt_invalid");
   const { prompt, chosen } = found;
@@ -1504,7 +1539,9 @@ async function handleSlackRouteChoice(
   // ledger rather than saying so.
   const replaceCard = async (outcome: string, text: string) => {
     await client.updateMessage({
-      operationId: deterministicUuid(`slack-route-answered:${prompt.id}:${actionId}:${outcome}`),
+      operationId: deterministicUuid(
+        `slack-route-answered:${prompt.id}:${actionId}:${chosen.id}:${outcome}`,
+      ),
       channelId: entry.slackChannelId,
       timestamp: entry.slackMessageTs,
       text,
@@ -1515,8 +1552,16 @@ async function handleSlackRouteChoice(
   };
 
   if (actionId === "opengeni.route.cancel") {
-    await settleSlackRoutePrompt(deps.db, home, { promptId: prompt.id, status: "cancelled" });
-    await replaceCard("cancelled", "OpenGeni did not start this task. No session was created.");
+    const cancelled = await settleSlackRoutePrompt(deps.db, home, {
+      promptId: prompt.id,
+      status: "cancelled",
+    });
+    await replaceCard(
+      cancelled ? "cancelled" : "already_settled",
+      cancelled
+        ? "OpenGeni did not start this task. No session was created."
+        : "OpenGeni already settled this choice.",
+    );
     return;
   }
 
@@ -1534,12 +1579,16 @@ async function handleSlackRouteChoice(
       })
     : null;
   if (!grant || !hasPermission(grant.permissions, "sessions:create")) {
-    // Fail closed and leave the prompt answerable: the person may still have
-    // another workspace on the same card they can use.
-    await replaceCard(
-      "denied",
-      `OpenGeni cannot start work in *${chosen.candidateLabel}*: you do not have access to it. No session was created.`,
-    );
+    // Fail closed WITHOUT touching the card: the person may still have another
+    // workspace on it that they can use, and replacing the card would take the
+    // remaining buttons away and leave a pending prompt nobody can answer.
+    await client.postMessage({
+      operationId: deterministicUuid(`slack-route-denied:${prompt.id}:${chosen.id}`),
+      userId: entry.slackUserId,
+      text: boundedOutput(
+        `OpenGeni cannot start work in ${chosen.candidateLabel}: you do not have access to it. No session was created. Pick another workspace on the card, or ask an OpenGeni administrator for access.`,
+      ),
+    });
     return;
   }
 

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -61,6 +61,11 @@ import {
   getSlackInteractionById,
   getSlackInteractionByConnectionRoute,
   probeSlackActionHandleTenancy,
+  openSlackRoutePrompt,
+  getSlackRoutePromptByOption,
+  settleSlackRoutePrompt,
+  answerSlackRoutePrompt,
+  type SlackRoutableWorkspace,
   getSlackChannelRoute,
   getSlackUserDmRoute,
   listNamedSubjectSlackRoutableWorkspaces,
@@ -1369,6 +1374,195 @@ async function postSlackRouteRefusal(
   });
 }
 
+/** How long a first-use picker stays answerable. */
+const SLACK_ROUTE_PROMPT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Buttons a card can carry before it stops being readable. */
+const MAX_SLACK_ROUTE_PROMPT_BUTTONS = 5;
+
+/**
+ * Ask, once, where this conversation should work.
+ *
+ * The card is a bot DM rather than an ephemeral message: `chat.postEphemeral`
+ * returns no durable `(channel, ts)` and no `client_msg_id` echo, and the whole
+ * post ledger and its reconciliation are built on both.
+ *
+ * Nothing is created in any workspace here. The request is parked on the prompt
+ * row and re-queued only once the person answers, so a picker that is never
+ * answered leaves no session, no interaction and no half-started work.
+ */
+async function askSlackRouteChoice(
+  deps: ApiRouteDeps,
+  client: OpenGeniSlackBotClient,
+  home: SlackRouteTenancy,
+  entry: SlackInteractionInboxEntry,
+  candidates: readonly SlackRoutableWorkspace[],
+): Promise<void> {
+  const offered = candidates.slice(0, MAX_SLACK_ROUTE_PROMPT_BUTTONS);
+  const opened = await openSlackRoutePrompt(deps.db, home, {
+    connectionId: entry.connectionId,
+    inboxId: entry.id,
+    slackTeamId: entry.slackTeamId,
+    slackUserId: entry.slackUserId,
+    slackChannelId: entry.slackChannelId,
+    slackMessageTs: entry.slackMessageTs,
+    providerEventId: entry.providerEventId,
+    triggerKind: entry.triggerKind,
+    requestText: entry.text,
+    hasFiles: entry.hasFiles,
+    slackThreadTs: entry.slackThreadTs,
+    messageOperationId: deterministicUuid(`slack-route-prompt:${entry.id}`),
+    expiresAt: new Date(Date.now() + SLACK_ROUTE_PROMPT_TTL_MS),
+    candidates: offered,
+  });
+  // Someone is already being asked this exact question in this conversation.
+  // Asking again would put two live cards in front of one person.
+  if (!opened || !opened.opened) return;
+
+  const where = entry.slackChannelId.startsWith("D")
+    ? "your messages with OpenGeni"
+    : `<#${entry.slackChannelId}>`;
+  const blocks: SlackMessageBlock[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `OpenGeni can start this task in more than one workspace. Pick where ${where} should work. This choice is remembered.`,
+      },
+    },
+    {
+      type: "actions",
+      block_id: "opengeni-route-choice",
+      elements: [
+        ...opened.prompt.options.map((option) => ({
+          type: "button" as const,
+          action_id: "opengeni.route.select",
+          value: option.id,
+          text: { type: "plain_text" as const, text: option.candidateLabel },
+        })),
+        {
+          type: "button" as const,
+          action_id: "opengeni.route.cancel",
+          value: opened.prompt.options[0]?.id ?? opened.prompt.id,
+          text: { type: "plain_text" as const, text: "Not now" },
+        },
+      ],
+    },
+  ];
+  if (candidates.length > offered.length) {
+    const url = slackWorkspaceUrl(deps, home.workspaceId);
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: url
+          ? `More workspaces: <${url}|Choose in OpenGeni>`
+          : "More workspaces are available in OpenGeni under Capabilities, then Slack.",
+      },
+    });
+  }
+  await client.postMessage({
+    operationId: opened.prompt.messageOperationId,
+    userId: entry.slackUserId,
+    text: boundedOutput(
+      `OpenGeni can start this task in more than one workspace. Pick where ${where} should work.`,
+    ),
+    blocks,
+  });
+}
+
+/**
+ * Process one click on a picker.
+ *
+ * The stored option row is a prompt-time snapshot and is NEVER authority: the
+ * chosen workspace is re-authorized live, because access can have been revoked
+ * between the question and the answer.
+ */
+async function handleSlackRouteChoice(
+  deps: ApiRouteDeps,
+  home: SlackRouteTenancy,
+  entry: SlackInteractionInboxEntry,
+  actionId: string,
+  optionId: string,
+): Promise<void> {
+  const found = await getSlackRoutePromptByOption(deps.db, home, optionId);
+  if (!found) throw new SlackInteractionPermanentError("slack_route_prompt_invalid");
+  const { prompt, chosen } = found;
+  // The same authorization pinning ordinary action handles use: a different
+  // Slack human clicking someone else's card is ignored, not obeyed.
+  if (prompt.slackUserId !== entry.slackUserId) {
+    throw new SlackInteractionPermanentError("slack_route_prompt_user_mismatch");
+  }
+  const client = await createOpenGeniSlackBotInteractionClient(deps, {
+    ...home,
+    connectionId: entry.connectionId,
+    subjectId: SLACK_INTERACTION_BOT_SUBJECT_ID,
+  });
+  // The post ledger binds one operation id to a digest over the text, so the
+  // outcome has to be part of the seed. A second click on a settled card
+  // renders different bytes than the first, and reusing one id would wedge the
+  // ledger rather than saying so.
+  const replaceCard = async (outcome: string, text: string) => {
+    await client.updateMessage({
+      operationId: deterministicUuid(`slack-route-answered:${prompt.id}:${actionId}:${outcome}`),
+      channelId: entry.slackChannelId,
+      timestamp: entry.slackMessageTs,
+      text,
+      // Every button goes with the card, so a sibling option cannot be pressed
+      // after the question is settled.
+      blocks: [{ type: "section", text: { type: "mrkdwn", text } }],
+    });
+  };
+
+  if (actionId === "opengeni.route.cancel") {
+    await settleSlackRoutePrompt(deps.db, home, { promptId: prompt.id, status: "cancelled" });
+    await replaceCard("cancelled", "OpenGeni did not start this task. No session was created.");
+    return;
+  }
+
+  const link = await getSlackBotUserLink(
+    deps.db,
+    home.workspaceId,
+    entry.connectionId,
+    entry.slackUserId,
+  );
+  const grant = link
+    ? await resolveSlackTargetAuthority(deps.db, {
+        subjectId: link.subjectId,
+        targetAccountId: chosen.candidateAccountId,
+        targetWorkspaceId: chosen.candidateWorkspaceId,
+      })
+    : null;
+  if (!grant || !hasPermission(grant.permissions, "sessions:create")) {
+    // Fail closed and leave the prompt answerable: the person may still have
+    // another workspace on the same card they can use.
+    await replaceCard(
+      "denied",
+      `OpenGeni cannot start work in *${chosen.candidateLabel}*: you do not have access to it. No session was created.`,
+    );
+    return;
+  }
+
+  const answered = await answerSlackRoutePrompt(deps.db, home, {
+    promptId: prompt.id,
+    targetAccountId: chosen.candidateAccountId,
+    targetWorkspaceId: chosen.candidateWorkspaceId,
+    answeredBySubjectId: grant.subjectId,
+    decidedBySlackUserId: entry.slackUserId,
+  });
+  if (!answered.answered) {
+    await replaceCard(
+      "settled",
+      "OpenGeni already settled this choice. No new session was created.",
+    );
+    return;
+  }
+  await replaceCard(
+    "answered",
+    `OpenGeni will use *${chosen.candidateLabel}* here. You can change this in OpenGeni under Capabilities, then Slack.`,
+  );
+}
+
 async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractionInboxEntry) {
   if (entry.triggerKind === "block_action") {
     await processSlackBlockAction(deps, entry);
@@ -1451,14 +1645,11 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     threadTenancy: existing
       ? { accountId: existing.accountId, workspaceId: existing.workspaceId }
       : null,
-    // The first-use picker does not exist yet, so genuine ambiguity keeps the
-    // installation's workspace rather than inventing an answer.
-    askEnabled: false,
+    askEnabled: true,
   });
   if (resolution.kind === "ask") {
-    // Unreachable: `askEnabled` is false above because the first-use picker
-    // lands in a later change. Fail loudly rather than guessing a workspace.
-    throw new SlackInteractionPermanentError("slack_route_choice_unavailable");
+    await askSlackRouteChoice(deps, client, home, entry, resolution.candidates);
+    return;
   }
   if (resolution.kind === "denied") {
     await postSlackRouteRefusal(deps, client, entry, resolution);
@@ -2714,6 +2905,13 @@ async function processSlackBlockAction(deps: ApiRouteDeps, entry: SlackInteracti
     route.connectionId !== entry.connectionId
   ) {
     throw new SlackInteractionPermanentError("slack_action_installation_changed");
+  }
+  // A route choice is not an action handle: the picker exists BEFORE any
+  // session, so there is no handle row to load and the ordinary path below
+  // would refuse it. Branch first.
+  if (actionId === "opengeni.route.select" || actionId === "opengeni.route.cancel") {
+    await handleSlackRouteChoice(deps, home, entry, actionId, handleId);
+    return;
   }
   // A handle lives in the workspace that owns its session, which is not the
   // installation's workspace once routing is on. Learn that scope from the
@@ -4104,6 +4302,8 @@ const SLACK_BLOCK_ACTION_IDS = new Set([
   "opengeni.session.pause",
   "opengeni.session.resume",
   "opengeni.shared_result.publish",
+  "opengeni.route.select",
+  "opengeni.route.cancel",
 ]);
 
 export function normalizedBlockActionInteraction(

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -1354,13 +1354,37 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
       where workspace_id in (${value.owner.workspaceId}, ${routed.workspaceId})`;
     expect(beforeAnswer!.n).toBe(0);
 
-    // Slack retries the same event: still one card, still one prompt.
+    const cardsAfterFirst = value.slack.posts.length;
+    // Slack retries the same event: the inbox dedupe means there is nothing new
+    // to drain at all.
     expect((await postEvent(value.app, first)).status).toBe(200);
-    await drainAll(value.deps);
+    expect(await drainAll(value.deps)).toBe(0);
+
+    // A genuinely DIFFERENT message in the same channel is the case the pending
+    // index governs. It must not open a second prompt or post a second card.
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_ASK_SECOND_${crypto.randomUUID()}`,
+          event: {
+            type: "app_mention",
+            user: value.ownerSlackUserId,
+            channel: channelId,
+            ts: "1700000700.0009",
+            text: "and another thing",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    expect(await drainAll(value.deps)).toBe(1);
     const [prompts] = await shared!.admin<{ n: number }[]>`
       select count(*)::int as n from slack_route_prompts
       where connection_id = ${value.connectionId} and status = 'pending'`;
     expect(prompts!.n).toBe(1);
+    // The card is re-posted through the same operation id, so the ledger
+    // returns the completed original rather than putting a second card up.
+    expect(value.slack.posts).toHaveLength(cardsAfterFirst);
 
     const [option] = await shared!.admin<{ id: string }[]>`
       select o.id from slack_route_prompt_options o
@@ -1462,7 +1486,7 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
       join slack_route_prompts p on p.id = o.prompt_id
       where p.connection_id = ${value.connectionId}
         and o.candidate_workspace_id = ${routed.workspaceId}`;
-    const click = () =>
+    const click = (actionTs: string) =>
       value.app.request(
         signedRequest(
           "/v1/integrations/slack/interactions",
@@ -1476,7 +1500,7 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
               actions: [
                 {
                   action_id: "opengeni.route.select",
-                  action_ts: `176000000${Math.floor(Math.random() * 9)}.000011`,
+                  action_ts: actionTs,
                   value: option!.id,
                 },
               ],
@@ -1485,10 +1509,100 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
           "application/x-www-form-urlencoded",
         ),
       );
-    expect((await click()).status).toBe(200);
-    expect((await click()).status).toBe(200);
+    // Two distinct clicks, not one deduped by a colliding timestamp.
+    expect((await click("1760000000.000011")).status).toBe(200);
+    expect((await click("1760000000.000012")).status).toBe(200);
     await drainAll(value.deps);
     expect(await interactions(routed.workspaceId)).toHaveLength(1);
+    // The second click says so rather than wedging the post ledger.
+    expect(value.slack.calls.filter((call) => call.method === "chat.update").length).toBe(2);
+  });
+
+  test("an unanswered picker expires instead of deadening the conversation", async () => {
+    if (!available) return;
+    const value = await fixture({
+      slackWorkspaceRouting: true,
+      routedWorkspaceName: "Platform",
+    });
+    const channelId = "C_EXPIRING";
+    const ask = (suffix: string, ts: string) =>
+      postEvent(value.app, {
+        teamId: value.teamId,
+        eventId: `E_EXPIRE_${suffix}_${crypto.randomUUID()}`,
+        event: {
+          type: "app_mention",
+          user: value.ownerSlackUserId,
+          channel: channelId,
+          ts,
+          text: "please decide",
+        },
+      });
+    expect((await ask("first", "1700000900.0001")).status).toBe(200);
+    await drainAll(value.deps);
+    const [pending] = await shared!.admin<{ id: string }[]>`
+      select id from slack_route_prompts
+      where connection_id = ${value.connectionId} and status = 'pending'`;
+    expect(pending?.id).toBeTruthy();
+
+    // Nobody clicks, and the card ages out.
+    await shared!.admin`
+      update slack_route_prompts set expires_at = now() - interval '1 minute'
+      where id = ${pending!.id}::uuid`;
+
+    expect((await ask("second", "1700000900.0002")).status).toBe(200);
+    await drainAll(value.deps);
+    const rows = await shared!.admin<{ id: string; status: string }[]>`
+      select id, status from slack_route_prompts
+      where connection_id = ${value.connectionId} order by created_at`;
+    // The dead row is settled and a fresh question is asked, rather than the
+    // channel silently swallowing every later message forever.
+    expect(rows.map((row) => row.status)).toEqual(["expired", "pending"]);
+  });
+
+  test("asking one person in a channel does not swallow another person's request", async () => {
+    if (!available) return;
+    const value = await fixture({
+      slackWorkspaceRouting: true,
+      routedWorkspaceName: "Platform",
+      linkOther: true,
+    });
+    // Both people must be genuinely ambiguous, or the sole-candidate rule
+    // correctly answers for them without asking.
+    await grantWorkspaceAccess(client.db, {
+      accountId: value.owner.accountId,
+      workspaceId: value.routed!.workspaceId,
+      subjectId: value.otherSubjectId,
+      permissions: ["sessions:create", "sessions:read", "sessions:control"],
+    });
+    const channelId = "C_TWO_PEOPLE";
+    for (const [suffix, user, ts] of [
+      ["owner", value.ownerSlackUserId, "1700001000.0001"],
+      ["other", value.otherSlackUserId, "1700001000.0002"],
+    ] as const) {
+      expect(
+        (
+          await postEvent(value.app, {
+            teamId: value.teamId,
+            eventId: `E_TWO_${suffix}_${crypto.randomUUID()}`,
+            event: {
+              type: "app_mention",
+              user,
+              channel: channelId,
+              ts,
+              text: "my own request",
+            },
+          })
+        ).status,
+      ).toBe(200);
+    }
+    await drainAll(value.deps);
+    const asked = await shared!.admin<{ slack_user_id: string }[]>`
+      select slack_user_id from slack_route_prompts
+      where connection_id = ${value.connectionId} and status = 'pending'
+      order by slack_user_id`;
+    expect(asked.map((row) => row.slack_user_id).sort()).toEqual(
+      [value.ownerSlackUserId, value.otherSlackUserId].sort(),
+    );
   });
 
   test("a routed workspace the person cannot reach never falls back to another one", async () => {

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -1322,6 +1322,175 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
     expect(refusal?.text).toContain("No session was created.");
   });
 
+  test("asks once, remembers the answer, and never asks that channel again", async () => {
+    if (!available) return;
+    const value = await fixture({
+      slackWorkspaceRouting: true,
+      routedWorkspaceName: "Platform",
+    });
+    const routed = value.routed!;
+    const channelId = "C_ASK_ONCE";
+    const first = {
+      teamId: value.teamId,
+      eventId: `E_ASK_${crypto.randomUUID()}`,
+      event: {
+        type: "app_mention",
+        user: value.ownerSlackUserId,
+        channel: channelId,
+        ts: "1700000700.0001",
+        text: "audit the terraform",
+      },
+    };
+    expect((await postEvent(value.app, first)).status).toBe(200);
+    await drainAll(value.deps);
+
+    // The question is asked, and NOTHING is started anywhere while it is open.
+    const card = value.slack.posts.at(-1)!;
+    expect(card.text).toContain("more than one workspace");
+    expect(await interactions(value.owner.workspaceId)).toHaveLength(0);
+    expect(await interactions(routed.workspaceId)).toHaveLength(0);
+    const [beforeAnswer] = await shared!.admin<{ n: number }[]>`
+      select count(*)::int as n from sessions
+      where workspace_id in (${value.owner.workspaceId}, ${routed.workspaceId})`;
+    expect(beforeAnswer!.n).toBe(0);
+
+    // Slack retries the same event: still one card, still one prompt.
+    expect((await postEvent(value.app, first)).status).toBe(200);
+    await drainAll(value.deps);
+    const [prompts] = await shared!.admin<{ n: number }[]>`
+      select count(*)::int as n from slack_route_prompts
+      where connection_id = ${value.connectionId} and status = 'pending'`;
+    expect(prompts!.n).toBe(1);
+
+    const [option] = await shared!.admin<{ id: string }[]>`
+      select o.id from slack_route_prompt_options o
+      join slack_route_prompts p on p.id = o.prompt_id
+      where p.connection_id = ${value.connectionId}
+        and o.candidate_workspace_id = ${routed.workspaceId}`;
+    expect(option?.id).toBeTruthy();
+
+    const click = (actionId: string) =>
+      value.app.request(
+        signedRequest(
+          "/v1/integrations/slack/interactions",
+          new URLSearchParams({
+            payload: JSON.stringify({
+              type: "block_actions",
+              team: { id: value.teamId },
+              user: { id: value.ownerSlackUserId },
+              channel: { id: card.channel },
+              message: { ts: card.timestamp },
+              actions: [{ action_id: actionId, action_ts: "1760000000.000009", value: option!.id }],
+            }),
+          }).toString(),
+          "application/x-www-form-urlencoded",
+        ),
+      );
+    expect((await click("opengeni.route.select")).status).toBe(200);
+    await drainAll(value.deps);
+
+    // The answer starts the work the person originally asked for, in the
+    // workspace they chose.
+    const [route] = await interactions(routed.workspaceId);
+    expect(route?.session_id).toBeTruthy();
+    expect(await interactions(value.owner.workspaceId)).toHaveLength(0);
+    const [session] = await shared!.admin<{ initial_message: string }[]>`
+      select initial_message from sessions
+      where workspace_id = ${routed.workspaceId} and id = ${route!.session_id}`;
+    expect(session!.initial_message).toContain("audit the terraform");
+
+    // The choice is remembered, so the next message never asks again.
+    const stored = await getSlackChannelRoute(
+      client.db,
+      { accountId: value.owner.accountId, workspaceId: value.owner.workspaceId },
+      { connectionId: value.connectionId, slackChannelId: channelId },
+    );
+    expect(stored?.targetWorkspaceId).toBe(routed.workspaceId);
+    expect(stored?.source).toBe("picker");
+
+    const cardsBefore = value.slack.posts.length;
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_ASK_NEXT_${crypto.randomUUID()}`,
+          event: {
+            type: "app_mention",
+            user: value.ownerSlackUserId,
+            channel: channelId,
+            ts: "1700000700.0002",
+            text: "and the second one",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+    expect(await interactions(routed.workspaceId)).toHaveLength(2);
+    expect(
+      value.slack.posts
+        .slice(cardsBefore)
+        .filter((post) => post.text.includes("more than one workspace")),
+    ).toHaveLength(0);
+  });
+
+  test("a second click on a settled picker cannot start a second session", async () => {
+    if (!available) return;
+    const value = await fixture({
+      slackWorkspaceRouting: true,
+      routedWorkspaceName: "Platform",
+    });
+    const routed = value.routed!;
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_DOUBLE_${crypto.randomUUID()}`,
+          event: {
+            type: "app_mention",
+            user: value.ownerSlackUserId,
+            channel: "C_DOUBLE_CLICK",
+            ts: "1700000800.0001",
+            text: "ship it",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+    const card = value.slack.posts.at(-1)!;
+    const [option] = await shared!.admin<{ id: string }[]>`
+      select o.id from slack_route_prompt_options o
+      join slack_route_prompts p on p.id = o.prompt_id
+      where p.connection_id = ${value.connectionId}
+        and o.candidate_workspace_id = ${routed.workspaceId}`;
+    const click = () =>
+      value.app.request(
+        signedRequest(
+          "/v1/integrations/slack/interactions",
+          new URLSearchParams({
+            payload: JSON.stringify({
+              type: "block_actions",
+              team: { id: value.teamId },
+              user: { id: value.ownerSlackUserId },
+              channel: { id: card.channel },
+              message: { ts: card.timestamp },
+              actions: [
+                {
+                  action_id: "opengeni.route.select",
+                  action_ts: `176000000${Math.floor(Math.random() * 9)}.000011`,
+                  value: option!.id,
+                },
+              ],
+            }),
+          }).toString(),
+          "application/x-www-form-urlencoded",
+        ),
+      );
+    expect((await click()).status).toBe(200);
+    expect((await click()).status).toBe(200);
+    await drainAll(value.deps);
+    expect(await interactions(routed.workspaceId)).toHaveLength(1);
+  });
+
   test("a routed workspace the person cannot reach never falls back to another one", async () => {
     if (!available) return;
     // The headline rule: OpenGeni does not quietly serve this from a workspace

--- a/packages/db/drizzle/0342_slack_route_prompt_single_pending.sql
+++ b/packages/db/drizzle/0342_slack_route_prompt_single_pending.sql
@@ -1,15 +1,22 @@
 -- deployment-mode: rolling
--- One pending Slack route picker per conversation.
+-- One pending Slack route picker per person per conversation.
 --
 -- `slack_route_prompts` is unique on `(connection_id, inbox_id)` and
 -- `(connection_id, provider_event_id)`, both keyed to the originating event, so
 -- Slack's retries of one event cannot post a second card but two DIFFERENT
--- messages in the same channel each open their own. The person would get two
--- cards for the same question, and answering either would write the channel's
--- route while the other stayed live and answerable.
+-- messages each open their own. One person would get two cards for the same
+-- question, and answering either would write the route while the other stayed
+-- live and answerable.
 --
--- A direct message needs no separate index: a DM's channel id is already one
--- per person, so the channel predicate covers both surfaces.
+-- The key includes `slack_user_id` on purpose. A shared channel has many people
+-- in it, and asking one of them must not swallow another's request: each person
+-- is asked once. A direct message is already one channel per person, so the same
+-- index covers both surfaces.
+--
+-- Expiry is not part of the predicate, because `now()` is not immutable and a
+-- partial index cannot call it. A timed-out row is settled `expired`
+-- opportunistically by the writer before it opens a new prompt, which is what
+-- keeps a card nobody ever clicked from holding the slot forever.
 --
 -- Rolling and safe to build without CONCURRENTLY: the table has no rows and no
 -- writer until the picker ships in this same change.
@@ -17,8 +24,8 @@
 SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '10min';
 
-CREATE UNIQUE INDEX "slack_route_prompts_pending_channel_uq"
-  ON "slack_route_prompts" ("connection_id", "slack_channel_id")
+CREATE UNIQUE INDEX "slack_route_prompts_pending_conversation_uq"
+  ON "slack_route_prompts" ("connection_id", "slack_channel_id", "slack_user_id")
   WHERE "status" = 'pending';
 
 RESET statement_timeout;

--- a/packages/db/drizzle/0342_slack_route_prompt_single_pending.sql
+++ b/packages/db/drizzle/0342_slack_route_prompt_single_pending.sql
@@ -1,0 +1,25 @@
+-- deployment-mode: rolling
+-- One pending Slack route picker per conversation.
+--
+-- `slack_route_prompts` is unique on `(connection_id, inbox_id)` and
+-- `(connection_id, provider_event_id)`, both keyed to the originating event, so
+-- Slack's retries of one event cannot post a second card but two DIFFERENT
+-- messages in the same channel each open their own. The person would get two
+-- cards for the same question, and answering either would write the channel's
+-- route while the other stayed live and answerable.
+--
+-- A direct message needs no separate index: a DM's channel id is already one
+-- per person, so the channel predicate covers both surfaces.
+--
+-- Rolling and safe to build without CONCURRENTLY: the table has no rows and no
+-- writer until the picker ships in this same change.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+CREATE UNIQUE INDEX "slack_route_prompts_pending_channel_uq"
+  ON "slack_route_prompts" ("connection_id", "slack_channel_id")
+  WHERE "status" = 'pending';
+
+RESET statement_timeout;
+RESET lock_timeout;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2060,12 +2060,18 @@ export const slackRoutePrompts = pgTable(
     pending: index("slack_route_prompts_pending_idx")
       .on(table.expiresAt, table.id)
       .where(sql`${table.status} = 'pending'`),
-    // One live card per conversation. The existing uniques are keyed to the
-    // originating event, so they stop Slack's retries of ONE event from posting
-    // twice but not two different messages in the same channel. A direct
-    // message needs no separate index: its channel id is already one per person.
-    pendingChannel: uniqueIndex("slack_route_prompts_pending_channel_uq")
-      .on(table.connectionId, table.slackChannelId)
+    // One live card per person per conversation. The existing uniques are keyed
+    // to the originating event, so they stop Slack's retries of ONE event from
+    // posting twice but not two different messages. `slackUserId` is in the key
+    // on purpose: a shared channel has many people in it, and asking one of them
+    // must not swallow another's request. A direct message is already one
+    // channel per person, so the same index covers both surfaces.
+    //
+    // Expiry is not in the predicate because `now()` is not immutable. A
+    // timed-out row is settled `expired` by the writer before it opens a new
+    // prompt.
+    pendingConversation: uniqueIndex("slack_route_prompts_pending_conversation_uq")
+      .on(table.connectionId, table.slackChannelId, table.slackUserId)
       .where(sql`${table.status} = 'pending'`),
     statusValid: check(
       "slack_route_prompts_status_check",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2060,6 +2060,13 @@ export const slackRoutePrompts = pgTable(
     pending: index("slack_route_prompts_pending_idx")
       .on(table.expiresAt, table.id)
       .where(sql`${table.status} = 'pending'`),
+    // One live card per conversation. The existing uniques are keyed to the
+    // originating event, so they stop Slack's retries of ONE event from posting
+    // twice but not two different messages in the same channel. A direct
+    // message needs no separate index: its channel id is already one per person.
+    pendingChannel: uniqueIndex("slack_route_prompts_pending_channel_uq")
+      .on(table.connectionId, table.slackChannelId)
+      .where(sql`${table.status} = 'pending'`),
     statusValid: check(
       "slack_route_prompts_status_check",
       sql`${table.status} in ('pending', 'answered', 'expired', 'cancelled')`,

--- a/packages/db/src/slack-routing.ts
+++ b/packages/db/src/slack-routing.ts
@@ -21,7 +21,7 @@
  * `namedSubjectHasLiveWorkspaceAuthority`, because no sibling module in this
  * package imports `./index` and this one must not be the first.
  */
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, lte, sql } from "drizzle-orm";
 
 import { rawRows, withRlsContext, type Database } from "./database";
 import { namedSubjectPersonalWorkspaceId } from "./slack-routing-personal-workspace";
@@ -574,11 +574,29 @@ export async function openSlackRoutePrompt(
     messageOperationId: string;
     expiresAt: Date;
     candidates: readonly SlackRoutableWorkspace[];
+    now?: Date;
   },
 ): Promise<{ opened: boolean; prompt: SlackRoutePrompt } | null> {
+  const now = input.now ?? new Date();
   return await withRlsContext(db, home, async (scopedDb) => {
     return await scopedDb.transaction(async (tx) => {
       const scoped = tx as unknown as Database;
+      // A card nobody ever clicked must not hold this person's slot forever.
+      // `now()` is not immutable, so the partial unique index cannot exclude an
+      // aged-out row; the writer settles it here instead, immediately before
+      // trying to open the next one. This is what gives `expired` a writer.
+      await scoped
+        .update(schema.slackRoutePrompts)
+        .set({ status: "expired", updatedAt: sql`now()` })
+        .where(
+          and(
+            eq(schema.slackRoutePrompts.connectionId, input.connectionId),
+            eq(schema.slackRoutePrompts.slackChannelId, input.slackChannelId),
+            eq(schema.slackRoutePrompts.slackUserId, input.slackUserId),
+            eq(schema.slackRoutePrompts.status, "pending"),
+            lte(schema.slackRoutePrompts.expiresAt, now),
+          ),
+        );
       const [created] = await scoped
         .insert(schema.slackRoutePrompts)
         .values([
@@ -611,6 +629,7 @@ export async function openSlackRoutePrompt(
             and(
               eq(schema.slackRoutePrompts.connectionId, input.connectionId),
               eq(schema.slackRoutePrompts.slackChannelId, input.slackChannelId),
+              eq(schema.slackRoutePrompts.slackUserId, input.slackUserId),
               eq(schema.slackRoutePrompts.status, "pending"),
             ),
           )
@@ -742,7 +761,21 @@ export async function answerSlackRoutePrompt(
         .where(eq(schema.slackRoutePrompts.id, input.promptId))
         .limit(1)
         .for("update");
-      if (!prompt || prompt.status !== "pending" || prompt.expiresAt.getTime() <= now.getTime()) {
+      if (!prompt || prompt.status !== "pending") {
+        return { answered: false, queuedProviderEventId: null };
+      }
+      if (prompt.expiresAt.getTime() <= now.getTime()) {
+        // Settle it here rather than leaving a dead row holding this person's
+        // slot: `expired` needs a writer on every path that observes expiry.
+        await scoped
+          .update(schema.slackRoutePrompts)
+          .set({ status: "expired", updatedAt: sql`now()` })
+          .where(
+            and(
+              eq(schema.slackRoutePrompts.id, prompt.id),
+              eq(schema.slackRoutePrompts.status, "pending"),
+            ),
+          );
         return { answered: false, queuedProviderEventId: null };
       }
       await scoped

--- a/packages/db/src/slack-routing.ts
+++ b/packages/db/src/slack-routing.ts
@@ -467,3 +467,346 @@ function compareCodeUnits(left: string, right: string): number {
   if (left === right) return 0;
   return left < right ? -1 : 1;
 }
+
+/** The trigger kinds a picker can be opened from, mirroring the table's CHECK. */
+export type SlackRoutePromptTriggerKind =
+  (typeof schema.slackRoutePrompts.$inferSelect)["triggerKind"];
+
+/** A pending first-use picker plus the workspaces it offered. */
+export type SlackRoutePrompt = {
+  id: string;
+  accountId: string;
+  workspaceId: string;
+  connectionId: string;
+  inboxId: string;
+  slackTeamId: string;
+  slackUserId: string;
+  slackChannelId: string;
+  slackMessageTs: string;
+  providerEventId: string;
+  triggerKind: SlackRoutePromptTriggerKind;
+  requestText: string;
+  hasFiles: boolean;
+  slackThreadTs: string | null;
+  messageOperationId: string;
+  status: "pending" | "answered" | "expired" | "cancelled";
+  expiresAt: Date;
+  options: readonly SlackRoutePromptOption[];
+};
+
+export type SlackRoutePromptOption = {
+  id: string;
+  candidateAccountId: string;
+  candidateWorkspaceId: string;
+  candidateLabel: string;
+  position: number;
+};
+
+function mapPrompt(
+  row: typeof schema.slackRoutePrompts.$inferSelect,
+  options: readonly SlackRoutePromptOption[],
+): SlackRoutePrompt {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    workspaceId: row.workspaceId,
+    connectionId: row.connectionId,
+    inboxId: row.inboxId,
+    slackTeamId: row.slackTeamId,
+    slackUserId: row.slackUserId,
+    slackChannelId: row.slackChannelId,
+    slackMessageTs: row.slackMessageTs,
+    providerEventId: row.providerEventId,
+    triggerKind: row.triggerKind,
+    requestText: row.requestText,
+    hasFiles: row.hasFiles,
+    slackThreadTs: row.slackThreadTs,
+    messageOperationId: row.messageOperationId,
+    status: row.status,
+    expiresAt: row.expiresAt,
+    options,
+  };
+}
+
+async function promptOptions(
+  scopedDb: Database,
+  promptId: string,
+): Promise<SlackRoutePromptOption[]> {
+  const rows = await scopedDb
+    .select()
+    .from(schema.slackRoutePromptOptions)
+    .where(eq(schema.slackRoutePromptOptions.promptId, promptId))
+    .orderBy(schema.slackRoutePromptOptions.position);
+  return rows.map((row) => ({
+    id: row.id,
+    candidateAccountId: row.candidateAccountId,
+    candidateWorkspaceId: row.candidateWorkspaceId,
+    candidateLabel: row.candidateLabel,
+    position: row.position,
+  }));
+}
+
+/**
+ * Open one first-use picker for a conversation, or return the one already open.
+ *
+ * Three separate uniques make this idempotent from three directions: Slack's
+ * retries of one event collide on `(connection_id, provider_event_id)`, a
+ * replayed inbox row collides on `(connection_id, inbox_id)`, and a genuinely
+ * different message in the same conversation collides on the partial pending
+ * index. The last one is why a second message never posts a second card: the
+ * person is already being asked the same question.
+ */
+export async function openSlackRoutePrompt(
+  db: Database,
+  home: SlackRouteHome,
+  input: {
+    connectionId: string;
+    inboxId: string;
+    slackTeamId: string;
+    slackUserId: string;
+    slackChannelId: string;
+    slackMessageTs: string;
+    providerEventId: string;
+    triggerKind: SlackRoutePromptTriggerKind;
+    requestText: string;
+    hasFiles: boolean;
+    slackThreadTs: string | null;
+    messageOperationId: string;
+    expiresAt: Date;
+    candidates: readonly SlackRoutableWorkspace[];
+  },
+): Promise<{ opened: boolean; prompt: SlackRoutePrompt } | null> {
+  return await withRlsContext(db, home, async (scopedDb) => {
+    return await scopedDb.transaction(async (tx) => {
+      const scoped = tx as unknown as Database;
+      const [created] = await scoped
+        .insert(schema.slackRoutePrompts)
+        .values([
+          {
+            accountId: home.accountId,
+            workspaceId: home.workspaceId,
+            connectionId: input.connectionId,
+            inboxId: input.inboxId,
+            slackTeamId: input.slackTeamId,
+            slackUserId: input.slackUserId,
+            slackChannelId: input.slackChannelId,
+            slackMessageTs: input.slackMessageTs,
+            providerEventId: input.providerEventId,
+            triggerKind: input.triggerKind,
+            requestText: input.requestText,
+            hasFiles: input.hasFiles,
+            slackThreadTs: input.slackThreadTs,
+            messageOperationId: input.messageOperationId,
+            status: "pending",
+            expiresAt: input.expiresAt,
+          },
+        ])
+        .onConflictDoNothing()
+        .returning();
+      if (!created) {
+        const [existing] = await scoped
+          .select()
+          .from(schema.slackRoutePrompts)
+          .where(
+            and(
+              eq(schema.slackRoutePrompts.connectionId, input.connectionId),
+              eq(schema.slackRoutePrompts.slackChannelId, input.slackChannelId),
+              eq(schema.slackRoutePrompts.status, "pending"),
+            ),
+          )
+          .limit(1);
+        if (!existing) return null;
+        return {
+          opened: false,
+          prompt: mapPrompt(existing, await promptOptions(scoped, existing.id)),
+        };
+      }
+      const offered = input.candidates.map((candidate, index) => ({
+        accountId: home.accountId,
+        workspaceId: home.workspaceId,
+        promptId: created.id,
+        candidateAccountId: candidate.accountId,
+        candidateWorkspaceId: candidate.workspaceId,
+        candidateLabel: candidate.label,
+        position: index,
+      }));
+      if (offered.length > 0) {
+        await scoped.insert(schema.slackRoutePromptOptions).values(offered);
+      }
+      return { opened: true, prompt: mapPrompt(created, await promptOptions(scoped, created.id)) };
+    });
+  });
+}
+
+/**
+ * The prompt one offered button belongs to.
+ *
+ * The button's `value` is the option row id, which is a UUID precisely because
+ * the block-action normalizer already requires that shape. The option rows are a
+ * prompt-time SNAPSHOT and are never authority: the caller must re-authorize the
+ * chosen workspace live.
+ */
+export async function getSlackRoutePromptByOption(
+  db: Database,
+  home: SlackRouteHome,
+  optionId: string,
+): Promise<{ prompt: SlackRoutePrompt; chosen: SlackRoutePromptOption } | null> {
+  return await withRlsContext(db, home, async (scopedDb) => {
+    const [option] = await scopedDb
+      .select()
+      .from(schema.slackRoutePromptOptions)
+      .where(eq(schema.slackRoutePromptOptions.id, optionId))
+      .limit(1);
+    if (!option) return null;
+    const [row] = await scopedDb
+      .select()
+      .from(schema.slackRoutePrompts)
+      .where(eq(schema.slackRoutePrompts.id, option.promptId))
+      .limit(1);
+    if (!row) return null;
+    return {
+      prompt: mapPrompt(row, await promptOptions(scopedDb, row.id)),
+      chosen: {
+        id: option.id,
+        candidateAccountId: option.candidateAccountId,
+        candidateWorkspaceId: option.candidateWorkspaceId,
+        candidateLabel: option.candidateLabel,
+        position: option.position,
+      },
+    };
+  });
+}
+
+/**
+ * Settle a prompt without answering it: the person pressed the cancel action, or
+ * it aged out. Only a still-pending row moves, so this cannot overwrite an
+ * answer that landed first.
+ */
+export async function settleSlackRoutePrompt(
+  db: Database,
+  home: SlackRouteHome,
+  input: { promptId: string; status: "expired" | "cancelled" },
+): Promise<boolean> {
+  return await withRlsContext(db, home, async (scopedDb) => {
+    const settled = await scopedDb
+      .update(schema.slackRoutePrompts)
+      .set({ status: input.status, updatedAt: sql`now()` })
+      .where(
+        and(
+          eq(schema.slackRoutePrompts.id, input.promptId),
+          eq(schema.slackRoutePrompts.status, "pending"),
+        ),
+      )
+      .returning({ id: schema.slackRoutePrompts.id });
+    return settled.length > 0;
+  });
+}
+
+/**
+ * Answer a picker: freeze the choice, remember it, and re-queue the request.
+ *
+ * All three commit together. The route row is the ask-once memory, so a later
+ * message in that conversation never asks again, and the re-queued inbox row is
+ * what actually starts the work the person asked for before they were
+ * interrupted by the question.
+ *
+ * The re-queued row carries a DERIVED provider event id, not the original one.
+ * The original inbox row still exists and is settled, so re-using its id would
+ * collide with the inbox's own `(connection_id, provider_event_id)` dedupe and
+ * silently queue nothing at all. Deriving it from the prompt keeps the insert
+ * idempotent for exactly this answer, so a double-click cannot create two
+ * sessions.
+ *
+ * Only a still-pending prompt answers. A second click, an expiry sweep, or a
+ * cancel that landed first all leave `answered: false` and change nothing.
+ */
+export async function answerSlackRoutePrompt(
+  db: Database,
+  home: SlackRouteHome,
+  input: {
+    promptId: string;
+    targetAccountId: string;
+    targetWorkspaceId: string;
+    answeredBySubjectId: string;
+    decidedBySlackUserId: string;
+    now?: Date;
+  },
+): Promise<{ answered: boolean; queuedProviderEventId: string | null }> {
+  const now = input.now ?? new Date();
+  return await withRlsContext(db, home, async (scopedDb) => {
+    return await scopedDb.transaction(async (tx) => {
+      const scoped = tx as unknown as Database;
+      const [prompt] = await scoped
+        .select()
+        .from(schema.slackRoutePrompts)
+        .where(eq(schema.slackRoutePrompts.id, input.promptId))
+        .limit(1)
+        .for("update");
+      if (!prompt || prompt.status !== "pending" || prompt.expiresAt.getTime() <= now.getTime()) {
+        return { answered: false, queuedProviderEventId: null };
+      }
+      await scoped
+        .update(schema.slackRoutePrompts)
+        .set({
+          status: "answered",
+          answeredTargetAccountId: input.targetAccountId,
+          answeredTargetWorkspaceId: input.targetWorkspaceId,
+          answeredBySubjectId: input.answeredBySubjectId,
+          answeredAt: now,
+          updatedAt: sql`now()`,
+        })
+        .where(eq(schema.slackRoutePrompts.id, prompt.id));
+
+      const directMessage = prompt.slackChannelId.startsWith("D") || prompt.triggerKind === "dm";
+      if (directMessage) {
+        await upsertSlackUserDmRoute(scoped, home, {
+          connectionId: prompt.connectionId,
+          slackTeamId: prompt.slackTeamId,
+          slackUserId: prompt.slackUserId,
+          targetAccountId: input.targetAccountId,
+          targetWorkspaceId: input.targetWorkspaceId,
+          decidedBySubjectId: input.answeredBySubjectId,
+          decidedBySlackUserId: input.decidedBySlackUserId,
+          source: "picker",
+        });
+      } else {
+        await upsertSlackChannelRoute(scoped, home, {
+          connectionId: prompt.connectionId,
+          slackTeamId: prompt.slackTeamId,
+          slackChannelId: prompt.slackChannelId,
+          targetAccountId: input.targetAccountId,
+          targetWorkspaceId: input.targetWorkspaceId,
+          decidedBySubjectId: input.answeredBySubjectId,
+          decidedBySlackUserId: input.decidedBySlackUserId,
+          source: "picker",
+        });
+      }
+
+      const queuedProviderEventId = `${prompt.providerEventId}:route:${prompt.id}`;
+      await scoped
+        .insert(schema.slackInteractionInbox)
+        .values([
+          {
+            accountId: home.accountId,
+            workspaceId: home.workspaceId,
+            connectionId: prompt.connectionId,
+            providerEventId: queuedProviderEventId,
+            providerMessageId: queuedProviderEventId,
+            slackTeamId: prompt.slackTeamId,
+            slackUserId: prompt.slackUserId,
+            slackChannelId: prompt.slackChannelId,
+            slackMessageTs: prompt.slackMessageTs,
+            slackThreadTs: prompt.slackThreadTs,
+            triggerKind: prompt.triggerKind,
+            text: prompt.requestText,
+            hasFiles: prompt.hasFiles,
+            routeState: "resolved",
+            targetAccountId: input.targetAccountId,
+            targetWorkspaceId: input.targetWorkspaceId,
+          },
+        ])
+        .onConflictDoNothing();
+      return { answered: true, queuedProviderEventId };
+    });
+  });
+}

--- a/packages/db/test/migration-0342-slack-route-prompt-single-pending.test.ts
+++ b/packages/db/test/migration-0342-slack-route-prompt-single-pending.test.ts
@@ -1,0 +1,128 @@
+// Migration 0342 keeps one pending Slack route picker per person per
+// conversation. The key includes the Slack user on purpose: a shared channel has
+// many people in it, and asking one of them must not swallow another's request.
+//
+// Expiry is deliberately NOT in the predicate, because `now()` is not immutable
+// and a partial index cannot call it. A timed-out row is settled `expired` by
+// the writer instead, which is what these assertions pin.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { migrate } from "../src/migrate";
+
+const migrationUrl = new URL(
+  "../drizzle/0342_slack_route_prompt_single_pending.sql",
+  import.meta.url,
+);
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+const ACCOUNT = "aaaaaaaa-0342-4342-8342-aaaaaaaaaaaa";
+const WORKSPACE = "11111111-0342-4342-8342-111111111111";
+const CONNECTION = "33333333-0342-4342-8342-333333333333";
+
+let owned: OwnerMigratedTestDatabase | null = null;
+
+async function insertPrompt(
+  database: OwnerMigratedTestDatabase,
+  input: { channelId: string; userId: string; status?: string; expiresIn?: string },
+): Promise<string | null> {
+  const id = crypto.randomUUID();
+  try {
+    await database.admin.unsafe(`
+      insert into slack_route_prompts
+        (id, account_id, workspace_id, connection_id, inbox_id, slack_team_id, slack_user_id,
+         slack_channel_id, slack_message_ts, provider_event_id, trigger_kind, request_text,
+         has_files, message_operation_id, status, expires_at)
+      values ('${id}', '${ACCOUNT}', '${WORKSPACE}', '${CONNECTION}', gen_random_uuid(),
+              'T0342', '${input.userId}', '${input.channelId}', '1.0',
+              '${crypto.randomUUID()}', 'app_mention', 'decide please', false,
+              gen_random_uuid(), '${input.status ?? "pending"}',
+              now() + interval '${input.expiresIn ?? "1 hour"}')`);
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+describe("migration 0342 one pending Slack route picker per person", () => {
+  beforeAll(async () => {
+    owned = await acquireOwnerMigratedTestDatabase("slack-route-pending");
+    if (!owned) {
+      if (requireRealDatabase) {
+        throw new Error("OPENGENI_REQUIRE_REAL_DB=1 but no owner-migrated database was available");
+      }
+      return;
+    }
+    await migrate(owned.ownerUrl);
+    await owned.admin.unsafe(`
+      insert into managed_accounts (id, name) values ('${ACCOUNT}', 'prompts');
+      insert into workspaces (id, account_id, name) values
+        ('${WORKSPACE}', '${ACCOUNT}', 'Home');
+      insert into connections
+        (id, account_id, workspace_id, provider_domain, kind, status, credential_encrypted)
+        values ('${CONNECTION}', '${ACCOUNT}', '${WORKSPACE}', 'slack.com', 'app_install',
+                'active', '\\x00'::bytea);
+    `);
+  }, 900_000);
+
+  afterAll(async () => {
+    await owned?.release();
+  });
+
+  test("declares a rolling additive index and says why expiry is not in the predicate", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.startsWith("-- deployment-mode: rolling")).toBe(true);
+    expect(source).toContain("slack_route_prompts_pending_conversation_uq");
+    expect(source).toContain('"slack_user_id"');
+    expect(source).not.toMatch(/DROP\s+(INDEX|TABLE|CONSTRAINT)/u);
+  });
+
+  test("asks one person once, and does not swallow another person in the same channel", async () => {
+    if (!owned) return;
+    expect(await insertPrompt(owned, { channelId: "C-SHARED", userId: "U-ONE" })).toBeTruthy();
+    // A second pending card for the SAME person in the same channel is refused.
+    expect(await insertPrompt(owned, { channelId: "C-SHARED", userId: "U-ONE" })).toBeNull();
+    // A different person in the same channel is asked their own question.
+    expect(await insertPrompt(owned, { channelId: "C-SHARED", userId: "U-TWO" })).toBeTruthy();
+    // The same person in a different channel is asked there too.
+    expect(await insertPrompt(owned, { channelId: "C-OTHER", userId: "U-ONE" })).toBeTruthy();
+  }, 120_000);
+
+  test("frees the slot once the card is settled, whatever settled it", async () => {
+    if (!owned) return;
+    for (const status of ["answered", "expired", "cancelled"] as const) {
+      const channelId = `C-SETTLE-${status}`;
+      const first = await insertPrompt(owned, { channelId, userId: "U-SETTLE" });
+      expect(first).toBeTruthy();
+      expect(await insertPrompt(owned, { channelId, userId: "U-SETTLE" })).toBeNull();
+      await owned.admin.unsafe(`
+        update slack_route_prompts
+        set status = '${status}',
+            answered_target_account_id = ${status === "answered" ? `'${ACCOUNT}'` : "null"},
+            answered_target_workspace_id = ${status === "answered" ? `'${WORKSPACE}'` : "null"},
+            answered_at = ${status === "answered" ? "now()" : "null"}
+        where id = '${first}'`);
+      expect(await insertPrompt(owned, { channelId, userId: "U-SETTLE" })).toBeTruthy();
+    }
+  }, 120_000);
+
+  test("an aged-out card still holds the slot until a writer settles it", async () => {
+    if (!owned) return;
+    // This is the reason `expired` needs a writer: the index cannot exclude an
+    // aged-out row by itself.
+    const stale = await insertPrompt(owned, {
+      channelId: "C-STALE",
+      userId: "U-STALE",
+      expiresIn: "-1 minute",
+    });
+    expect(stale).toBeTruthy();
+    expect(await insertPrompt(owned, { channelId: "C-STALE", userId: "U-STALE" })).toBeNull();
+    await owned.admin.unsafe(
+      `update slack_route_prompts set status = 'expired' where id = '${stale}'`,
+    );
+    expect(await insertPrompt(owned, { channelId: "C-STALE", userId: "U-STALE" })).toBeTruthy();
+  }, 120_000);
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -175,6 +175,7 @@ describe("release schema contract", () => {
       "0339_document_authority_reclassification.sql",
       "0340_tenancy_backfill_activation_evidence.sql",
       "0341_slack_routing_probe_organization_fence.sql",
+      "0342_slack_route_prompt_single_pending.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -197,23 +198,30 @@ describe("release schema contract", () => {
     const slackRoutingProbeFence = completeSourceContract.migrations.some(
       (migration) => migration.path === "0341_slack_routing_probe_organization_fence.sql",
     );
+
+    const slackRoutePromptSinglePending = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0342_slack_route_prompt_single_pending.sql",
+    );
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
         (documentAuthorityReclassification ? 1 : 0) +
         (tenancyBackfillActivationEvidence ? 1 : 0) +
-        (slackRoutingProbeFence ? 1 : 0),
-      latestMigration: slackRoutingProbeFence
-        ? "0341_slack_routing_probe_organization_fence.sql"
-        : tenancyBackfillActivationEvidence
-          ? "0340_tenancy_backfill_activation_evidence.sql"
-          : documentAuthorityReclassification
-            ? "0339_document_authority_reclassification.sql"
-            : atomicConnectedMachineAttachments
-              ? "0338_atomic_connected_machine_attachments.sql"
-              : routedSlackHandles
-                ? "0337_slack_routed_action_handles.sql"
-                : "0336_atomic_session_fork_visibility.sql",
+        (slackRoutingProbeFence ? 1 : 0) +
+        (slackRoutePromptSinglePending ? 1 : 0),
+      latestMigration: slackRoutePromptSinglePending
+        ? "0342_slack_route_prompt_single_pending.sql"
+        : slackRoutingProbeFence
+          ? "0341_slack_routing_probe_organization_fence.sql"
+          : tenancyBackfillActivationEvidence
+            ? "0340_tenancy_backfill_activation_evidence.sql"
+            : documentAuthorityReclassification
+              ? "0339_document_authority_reclassification.sql"
+              : atomicConnectedMachineAttachments
+                ? "0338_atomic_connected_machine_attachments.sql"
+                : routedSlackHandles
+                  ? "0337_slack_routed_action_handles.sql"
+                  : "0336_atomic_session_fork_visibility.sql",
     });
     expect(
       completeSourceContract.migrations.find(


### PR DESCRIPTION
The first-use picker. The first message in a channel OpenGeni has no route for now asks, in the person's own bot DM, and remembers the answer. Behind the routing flag, which stays **off** by default.

## The shape

**Nothing is created anywhere while the question is open.** The request is parked on the prompt row and re-queued only once someone answers, so a card that is never answered leaves no session, no interaction and no half-started work.

**A bot DM, not an ephemeral message.** `chat.postEphemeral` returns no durable `(channel, ts)` and no `client_msg_id` echo, and the whole post ledger and its reconciliation are built on both.

**No ingest change beyond two action ids.** Each button's `value` is an option row id, which is a UUID precisely because `normalizedBlockActionInteraction` already requires that shape. The block-action path branches to the picker *before* the handle load, because a picker exists before any session and there is no handle row to find.

**One live card per conversation**, enforced by a partial unique index (migration 0342). The existing uniques are keyed to the originating event, so they stop Slack's retries of one event from posting twice but not two different messages in the same channel: the person would get two cards for one question, and answering either would write the route while the other stayed answerable. A direct message needs no separate index, because its channel id is already one per person.

**Answering commits three things together**: the frozen choice, the remembered route, and the re-queued request.

## The derived event id

The re-queued inbox row carries `<originalProviderEventId>:route:<promptId>`, not the original id. The original inbox row still exists and is settled `processed`, so reusing its id would collide with the inbox's own `(connection_id, provider_event_id)` dedupe and quietly queue nothing at all. That is exactly what migration 0335's comment described; the schema definition was corrected in the previous PR and this implements the corrected thing.

## Authority

The stored option rows are a prompt-time **snapshot and never authority**: the chosen workspace is re-authorized live, because access can be revoked between the question and the answer. A different Slack human clicking someone else's card is ignored, the same pinning ordinary action handles use. A failed authorization leaves the prompt answerable, since another workspace on the same card may still work.

## A real defect the tests found

The double-click scenario caught the card update seeding one operation id per `(prompt, actionId)`. A second click renders different bytes than the first, so under one id the post ledger's digest check would reject it and the entry would retry rather than saying the choice was already settled. The outcome is now part of the seed, matching the ordinary control-card path.

## Proof

Two new real-Postgres scenarios on top of the existing suite: the ask-once round trip (question asked, nothing started, Slack's retry does not post a second card, the answer starts the original request in the chosen workspace, the route is remembered with `source: picker`, and the next message never asks again); and a double-click that cannot produce a second session. Local: 69 Slack acceptance tests, 118 further Slack API and db tests, schema contract, lint, format, typecheck and all four repo guards green.

Remaining after this: the target-workspace access link, the per-message workspace line with its five operation-id seed bumps, the capability-sheet settings UI, and the docs rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111dShuHC2eNj1Z53dtS1dL