### PR TITLE
feat(slack): request access to the workspace a conversation actually uses

### DIFF
--- a/.changeset/slack-target-access-link.md
+++ b/.changeset/slack-target-access-link.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Let a Slack access-request link name the workspace a routed conversation actually works in, instead of only the installation's own. Both intent routes now assert that the installation binding resolves for the token's team, that it is the same connection the token was minted against, and that the named workspace belongs to that installation's organization.

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -79,6 +79,7 @@ import {
   listSessionEventPage,
   listSessionHumanInputRequests,
   listPendingSlackUserLinkAccessRequests,
+  slackUserLinkAccessRequestTeam,
   rekeySlackInteractionRoute,
   reopenSlackInteractionDelivery,
   reserveSlackInteractionActionHandles,
@@ -425,7 +426,13 @@ async function resolveSlackLinkTargetInstallation(
   deps: ApiRouteDeps,
   link: { slackTeamId: string; connectionId: string },
   workspaceId: string,
-): Promise<{ accountId: string; connectionId: string; workspaceName: string } | null> {
+): Promise<{
+  accountId: string;
+  connectionId: string;
+  workspaceName: string;
+  /** Where the identity link lives, which is not the routed workspace. */
+  identityHome: { accountId: string; workspaceId: string };
+} | null> {
   const route = await resolveSlackInstallationRoute(deps.db, link.slackTeamId);
   if (!route || route.connectionId !== link.connectionId || route.accountId.length === 0) {
     return null;
@@ -436,6 +443,7 @@ async function resolveSlackLinkTargetInstallation(
     accountId: route.accountId,
     connectionId: route.connectionId,
     workspaceName: workspace.name,
+    identityHome: { accountId: route.accountId, workspaceId: route.workspaceId },
   };
 }
 
@@ -621,6 +629,7 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
         workspaceId,
         requestId: prepared.id,
         subjectId: context.subjectId,
+        identityHome: installation.identityHome,
       });
       if (!completed) throw freshSlackLinkRequired();
       return c.json(
@@ -734,14 +743,33 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
       const workspaceId = c.req.param("workspaceId");
       const grant = await requireAccessGrant(c, deps, workspaceId, "members:manage");
       const payload = ApproveSlackUserLinkAccessRequest.parse(await c.req.json());
+      // The identity link belongs to the installation, which for a routed
+      // request is a different workspace from the one being granted. The
+      // request row names its Slack team, so the binding resolves from it.
+      const requestId = c.req.param("requestId");
+      const requestTeam = await slackUserLinkAccessRequestTeam(deps.db, {
+        workspaceId,
+        requestId,
+      });
+      const installation = requestTeam
+        ? await resolveSlackInstallationRoute(deps.db, requestTeam.slackTeamId)
+        : null;
       try {
         const request = await approveSlackUserLinkAccessRequest(deps.db, {
           workspaceId,
-          requestId: c.req.param("requestId"),
+          requestId,
           actorSubjectId: grant.subjectId,
           expectedVersion: payload.expectedVersion,
           idempotencyKey: payload.idempotencyKey,
           permissions: payload.permissions,
+          ...(installation
+            ? {
+                identityHome: {
+                  accountId: installation.accountId,
+                  workspaceId: installation.workspaceId,
+                },
+              }
+            : {}),
           ...(payload.role !== undefined ? { role: payload.role } : {}),
         });
         const workspace = await getWorkspace(deps.db, workspaceId);
@@ -822,6 +850,7 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
         workspaceId,
         requestId: prepared.id,
         subjectId: grant.subjectId,
+        identityHome: installation.identityHome,
       });
       if (completed?.status !== "completed") throw freshSlackLinkRequired();
       const saved = await getSlackBotUserLink(

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -1389,15 +1389,19 @@ async function postSlackRouteRefusal(
       : refusal.reason === "no_access_to_route"
         ? `OpenGeni starts work from this conversation in ${
             refusal.requested ?? "another workspace"
-          }, and you do not have access to it. Request access: ${linkUrl(deps, {
-            // Minted for the workspace they actually need, not the
-            // installation's. The token only decides which workspace an access
-            // request may be raised for; approval is unchanged.
-            workspaceId: refusal.workspaceId ?? entry.workspaceId,
-            connectionId: entry.connectionId,
-            slackTeamId: entry.slackTeamId,
-            slackUserId: entry.slackUserId,
-          })}. No session was created.`
+          }, and you do not have access to it. Request access: ${linkUrl(
+            deps,
+            {
+              // Minted for the workspace they actually need, not the
+              // installation's. The token only decides which workspace an
+              // access request may be raised for; approval is unchanged.
+              workspaceId: refusal.workspaceId ?? entry.workspaceId,
+              connectionId: entry.connectionId,
+              slackTeamId: entry.slackTeamId,
+              slackUserId: entry.slackUserId,
+            },
+            entry.createdAt.getTime(),
+          )}. No session was created.`
         : "OpenGeni has no workspace it can start this task in for you. Ask an OpenGeni administrator to give you access to one. No session was created.";
   await client.postMessage({
     operationId: deterministicUuid(`slack-route-denied:${entry.id}:${refusal.reason}`),
@@ -1803,7 +1807,7 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     await client.postMessage({
       operationId: deterministicUuid(`slack-link:${entry.id}`),
       userId: entry.slackUserId,
-      text: `Link your Slack identity to OpenGeni before starting work: ${linkUrl(deps, entry)}. No session was created.`,
+      text: `Link your Slack identity to OpenGeni before starting work: ${linkUrl(deps, entry, entry.createdAt.getTime())}. No session was created.`,
     });
     return;
   }
@@ -4802,6 +4806,16 @@ function linkUrl(
     SlackInteractionInboxEntry,
     "workspaceId" | "connectionId" | "slackTeamId" | "slackUserId"
   >,
+  /**
+   * When this URL goes into a message posted under a deterministic operation
+   * id, the token has to be deterministic too. The post ledger binds that id to
+   * a digest over the text, so a retry that mints a fresh token renders
+   * different bytes and is refused as a conflicting request, permanently. Pass
+   * the originating inbox row's creation time: the token is then stable for that
+   * row and still expires fifteen minutes after the message could first have
+   * been read.
+   */
+  mintedAtMs?: number,
 ) {
   const base = deps.settings.webBaseUrl ?? deps.settings.publicBaseUrl;
   const signingSecret = deps.settings.slackSigningSecret;
@@ -4810,7 +4824,7 @@ function linkUrl(
   // Fragments stay out of HTTP request lines, reverse-proxy logs, Referer
   // headers, and managed-auth callback URLs. Query-form bearers are rejected.
   url.hash = new URLSearchParams({
-    slack_link: createSlackUserLinkToken(signingSecret, entry),
+    slack_link: createSlackUserLinkToken(signingSecret, entry, mintedAtMs),
   }).toString();
   return url.toString();
 }

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -406,6 +406,39 @@ export function slackReactionInboxEntry(
   };
 }
 
+/**
+ * Prove a Slack link token may name this workspace.
+ *
+ * Before routing, a token could only ever name the installation's own
+ * workspace, and both intent routes asserted exactly that. A routed
+ * conversation asks for access to the workspace the work would actually land
+ * in, which is a different one, so the assertion becomes: the installation
+ * binding resolves for the token's team, it is the same connection the token
+ * was minted against, and the named workspace belongs to that installation's
+ * organization.
+ *
+ * That is the same fence the route tables carry. It does not widen access by
+ * itself: this only decides which workspace an access REQUEST may be raised
+ * for, and the request still goes through the ordinary approval path.
+ */
+async function resolveSlackLinkTargetInstallation(
+  deps: ApiRouteDeps,
+  link: { slackTeamId: string; connectionId: string },
+  workspaceId: string,
+): Promise<{ accountId: string; connectionId: string; workspaceName: string } | null> {
+  const route = await resolveSlackInstallationRoute(deps.db, link.slackTeamId);
+  if (!route || route.connectionId !== link.connectionId || route.accountId.length === 0) {
+    return null;
+  }
+  const workspace = await getWorkspace(deps.db, workspaceId);
+  if (!workspace || workspace.accountId !== route.accountId) return null;
+  return {
+    accountId: route.accountId,
+    connectionId: route.connectionId,
+    workspaceName: workspace.name,
+  };
+}
+
 export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.post("/v1/integrations/slack/events", async (c) => {
     const signed = await readSignedSlackRequest(c, deps);
@@ -568,22 +601,13 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
     if (!link || link.workspaceId !== workspaceId) {
       throw freshSlackLinkRequired();
     }
-    const route = await resolveSlackInstallationRoute(deps.db, link.slackTeamId);
-    if (
-      !route ||
-      route.workspaceId !== workspaceId ||
-      route.connectionId !== link.connectionId ||
-      route.accountId.length === 0
-    ) {
-      throw freshSlackLinkRequired();
-    }
-    const workspace = await getWorkspace(deps.db, workspaceId);
-    if (!workspace || workspace.accountId !== route.accountId) {
+    const installation = await resolveSlackLinkTargetInstallation(deps, link, workspaceId);
+    if (!installation) {
       throw freshSlackLinkRequired();
     }
     try {
       const prepared = await prepareSlackUserLinkAccessRequest(deps.db, {
-        accountId: route.accountId,
+        accountId: installation.accountId,
         workspaceId,
         tokenDigest: createHash("sha256").update(payload.linkToken).digest("hex"),
         connectionId: link.connectionId,
@@ -602,7 +626,7 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
       return c.json(
         SlackUserLinkAccessRequest.parse({
           ...completed,
-          workspaceDisplayName: workspace.name,
+          workspaceDisplayName: installation.workspaceName,
         }),
         201,
       );
@@ -776,8 +800,8 @@ export function registerSlackInteractionRoutes(app: Hono, deps: ApiRouteDeps): v
         message: "invalid or expired Slack identity link",
       });
     }
-    const route = await resolveSlackInstallationRoute(deps.db, link.slackTeamId);
-    if (!route || route.workspaceId !== workspaceId || route.connectionId !== link.connectionId) {
+    const installation = await resolveSlackLinkTargetInstallation(deps, link, workspaceId);
+    if (!installation) {
       throw new HTTPException(404, {
         message: "Slack installation not found",
       });
@@ -1365,7 +1389,15 @@ async function postSlackRouteRefusal(
       : refusal.reason === "no_access_to_route"
         ? `OpenGeni starts work from this conversation in ${
             refusal.requested ?? "another workspace"
-          }, and you do not have access to it. Ask an OpenGeni administrator for access to that workspace, or point this conversation somewhere else in OpenGeni under Capabilities, then Slack. No session was created.`
+          }, and you do not have access to it. Request access: ${linkUrl(deps, {
+            // Minted for the workspace they actually need, not the
+            // installation's. The token only decides which workspace an access
+            // request may be raised for; approval is unchanged.
+            workspaceId: refusal.workspaceId ?? entry.workspaceId,
+            connectionId: entry.connectionId,
+            slackTeamId: entry.slackTeamId,
+            slackUserId: entry.slackUserId,
+          })}. No session was created.`
         : "OpenGeni has no workspace it can start this task in for you. Ask an OpenGeni administrator to give you access to one. No session was created.";
   await client.postMessage({
     operationId: deterministicUuid(`slack-route-denied:${entry.id}:${refusal.reason}`),

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -1738,6 +1738,37 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
     expect(verifySlackUserLinkToken(signingMaterial, linkToken!)?.workspaceId).toBe(
       routed.workspaceId,
     );
+
+    // The message carries a signed token and is posted under a deterministic
+    // operation id, so a retry has to render the SAME bytes. A freshly minted
+    // token would be a different digest under one id, which the post ledger
+    // refuses permanently.
+    const before = value.slack.posts.length;
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_NO_ACCESS_RETRY_${crypto.randomUUID()}`,
+          event: {
+            type: "app_mention",
+            user: value.otherSlackUserId,
+            channel: channelId,
+            ts: "1700000600.0002",
+            text: "please do this again",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+    const second = value.slack.posts
+      .slice(before)
+      .find((post) => post.text.includes("Request access"));
+    expect(second).toBeTruthy();
+    // Same inbox row would give identical bytes; a different row legitimately
+    // mints its own token, so compare the stable half.
+    expect(second!.text.split("Request access:")[0]).toBe(
+      refusal!.text.split("Request access:")[0],
+    );
   });
 
   test("one workspace is not a choice, so an ordinary install never notices the flag", async () => {

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -1731,6 +1731,13 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
     expect(sessions!.n).toBe(0);
     const refusal = value.slack.posts.find((post) => post.text.includes("No session was created."));
     expect(refusal?.text).toContain("do not have access");
+    // The access-request link is minted for the workspace they actually need,
+    // not the installation's, or it would send them to a page that refuses them.
+    const url = /https:\/\/\S+/u.exec(refusal!.text)![0].replace(/\.$/u, "");
+    const linkToken = new URLSearchParams(new URL(url).hash.slice(1)).get("slack_link");
+    expect(verifySlackUserLinkToken(signingMaterial, linkToken!)?.workspaceId).toBe(
+      routed.workspaceId,
+    );
   });
 
   test("one workspace is not a choice, so an ordinary install never notices the flag", async () => {

--- a/packages/db/src/slack-user-link-access.ts
+++ b/packages/db/src/slack-user-link-access.ts
@@ -6,7 +6,7 @@ import {
   type SlackUserLinkAccessRequest,
   type SlackUserLinkAccessRequestStatus,
 } from "@opengeni/contracts";
-import { and, asc, eq, gt, inArray, ne } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, ne, sql } from "drizzle-orm";
 
 import { type Database, withWorkspaceRls } from "./database";
 import { namedSubjectPersonalWorkspaceId } from "./slack-routing-personal-workspace";
@@ -53,9 +53,45 @@ export type SlackUserLinkAccessMutationInput = {
   idempotencyKey: string;
 };
 
+/**
+ * The Slack team one access request was raised from.
+ *
+ * The public request shape deliberately omits it, but an approver has to
+ * resolve the installation binding to know where the identity link belongs, and
+ * for a routed request that is not the workspace being granted.
+ */
+export async function slackUserLinkAccessRequestTeam(
+  db: Database,
+  input: { workspaceId: string; requestId: string },
+): Promise<{ slackTeamId: string; connectionId: string } | null> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
+      .select({
+        slackTeamId: schema.slackUserLinkAccessRequests.slackTeamId,
+        connectionId: schema.slackUserLinkAccessRequests.connectionId,
+      })
+      .from(schema.slackUserLinkAccessRequests)
+      .where(
+        and(
+          eq(schema.slackUserLinkAccessRequests.workspaceId, input.workspaceId),
+          eq(schema.slackUserLinkAccessRequests.id, input.requestId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+/**
+ * The tenancy an identity link belongs to. See `withSlackIdentityHomeScope`.
+ */
+export type SlackIdentityHome = { accountId: string; workspaceId: string };
+
 export type ApproveSlackUserLinkAccessInput = SlackUserLinkAccessMutationInput & {
   role?: string;
   permissions: Permission[];
+  /** The installation's tenancy, when it differs from the routed request's. */
+  identityHome?: SlackIdentityHome;
 };
 
 const activeStatuses: SlackUserLinkAccessRequestStatus[] = ["prepared", "pending"];
@@ -156,7 +192,13 @@ export async function prepareSlackUserLinkAccessRequest(
 
 export async function getSlackUserLinkAccessRequestForSubject(
   db: Database,
-  input: { workspaceId: string; requestId: string; subjectId: string },
+  input: {
+    workspaceId: string;
+    requestId: string;
+    subjectId: string;
+    /** The installation's tenancy, when it differs from the routed request's. */
+    identityHome?: SlackIdentityHome;
+  },
   now = new Date(),
 ): Promise<SlackUserLinkAccessRequest | null> {
   return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
@@ -320,7 +362,10 @@ export async function approveSlackUserLinkAccessRequest(
         });
       const membership = await membershipAllowsSlackLink(database, row);
       if (!membership) throw new Error("Slack access approval did not create the required grant");
-      await upsertSlackIdentityLink(database, row, input.actorSubjectId, now);
+      await withSlackIdentityHomeScope(database, row, input.identityHome, async () => {
+        await assertSlackIdentityAvailable(database, row);
+        await upsertSlackIdentityLink(database, row, input.actorSubjectId, now, input.identityHome);
+      });
       const [updated] = await database
         .update(schema.slackUserLinkAccessRequests)
         .set({
@@ -364,7 +409,13 @@ export async function approveSlackUserLinkAccessRequest(
  */
 export async function completeSlackUserLinkAccessIfGranted(
   db: Database,
-  input: { workspaceId: string; requestId: string; subjectId: string },
+  input: {
+    workspaceId: string;
+    requestId: string;
+    subjectId: string;
+    /** The installation's tenancy, when it differs from the routed request's. */
+    identityHome?: SlackIdentityHome;
+  },
   now = new Date(),
 ): Promise<SlackUserLinkAccessRequest | null> {
   return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
@@ -390,8 +441,10 @@ export async function completeSlackUserLinkAccessIfGranted(
       if (!(await membershipAllowsSlackLink(database, row))) {
         return mapRequest(row);
       }
-      await assertSlackIdentityAvailable(database, row);
-      await upsertSlackIdentityLink(database, row, input.subjectId, now);
+      await withSlackIdentityHomeScope(database, row, input.identityHome, async () => {
+        await assertSlackIdentityAvailable(database, row);
+        await upsertSlackIdentityLink(database, row, input.subjectId, now, input.identityHome);
+      });
       const [updated] = await tx
         .update(schema.slackUserLinkAccessRequests)
         .set({
@@ -600,17 +653,75 @@ async function assertSlackIdentityAvailable(database: Database, row: RequestRow)
   }
 }
 
+/**
+ * The tenancy an identity link belongs to.
+ *
+ * `slack_bot_user_links` is unique on `(connection_id, slack_user_id)` globally
+ * but RLS-visible only under ONE workspace, and the Slack pump reads it under
+ * the installation's. A request for a ROUTED workspace runs under that routed
+ * scope, so writing the link there would file it where the pump cannot see it,
+ * and reading it there is blind to the row that already exists at home. Both the
+ * availability check and the write therefore take the installation's tenancy
+ * explicitly, and fall back to the request row's when a caller has none, which
+ * is exactly the pre-routing behaviour.
+ */
+function identityHomeFor(row: RequestRow, home: SlackIdentityHome | undefined): SlackIdentityHome {
+  return home ?? { accountId: row.accountId, workspaceId: row.workspaceId };
+}
+
+/**
+ * Run the identity-link statements under the installation's own tenancy.
+ *
+ * The surrounding transaction is scoped to the request's workspace, which for a
+ * routed request is NOT where the link lives, and it must stay one transaction:
+ * an approval that granted membership without linking the identity, or the
+ * reverse, would be worse than either. So the tenant GUCs are swapped for
+ * exactly these statements and restored, rather than opening a second
+ * transaction. Restoring is not optional: everything after this call still
+ * belongs to the request's workspace.
+ */
+async function withSlackIdentityHomeScope<T>(
+  database: Database,
+  row: RequestRow,
+  home: SlackIdentityHome | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const identity = identityHomeFor(row, home);
+  if (identity.accountId === row.accountId && identity.workspaceId === row.workspaceId) {
+    return await fn();
+  }
+  await database.execute(
+    sql`select set_config('opengeni.account_id', ${identity.accountId}, true),
+               set_config('opengeni.workspace_id', ${identity.workspaceId}, true)`,
+  );
+  try {
+    return await fn();
+  } finally {
+    // A failed statement can leave the transaction aborted and unwinding to
+    // rollback, so preserve the original diagnostic rather than replacing it
+    // with the restore's own error.
+    await database
+      .execute(
+        sql`select set_config('opengeni.account_id', ${row.accountId}, true),
+                   set_config('opengeni.workspace_id', ${row.workspaceId}, true)`,
+      )
+      .catch(() => undefined);
+  }
+}
+
 async function upsertSlackIdentityLink(
   database: Database,
   row: RequestRow,
   actorSubjectId: string,
   now: Date,
+  home?: SlackIdentityHome,
 ) {
+  const identity = identityHomeFor(row, home);
   const [created] = await database
     .insert(schema.slackBotUserLinks)
     .values({
-      accountId: row.accountId,
-      workspaceId: row.workspaceId,
+      accountId: identity.accountId,
+      workspaceId: identity.workspaceId,
       connectionId: row.connectionId,
       slackTeamId: row.slackTeamId,
       slackUserId: row.slackUserId,
@@ -640,8 +751,8 @@ async function upsertSlackIdentityLink(
   await database
     .update(schema.slackBotUserLinks)
     .set({
-      accountId: row.accountId,
-      workspaceId: row.workspaceId,
+      accountId: identity.accountId,
+      workspaceId: identity.workspaceId,
       slackTeamId: row.slackTeamId,
       linkedBySubjectId: actorSubjectId,
       updatedAt: now,

--- a/packages/db/test/slack-user-link-access.test.ts
+++ b/packages/db/test/slack-user-link-access.test.ts
@@ -13,6 +13,7 @@ import postgres from "postgres";
 
 import {
   approveSlackUserLinkAccessRequest,
+  slackUserLinkAccessRequestTeam,
   cancelSlackUserLinkAccessRequest,
   completeSlackUserLinkAccessIfGranted,
   createConnection,
@@ -151,6 +152,76 @@ async function insertOperationReceipt(input: {
 }
 
 describe("Slack user-link access migration and lifecycle", () => {
+  test("files the identity link at the installation when the request is for a routed workspace", async () => {
+    if (!available) return;
+    // Slack workspace routing raises the access request in the workspace the
+    // work would land in, but `slack_bot_user_links` is unique per connection
+    // and Slack user and is read only under the INSTALLATION's tenancy. Writing
+    // it in the routed workspace would file it where the pump cannot see it, so
+    // every later message would ask the person to link again.
+    const label = `routed-${randomUUID().slice(0, 8)}`;
+    const home = await workspace(`${label}-home`);
+    const connection = await slackConnection(home, label);
+    const [routed] = await admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${home.accountId}, ${`Slack access ${label} routed`}) returning id`;
+    await admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${routed!.id}, ${home.accountId})`;
+
+    const subjectId = `user:${randomUUID()}`;
+    const token = `signed-${label}`;
+    const prepared = await prepareSlackUserLinkAccessRequest(db, {
+      accountId: home.accountId,
+      workspaceId: routed!.id,
+      tokenDigest: digest(token),
+      connectionId: connection.id,
+      slackTeamId: `T_${label}`,
+      slackUserId: `U_${label}`,
+      subjectId,
+      subjectLabel: `${label}@example.test`,
+      expiresAt: new Date(Date.now() + 5 * 60_000),
+    });
+    const team = await slackUserLinkAccessRequestTeam(db, {
+      workspaceId: routed!.id,
+      requestId: prepared.id,
+    });
+    expect(team).toEqual({ slackTeamId: `T_${label}`, connectionId: connection.id });
+
+    const pending = await requestSlackUserLinkWorkspaceAccess(db, {
+      workspaceId: routed!.id,
+      requestId: prepared.id,
+      actorSubjectId: subjectId,
+      expectedVersion: prepared.version,
+      idempotencyKey: randomUUID(),
+    });
+    await approveSlackUserLinkAccessRequest(db, {
+      workspaceId: routed!.id,
+      requestId: prepared.id,
+      actorSubjectId: `user:${randomUUID()}`,
+      expectedVersion: pending.version,
+      idempotencyKey: randomUUID(),
+      permissions: ["sessions:create", "sessions:read"],
+      identityHome: home,
+    });
+
+    // The grant is in the routed workspace, where the work will run.
+    const [membership] = await admin<{ n: number }[]>`
+      select count(*)::int as n from workspace_memberships
+      where workspace_id = ${routed!.id} and subject_id = ${subjectId}`;
+    expect(membership!.n).toBe(1);
+    // The identity link is at home, where the Slack pump reads it.
+    const [link] = await admin<{ workspace_id: string }[]>`
+      select workspace_id from slack_bot_user_links
+      where connection_id = ${connection.id} and slack_user_id = ${`U_${label}`}`;
+    expect(link?.workspace_id).toBe(home.workspaceId);
+    expect(
+      await getSlackBotUserLink(db, home.workspaceId, connection.id, `U_${label}`),
+    ).toMatchObject({
+      subjectId,
+    });
+  });
+
   test("declares rolling FORCE-RLS tables, exact constraints, policies, and runtime DML", async () => {
     const candidates = (await readdir(migrationsDir)).filter((file) =>
       file.endsWith("_slack_user_link_access_requests.sql"),


### PR DESCRIPTION
A person routed into a workspace they cannot reach was told to find an administrator, because the access-request link could only ever name the installation's own workspace and sending them to a page that refuses them is worse than saying nothing. Now the link names the workspace they actually need.

## The relaxation

Both intent routes asserted `route.workspaceId === workspaceId`, which was exactly right before routing existed: a token could only ever name the installation's workspace. The assertion becomes:

- the installation binding resolves for the token's team,
- it is the same connection the token was minted against, and
- the named workspace belongs to that installation's organization.

That is the same fence the route tables carry (`target_account_id = account_id`), applied to the link flow.

## What this does not do

It widens no access by itself. It decides which workspace an access **request** may be raised for; the request still goes through the ordinary approval path, the identity link is still required, and `requireManagedSlackLinkHuman` — the only cookie proof in this flow — is untouched. `membershipAllowsSlackLink` already learned about personal workspaces in an earlier PR, so a person whose DM lands in their own workspace is not told to request access to it.

## Proof

The refusal scenario now parses the minted token out of the message and verifies it names the **routed** workspace, rather than only asserting the message mentions access. Local: 72 Slack acceptance tests, 96 further Slack API and db tests, lint, format, typecheck and the repo guards green.

Remaining after this: the capability-sheet settings UI, and the docs rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111dShuHC2eNj1Z53dtS1dL