### PR TITLE
fix(release): delete every unreachable forward-listed contract reference

### DIFF
--- a/scripts/check-migration-schema-contract.test.ts
+++ b/scripts/check-migration-schema-contract.test.ts
@@ -12,7 +12,9 @@ import {
   parseForwardMigrations,
   parseLedgerPaths,
   probeName,
+  parseFilteredMembershipTests,
   registrationFixLines,
+  unreachableContractReferences,
   unregisteredMigrations,
 } from "./migration-schema-contract";
 
@@ -79,6 +81,12 @@ function miniContract(sites: {
     "    });",
     '    const laterPin = "0004_later.sql";',
     "    const releaseSchemaContractHash = (includesActivation: boolean): string | null => {",
+    // The real contract always carries a ladder, and `parseLadderRungs` is
+    // strict about that so a refactor cannot silently disable the audit. Give
+    // every fixture a baseline rung, the same way it gets a baseline probe.
+    '      if (migrations.has("0001_first.sql")) {',
+    '        return includesActivation ? "cc" : "dd";',
+    "      }",
     ...(sites.ladder ?? []).flatMap((file) => [
       `      if (migrations.has("${file}")) {`,
       '        return includesActivation ? "aa" : "bb";',
@@ -244,6 +252,74 @@ describe("release-schema registration rule", () => {
         registration({}),
       ).map((violation) => violation.file),
     ).toEqual(["custom_probe.sql"]);
+  });
+});
+
+describe("unreachable contract references", () => {
+  const contract = (ladder: readonly string[], forward: readonly string[]) =>
+    miniContract({ ladder, forward });
+
+  test("reports a rung whose migration is forward-listed and present", () => {
+    expect(
+      unreachableContractReferences(
+        contract(["0003_new.sql"], ["0003_new.sql"]),
+        ["0003_new.sql"],
+        ["0003_new.sql"],
+      ),
+    ).toEqual(["0003_new.sql"]);
+  });
+
+  test("accepts a rung whose migration is not forward-listed", () => {
+    expect(
+      unreachableContractReferences(contract(["0003_new.sql"], []), ["0003_new.sql"], []),
+    ).toEqual([]);
+  });
+
+  /**
+   * A rung for a migration this tree does not carry is an ordinary
+   * compatibility rung: it fires on a branch holding fewer migrations, and the
+   * check must not touch it.
+   */
+  test("leaves a compatibility rung for an absent migration alone", () => {
+    expect(
+      unreachableContractReferences(
+        contract(["0003_new.sql"], ["0003_new.sql"]),
+        [],
+        ["0003_new.sql"],
+      ),
+    ).toEqual([]);
+  });
+
+  test("reads every membership test in source order", () => {
+    expect(parseFilteredMembershipTests(contract(["0004_next.sql", "0003_new.sql"], []))).toEqual([
+      "0001_first.sql",
+      "0004_next.sql",
+      "0003_new.sql",
+    ]);
+  });
+
+  /**
+   * The strictness is the anti-no-op guard: if a refactor removed every
+   * membership test the audit would otherwise pass vacuously forever.
+   */
+  test("fails loudly when nothing tests the filtered set at all", () => {
+    const stripped = contract(["0003_new.sql"], []).replaceAll("migrations.has(", "other.has(");
+    expect(() => parseFilteredMembershipTests(stripped)).toThrow(ContractParseError);
+  });
+
+  /**
+   * The `latestCompatibleMigration` shape resolves its entries through
+   * `.find((path) => migrations.has(path))`, so its names are membership tests
+   * too and a dead entry there is the same debris as a dead rung.
+   */
+  test("reads names resolved through a .find over migrations.has", () => {
+    const withFind =
+      contract([], []) +
+      '\nconst latestCompatibleMigration = ["0003_new.sql"].find((path) => migrations.has(path));\n';
+    expect(parseFilteredMembershipTests(withFind)).toContain("0003_new.sql");
+    expect(unreachableContractReferences(withFind, ["0003_new.sql"], ["0003_new.sql"])).toEqual([
+      "0003_new.sql",
+    ]);
   });
 });
 
@@ -461,6 +537,21 @@ describe("check-migration-schema-contract CLI", () => {
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("- 0003_bad-name.sql");
     expect(result.stderr).toContain("- custom_probe.sql");
+  });
+
+  test("fails on an unreachable ladder rung even when nothing new was added", async () => {
+    const root = await fixtureRepo({
+      added: [],
+      sites: { forward: ["0002_second.sql"], ladder: ["0002_second.sql"] },
+    });
+    const result = await run(root, guard);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("where the check can never match");
+    expect(result.stderr).toContain("- 0002_second.sql");
+    expect(result.stderr).toContain("Delete every reference to them");
+    // Nothing new was added, so the registration report must stay suppressed
+    // rather than announcing "0 new migrations are not fully registered".
+    expect(result.stderr).not.toContain("not fully registered");
   });
 
   test("stays quiet when the head adds no migration at all", async () => {

--- a/scripts/check-migration-schema-contract.ts
+++ b/scripts/check-migration-schema-contract.ts
@@ -31,6 +31,7 @@ import {
   readContractSource,
   declaredIdentifiers,
   registrationFixLines,
+  unreachableContractReferences,
   unregisteredMigrations,
 } from "./migration-schema-contract";
 
@@ -85,12 +86,32 @@ async function main(): Promise<void> {
   const registration = parseContractRegistration(source);
   const head = listLedger(root);
   const violations = unregisteredMigrations(head, base, registration);
-  if (violations.length === 0) {
+
+  // Independent of what this head adds: a ladder rung naming a forward-listed
+  // migration can never fire, and reads as a live pin that it is not.
+  const unreachable = unreachableContractReferences(source, head, registration.forward);
+  if (unreachable.length > 0) {
+    const plural = unreachable.length === 1 ? "migration is" : "migrations are";
+    console.error(
+      `[migration-schema-contract] ${unreachable.length} forward-listed ${plural} still referenced in ${RELEASE_CONTRACT_TEST} where the check can never match, because forward-listing removes it from the filtered set those checks query:`,
+    );
+    for (const file of unreachable) console.error(`  - ${file}`);
+    console.error("");
+    console.error("Delete every reference to them: the hash ladders, the `fileCount` sum, and");
+    console.error("the `latestMigration` chain. They are the residue of pinning or counting your");
+    console.error("own migration instead of registering it, and a dead hash rung reads as a live");
+    console.error("pin. It is not a fallback either: an aggregate pinned while the migration was");
+    console.error("still framed is already wrong for the only tree that could ever read it.");
+  }
+
+  if (violations.length === 0 && unreachable.length === 0) {
     console.log(
       `[migration-schema-contract] ok: ${head.length} migrations, base ${base.ref}, ${registration.forward.length} forward additions`,
     );
     return;
   }
+
+  if (violations.length === 0) process.exit(1);
 
   const plural = violations.length === 1 ? "migration is" : "migrations are";
   console.error(

--- a/scripts/migration-schema-contract.ts
+++ b/scripts/migration-schema-contract.ts
@@ -174,6 +174,38 @@ export function parseForwardMigrations(source: string): string[] {
   return forward;
 }
 
+/**
+ * Every migration the contract tests for membership of the FILTERED set.
+ *
+ * Two shapes carry that test: a direct `migrations.has("<file>")`, and an array
+ * of names resolved through `.find((path) => migrations.has(path))`. Both the
+ * hash ladders and the `fileCount` / `latestMigration` pins are built from them,
+ * so scanning the whole file rather than one ladder is what keeps the audit
+ * total.
+ */
+export function parseFilteredMembershipTests(source: string): string[] {
+  const clean = withoutLineComments(source);
+  const found: string[] = [];
+  for (const match of clean.matchAll(/migrations\.has\("(\d{4}_[A-Za-z0-9_]+\.sql)"\)/g)) {
+    if (!found.includes(match[1]!)) found.push(match[1]!);
+  }
+  for (const match of clean.matchAll(
+    /\[([^\]]*?)\]\s*\.find\(\([A-Za-z_$][\w$]*\)\s*=>\s*migrations\.has\(/g,
+  )) {
+    for (const entry of match[1]!.matchAll(MIGRATION_LITERAL)) {
+      if (!found.includes(entry[1]!)) found.push(entry[1]!);
+    }
+  }
+  if (found.length === 0) {
+    throw new ContractParseError(
+      `${RELEASE_CONTRACT_TEST} tests no migration against the filtered set. ` +
+        "The registration guard cannot audit it; update " +
+        "scripts/migration-schema-contract.ts to match the contract.",
+    );
+  }
+  return found;
+}
+
 /** Every registration site the contract declares, parsed from its source. */
 export function parseContractRegistration(source: string): ContractRegistration {
   const clean = withoutLineComments(source);
@@ -208,6 +240,36 @@ export function parseContractRegistration(source: string): ContractRegistration 
     );
   }
   return { forward: parseForwardMigrations(source), fileCountProbes, latestMigrationPins };
+}
+
+/**
+ * Contract references that can never match.
+ *
+ * The hash ladders and the `fileCount` / `latestMigration` pins all ask
+ * `migrations.has(...)` over the ALREADY-FILTERED set, so a reference to a
+ * forward-listed migration present on this tree is unreachable: forward-listing
+ * is what removes it from that map, and if the file were absent the check would
+ * be false anyway.
+ *
+ * Such a reference is the residue of the wrong repair - pinning or counting your
+ * own migration instead of registering it - and a dead hash rung is worse than
+ * dead weight, because it reads as a live pin. It is not a fallback either: an
+ * aggregate pinned while the migration was still framed is already wrong for the
+ * only tree that could ever read it.
+ *
+ * A reference to a migration that is not on this tree is left alone. Those are
+ * the ordinary compatibility branches that fire where fewer migrations exist.
+ */
+export function unreachableContractReferences(
+  source: string,
+  ledger: readonly string[],
+  forwardMigrations: readonly string[],
+): string[] {
+  const present = new Set(ledger);
+  const forward = new Set(forwardMigrations);
+  return parseFilteredMembershipTests(source).filter(
+    (file) => present.has(file) && forward.has(file),
+  );
 }
 
 /**

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -691,21 +691,6 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
-      if (migrations.has("0334_connected_machine_workspace_root.sql")) {
-        // Re-pinned: #1799 computed these against a tree that did not yet
-        // contain #1805's reconciliation, so protected main landed red at
-        // ca8aad33d. The aggregate covers the whole filtered migration set, not
-        // just the file a PR adds, so a pin goes stale the moment another
-        // migration merges first. Recomputed from origin/main.
-        return includesActivation
-          ? "3d058b3b8c05d2ebf84de1b1024c995ec131c3c4dcb973a0c42014bca1046e3f"
-          : "eab718bef0df92dd9c78feb9639c0098ec0bbce267de79146315091ce8289d98";
-      }
-      if (migrations.has("0333_session_turn_prompt_routing.sql")) {
-        return includesActivation
-          ? "81a28040b800ad49a3c49e1d9bec22303884646b16afbfb9cf0f9e8f470c52ff"
-          : "859139de533a92053241f2dfc1c1eba04a4c9e62c4290564b533899a32c3d204";
-      }
       if (migrations.has("0326_interaction_operation_error_codes.sql")) {
         return includesActivation
           ? "c4ec5d41697c791e8083ae6285c7dd46b33d843b1ddf4024925d05fdceb5115c"
@@ -1363,15 +1348,10 @@ describe("release schema contract", () => {
         (migrations.has("0309_channel_project_pins.sql") ? 1 : 0) +
         (migrations.has("0310_channel_project_order.sql") ? 1 : 0) +
         (migrations.has("0321_slack_bot_environment_display_name.sql") ? 1 : 0) +
-        (migrations.has("0326_interaction_operation_error_codes.sql") ? 1 : 0) +
-        (migrations.has("0331_managed_organization_creation.sql") ? 1 : 0) +
-        (migrations.has("0332_organization_shared_workspace_control_plane.sql") ? 1 : 0) +
-        (migrations.has("0333_session_turn_prompt_routing.sql") ? 1 : 0) +
-        (migrations.has("0334_connected_machine_workspace_root.sql") ? 1 : 0),
+        (migrations.has("0326_interaction_operation_error_codes.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
-      "0334_connected_machine_workspace_root.sql",
       "0259_company_brain_context_selection_receipts.sql",
       "0258_three_scope_document_knowledge_authority.sql",
       "0257_goal_revision_decisions_and_root_constraints.sql",
@@ -1403,183 +1383,171 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0334_connected_machine_workspace_root.sql")
-        ? "0334_connected_machine_workspace_root.sql"
-        : migrations.has("0333_session_turn_prompt_routing.sql")
-          ? "0333_session_turn_prompt_routing.sql"
-          : migrations.has("0332_organization_shared_workspace_control_plane.sql")
-            ? "0332_organization_shared_workspace_control_plane.sql"
-            : migrations.has("0331_managed_organization_creation.sql")
-              ? "0331_managed_organization_creation.sql"
-              : migrations.has("0326_interaction_operation_error_codes.sql")
-                ? "0326_interaction_operation_error_codes.sql"
-                : migrations.has("0321_slack_bot_environment_display_name.sql")
-                  ? "0321_slack_bot_environment_display_name.sql"
-                  : migrations.has("0310_channel_project_order.sql")
-                    ? "0310_channel_project_order.sql"
-                    : migrations.has("0309_channel_project_pins.sql")
-                      ? "0309_channel_project_pins.sql"
-                      : migrations.has("0308_session_archives.sql")
-                        ? "0308_session_archives.sql"
-                        : migrations.has("0307_session_attention_state.sql")
-                          ? "0307_session_attention_state.sql"
-                          : migrations.has("0303_session_tenancy_product_activation.sql")
-                            ? "0303_session_tenancy_product_activation.sql"
-                            : migrations.has("0302_personal_workspace_session_ownership.sql")
-                              ? "0302_personal_workspace_session_ownership.sql"
-                              : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
-                                ? "0301_session_snapshot_and_pin_visibility.sql"
-                                : migrations.has("0300_tenancy_backfill_ledger.sql")
-                                  ? "0300_tenancy_backfill_ledger.sql"
-                                  : migrations.has("0299_organization_membership_lock_order.sql")
-                                    ? "0299_organization_membership_lock_order.sql"
-                                    : migrations.has("0298_organization_tenancy_parity.sql")
-                                      ? "0298_organization_tenancy_parity.sql"
+      migrations.has("0326_interaction_operation_error_codes.sql")
+        ? "0326_interaction_operation_error_codes.sql"
+        : migrations.has("0321_slack_bot_environment_display_name.sql")
+          ? "0321_slack_bot_environment_display_name.sql"
+          : migrations.has("0310_channel_project_order.sql")
+            ? "0310_channel_project_order.sql"
+            : migrations.has("0309_channel_project_pins.sql")
+              ? "0309_channel_project_pins.sql"
+              : migrations.has("0308_session_archives.sql")
+                ? "0308_session_archives.sql"
+                : migrations.has("0307_session_attention_state.sql")
+                  ? "0307_session_attention_state.sql"
+                  : migrations.has("0303_session_tenancy_product_activation.sql")
+                    ? "0303_session_tenancy_product_activation.sql"
+                    : migrations.has("0302_personal_workspace_session_ownership.sql")
+                      ? "0302_personal_workspace_session_ownership.sql"
+                      : migrations.has("0301_session_snapshot_and_pin_visibility.sql")
+                        ? "0301_session_snapshot_and_pin_visibility.sql"
+                        : migrations.has("0300_tenancy_backfill_ledger.sql")
+                          ? "0300_tenancy_backfill_ledger.sql"
+                          : migrations.has("0299_organization_membership_lock_order.sql")
+                            ? "0299_organization_membership_lock_order.sql"
+                            : migrations.has("0298_organization_tenancy_parity.sql")
+                              ? "0298_organization_tenancy_parity.sql"
+                              : migrations.has("0295_retire_legacy_standing_memory_mode.sql")
+                                ? "0295_retire_legacy_standing_memory_mode.sql"
+                                : migrations.has("0294_preference_activation_authority.sql")
+                                  ? "0294_preference_activation_authority.sql"
+                                  : migrations.has("0293_confirm_time_rule_rebaseline.sql")
+                                    ? "0293_confirm_time_rule_rebaseline.sql"
+                                    : migrations.has("0292_truthful_tenancy_inventory_counters.sql")
+                                      ? "0292_truthful_tenancy_inventory_counters.sql"
                                       : migrations.has(
-                                            "0295_retire_legacy_standing_memory_mode.sql",
+                                            "0291_resource_authority_classification_assertion.sql",
                                           )
-                                        ? "0295_retire_legacy_standing_memory_mode.sql"
-                                        : migrations.has("0294_preference_activation_authority.sql")
-                                          ? "0294_preference_activation_authority.sql"
-                                          : migrations.has("0293_confirm_time_rule_rebaseline.sql")
-                                            ? "0293_confirm_time_rule_rebaseline.sql"
+                                        ? "0291_resource_authority_classification_assertion.sql"
+                                        : migrations.has(
+                                              "0290_organization_membership_backfill.sql",
+                                            )
+                                          ? "0290_organization_membership_backfill.sql"
+                                          : migrations.has(
+                                                "0289_session_composer_policy_authority.sql",
+                                              )
+                                            ? "0289_session_composer_policy_authority.sql"
                                             : migrations.has(
-                                                  "0292_truthful_tenancy_inventory_counters.sql",
+                                                  "0288_attached_browser_reenrollment.sql",
                                                 )
-                                              ? "0292_truthful_tenancy_inventory_counters.sql"
+                                              ? "0288_attached_browser_reenrollment.sql"
                                               : migrations.has(
-                                                    "0291_resource_authority_classification_assertion.sql",
+                                                    "0287_open_suffix_pending_tool_calls.sql",
                                                   )
-                                                ? "0291_resource_authority_classification_assertion.sql"
+                                                ? "0287_open_suffix_pending_tool_calls.sql"
                                                 : migrations.has(
-                                                      "0290_organization_membership_backfill.sql",
+                                                      "0286_widen_task_note_expiry_ceiling.sql",
                                                     )
-                                                  ? "0290_organization_membership_backfill.sql"
+                                                  ? "0286_widen_task_note_expiry_ceiling.sql"
                                                   : migrations.has(
-                                                        "0289_session_composer_policy_authority.sql",
+                                                        "0285_organization_tenancy_inventory.sql",
                                                       )
-                                                    ? "0289_session_composer_policy_authority.sql"
+                                                    ? "0285_organization_tenancy_inventory.sql"
                                                     : migrations.has(
-                                                          "0288_attached_browser_reenrollment.sql",
+                                                          "0284_truthful_human_confirmed_review_reason.sql",
                                                         )
-                                                      ? "0288_attached_browser_reenrollment.sql"
+                                                      ? "0284_truthful_human_confirmed_review_reason.sql"
                                                       : migrations.has(
-                                                            "0287_open_suffix_pending_tool_calls.sql",
+                                                            "0283_editable_spreadsheet_authored_state.sql",
                                                           )
-                                                        ? "0287_open_suffix_pending_tool_calls.sql"
+                                                        ? "0283_editable_spreadsheet_authored_state.sql"
                                                         : migrations.has(
-                                                              "0286_widen_task_note_expiry_ceiling.sql",
+                                                              "0282_variable_set_session_attach_attribution.sql",
                                                             )
-                                                          ? "0286_widen_task_note_expiry_ceiling.sql"
+                                                          ? "0282_variable_set_session_attach_attribution.sql"
                                                           : migrations.has(
-                                                                "0285_organization_tenancy_inventory.sql",
+                                                                "0281_viewer_holder_authority_claims.sql",
                                                               )
-                                                            ? "0285_organization_tenancy_inventory.sql"
+                                                            ? "0281_viewer_holder_authority_claims.sql"
                                                             : migrations.has(
-                                                                  "0284_truthful_human_confirmed_review_reason.sql",
+                                                                  "0280_connection_and_variable_set_audit_attribution.sql",
                                                                 )
-                                                              ? "0284_truthful_human_confirmed_review_reason.sql"
+                                                              ? "0280_connection_and_variable_set_audit_attribution.sql"
                                                               : migrations.has(
-                                                                    "0283_editable_spreadsheet_authored_state.sql",
+                                                                    "0279_workspace_connection_use_lane.sql",
                                                                   )
-                                                                ? "0283_editable_spreadsheet_authored_state.sql"
+                                                                ? "0279_workspace_connection_use_lane.sql"
                                                                 : migrations.has(
-                                                                      "0282_variable_set_session_attach_attribution.sql",
+                                                                      "0278_workspace_membership_removal_fencing.sql",
                                                                     )
-                                                                  ? "0282_variable_set_session_attach_attribution.sql"
+                                                                  ? "0278_workspace_membership_removal_fencing.sql"
                                                                   : migrations.has(
-                                                                        "0281_viewer_holder_authority_claims.sql",
+                                                                        "0277_workspace_writer_authority_attribution.sql",
                                                                       )
-                                                                    ? "0281_viewer_holder_authority_claims.sql"
+                                                                    ? "0277_workspace_writer_authority_attribution.sql"
                                                                     : migrations.has(
-                                                                          "0280_connection_and_variable_set_audit_attribution.sql",
+                                                                          "0276_onboarding_proposal_initiating_human_guc.sql",
                                                                         )
-                                                                      ? "0280_connection_and_variable_set_audit_attribution.sql"
+                                                                      ? "0276_onboarding_proposal_initiating_human_guc.sql"
                                                                       : migrations.has(
-                                                                            "0279_workspace_connection_use_lane.sql",
+                                                                            "0275_scheduled_connection_authority.sql",
                                                                           )
-                                                                        ? "0279_workspace_connection_use_lane.sql"
+                                                                        ? "0275_scheduled_connection_authority.sql"
                                                                         : migrations.has(
-                                                                              "0278_workspace_membership_removal_fencing.sql",
+                                                                              "0274_human_confirmed_knowledge_review.sql",
                                                                             )
-                                                                          ? "0278_workspace_membership_removal_fencing.sql"
+                                                                          ? "0274_human_confirmed_knowledge_review.sql"
                                                                           : migrations.has(
-                                                                                "0277_workspace_writer_authority_attribution.sql",
+                                                                                "0272_human_confirmed_learning_activation.sql",
                                                                               )
-                                                                            ? "0277_workspace_writer_authority_attribution.sql"
+                                                                            ? "0272_human_confirmed_learning_activation.sql"
                                                                             : migrations.has(
-                                                                                  "0276_onboarding_proposal_initiating_human_guc.sql",
+                                                                                  "0271_company_brain_retrieval_only_default.sql",
                                                                                 )
-                                                                              ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                                                                              ? "0271_company_brain_retrieval_only_default.sql"
                                                                               : migrations.has(
-                                                                                    "0275_scheduled_connection_authority.sql",
+                                                                                    "0270_governed_learning_history_inspection.sql",
                                                                                   )
-                                                                                ? "0275_scheduled_connection_authority.sql"
+                                                                                ? "0270_governed_learning_history_inspection.sql"
                                                                                 : migrations.has(
-                                                                                      "0274_human_confirmed_knowledge_review.sql",
+                                                                                      "0269_governed_learning_activation_controller.sql",
                                                                                     )
-                                                                                  ? "0274_human_confirmed_knowledge_review.sql"
+                                                                                  ? "0269_governed_learning_activation_controller.sql"
                                                                                   : migrations.has(
-                                                                                        "0272_human_confirmed_learning_activation.sql",
+                                                                                        "0268_governed_learning_decision_receipts.sql",
                                                                                       )
-                                                                                    ? "0272_human_confirmed_learning_activation.sql"
+                                                                                    ? "0268_governed_learning_decision_receipts.sql"
                                                                                     : migrations.has(
-                                                                                          "0271_company_brain_retrieval_only_default.sql",
+                                                                                          "0266_company_brain_context_receipt_inspection.sql",
                                                                                         )
-                                                                                      ? "0271_company_brain_retrieval_only_default.sql"
+                                                                                      ? "0266_company_brain_context_receipt_inspection.sql"
                                                                                       : migrations.has(
-                                                                                            "0270_governed_learning_history_inspection.sql",
+                                                                                            "0261_preference_knowledge_proposal_actor_binding.sql",
                                                                                           )
-                                                                                        ? "0270_governed_learning_history_inspection.sql"
+                                                                                        ? "0261_preference_knowledge_proposal_actor_binding.sql"
                                                                                         : migrations.has(
-                                                                                              "0269_governed_learning_activation_controller.sql",
+                                                                                              "0260_task_note_knowledge_promotion.sql",
                                                                                             )
-                                                                                          ? "0269_governed_learning_activation_controller.sql"
+                                                                                          ? "0260_task_note_knowledge_promotion.sql"
                                                                                           : migrations.has(
-                                                                                                "0268_governed_learning_decision_receipts.sql",
+                                                                                                "0259_company_brain_context_selection_receipts.sql",
                                                                                               )
-                                                                                            ? "0268_governed_learning_decision_receipts.sql"
+                                                                                            ? "0259_company_brain_context_selection_receipts.sql"
                                                                                             : migrations.has(
-                                                                                                  "0266_company_brain_context_receipt_inspection.sql",
+                                                                                                  "0258_three_scope_document_knowledge_authority.sql",
                                                                                                 )
-                                                                                              ? "0266_company_brain_context_receipt_inspection.sql"
+                                                                                              ? "0258_three_scope_document_knowledge_authority.sql"
                                                                                               : migrations.has(
-                                                                                                    "0261_preference_knowledge_proposal_actor_binding.sql",
+                                                                                                    "0257_goal_revision_decisions_and_root_constraints.sql",
                                                                                                   )
-                                                                                                ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                                                                                ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                                                                                 : migrations.has(
-                                                                                                      "0260_task_note_knowledge_promotion.sql",
+                                                                                                      "0255_company_brain_governed_write_proposals.sql",
                                                                                                     )
-                                                                                                  ? "0260_task_note_knowledge_promotion.sql"
+                                                                                                  ? "0255_company_brain_governed_write_proposals.sql"
                                                                                                   : migrations.has(
-                                                                                                        "0259_company_brain_context_selection_receipts.sql",
+                                                                                                        "0248_terraform_stacks_component_resolution_fence.sql",
                                                                                                       )
-                                                                                                    ? "0259_company_brain_context_selection_receipts.sql"
+                                                                                                    ? "0248_terraform_stacks_component_resolution_fence.sql"
                                                                                                     : migrations.has(
-                                                                                                          "0258_three_scope_document_knowledge_authority.sql",
+                                                                                                          "0247_terraform_stacks_provenance_repair.sql",
                                                                                                         )
-                                                                                                      ? "0258_three_scope_document_knowledge_authority.sql"
+                                                                                                      ? "0247_terraform_stacks_provenance_repair.sql"
                                                                                                       : migrations.has(
-                                                                                                            "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                                                                            "0263_organization_membership_lifecycle.sql",
                                                                                                           )
-                                                                                                        ? "0257_goal_revision_decisions_and_root_constraints.sql"
-                                                                                                        : migrations.has(
-                                                                                                              "0255_company_brain_governed_write_proposals.sql",
-                                                                                                            )
-                                                                                                          ? "0255_company_brain_governed_write_proposals.sql"
-                                                                                                          : migrations.has(
-                                                                                                                "0248_terraform_stacks_component_resolution_fence.sql",
-                                                                                                              )
-                                                                                                            ? "0248_terraform_stacks_component_resolution_fence.sql"
-                                                                                                            : migrations.has(
-                                                                                                                  "0247_terraform_stacks_provenance_repair.sql",
-                                                                                                                )
-                                                                                                              ? "0247_terraform_stacks_provenance_repair.sql"
-                                                                                                              : migrations.has(
-                                                                                                                    "0263_organization_membership_lifecycle.sql",
-                                                                                                                  )
-                                                                                                                ? "0263_organization_membership_lifecycle.sql"
-                                                                                                                : latestCompatibleMigration,
+                                                                                                        ? "0263_organization_membership_lifecycle.sql"
+                                                                                                        : latestCompatibleMigration,
     );
     expect(migrations.get("0289_session_composer_policy_authority.sql")).toMatchObject({
       sha256: "478e7ba49b6940bdd849223a0965b7dcc20a0d4428f0fc85078961dbd3984285",


### PR DESCRIPTION
The release-schema contract's hash ladders, its `fileCount` sum, and its `latestMigration` chain all ask `migrations.has(...)` over the **already-filtered** migration set. A reference to a forward-listed migration present on the tree can therefore never match: forward-listing is what removes it from that map, and if the file were absent the check would be false anyway.

Eleven such references existed, all residue of the same four commits. #1793 added `0331` and `0332` without registering them; #1798 and #1799 then pinned a fresh aggregate hash for `0333` and `0334` instead of registering those. All four were later added to `appendedMigrationPaths`, which is the fix that works, and that made every reference to them unreachable. Nobody removed them.

| construct | count | migrations |
| --- | --- | --- |
| `releaseSchemaContractHash` rungs | 2 | 0333, 0334 |
| `fileCount` indicator terms | 4 | 0331-0334 |
| `latestMigration` ternary branches | 4 | 0331-0334 |
| `latestCompatibleMigration` entry | 1 | 0334 |

## They are not a fallback

A dead hash rung is worse than dead weight, because it reads as a live pin. It is also **already wrong**: take `0334` back out of the forward list and its rung fires returning `3d058b3b…` where the tree actually hashes to `34e6f107…`. There is no tree on which the pinned value would be correct if it were ever read.

## Removal is provably neutral

A reference resolves only when its migration is in the filtered map; for these it is either forward-listed (removed from the map) or absent from the tree (check false). Both paths skip it with or without the reference.

Verified two independent ways. Analytically, and differentially: the pre- and post-deletion `fileCount` expression, `latestMigration` ternary, `latestCompatibleMigration` array, both hash ladders, and `currentMainContractHash` were extracted mechanically from each file version and evaluated side by side over **5,201 distinct filtered maps** - 200 real first-parent `main` ledgers plus `origin/production` (47 distinct ledger sizes, 301-351 files), 3,000 random subsets, and 2,000 adversarial subsets that always retain 0331-0334. **Zero divergence.**

`scripts/release-schema-contract.test.ts` stays at 6 pass with the same 224 assertions. A token-level diff of that file shows **zero insertions**: the remaining churn is oxfmt unwrapping lines whose nesting depth dropped, plus two trailing commas it drops when a broken-out call collapses to one line.

## The guard now catches the shape

`bun run check:migration-schema-contract` audits the whole contract file rather than one ladder: every direct `migrations.has("<literal>")` plus every name resolved through a `[...].find(...)` or `[...].filter(...)` over `migrations.has`. It returns all four migrations against the pre-cleanup file and nothing against this one.

A reference to a migration that is not on the tree is untouched - those are the ordinary compatibility branches that fire where fewer migrations exist.

Two limits are documented in the source rather than special-cased on shapes that do not yet exist: a **negated** test (`if (!migrations.has(X))`) is live exactly when `X` is forward-listed, so flagging it would be wrong; and the array arm matches the callback shapes the contract actually uses.

## Review

Independently reviewed twice. The first pass confirmed the two-rung deletion was neutral and found the strongest argument in the change - that the pin is already wrong rather than merely unused - but flagged the scope as half-done: nine sibling dead sites in the same file, and an audit covering only one of the ladders. Hence the widened deletion and the whole-file rule.

The second pass ran the 5,201-map differential above, the token-level diff, and 8 mutations of the detector (all killed). Its two remaining nits - a stale `parseLadderRungs` reference in a test comment and a too-narrow inline comment - and its two latent limitations (`.filter` arrays unscanned, callback regex brittle against annotated parameters) are all addressed here, with a test covering each widened shape.

## Verification

- `bun run typecheck` all projects clean; `bun run lint`, `bun run format:check` clean
- 92 tests across the guard, contract, impact-plan and ordinal suites: 92 pass, 0 fail
- `check:migration-schema-contract`, `check:migration-ordinals`, `check:public-hygiene`, `check:docs-refs` pass
- `origin/production` reports 0 unreachable; the merge tree reports 0

Test-only and CI-only changes, so no changeset.