### PR TITLE
test(db): budget every full-ledger migrate() test against shard repacking

### DIFF
--- a/packages/db/test/migration-0213-browser-interaction-authority.test.ts
+++ b/packages/db/test/migration-0213-browser-interaction-authority.test.ts
@@ -7,6 +7,21 @@ import { migrate } from "../src/migrate";
 const migrationUrl = new URL("../drizzle/0213_browser_interaction_authority.sql", import.meta.url);
 
 describe("migration 0213 browser interaction authority", () => {
+  // A full-ledger replay against a fresh database, so its cost is the whole
+  // migration history and its only variable is I/O contention. Every co-located
+  // sibling that does the same (0184, 0186, 0188, 0203, 0206) carries `180_000`;
+  // this one carried nothing and so inherited the 30 s cap that
+  // `scripts/ci/run-unit-shard.ts` passes as `--timeout=30000`.
+  //
+  // That cap is not a guarantee about anything asserted here - the assertions are
+  // on the migration source and the resulting columns - and it is not survivable
+  // either. `deterministicShards` packs shards by source-file BYTE SIZE, which is
+  // a poor proxy for a test whose cost is a 351-migration replay, so any file
+  // added anywhere can re-cluster the six full-ledger replays into one shard.
+  // That is what happened at d13a9849b: all six landed in shard 3, four ran
+  // concurrently against the single shared container, each took roughly five
+  // times its usual wall time, and this test was killed at 30000 ms after 6 of
+  // its 9 assertions. Uncontended it takes about 4 s.
   test("snapshots routes and extends interventions without secret material", async () => {
     const source = await readFile(migrationUrl, "utf8");
     expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: maintenance");
@@ -58,5 +73,5 @@ describe("migration 0213 browser interaction authority", () => {
       await sql.end();
       await blank.release();
     }
-  });
+  }, 180_000);
 });

--- a/packages/db/test/migration-0241-atomic-personal-resource-delegation.test.ts
+++ b/packages/db/test/migration-0241-atomic-personal-resource-delegation.test.ts
@@ -749,7 +749,7 @@ describe("migration 0241 atomic personal-resource delegation", () => {
       await sql?.end({ timeout: 5 }).catch(() => undefined);
       await blank.release();
     }
-  });
+  }, 180_000);
 
   test("serializes concurrent once use and fails closed after live authority drift", async () => {
     let admin: postgres.Sql | undefined;
@@ -944,7 +944,7 @@ describe("migration 0241 atomic personal-resource delegation", () => {
       await admin?.end({ timeout: 5 }).catch(() => undefined);
       await blank.release();
     }
-  });
+  }, 180_000);
 
   test("requires the exact current uninterrupted attempt at admission and resolution", async () => {
     let sql: postgres.Sql | undefined;
@@ -1155,7 +1155,7 @@ describe("migration 0241 atomic personal-resource delegation", () => {
       await sql?.end({ timeout: 5 }).catch(() => undefined);
       await blank.release();
     }
-  });
+  }, 180_000);
 });
 
 type FixtureIds = {

--- a/packages/db/test/migration-0257-goal-revision-authority.test.ts
+++ b/packages/db/test/migration-0257-goal-revision-authority.test.ts
@@ -42,7 +42,7 @@ describe("0257 governed goal revision authority migration", () => {
     } finally {
       await blank.release();
     }
-  });
+  }, 180_000);
 
   test("rejects an explicitly configured custom live role and succeeds only after drain", async () => {
     const blank = await acquireBlankTestDatabase("migration-0257-live-writer-guard");


### PR DESCRIPTION
Protected main went red at `d13a9849b` on `migration 0213 browser interaction authority`, timed out after 30000 ms.

## The cause is shard repacking, not a slow runner

`scripts/ci/run-unit-shard.ts` calls `deterministicShards` with no weight map, so shards are packed by source-file **byte size**. That is a poor proxy for these tests: `0213` is a small file whose real cost is replaying 351 migrations against a fresh database.

`d13a9849b` added one file (1327 → 1328 unit tests), and that single perturbation collapsed all six full-ledger replay tests into shard 3, where the runner executes four at a time against one shared container:

| tree | shard holding 0213 | 0206 | 0188 | 0203 | 0184 | 0186 |
| --- | --- | --- | --- | --- | --- | --- |
| `1789977088` (`d13a9849b^`) | 5 | 2 | 1 | 2 | 1 | 4 |
| **`d13a9849b`** | **3** | **3** | **3** | **3** | **3** | **3** |
| `ad6acbe701` | 2 | 1 | 5 | 5 | 2 | 4 |

In the failing log each took roughly five times its usual wall time - `0188` 42.8 s, `0186` 43.3 s, `0184` 43.7 s - while non-database tests in the same shard ran normally. `0213` was the only one of the six with no budget, so it was the only one killed, after 6 of its 9 assertions.

The exposure is therefore not "one unlucky runner". Any file added anywhere can re-cluster these, which is why each needs an explicit budget rather than favourable packing.

## Five tests lacked one

All now carry `180_000`, matching the sibling convention (`0184`, `0186`, `0188`, `0203`, `0206` all use it):

- `migration-0213-browser-interaction-authority.test.ts`
- `migration-0241-atomic-personal-resource-delegation.test.ts` (3 tests)
- `migration-0257-goal-revision-authority.test.ts`

`0241` is the sharper case: it takes **29.09 s uncontended** on this machine against the 30 s cap three of its tests were inheriting, while four other tests **in the same file** already carried `180_000`. It was one packing shuffle from the same failure.

The budget bounds nothing any of these assert - they check migration source, resulting columns, and authority fences - so no guarantee is weakened. `0213` now reports 9 expect() calls rather than the 6 it reached before being killed.

## Completeness

A sweep resolving `test`/`it` with modifiers, numeric and object timeout arguments, and file-level `setDefaultTimeout` finds no remaining `migrate()` test without a budget. The 29 files that migrate from `beforeAll`/`beforeEach` all already carry one, and Bun does apply `--timeout` to hooks.

## Review

Independently reviewed, and the review overturned my first three claims. I had called the failure unrelated to `d13a9849b`; the reviewer reproduced the LPT bin-packing against the real git trees and showed the causal link, validating the reproduction against two independent CI observations (it predicts shard 3 at `d13a9849b`, where the failing job is literally `Unit tests (shard 3/6)`, and shard 2 at `ad6acbe701`, where the test ran and passed). I had also claimed `0213` was the only exposed test - an AST sweep found four more that my regex missed - and mis-stated the local runtime as 7-8 s when uncontended it is ~4 s. All corrected here.

## Follow-up, not in this change

Weighting `deterministicShards` by measured cost rather than file size would stop CI clustering the expensive replays at all. `workspace.ts` already has a profile-based `shardWeightResolution` mode. These budgets are the correct minimal repair.

## Verification

- `bun run lint`, `bun run format:check`, `bun run check:public-hygiene` clean
- All five changed tests pass under the CI flag `--timeout=30000`: `0213` + `0257` 5 pass, `0241` 9 pass
- No em-dashes on added lines, no Linear identifiers

Test-only change, so no changeset.