### PR TITLE
fix(db): repair personal Document FORCE-RLS admission (OPE-354)

### DIFF
--- a/docs/force-rls-migration-backfills.md
+++ b/docs/force-rls-migration-backfills.md
@@ -108,6 +108,13 @@ Two rules, both of which fail silently when broken:
 before the read, so a regression aborts instead of quietly pinning a personal
 Document to its origin workspace forever.
 
+Migration `0343_personal_document_force_rls_lock_repair.sql` repairs the two
+shipped 0258 routines that violated rule 2. Its owner-migrated regression test
+proves the silent legacy fallback before the repair and the portable authority
+mint after it. New SECURITY DEFINER routines that touch FORCE-RLS tables must
+carry the same `acquireOwnerMigratedTestDatabase` coverage for every command
+they issue; a superuser-migrated test is not evidence for this boundary.
+
 Two other worked examples of a definer that satisfies a policy branch it can
 actually reach: `0263`'s
 `assert_active_managed_human_organization_membership`, which gates on one of the

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -155,6 +155,16 @@ per organization workspace without using collections as authority. A later
 cross-domain migration may consume these receipts as evidence but must not
 perform a second Document reclassification.
 
+Migration `0343_personal_document_force_rls_lock_repair.sql` restores the
+portable mint and exact-attempt admission paths under the real
+NOSUPERUSER/NOBYPASSRLS owner. Migration 0258's capability was open, but its
+membership `FOR SHARE` also required an UPDATE-applicable policy and therefore
+returned no row. The repair drops the redundant lock and makes future
+visibility disagreement abort with SQLSTATE `55000`. It does not bulk-convert
+already affected Documents: they are byte-identical in authority shape to
+deliberately legacy personal Documents. Operators use the explicit 0339
+original-owner-fenced lifecycle when the owner elects portability.
+
 Agent access is separate from human ownership. At exact attempt admission the
 database freezes only ready, agent-enabled personal Documents backed by an
 active `document.read` grant for that target workspace and the session's exact

--- a/docs/scoped-knowledge.md
+++ b/docs/scoped-knowledge.md
@@ -242,6 +242,14 @@ zero rows. The referential pin is taken by the
 `organization_user_resource_authorities` foreign-key check instead, which bypasses
 row security. See [`force-rls-migration-backfills.md`](force-rls-migration-backfills.md).
 
+Migration `0343_personal_document_force_rls_lock_repair.sql` removes the shipped
+0258 locks from both creation and exact-attempt admission and adds SQLSTATE
+`55000` control assertions for future visibility drift. It deliberately does
+not bulk-convert Documents already written on the wrong lane: their stored
+authority shape is identical to an intentional legacy personal Document.
+Migration 0339's explicit original-owner-fenced reclassification is the
+supported repair when a human chooses to make one portable.
+
 Personal Document ownership never becomes ambient agent authority. The exact
 attempt-admission transaction freezes only Documents covered by a live
 `document.read` once/session/always grant for the target workspace and exact

--- a/packages/db/drizzle/0343_personal_document_force_rls_lock_repair.sql
+++ b/packages/db/drizzle/0343_personal_document_force_rls_lock_repair.sql
@@ -1,0 +1,146 @@
+-- deployment-mode: rolling
+-- Repair the two personal-Document membership reads shipped by 0258. A
+-- row-locking SELECT is also subject to an UPDATE policy; the capability only
+-- grants SELECT, so a real NOSUPERUSER/NOBYPASSRLS migration owner saw zero
+-- memberships and silently selected the legacy workspace-anchored lane.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- The checker cannot distinguish the function-body source strings below from
+-- top-level executable membership probes. Keep the migration owner's own
+-- transformation/assertion block inside the house owner-only window; ordinary
+-- runtime roles remain RLS-bound throughout and FORCE is restored atomically.
+ALTER TABLE organization_memberships NO FORCE ROW LEVEL SECURITY;
+
+DO $repair_personal_document_membership_reads$
+DECLARE
+  data_schema text := pg_catalog.current_schema();
+  function_oid regprocedure;
+  definition text;
+  repaired text;
+  old_fragment text;
+  new_fragment text;
+BEGIN
+  function_oid := pg_catalog.to_regprocedure(
+    pg_catalog.format('%I.create_personal_document_authority(uuid,uuid,uuid)', data_schema)
+  );
+  IF function_oid IS NULL THEN
+    RAISE EXCEPTION 'create_personal_document_authority is unavailable for repair'
+      USING ERRCODE = '55000';
+  END IF;
+  definition := pg_catalog.pg_get_functiondef(function_oid);
+  old_fragment := $old$
+      SELECT membership.* INTO member_row
+      FROM organization_memberships membership
+      WHERE membership.account_id = p_account_id
+        AND membership.subject_id = caller_subject
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL
+      FOR SHARE;
+$old$;
+  new_fragment := $new$
+      SELECT membership.* INTO member_row
+      FROM organization_memberships membership
+      WHERE membership.account_id = p_account_id
+        AND membership.subject_id = caller_subject
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL;
+
+      -- The plain control probe makes a future command/policy mismatch loud.
+      -- With this migration's non-locking read the two predicates are
+      -- identical. If a later revision restores a locking read without its
+      -- exact policy, the capability-visible control row cannot silently fall
+      -- through to the legacy authority lane.
+      IF NOT FOUND AND EXISTS (
+        SELECT 1
+        FROM organization_memberships membership
+        WHERE membership.account_id = p_account_id
+          AND membership.subject_id = caller_subject
+          AND membership.status = 'active'
+          AND membership.revoked_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'personal document membership read was RLS-blinded'
+          USING ERRCODE = '55000';
+      END IF;
+$new$;
+  repaired := pg_catalog.replace(definition, old_fragment, new_fragment);
+  IF repaired = definition THEN
+    RAISE EXCEPTION 'create_personal_document_authority repair shape changed'
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE repaired;
+
+  function_oid := pg_catalog.to_regprocedure(
+    pg_catalog.format(
+      '%I.prepare_session_attempt_personal_document_reads(uuid,uuid,uuid,uuid)',
+      data_schema
+    )
+  );
+  IF function_oid IS NULL THEN
+    RAISE EXCEPTION 'prepare_session_attempt_personal_document_reads is unavailable for repair'
+      USING ERRCODE = '55000';
+  END IF;
+  definition := pg_catalog.pg_get_functiondef(function_oid);
+  old_fragment := $old$
+      SELECT membership.* INTO member_row
+      FROM organization_memberships membership
+      WHERE membership.account_id = p_account_id
+        AND membership.subject_id = initiating_subject
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL
+      FOR SHARE;
+$old$;
+  new_fragment := $new$
+      SELECT membership.* INTO member_row
+      FROM organization_memberships membership
+      WHERE membership.account_id = p_account_id
+        AND membership.subject_id = initiating_subject
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL;
+
+      IF NOT FOUND AND EXISTS (
+        SELECT 1
+        FROM organization_memberships membership
+        WHERE membership.account_id = p_account_id
+          AND membership.subject_id = initiating_subject
+          AND membership.status = 'active'
+          AND membership.revoked_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'personal document admission membership read was RLS-blinded'
+          USING ERRCODE = '55000';
+      END IF;
+$new$;
+  repaired := pg_catalog.replace(definition, old_fragment, new_fragment);
+  IF repaired = definition THEN
+    RAISE EXCEPTION 'prepare_session_attempt_personal_document_reads repair shape changed'
+      USING ERRCODE = '55000';
+  END IF;
+
+  -- The later portable-document scan has the same command mismatch: locking
+  -- both documents and authorities makes PostgreSQL require UPDATE-applicable
+  -- policies, while this admission capability is intentionally read-only.
+  -- Snapshot foreign keys take the durable referential pins at insertion.
+  definition := repaired;
+  old_fragment := $old$
+        ORDER BY document_value.id
+        FOR SHARE OF document_value, authority
+$old$;
+  new_fragment := $new$
+        ORDER BY document_value.id
+$new$;
+  repaired := pg_catalog.replace(definition, old_fragment, new_fragment);
+  IF repaired = definition THEN
+    RAISE EXCEPTION 'prepare_session_attempt_personal_document_reads document scan repair shape changed'
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE repaired;
+END
+$repair_personal_document_membership_reads$;
+
+ALTER TABLE organization_memberships FORCE ROW LEVEL SECURITY;
+
+COMMENT ON FUNCTION create_personal_document_authority(uuid, uuid, uuid) IS
+  'Creates portable personal Document authority for an exact active organization membership; 0343 removes an RLS-blind row lock and fails loudly on visibility drift.';
+COMMENT ON FUNCTION prepare_session_attempt_personal_document_reads(uuid, uuid, uuid, uuid) IS
+  'Freezes exact-attempt personal Document reads; 0343 removes RLS-blind membership and portable-document row locks and fails loudly on definition or visibility drift.';

--- a/packages/db/test/migration-0254-scoped-variable-set-authority.test.ts
+++ b/packages/db/test/migration-0254-scoped-variable-set-authority.test.ts
@@ -108,7 +108,8 @@ describe("migration 0254 scoped variable-set authority", () => {
     }
     if (!blank) return;
 
-    const appPassword = `app-${crypto.randomUUID()}`;
+    const appPassword = blank.appPassword;
+    if (!appPassword) throw new Error("shared PostgreSQL app password is unavailable");
     let admin: postgres.Sql | undefined;
     let app: postgres.Sql | undefined;
     let db: ReturnType<typeof createDb> | undefined;

--- a/packages/db/test/migration-0258-three-scope-document-knowledge-authority.test.ts
+++ b/packages/db/test/migration-0258-three-scope-document-knowledge-authority.test.ts
@@ -57,7 +57,8 @@ describe("migration 0258 three-scope Document/Knowledge authority", () => {
     }
     if (!blank) return;
 
-    const appPassword = `app-${crypto.randomUUID()}`;
+    const appPassword = blank.appPassword;
+    if (!appPassword) throw new Error("shared PostgreSQL app password is unavailable");
     let admin: postgres.Sql | undefined;
     let app: postgres.Sql | undefined;
     let db: ReturnType<typeof createDb> | undefined;

--- a/packages/db/test/migration-0262-scoped-connected-machines-and-rigs.test.ts
+++ b/packages/db/test/migration-0262-scoped-connected-machines-and-rigs.test.ts
@@ -55,7 +55,8 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
     }
     if (!blank) return;
 
-    const appPassword = `app-${crypto.randomUUID()}`;
+    const appPassword = blank.appPassword;
+    if (!appPassword) throw new Error("shared PostgreSQL app password is unavailable");
     let admin: postgres.Sql | undefined;
     let app: postgres.Sql | undefined;
     let db: ReturnType<typeof createDb> | undefined;

--- a/packages/db/test/migration-0343-personal-document-force-rls-lock-repair.test.ts
+++ b/packages/db/test/migration-0343-personal-document-force-rls-lock-repair.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { claimSessionWorkForAttempt, createDb, createSession } from "../src";
+import { migrate } from "../src/migrate";
+import { provisionRoles } from "../src/provision-roles";
+
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
+const REPAIR = "0343_personal_document_force_rls_lock_repair.sql";
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+async function applyBelow(url: string, upperBound: string): Promise<void> {
+  const deferred = (await readdir(migrationsDir))
+    .filter((file) => file.endsWith(".sql") && file >= upperBound)
+    .sort();
+  const ledger = postgres(url, { max: 1, onnotice: () => undefined });
+  try {
+    await ledger.unsafe(`CREATE TABLE IF NOT EXISTS schema_migrations (
+      name text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now()
+    )`);
+    for (const file of deferred) {
+      await ledger`insert into schema_migrations (name) values (${file}) on conflict do nothing`;
+    }
+    await migrate(url);
+    await ledger`delete from schema_migrations where name >= ${upperBound}`;
+  } finally {
+    await ledger.end({ timeout: 5 });
+  }
+}
+
+describe("migration 0343 personal Document FORCE-RLS lock repair", () => {
+  let owned: OwnerMigratedTestDatabase | null = null;
+
+  beforeAll(async () => {
+    owned = await acquireOwnerMigratedTestDatabase("migration-0343-personal-documents");
+    if (!owned && requireRealDatabase) {
+      throw new Error(
+        "[migration-0343-personal-documents] OPENGENI_REQUIRE_REAL_DB=1 but the owner-migrated PostgreSQL harness is unavailable",
+      );
+    }
+  }, 600_000);
+
+  afterAll(async () => {
+    await owned?.release();
+  }, 120_000);
+
+  test("reproduces the shipped legacy fallback and restores portable authority", async () => {
+    if (!owned) return;
+    const { admin, adminUrl, ownerUrl, ownerRole, appPassword } = owned;
+    await applyBelow(ownerUrl, REPAIR);
+    await provisionRoles(adminUrl, { appPassword, rlsStrategy: "force" });
+
+    const [posture] = await admin<Array<{ superuser: boolean; bypassRls: boolean }>>`
+      select rolsuper as superuser, rolbypassrls as "bypassRls"
+      from pg_roles where rolname = ${ownerRole}`;
+    expect(posture).toEqual({ superuser: false, bypassRls: false });
+
+    const accountId = crypto.randomUUID();
+    const personalWorkspaceId = crypto.randomUUID();
+    const sharedWorkspaceId = crypto.randomUUID();
+    const subjectId = `user:${crypto.randomUUID()}`;
+    const membershipId = crypto.randomUUID();
+    await admin`insert into managed_accounts (id, name) values (${accountId}, '0343 account')`;
+    await admin`
+      insert into workspaces (id, account_id, name) values
+        (${personalWorkspaceId}, ${accountId}, 'Personal'),
+        (${sharedWorkspaceId}, ${accountId}, 'Shared')`;
+    await admin`
+      insert into workspace_inference_controls (workspace_id, account_id) values
+        (${personalWorkspaceId}, ${accountId}), (${sharedWorkspaceId}, ${accountId})`;
+    await admin`
+      insert into organization_memberships (
+        id, account_id, subject_id, status, personal_workspace_id
+      ) values (${membershipId}, ${accountId}, ${subjectId}, 'active', ${personalWorkspaceId})`;
+    await admin`
+      insert into workspace_memberships (account_id, workspace_id, subject_id)
+      values (${accountId}, ${sharedWorkspaceId}, ${subjectId})`;
+
+    const appUrl = new URL(ownerUrl);
+    appUrl.username = "opengeni_app";
+    appUrl.password = appPassword;
+    const app = postgres(appUrl.toString(), { max: 1, onnotice: () => undefined });
+    const runtimeOwner = postgres(ownerUrl, { max: 1, onnotice: () => undefined });
+    const db = createDb(adminUrl, { max: 1 });
+
+    const session = await createSession(db.db, {
+      requestedSessionId: crypto.randomUUID(),
+      accountId,
+      workspaceId: sharedWorkspaceId,
+      initialMessage: "read portable personal document",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId },
+      subjectId,
+      model: "test-model",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "modal",
+      firstPartyMcpTools: [],
+    });
+    const [sessionAuthority] = await admin<
+      Array<{ visibility: string; epoch: number; membershipId: string | null }>
+    >`
+      select visibility, authority_epoch as epoch,
+        owner_organization_membership_id as "membershipId"
+      from sessions where id = ${session.id}`;
+    const [turn] = await admin.begin(async (tx) => {
+      await tx`select
+        set_config('opengeni.account_id', ${accountId}, true),
+        set_config('opengeni.workspace_id', ${sharedWorkspaceId}, true),
+        set_config('opengeni.subject_id', ${subjectId}, true)`;
+      return await tx<Array<{ id: string }>>`
+        insert into session_turns (
+          account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+          status, position, prompt, model, reasoning_effort, latency_mode, sandbox_backend,
+          initiator_kind, initiator_subject_id, initiating_human_subject_id
+        ) values (
+          ${accountId}, ${sharedWorkspaceId}, ${session.id}, ${crypto.randomUUID()},
+          ${`session-${session.id}`}, 'queued', 1, 'read', 'test-model', 'medium',
+          'standard', 'modal', 'subject', ${subjectId}, ${subjectId}
+        ) returning id`;
+    });
+    const attemptId = crypto.randomUUID();
+    const claimed = await claimSessionWorkForAttempt(db.db, sharedWorkspaceId, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: `dispatch-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    expect(claimed.action).toBe("claimed");
+    if (claimed.action === "claimed") expect(claimed.turn.id).toBe(turn!.id);
+    const prepare = async () =>
+      await runtimeOwner.begin(async (tx) => {
+        await tx`select
+          set_config('opengeni.account_id', ${accountId}, true),
+          set_config('opengeni.workspace_id', ${sharedWorkspaceId}, true),
+          set_config('opengeni.subject_id', ${subjectId}, true)`;
+        const [row] = await tx<Array<{ count: number }>>`
+          select prepare_session_attempt_personal_document_reads(
+            ${accountId}::uuid, ${sharedWorkspaceId}::uuid,
+            ${session.id}::uuid, ${attemptId}::uuid
+          )::int as count`;
+        return row!.count;
+      });
+    expect(await prepare()).toBe(0);
+    const preRepairAdmissions = await admin<Array<{ id: string }>>`
+      select attempt_id as id from session_attempt_personal_document_admissions
+      where attempt_id = ${attemptId}`;
+    expect(preRepairAdmissions).toHaveLength(0);
+    const mint = async (documentId: string) =>
+      await app.begin(async (tx) => {
+        await tx`select
+          set_config('opengeni.account_id', ${accountId}, true),
+          set_config('opengeni.workspace_id', ${sharedWorkspaceId}, true),
+          set_config('opengeni.subject_id', ${subjectId}, true)`;
+        return [
+          ...(await tx<Array<{ authorityId: string; membershipId: string }>>`
+            select authority_id as "authorityId",
+              owner_organization_membership_id as "membershipId"
+            from create_personal_document_authority(
+              ${accountId}::uuid, ${sharedWorkspaceId}::uuid, ${documentId}::uuid
+            )`),
+        ];
+      });
+
+    const beforeDocument = crypto.randomUUID();
+    expect(await mint(beforeDocument)).toEqual([]);
+    const legacyAuthorities = await admin<Array<{ id: string }>>`
+      select id from organization_user_resource_authorities
+      where resource_kind = 'document' and resource_id = ${beforeDocument}`;
+    expect(legacyAuthorities).toHaveLength(0);
+
+    await migrate(ownerUrl);
+
+    const afterDocument = crypto.randomUUID();
+    const [authority] = await mint(afterDocument);
+    expect(authority?.membershipId).toBe(membershipId);
+    expect(authority?.authorityId).toBeTruthy();
+
+    const [file] = await admin<Array<{ id: string }>>`
+      insert into files (
+        account_id, workspace_id, status, filename, safe_filename, content_type,
+        size_bytes, bucket, object_key
+      ) values (
+        ${accountId}, ${sharedWorkspaceId}, 'ready', '0343.txt', '0343.txt',
+        'text/plain', 4, 'test', ${`documents/${crypto.randomUUID()}`}
+      ) returning id`;
+    const [base] = await admin<Array<{ id: string }>>`
+      insert into document_bases (account_id, workspace_id, name)
+      values (${accountId}, ${sharedWorkspaceId}, '0343') returning id`;
+    await admin`
+      insert into documents (
+        id, account_id, workspace_id, base_id, file_id, status, title, created_by,
+        authority_kind, authority_workspace_id, authority_subject_id, authority_id,
+        owner_organization_membership_id, origin_workspace_id, visibility, agent_access
+      ) values (
+        ${afterDocument}, ${accountId}, ${sharedWorkspaceId}, ${base!.id}, ${file!.id},
+        'ready', 'portable', ${subjectId}, 'personal', null, ${subjectId},
+        ${authority!.authorityId}, ${membershipId}, ${sharedWorkspaceId}, 'private', true
+      )`;
+    await admin`
+      insert into organization_user_resource_grants (
+        account_id, authority_id, owner_organization_membership_id, workspace_id,
+        session_id, action, mode, context, authority_epoch, generation, status
+      ) values (
+        ${accountId}, ${authority!.authorityId}, ${membershipId}, ${sharedWorkspaceId},
+        ${session.id}, 'document.read', 'session', ${sessionAuthority!.visibility},
+        ${sessionAuthority!.epoch}, 1, 'active'
+      )`;
+    const eligibleDocuments = await admin<Array<{ id: string }>>`
+      select document_value.id
+      from documents document_value
+      join organization_user_resource_authorities authority
+        on authority.id = document_value.authority_id
+       and authority.account_id = document_value.account_id
+       and authority.organization_membership_id = document_value.owner_organization_membership_id
+       and authority.resource_kind = 'document'
+       and authority.resource_id = document_value.id
+       and authority.status = 'active'
+       and authority.revoked_at is null
+      join organization_user_resource_grants grant_value
+        on grant_value.account_id = document_value.account_id
+       and grant_value.authority_id = document_value.authority_id
+       and grant_value.owner_organization_membership_id = document_value.owner_organization_membership_id
+       and grant_value.workspace_id = ${sharedWorkspaceId}
+       and grant_value.session_id = ${session.id}
+       and grant_value.action = 'document.read'
+       and grant_value.mode = 'session'
+       and grant_value.context = ${sessionAuthority!.visibility}
+       and grant_value.authority_epoch = ${sessionAuthority!.epoch}
+       and grant_value.status = 'active'
+      where document_value.id = ${afterDocument}
+        and document_value.authority_kind = 'personal'
+        and document_value.authority_workspace_id is null
+        and document_value.authority_subject_id = ${subjectId}
+        and document_value.owner_organization_membership_id = ${membershipId}
+        and document_value.status = 'ready'
+        and document_value.agent_access = true`;
+    expect([...eligibleDocuments]).toEqual([{ id: afterDocument }]);
+    expect(await prepare()).toBe(1);
+    const [snapshot] = await admin<Array<{ documentId: string; membershipId: string }>>`
+      select document_id as "documentId",
+        owner_organization_membership_id as "membershipId"
+      from session_attempt_personal_document_snapshots where attempt_id = ${attemptId}`;
+    expect(snapshot).toEqual({ documentId: afterDocument, membershipId });
+
+    const routines = await admin<Array<{ name: string; definition: string }>>`
+      select proname as name, pg_get_functiondef(oid) as definition
+      from pg_proc
+      where oid in (
+        'create_personal_document_authority(uuid,uuid,uuid)'::regprocedure,
+        'prepare_session_attempt_personal_document_reads(uuid,uuid,uuid,uuid)'::regprocedure
+      ) order by proname`;
+    expect(routines).toHaveLength(2);
+    for (const routine of routines) {
+      expect(routine.definition).toContain("membership read was RLS-blinded");
+      expect(routine.definition).not.toMatch(
+        /FROM organization_memberships membership[\s\S]*?membership\.revoked_at IS NULL\s+FOR SHARE;/u,
+      );
+    }
+    const [rlsPosture] = await admin<Array<{ forced: boolean }>>`
+      select relforcerowsecurity as forced from pg_class
+      where oid = 'organization_memberships'::regclass`;
+    expect(rlsPosture).toEqual({ forced: true });
+    await expect(
+      app.begin(async (tx) => {
+        await tx`select
+          set_config('opengeni.account_id', ${accountId}, true),
+          set_config('opengeni.workspace_id', ${sharedWorkspaceId}, true),
+          set_config('opengeni.subject_id', ${`human:${crypto.randomUUID()}`}, true)`;
+        return await tx<Array<{ id: string }>>`
+          select id from organization_memberships where id = ${membershipId}`;
+      }),
+    ).rejects.toMatchObject({ code: "42501" });
+    await db.close();
+    await runtimeOwner.end({ timeout: 5 });
+    await app.end({ timeout: 5 });
+  }, 900_000);
+
+  test("the migration source guards every exact predecessor fragment", async () => {
+    const source = await readFile(join(migrationsDir, REPAIR), "utf8");
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(source.match(/repair shape changed/g)).toHaveLength(3);
+    expect(source.match(/USING ERRCODE = '55000'/g)?.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/testing/src/shared-pg.ts
+++ b/packages/testing/src/shared-pg.ts
@@ -142,6 +142,11 @@ export type SharedTestDatabase = {
 export type BlankTestDatabase = {
   /** Superuser URL for this file's pristine (un-migrated) database. */
   databaseUrl: string;
+  /**
+   * The shared cluster's real app-role password. Pass this to `provisionRoles`
+   * instead of rotating the cluster-wide `opengeni_app` role from one test.
+   */
+  appPassword?: string;
   /** Release this file's handle: drops the database + decrements the refcount. */
   release: () => Promise<void>;
 };
@@ -690,6 +695,7 @@ export async function acquireBlankTestDatabase(label = "blank"): Promise<BlankTe
     let released = false;
     return {
       databaseUrl,
+      appPassword: APP_PASSWORD,
       release: async () => {
         if (released) {
           return;

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -176,6 +176,7 @@ describe("release schema contract", () => {
       "0340_tenancy_backfill_activation_evidence.sql",
       "0341_slack_routing_probe_organization_fence.sql",
       "0342_slack_route_prompt_single_pending.sql",
+      "0343_personal_document_force_rls_lock_repair.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -202,26 +203,32 @@ describe("release schema contract", () => {
     const slackRoutePromptSinglePending = completeSourceContract.migrations.some(
       (migration) => migration.path === "0342_slack_route_prompt_single_pending.sql",
     );
+    const personalDocumentForceRlsRepair = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0343_personal_document_force_rls_lock_repair.sql",
+    );
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
         (documentAuthorityReclassification ? 1 : 0) +
         (tenancyBackfillActivationEvidence ? 1 : 0) +
         (slackRoutingProbeFence ? 1 : 0) +
-        (slackRoutePromptSinglePending ? 1 : 0),
-      latestMigration: slackRoutePromptSinglePending
-        ? "0342_slack_route_prompt_single_pending.sql"
-        : slackRoutingProbeFence
-          ? "0341_slack_routing_probe_organization_fence.sql"
-          : tenancyBackfillActivationEvidence
-            ? "0340_tenancy_backfill_activation_evidence.sql"
-            : documentAuthorityReclassification
-              ? "0339_document_authority_reclassification.sql"
-              : atomicConnectedMachineAttachments
-                ? "0338_atomic_connected_machine_attachments.sql"
-                : routedSlackHandles
-                  ? "0337_slack_routed_action_handles.sql"
-                  : "0336_atomic_session_fork_visibility.sql",
+        (slackRoutePromptSinglePending ? 1 : 0) +
+        (personalDocumentForceRlsRepair ? 1 : 0),
+      latestMigration: personalDocumentForceRlsRepair
+        ? "0343_personal_document_force_rls_lock_repair.sql"
+        : slackRoutePromptSinglePending
+          ? "0342_slack_route_prompt_single_pending.sql"
+          : slackRoutingProbeFence
+            ? "0341_slack_routing_probe_organization_fence.sql"
+            : tenancyBackfillActivationEvidence
+              ? "0340_tenancy_backfill_activation_evidence.sql"
+              : documentAuthorityReclassification
+                ? "0339_document_authority_reclassification.sql"
+                : atomicConnectedMachineAttachments
+                  ? "0338_atomic_connected_machine_attachments.sql"
+                  : routedSlackHandles
+                    ? "0337_slack_routed_action_handles.sql"
+                    : "0336_atomic_session_fork_visibility.sql",
     });
     expect(
       completeSourceContract.migrations.find(


### PR DESCRIPTION
## Summary

- repair the frozen 0258 personal Document authority and attempt-admission routines under real FORCE-RLS owner posture
- fail closed on predecessor drift or blinded membership reads instead of silently taking the legacy workspace lane
- fix the three remaining shared-cluster app-role password stomp tests and add the exact-command owner-migrated guard

## Verification

- independent exact-head AI review: PASS at 062bdc9dad4d2b7f738a5017ec89d6f0b589232b
- OPENGENI_REQUIRE_REAL_DB=1 owner-migrated test: 2 passed, 0 failed, 22 assertions
- stacked Bun 1.4 verification: 20 passed, 0 failed
- release schema, migration ordinal, and FORCE-RLS guards green
- current main e5e4664800b01abaed971c3d5eacce5d7272458b was terminal green before publication

No deployment is included.