### PR TITLE
Fix realtime human authority and route metrics

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1462,6 +1462,10 @@ const routeLabelPatterns: Array<{
     label: "/v1/workspaces/:workspaceId/sessions/:id/events",
   },
   {
+    pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/turns$/,
+    label: "/v1/workspaces/:workspaceId/sessions/:id/turns",
+  },
+  {
     pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/queue\/[^/]+\/(move|edit|steer|delete)$/,
     label: "/v1/workspaces/:workspaceId/sessions/:id/queue/:turnId/:action",
   },
@@ -1924,6 +1928,10 @@ const routeLabelPatterns: Array<{
   {
     pattern: /^\/v1\/github\/oauth\/callback$/,
     label: "/v1/github/oauth/callback",
+  },
+  {
+    pattern: /^\/v1\/workspaces\/[^/]+$/,
+    label: "/v1/workspaces/:workspaceId",
   },
 ];
 

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -521,6 +521,10 @@ describe("API helpers", () => {
     expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/events/stream`)).toBe(
       "/v1/workspaces/:workspaceId/sessions/:id/events/stream",
     );
+    expect(routeLabel(`/v1/workspaces/${workspace}`)).toBe("/v1/workspaces/:workspaceId");
+    expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/turns`)).toBe(
+      "/v1/workspaces/:workspaceId/sessions/:id/turns",
+    );
     expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/lineage`)).toBe(
       "/v1/workspaces/:workspaceId/sessions/:id/lineage",
     );

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -1549,6 +1549,8 @@ export async function submitHumanPromptInTransaction(
       text: string;
       context: string;
     };
+    /** False when the human input originated inside the active realtime provider session. */
+    mirrorToRealtime?: boolean;
     source: "user" | "api";
     /** Record the admitted run's durable usage fact in this transaction. */
     recordAgentRunUsage?: boolean;
@@ -1605,6 +1607,7 @@ export async function submitHumanPromptInTransaction(
     source: input.source,
     turnMetadata: input.turnMetadata ?? {},
     messagePresentation: input.messagePresentation ?? null,
+    mirrorToRealtime: input.mirrorToRealtime ?? true,
     mcpCredentialUpdates: input.mcpCredentialUpdates ?? [],
     personalConnectionDelegations: input.personalConnectionDelegations ?? [],
     personalResourceAttachment: input.personalResourceAttachment ?? null,
@@ -2201,7 +2204,7 @@ export async function submitHumanPromptInTransaction(
     .insert(schema.sessionEvents)
     .values(withLosslessContentWriteVersion(eventValues, "payload", "payloadCodecVersion"))
     .returning();
-  if (input.actor.type === "human") {
+  if (input.actor.type === "human" && input.mirrorToRealtime !== false) {
     await mirrorSessionRealtimeContextInTransaction(db, {
       accountId: input.accountId,
       workspaceId: input.workspaceId,

--- a/packages/db/src/session-realtime-context.ts
+++ b/packages/db/src/session-realtime-context.ts
@@ -293,10 +293,8 @@ export async function flushSessionRealtimeTranscriptTailInTransaction(
     subjectId: input.ownerSubjectId,
     subjectLabel: "Realtime",
     actor: {
-      type: "service",
+      type: "human",
       subjectId: input.ownerSubjectId,
-      subjectLabel: "Realtime",
-      context: { source: SESSION_REALTIME_TAIL_SOURCE, realtimeId: mode.id },
     },
     operationKey: deterministicUuid(`opengeni:session-realtime-tail-flush:${mode.id}`),
     delivery: "steer",

--- a/packages/db/src/session-realtime-ledger.ts
+++ b/packages/db/src/session-realtime-ledger.ts
@@ -1185,10 +1185,8 @@ async function admitRealtimeDelegationInTransaction(
     subjectId: input.ownerSubjectId,
     subjectLabel: "Realtime",
     actor: {
-      type: "service",
+      type: "human",
       subjectId: input.ownerSubjectId,
-      subjectLabel: "Realtime",
-      context: provenance,
     },
     operationKey: incoming.operationId,
     delivery: "steer",
@@ -1199,6 +1197,7 @@ async function admitRealtimeDelegationInTransaction(
       text: inputTranscript,
       context: incoming.text!,
     },
+    mirrorToRealtime: false,
     resources: [],
     model: latestStarted?.model ?? session.model,
     reasoningEffort: latestReasoning.success ? latestReasoning.data : sessionReasoning,
@@ -1511,6 +1510,10 @@ export async function syncSessionRealtimeLedgerInTransaction(
           entry.id,
           modelContext,
         );
+        // Human prompt admission can mirror a provider-out context row into this
+        // ledger. Continue after that canonical append instead of reusing its
+        // sequence for the next provider-in entry in this batch.
+        nextSequence = await nextLedgerSequence(db, input.realtimeId);
         const [linked] = await db
           .update(schema.sessionRealtimeEntries)
           .set({ turnId: admission.turnId, updatedAt: now })

--- a/packages/db/test/session-realtime-context.test.ts
+++ b/packages/db/test/session-realtime-context.test.ts
@@ -13,13 +13,20 @@ import {
   createDb,
   createSession,
   endSessionRealtimeInTransaction,
+  ensureManagedAccessForUser,
   getActiveSessionHistoryItems,
+  getOrCreateCompanyProfileSnapshot,
+  getOrCreatePreferenceRegistrySnapshot,
+  getOrCreateWorkspaceInstructionPolicySnapshot,
   getSessionRealtimeContinuityEntries,
   renderSessionRealtimeTail,
+  resolveCompanyBrainContextSelection,
   SESSION_REALTIME_CONTEXT_MAX_BYTES,
   SESSION_REALTIME_TAIL_INSTRUCTION,
   SESSION_REALTIME_TAIL_SOURCE,
   syncSessionRealtimeLedgerInTransaction,
+  transitionSessionVisibility,
+  withSessionRlsActorContext,
   withWorkspaceSessionActivityRls as withWorkspaceRls,
   type SessionActivityDatabase,
   type SessionRealtimeContextSourceEntry,
@@ -82,6 +89,47 @@ async function fixture() {
     subjectId: grant.subjectId,
     session,
   };
+}
+
+async function privateFixture() {
+  const suffix = crypto.randomUUID();
+  const userId = `realtime-context-owner-${suffix}`;
+  const subjectId = `user:${userId}`;
+  const access = await ensureManagedAccessForUser(client.db, {
+    userId,
+    email: `${userId}@example.test`,
+    name: "Realtime context owner",
+  });
+  const grant = access.workspaceGrants[0]!;
+  await shared.admin`
+    insert into session_tenancy_activations (
+      account_id, activation_version, inventory_digest, parity_digest, activated_by
+    ) values (${grant.accountId}, 1, ${"0".repeat(64)}, ${"1".repeat(64)}, 'database-test')
+    on conflict (account_id) do nothing`;
+  const session = await withSessionRlsActorContext({ subjectId }, () =>
+    createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "ordinary history before voice",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium" as const,
+      latencyMode: "standard" as const,
+      sandboxBackend: "none",
+      createdBy: { kind: "subject", subjectId },
+      createdByContext: {},
+    }),
+  );
+  await transitionSessionVisibility(client.db, {
+    workspaceId: grant.workspaceId!,
+    sessionId: session.id,
+    actorSubjectId: subjectId,
+    targetVisibility: "user_private",
+    expectedAuthorityEpoch: 1,
+    operationKey: `realtime-context-private-${suffix}`,
+  });
+  return { accountId: grant.accountId, workspaceId: grant.workspaceId!, subjectId, session };
 }
 
 type Fixture = Awaited<ReturnType<typeof fixture>>;
@@ -255,7 +303,7 @@ describe("session realtime transcript tail and continuity", () => {
   });
 
   test("ending with transcript tail attaches the latest user message context to one canonical Steer", async () => {
-    const value = await fixture();
+    const value = await privateFixture();
     const userModelContext = "Current application context: organization profile revision 42.";
     const mode = await runMode(value, [
       transcript("user", "Please remember the final constraint", {}, userModelContext),
@@ -308,6 +356,9 @@ describe("session realtime transcript tail and continuity", () => {
     expect(facts.turns[0]).toMatchObject({
       id: facts.projections[0]?.turnId,
       status: "queued",
+      initiatorKind: "subject",
+      initiatorSubjectId: value.subjectId,
+      initiatingHumanSubjectId: value.subjectId,
       modelContext: userModelContext,
       metadata: {
         delivery: "steer",
@@ -322,15 +373,39 @@ describe("session realtime transcript tail and continuity", () => {
         context: facts.projections[0]?.context,
       },
     });
+    const attemptId = crypto.randomUUID();
     const claim = await claimSessionWorkForAttempt(client.db, value.workspaceId, {
       sessionId: value.session.id,
       workflowId: `session-${value.session.id}`,
       workflowRunId: crypto.randomUUID(),
-      attemptId: crypto.randomUUID(),
+      attemptId,
       dispatchId: crypto.randomUUID(),
       trigger: { kind: "next" },
     });
     expect(claim).toMatchObject({ action: "claimed", turn: { id: facts.turns[0]?.id } });
+    if (claim.action !== "claimed")
+      throw new Error(`Voice tail was not claimable: ${claim.reason}`);
+    const claims = {
+      accountId: value.accountId,
+      workspaceId: value.workspaceId,
+      sessionId: value.session.id,
+      turnId: claim.turn.id,
+      attemptId,
+      executionGeneration: claim.turn.executionGeneration,
+    };
+    const selected = await withSessionRlsActorContext(
+      { subjectId: "worker:realtime-context", initiatingHumanSubjectId: value.subjectId },
+      async () => {
+        await getOrCreateCompanyProfileSnapshot(client.db, claims);
+        await getOrCreateWorkspaceInstructionPolicySnapshot(client.db, claims);
+        await getOrCreatePreferenceRegistrySnapshot(client.db, claims);
+        return await resolveCompanyBrainContextSelection(client.db, claims);
+      },
+    );
+    expect(selected.receipt).toMatchObject({
+      rootSessionId: value.session.id,
+      turnContextSnapshotSource: "accepted_turn",
+    });
     const history = await getActiveSessionHistoryItems(
       client.db,
       value.workspaceId,

--- a/packages/db/test/session-realtime-ledger.test.ts
+++ b/packages/db/test/session-realtime-ledger.test.ts
@@ -18,20 +18,27 @@ import {
   createDb,
   createSession,
   endSessionRealtimeInTransaction,
+  ensureManagedAccessForUser,
   evaluateSessionControl,
   failSessionRealtimeConnectionInTransaction,
   getActiveSessionHistoryItems,
+  getOrCreateCompanyProfileSnapshot,
+  getOrCreatePreferenceRegistrySnapshot,
+  getOrCreateWorkspaceInstructionPolicySnapshot,
   getSessionHumanInputRequest,
   listOutstandingSessionSystemUpdates,
   mutateSessionControlInTransaction,
   peekSessionWork,
   recoverSessionDispatch,
+  resolveCompanyBrainContextSelection,
   SessionControlInvariantError,
   SessionRealtimeConflictError,
   settleCodexCredentialLeaseLoss,
   settleSessionAttemptInterruptions,
   submitHumanPromptInTransaction,
   syncSessionRealtimeLedgerInTransaction,
+  transitionSessionVisibility,
+  withSessionRlsActorContext,
   withWorkspaceSessionActivityRls as withWorkspaceRls,
   type SessionActivityDatabase,
 } from "../src/index";
@@ -83,6 +90,60 @@ async function fixture() {
     sessionId: session.id,
     operationId: crypto.randomUUID(),
     ownerSubjectId: grant.subjectId,
+    browserInstanceId: `browser-${crypto.randomUUID()}`,
+    ownerKey: `owner-key-${crypto.randomUUID()}-${crypto.randomUUID()}`,
+    model: "gpt-live-1-boulder-alpha" as const,
+  };
+  const started = await transaction(owner.workspaceId, (tx) =>
+    beginSessionRealtimeInTransaction(tx, owner),
+  );
+  return { grant, session, owner, started };
+}
+
+async function privateFixture() {
+  const suffix = crypto.randomUUID();
+  const userId = `realtime-ledger-owner-${suffix}`;
+  const subjectId = `user:${userId}`;
+  const access = await ensureManagedAccessForUser(client.db, {
+    userId,
+    email: `${userId}@example.test`,
+    name: "Realtime ledger owner",
+  });
+  const grant = access.workspaceGrants[0]!;
+  await shared.admin`
+    insert into session_tenancy_activations (
+      account_id, activation_version, inventory_digest, parity_digest, activated_by
+    ) values (${grant.accountId}, 1, ${"0".repeat(64)}, ${"1".repeat(64)}, 'database-test')
+    on conflict (account_id) do nothing`;
+  const session = await withSessionRlsActorContext({ subjectId }, () =>
+    createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "ordinary history before voice",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium" as const,
+      latencyMode: "standard" as const,
+      sandboxBackend: "none",
+      createdBy: { kind: "subject", subjectId },
+      createdByContext: {},
+    }),
+  );
+  await transitionSessionVisibility(client.db, {
+    workspaceId: grant.workspaceId!,
+    sessionId: session.id,
+    actorSubjectId: subjectId,
+    targetVisibility: "user_private",
+    expectedAuthorityEpoch: 1,
+    operationKey: `realtime-ledger-private-${suffix}`,
+  });
+  const owner = {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId!,
+    sessionId: session.id,
+    operationId: crypto.randomUUID(),
+    ownerSubjectId: subjectId,
     browserInstanceId: `browser-${crypto.randomUUID()}`,
     ownerKey: `owner-key-${crypto.randomUUID()}-${crypto.randomUUID()}`,
     model: "gpt-live-1-boulder-alpha" as const,
@@ -1304,9 +1365,10 @@ describe("session realtime ledger", () => {
       latencyMode: "fast",
       sandboxBackend: "none",
       sandboxOs: null,
-      initiatorKind: "service",
+      initiatorKind: "subject",
       initiatorSubjectId: value.owner.ownerSubjectId,
-      lineage: { actor: "service" },
+      initiatingHumanSubjectId: value.owner.ownerSubjectId,
+      lineage: { actor: "human" },
       metadata: {
         delivery: "steer",
         realtimeDelegation: {
@@ -1340,6 +1402,42 @@ describe("session realtime ledger", () => {
     expect(persisted.count).toBe(before.count);
     expect(persisted.children).toBe(0);
     expect(persisted.session).toEqual(before.session);
+  });
+
+  test("private-session voice delegation retains human authority through Company Brain selection", async () => {
+    const value = await privateFixture();
+    const connection = await claimInitial(value);
+    await complete(value, connection.claimed.connection);
+    await proveProviderStarted(value, connection.claimed.connection);
+    const delegated = await admitAndClaimDelegation(value, connection.claimed.connection);
+    expect(delegated.turn).toMatchObject({
+      initiator: { kind: "subject", subjectId: value.owner.ownerSubjectId },
+      initiatingHumanSubjectId: value.owner.ownerSubjectId,
+    });
+    const claims = {
+      accountId: value.owner.accountId,
+      workspaceId: value.owner.workspaceId,
+      sessionId: value.session.id,
+      turnId: delegated.turn.id,
+      attemptId: delegated.attemptId,
+      executionGeneration: delegated.turn.executionGeneration,
+    };
+    const selected = await withSessionRlsActorContext(
+      {
+        subjectId: "worker:realtime-ledger",
+        initiatingHumanSubjectId: value.owner.ownerSubjectId,
+      },
+      async () => {
+        await getOrCreateCompanyProfileSnapshot(client.db, claims);
+        await getOrCreateWorkspaceInstructionPolicySnapshot(client.db, claims);
+        await getOrCreatePreferenceRegistrySnapshot(client.db, claims);
+        return await resolveCompanyBrainContextSelection(client.db, claims);
+      },
+    );
+    expect(selected.receipt).toMatchObject({
+      rootSessionId: value.session.id,
+      turnContextSnapshotSource: "accepted_turn",
+    });
   });
 
   test("delegation uses canonical Steer against an already-running ordinary turn", async () => {


### PR DESCRIPTION
## Summary
- attribute realtime delegation and transcript-tail turns to the authenticated human
- preserve private-session Company Brain selection and suppress redundant provider echo
- refresh ledger sequencing after admission side effects
- label workspace-detail and session-turn metrics instead of `/v1/unknown`

## Verification
- `bun test packages/db/test/session-realtime-context.test.ts` (8 passed)
- `bun test packages/db/test/session-realtime-ledger.test.ts` (37 passed)
- `bun test apps/api/test/app.test.ts` (60 passed)
- `bun run typecheck` in `packages/db` and `apps/api`