### PR TITLE
fix(web): account for held-turn bundle growth

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -205,12 +205,12 @@ const budgets = {
   // tree-shakeable, tracked separately.
   // Held-turn commentary projection adds the bounded waiting-state copy to
   // the shared session graph. The exact Linux/x64 production builds measure
-  // 2,173,426-2,173,468 raw bytes while gzip remains below its existing cap.
-  // Advance only the raw aggregate to the next whole-KiB envelope; every
-  // compressed, file-count, initial, per-file, lazy-chunk, and CSS cap stays
-  // fixed.
-  directSessionRaw: 2123 * kib,
-  directSessionGzip: 593 * kib,
+  // 2,173,426-2,173,468 raw bytes and 607,161-607,169 gzip bytes. Preserve the
+  // guard's one-KiB raw headroom and 1.5-KiB gzip platform-skew allowance by
+  // advancing each to its next compliant whole-KiB envelope. Every file-count,
+  // initial, per-file, lazy-chunk, and CSS cap stays fixed.
+  directSessionRaw: 2124 * kib,
+  directSessionGzip: 595 * kib,
   directSessionFiles: 24,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -203,7 +203,13 @@ const budgets = {
   // above mandates, so this advances to 2122 KiB. Every other cap stays fixed.
   // It remains a stopgap; the real fix is to make the client
   // tree-shakeable, tracked separately.
-  directSessionRaw: 2122 * kib,
+  // Held-turn commentary projection adds the bounded waiting-state copy to
+  // the shared session graph. The exact Linux/x64 production builds measure
+  // 2,173,426-2,173,468 raw bytes while gzip remains below its existing cap.
+  // Advance only the raw aggregate to the next whole-KiB envelope; every
+  // compressed, file-count, initial, per-file, lazy-chunk, and CSS cap stays
+  // fixed.
+  directSessionRaw: 2123 * kib,
   directSessionGzip: 593 * kib,
   directSessionFiles: 24,
   lazyChunkRaw: 800 * kib,


### PR DESCRIPTION
The held-turn commentary projection raises the exact Linux/x64 direct-session graph to 2,173,426-2,173,468 raw bytes and 607,161-607,169 gzip bytes. Preserve the bundle guard policy by advancing raw to 2,124 KiB (1,508-1,550 bytes headroom) and gzip to 595 KiB (2,111-2,119 bytes headroom), the first whole-KiB envelopes satisfying the documented one-KiB raw margin and 1.5-KiB platform-skew allowance. File-count, initial, per-file, lazy-chunk, and CSS caps remain unchanged.

Verification: full production web build and exact bundle-budget check are green. Independent AI exact-head review PASSed 1602afc8db94b6fe26ddcc4440a57e3fda5aef24.