### PR TITLE
fix(release): authorize canary package publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -47,4 +47,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          OPENGENI_RELEASE: "1"
         run: bun scripts/publish-canary.ts

--- a/scripts/prepublish-guard
+++ b/scripts/prepublish-guard
@@ -6,10 +6,10 @@ if [[ "${OPENGENI_RELEASE:-}" == "1" ]]; then
 fi
 
 cat >&2 <<'EOF'
-OpenGeni npm packages must be published through scripts/release-publish.sh.
+OpenGeni npm packages must be published through the repository release workflows.
 
-Direct npm publish is blocked because the blessed release path builds the
-publishable closure, rewrites workspace dependencies and entry points, and
-sets OPENGENI_RELEASE=1 before changesets publishes.
+Direct npm publish is blocked because the stable and canary release paths build
+the publishable closure, rewrite workspace dependencies and entry points, and
+set OPENGENI_RELEASE=1 before npm publishes.
 EOF
 exit 1

--- a/scripts/staging-production-split-contract.test.ts
+++ b/scripts/staging-production-split-contract.test.ts
@@ -36,6 +36,7 @@ describe("staging / production split workflows", () => {
     expect(source).toContain("bun scripts/publish-canary.ts");
     expect(source).toContain("group: publish-canary");
     expect(source).toContain('NPM_CONFIG_PROVENANCE: "true"');
+    expect(source).toContain('OPENGENI_RELEASE: "1"');
     expect(source).toContain("registry-url: https://registry.npmjs.org");
     expect(source).not.toContain("changeset publish");
     expect(source).not.toContain("--tag latest");

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": ".github/workflows/publish-canary.yml",
-      "sha256": "98e63b20977ab223f7ccf737a5d8b2aabeb0df02783eb6395646170681382a83"
+      "sha256": "15ae3450651d33fd5751c8ea0ca060522dd8681f4d6c30e5cbdde3e2f81dcdc1"
     },
     {
       "path": ".github/workflows/publish-desktop-image.yml",
@@ -781,7 +781,7 @@
       "workflow": ".github/workflows/publish-canary.yml",
       "job": "publish",
       "step": "Publish canary versions",
-      "sha256": "dc8ac6d56268cd6bdf86da4b418c393a303f90851923c24b9d5a995bb4bd0244"
+      "sha256": "7c1b768bb42a75e60e78fcad73d4655b249190a6268f232eae2d32f55af0a3b9"
     },
     {
       "workflow": ".github/workflows/publish-packages.yml",


### PR DESCRIPTION
## Summary
- authorize the canary workflow at the existing guarded npm publication boundary
- clarify that the prepublish guard admits both stable and canary release workflows
- pin the canary workflow contract in tests

## Tests
- `bun test scripts/publish-canary.test.ts scripts/staging-production-split-contract.test.ts`