### PR TITLE
fix(web): restore gzip bundle skew allowance

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -221,10 +221,13 @@ const budgets = {
   // The causal older-history receipt adds one boolean ownership mark to the
   // always-loaded session hook and timeline. The exact Bun 1.4 Linux/x64
   // production graph measures 2,182,276 raw / 609,893 gzip bytes. Advance only
-  // the raw aggregate to its next whole-KiB envelope; every compressed,
-  // file-count, initial, per-file, lazy-chunk, and CSS cap stays fixed.
+  // the raw aggregate to its next whole-KiB envelope. Protected-main Linux/x64
+  // then measured 610,305 gzip bytes, one byte beyond the old cap. Advance the
+  // gzip aggregate to the first whole-KiB envelope that preserves the existing
+  // 1.5-KiB platform-skew allowance over that maximum; every file-count,
+  // initial, per-file, lazy-chunk, and CSS cap stays fixed.
   directSessionRaw: 2132 * kib,
-  directSessionGzip: 596 * kib,
+  directSessionGzip: 598 * kib,
   directSessionFiles: 24,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,


### PR DESCRIPTION
## Summary

- restore the documented 1.5-KiB direct-session gzip platform-skew allowance after protected main measured 610,305 bytes against the 610,304-byte cap
- move only `directSessionGzip` from 596 to 598 KiB; 598 KiB is the first whole-KiB envelope satisfying `610,305 + 1,536 <= cap`
- keep raw, file-count, initial, per-file, lazy-chunk, and CSS caps unchanged

## Evidence

- independent exact-head AI review: PASS, no findings, head `05930efa0bf3c62a355b9678a4c3139b68ad0c21`
- independent production build: 2,182,705 raw / 610,270 gzip / 24 files, all budgets green
- independent impact/workflow tests: 65 pass / 0 fail / 953 assertions
- root impact/workflow tests: 36 pass / 0 fail / 278 assertions
- `oxlint --deny-warnings`, `oxfmt --check`, `git diff --check`, exact-head identity, and cleanliness green

## Protected-main failure

Run 32946670762 failed in the session-pin browser job before browser startup because its production build measured 2,182,723 raw / 610,305 gzip / 24 files. The missing screenshot uploads are downstream of that build gate.

No deployment or production mutation is included.
