### PR TITLE
test(e2e): wait for visible timeline settlements

### DIFF
--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -298,10 +298,27 @@ describe("timeline scroll ownership browser regression", () => {
   test("keeps a nested row anchored when prepend merges into its activity group", async () => {
     await page.goto(`${baseUrl}/timeline-scroll-merge-test.html`);
     await page.waitForFunction(() => window.timelineMergeHarness !== undefined);
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
     const target = page.getByText("reasoning-50", { exact: true });
     await target.waitFor({ timeout: 15_000 });
-    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
-    await page.waitForTimeout(100);
+    await target.evaluate(async (node) => {
+      const scroller = document.querySelector<HTMLElement>(
+        "[data-timeline-merge-test] .og-root > div",
+      );
+      if (!scroller) throw new Error("timeline merge scroller is unavailable");
+      const settled =
+        "onscrollend" in scroller
+          ? new Promise<void>((resolve) => {
+              scroller.addEventListener("scrollend", () => resolve(), { once: true });
+            })
+          : new Promise<void>((resolve) =>
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+            );
+      node.scrollIntoView({ block: "start" });
+      await settled;
+    });
 
     const before = await nestedVisible(page, "reasoning-50");
     await page.evaluate(() => window.timelineMergeHarness!.prependActivity());
@@ -428,27 +445,41 @@ describe("timeline scroll ownership browser regression", () => {
       const node = window.timelineCollapsedHistoryHarness!.scroller();
       return node.style.visibility !== "hidden";
     });
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
 
     const evidence = await page.evaluate(async () => {
       const harness = window.timelineCollapsedHistoryHarness!;
-      const before = harness.metrics();
       harness.settleOlder("success");
+      await new Promise<void>((resolve) => {
+        const prepended = () =>
+          document.querySelector('[data-conversation-message="user-1"]') !== null;
+        if (prepended()) {
+          resolve();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          if (!prepended()) return;
+          observer.disconnect();
+          resolve();
+        });
+        observer.observe(harness.scroller(), { childList: true, subtree: true });
+      });
       const samples = [];
       for (let index = 0; index < 24; index += 1) {
         await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
         samples.push(harness.metrics());
       }
-      return { before, samples };
+      return samples;
     });
     await page.locator('[data-conversation-message="user-1"]').waitFor({ timeout: 5_000 });
 
-    expect(evidence.samples).toHaveLength(24);
-    const parkedGap = evidence.samples[0]!.liveTailGap;
-    expect(evidence.samples.every((sample) => Math.abs(sample.liveTailGap - parkedGap) < 1)).toBe(
-      true,
-    );
+    expect(evidence).toHaveLength(24);
+    const parkedGap = evidence[0]!.liveTailGap;
+    expect(evidence.every((sample) => Math.abs(sample.liveTailGap - parkedGap) < 1)).toBe(true);
     expect(parkedGap).toBeLessThan(48);
-    expect(evidence.samples.every((sample) => sample.maxScroll - sample.scrollTop < 2)).toBe(true);
+    expect(evidence.every((sample) => sample.maxScroll - sample.scrollTop < 2)).toBe(true);
     expect(await page.evaluate(() => window.timelineCollapsedHistoryHarness!.loadCalls())).toBe(1);
   }, 30_000);
 


### PR DESCRIPTION
## Why

Protected-main run 32951042755 failed only the interaction browser lane because the delayed-underfill regression began sampling before the scheduled React prepend was visibly committed. The first frame could therefore capture the intentional pre-commit underfill while later frames captured the correctly parked live tail.

Repeated full-file proof also exposed the same setup race in the nested-row regression: its baseline used a fixed delay after programmatic navigation rather than the supported scroll settlement.

## What changed

- wait for the prepended row to exist before starting the 24-frame live-tail ledger
- wait for fonts before affected pixel baselines
- wait for scrollend, with a two-animation-frame fallback where unsupported, before the nested-row baseline
- retain every existing pixel tolerance, frame count, and single-load assertion

## Validation

- full 32-test timeline browser file: green six consecutive exact-worktree runs after the final synchronization repair, including one after formatting
- originally failed case: 12/12 root repetitions plus 10/10 independent-review repetitions
- companion nested-row case: 10/10 independent-review repetitions
- all 31 typecheck projects clean
- affected oxfmt, oxlint with warnings denied, and git diff checks green
- independent exact-head review PASS with no findings at 0d54a1a928cb9a42deaacb271529659439a92495

No product behavior, assertion threshold, deployment, or production state changes.