### PR TITLE
feat(observability): measure Workspace Insights latency

### DIFF
--- a/apps/api/src/routes/insights.ts
+++ b/apps/api/src/routes/insights.ts
@@ -1,30 +1,49 @@
 import { InsightsRange, WorkspaceInsightsResponse } from "@opengeni/contracts";
 import { getWorkspaceInsights, requireAccessGrant, type ApiRouteDeps } from "@opengeni/core";
+import { workspaceInsightsMetricObserver } from "@opengeni/observability";
 import type { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 
 export function registerInsightsRoutes(app: Hono, deps: ApiRouteDeps): void {
+  const observeRequest = workspaceInsightsMetricObserver(deps.observability);
   app.get("/v1/workspaces/:workspaceId/insights", async (c) => {
-    const workspaceId = c.req.param("workspaceId");
-    await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
-
+    const startedAtMs = performance.now();
     const rangeRaw = c.req.query("range") ?? "week";
-    const rangeParsed = InsightsRange.safeParse(rangeRaw);
-    if (!rangeParsed.success) {
-      throw new HTTPException(400, {
-        message: "range must be one of today|week|month|ytd",
+    const providerRaw = c.req.query("provider");
+    const modelRaw = c.req.query("model");
+    const provider = providerRaw && providerRaw !== "all" ? providerRaw : null;
+    const model = modelRaw && modelRaw !== "all" ? modelRaw : null;
+    let outcome = "failed";
+
+    try {
+      const workspaceId = c.req.param("workspaceId");
+      await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+
+      const rangeParsed = InsightsRange.safeParse(rangeRaw);
+      if (!rangeParsed.success) {
+        throw new HTTPException(400, {
+          message: "range must be one of today|week|month|ytd",
+        });
+      }
+
+      const response = await getWorkspaceInsights(deps.db, deps.settings, {
+        workspaceId,
+        range: rangeParsed.data,
+        provider,
+        model,
+      });
+      c.header("cache-control", "private, no-store");
+      const result = c.json(WorkspaceInsightsResponse.parse(response));
+      outcome = "completed";
+      return result;
+    } finally {
+      observeRequest({
+        range: rangeRaw,
+        providerFiltered: provider !== null,
+        modelFiltered: model !== null,
+        outcome,
+        durationMs: performance.now() - startedAtMs,
       });
     }
-    const provider = c.req.query("provider");
-    const model = c.req.query("model");
-
-    const response = await getWorkspaceInsights(deps.db, deps.settings, {
-      workspaceId,
-      range: rangeParsed.data,
-      provider: provider && provider !== "all" ? provider : null,
-      model: model && model !== "all" ? model : null,
-    });
-    c.header("cache-control", "private, no-store");
-    return c.json(WorkspaceInsightsResponse.parse(response));
   });
 }

--- a/apps/api/test/insights-route-discipline.test.ts
+++ b/apps/api/test/insights-route-discipline.test.ts
@@ -25,4 +25,22 @@ describe("insights route discipline", () => {
     expect(routesSrc.includes('"sessions:read"')).toBe(false);
     expect(routesSrc.includes('"workspace:read"')).toBe(false);
   });
+
+  test("records bounded route timing across success and failure without changing the response", () => {
+    const timerAt = routesSrc.indexOf("const startedAtMs = performance.now()");
+    const grantAt = routesSrc.indexOf(
+      'requireAccessGrant(c, deps, workspaceId, "workspace:admin")',
+    );
+    const responseAt = routesSrc.indexOf("WorkspaceInsightsResponse.parse(response)", grantAt);
+    const finallyAt = routesSrc.indexOf("} finally {", responseAt);
+    const observeAt = routesSrc.indexOf("observeRequest({", finallyAt);
+
+    expect(routesSrc).toContain("workspaceInsightsMetricObserver(deps.observability)");
+    expect(timerAt).toBeGreaterThanOrEqual(0);
+    expect(timerAt).toBeLessThan(grantAt);
+    expect(finallyAt).toBeGreaterThan(responseAt);
+    expect(observeAt).toBeGreaterThan(finallyAt);
+    expect(routesSrc).toContain("providerFiltered: provider !== null");
+    expect(routesSrc).toContain("modelFiltered: model !== null");
+  });
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2162,6 +2162,7 @@ helm upgrade --install opengeni deploy/helm/opengeni \
 Minimum production dashboards should cover:
 
 - API traffic: request rate, error rate, and p50/p95/p99 latency by `route`, `method`, `status`, `variable set`, and `component`.
+- Workspace Insights: `opengeni_workspace_insights_request_duration_seconds{range,provider_filter,model_filter,outcome}` measures the complete route handler, including access resolution, aggregation, contract projection, and response construction. Its exact `le="2"` bucket verifies the default unfiltered weekly view's two-second target. Labels carry only closed range/outcome values and filter-presence flags, never workspace, subject, provider, or model values.
 - Worker execution: activity run rate, failure rate, and p50/p95/p99 `runAgentTurn` duration by `activity`, `status`, `variable set`, and `component`.
 - Google Drive sync: run outcome and failure ratio, reconnect-required events, p95 terminal activity-batch duration, logical provider requests, physical provider attempts/retries, explicit limit hits, and bounded terminal failure reasons, scoped by namespace, environment, release, and provider where applicable.
 - Turn lifecycle: `opengeni_turns_total{outcome}`, `opengeni_turn_duration_seconds`, `opengeni_turns_inflight`, `opengeni_turn_oldest_inflight_age_seconds`, and `opengeni_turn_oldest_no_progress_age_seconds`.

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -235,6 +235,9 @@ const INTERACTION_INTERVENTION_OUTCOMES = new Set([
   "expired",
   "cancelled",
 ]);
+const WORKSPACE_INSIGHTS_RANGES = new Set(["today", "week", "month", "ytd"]);
+const WORKSPACE_INSIGHTS_OUTCOMES = new Set(["completed", "failed"]);
+const workspaceInsightsDurationHistogramBuckets = [0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 5, 10, 30];
 const PUBLIC_STARTUP_DEPENDENCIES = new Set([
   "Modal private-registry image",
   "NATS",
@@ -1039,6 +1042,55 @@ export function interactionInterventionMetricObserver(
       }
     } catch {
       recordObserverFailure(observability, "interaction_intervention");
+    }
+  };
+}
+
+export type WorkspaceInsightsMetricObservation = {
+  range: string;
+  providerFiltered: boolean;
+  modelFiltered: boolean;
+  outcome: string;
+  durationMs: number;
+};
+
+/**
+ * Identity-free route timing for Workspace Insights. The dedicated two-second
+ * bucket is the service target; fixed enums and filter-presence flags keep
+ * tenant ids and caller-supplied provider/model values out of telemetry.
+ */
+export function workspaceInsightsMetricObserver(
+  observability: Observability | null | undefined,
+): (observation: WorkspaceInsightsMetricObservation) => void {
+  if (!observability) return () => undefined;
+  return (observation) => {
+    const range = boundedMetricEnum(WORKSPACE_INSIGHTS_RANGES, observation.range);
+    const outcome = boundedMetricEnum(WORKSPACE_INSIGHTS_OUTCOMES, observation.outcome);
+    const providerFilter = observation.providerFiltered ? "filtered" : "all";
+    const modelFilter = observation.modelFiltered ? "filtered" : "all";
+    const durationSeconds = boundedMetricDuration(observation.durationMs);
+    try {
+      observability.observeHistogram({
+        name: "opengeni_workspace_insights_request_duration_seconds",
+        help: "Workspace Insights route service duration by bounded range, filter presence, and outcome.",
+        buckets: workspaceInsightsDurationHistogramBuckets,
+        labels: {
+          range,
+          provider_filter: providerFilter,
+          model_filter: modelFilter,
+          outcome,
+        },
+        value: durationSeconds,
+      });
+      observability.info("Workspace Insights request measured", {
+        surface: "workspace_insights",
+        eventType: "request_latency",
+        route: "/v1/workspaces/:workspaceId/insights",
+        outcome,
+        durationMs: Math.round(durationSeconds * 1_000),
+      });
+    } catch {
+      recordObserverFailure(observability, "workspace_insights");
     }
   };
 }

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -10,6 +10,7 @@ import {
   recordTenancyCompatibilityLaneUse,
   sandboxOperationMetricObserver,
   TENANCY_COMPATIBILITY_LANES,
+  workspaceInsightsMetricObserver,
 } from "../src";
 
 const settings = {
@@ -49,6 +50,55 @@ describe("observability", () => {
     expect(metrics).toContain("opengeni_http_request_duration_seconds_bucket");
     expect(metrics).toContain("opengeni_build_info");
     expect(metrics).toContain("opengeni_process_cpu_user_seconds_total");
+  });
+
+  test("records identity-free Insights timing with an exact two-second target bucket", async () => {
+    const obs = createObservability(settings, { component: "api", now: () => 1 });
+    const observe = workspaceInsightsMetricObserver(obs);
+    const observedLogs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => observedLogs.push(String(message));
+    try {
+      observe({
+        range: "week",
+        providerFiltered: false,
+        modelFiltered: false,
+        outcome: "completed",
+        durationMs: 1_750,
+      });
+      observe({
+        range: "caller-controlled-range",
+        providerFiltered: true,
+        modelFiltered: true,
+        outcome: "caller-controlled-outcome",
+        durationMs: Number.NaN,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const metrics = await obs.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_workspace_insights_request_duration_seconds_bucket\{[^}]*le="2"[^}]*model_filter="all"[^}]*outcome="completed"[^}]*provider_filter="all"[^}]*range="week"[^}]*\} 1\b/,
+    );
+    expect(metrics).toContain('range="unknown"');
+    expect(metrics).toContain('outcome="unknown"');
+    expect(metrics).not.toContain("caller-controlled-range");
+    expect(metrics).not.toContain("caller-controlled-outcome");
+
+    const completedLog = JSON.parse(observedLogs[0] ?? "{}") as Record<string, unknown>;
+    expect(completedLog).toMatchObject({
+      message: "Workspace Insights request measured",
+      surface: "workspace_insights",
+      eventType: "request_latency",
+      route: "/v1/workspaces/:workspaceId/insights",
+      outcome: "completed",
+      durationMs: 1_750,
+    });
+    expect(completedLog.workspaceId).toBeUndefined();
+    expect(completedLog.range).toBeUndefined();
+    expect(completedLog.provider).toBeUndefined();
+    expect(completedLog.model).toBeUndefined();
   });
 
   test("reports bounded configured and effective sandbox rollout state", async () => {


### PR DESCRIPTION
## Summary

- Record Workspace Insights route-handler latency across access resolution, aggregation, contract projection, and response construction.
- Expose a dedicated Prometheus histogram with an exact 2-second bucket for the default weekly target.
- Bound all labels to range, filter-presence flags, and outcome. Workspace, subject, provider, and model values never enter telemetry.
- Emit an identity-free structured timing event and keep observability failures isolated from request execution.

## Verification

- bun test packages/observability/test/observability.test.ts apps/api/test/insights-route-discipline.test.ts
- bun run typecheck
- bun run lint
- bun scripts/check-workspace-billing-static.ts
- bun run check:docs-refs
- bun run check:public-hygiene

Linear: https://linear.app/cloudgeni/issue/OPE-370/reduce-workspace-insights-load-from-15s-to-under-2s