### PR TITLE
fix(react): clear submitted composer draft before host callbacks

### DIFF
--- a/.changeset/quiet-composer-handoff.md
+++ b/.changeset/quiet-composer-handoff.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Clear ordinary Send drafts before host submission callbacks can re-project the submitted text.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -1984,10 +1984,12 @@ export function useComposer(
         },
         canRetry: true,
       };
-      replaceOptimisticSends((current) => [...current, operation]);
-      queueMicrotask(processOptimisticSends);
-      setError(null);
-      onSubmitted?.(sendText, input);
+      // The local submission acknowledgement owns the composer before any
+      // host callback or queued processor can observe it. Hosts commonly use
+      // onSubmitted to remove attachment/repository state, and those updates
+      // may synchronously re-render the controlled composer. Clear the refs
+      // first so that handoff cannot re-project the submitted text as the next
+      // draft. The immutable operation above still owns the exact retry input.
       if (explicit === undefined) {
         valueRef.current = "";
         annotationsRef.current = [];
@@ -1998,6 +2000,10 @@ export function useComposer(
         setAnnotationReviewTargetId(null);
         setRestoredResources([]);
       }
+      replaceOptimisticSends((current) => [...current, operation]);
+      queueMicrotask(processOptimisticSends);
+      setError(null);
+      onSubmitted?.(sendText, input);
       return true;
     },
     [

--- a/packages/react/test/use-composer-embedding.test.tsx
+++ b/packages/react/test/use-composer-embedding.test.tsx
@@ -101,6 +101,48 @@ describe("useComposer embedding policy", () => {
     await hook.unmount();
   });
 
+  test("ordinary Send clears its local draft before the host submission callback", async () => {
+    const draftVisibilityOnSubmitted: boolean[] = [];
+    let readDraftContent = () => true;
+    const client = fakeClient({
+      sendMessage: async (_workspaceId, _sessionId, input) => ({
+        id: crypto.randomUUID(),
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        sequence: 1,
+        type: "user.message",
+        clientEventId: typeof input === "string" ? undefined : input.clientEventId,
+        payload: input,
+        occurredAt: new Date().toISOString(),
+      }),
+    });
+    const hook = await renderHook(
+      () =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          draftPersistence: "disabled",
+          initialPolicy: {
+            model: "scripted-model",
+            reasoningEffort: "medium",
+            latencyMode: "standard",
+          },
+          onSubmitted: () => {
+            draftVisibilityOnSubmitted.push(readDraftContent());
+          },
+        }),
+      undefined,
+    );
+    readDraftContent = () => hook.result.current.hasDraftContent();
+
+    await actRun(() => hook.result.current.setValue("submitted once"));
+    expect(await actRun(() => hook.result.current.send())).toBe(true);
+
+    expect(draftVisibilityOnSubmitted).toEqual([false]);
+    expect(hook.result.current.value).toBe("");
+    await hook.unmount();
+  });
+
   test("annotation-only send preserves structured source data and clears on acceptance", async () => {
     const sent: unknown[] = [];
     const client = fakeClient({


### PR DESCRIPTION
## Summary

- clear ordinary Send draft refs before invoking host submission callbacks or starting optimistic delivery
- preserve the immutable optimistic operation as the retry/delivery source of truth
- cover the synchronous host-callback handoff with a regression test

## Testing

- [x] bun run --cwd packages/react typecheck
- [x] bun test packages/react/test/use-composer-embedding.test.tsx packages/react/test/hooks.test.tsx --timeout 20000
- [x] bunx oxfmt --check packages/react/src/hooks/use-composer.ts packages/react/test/use-composer-embedding.test.tsx .changeset/quiet-composer-handoff.md
- [x] bunx oxlint --deny-warnings packages/react/src/hooks/use-composer.ts packages/react/test/use-composer-embedding.test.tsx
- [x] git diff --check

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate started from current main; compatibility is verified without source mutation if main advances.

## Notes

- Fixes the session composer case where a synchronous host update could observe and re-project the just-submitted text.