### PR TITLE
fix(db): restore Insights migration upgrade path

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -7,15 +7,7 @@ const DEFAULT_DATABASE_URL = "postgres://opengeni:opengeni@127.0.0.1:5432/openge
 const DEFAULT_MAX_NESTED_AGENT_DEPTH = 3;
 const MAX_NESTED_AGENT_DEPTH = 2_147_483_647;
 const DEFAULT_APPLICATION_DATABASE_ROLE = "opengeni_app";
-const GOAL_REVISION_CUTOVER_MIGRATION = "0257_goal_revision_decisions_and_root_constraints.sql";
-const ATOMIC_PERSONAL_RESOURCE_CUTOVER_MIGRATION = "0306_atomic_personal_resource_attachments.sql";
-const UNREGISTERED_INVITATION_CUTOVER_MIGRATION = "0314_unregistered_organization_invitations.sql";
-const ATOMIC_CONNECTED_MACHINE_CUTOVER_MIGRATION = "0338_atomic_connected_machine_attachments.sql";
-const NAMED_SIGNUP_CUTOVER_MIGRATION = "0348_named_signup_and_user_setup.sql";
-const SESSION_VARIABLE_SET_ATTACHMENTS_CUTOVER_MIGRATION =
-  "0352_session_variable_set_attachments.sql";
-const AUTOMATIC_SESSION_TITLE_POLICY_FENCE_MIGRATION =
-  "0353_automatic_session_title_policy_fence.sql";
+const MIGRATION_APPLICATION_ROLES_SETTING = "opengeni.migration_application_roles";
 const MAX_MIGRATION_APPLICATION_ROLES = 16;
 const batchedBackfillDirective =
   /^-- opengeni:batched-backfill batch-size=(\d+) lock-timeout=(\d+(?:ms|s|min)) statement-timeout=(\d+(?:ms|s|min))$/;
@@ -393,18 +385,25 @@ export async function migrate(
     );
     const appliedRows = await sql`SELECT "name" FROM "schema_migrations"`;
     const applied = new Set(appliedRows.map((row) => row.name as string));
+    const pendingMigrationSources = new Map<string, string>();
+    for (const file of files) {
+      if (!applied.has(file)) {
+        pendingMigrationSources.set(file, await readFile(join(migrationsDir, file), "utf8"));
+      }
+    }
+    // Initialize this session GUC for every pending migration that consumes it,
+    // instead of maintaining a second filename list that can silently lag the
+    // shipped migration chain. The conservative source marker is intentional:
+    // setting the bounded role list for a migration that only mentions the GUC
+    // is harmless, while omitting it makes an otherwise valid upgrade fail.
     if (
-      !applied.has(GOAL_REVISION_CUTOVER_MIGRATION) ||
-      !applied.has(ATOMIC_PERSONAL_RESOURCE_CUTOVER_MIGRATION) ||
-      !applied.has(UNREGISTERED_INVITATION_CUTOVER_MIGRATION) ||
-      !applied.has(ATOMIC_CONNECTED_MACHINE_CUTOVER_MIGRATION) ||
-      !applied.has(NAMED_SIGNUP_CUTOVER_MIGRATION) ||
-      !applied.has(SESSION_VARIABLE_SET_ATTACHMENTS_CUTOVER_MIGRATION) ||
-      !applied.has(AUTOMATIC_SESSION_TITLE_POLICY_FENCE_MIGRATION)
+      Array.from(pendingMigrationSources.values()).some((source) =>
+        source.includes(MIGRATION_APPLICATION_ROLES_SETTING),
+      )
     ) {
       const applicationRoles = migrationApplicationRoles(schema, runtimeOptions);
       await sql`select set_config(
-        'opengeni.migration_application_roles',
+        ${MIGRATION_APPLICATION_ROLES_SETTING},
         ${JSON.stringify(applicationRoles)},
         false
       )`;
@@ -413,7 +412,10 @@ export async function migrate(
       if (applied.has(file)) {
         continue;
       }
-      const sqlText = await readFile(join(migrationsDir, file), "utf8");
+      const sqlText = pendingMigrationSources.get(file);
+      if (sqlText === undefined) {
+        throw new Error(`Pending migration source was not loaded: ${file}`);
+      }
       await executeMigrationFile(sql, file, sqlText);
       await sql`INSERT INTO "schema_migrations" ("name") VALUES (${file}) ON CONFLICT DO NOTHING`;
     }

--- a/packages/db/test/migration-0338-atomic-connected-machine-attachments.test.ts
+++ b/packages/db/test/migration-0338-atomic-connected-machine-attachments.test.ts
@@ -48,9 +48,9 @@ describe("migration 0338 atomic Connected Machine attachments", () => {
     expect(source).toContain("ALTER TABLE enrollments FORCE ROW LEVEL SECURITY");
     expect(source).not.toContain("CREATE TEMP");
     expect(migratorSource).toContain(
-      'ATOMIC_CONNECTED_MACHINE_CUTOVER_MIGRATION = "0338_atomic_connected_machine_attachments.sql"',
+      'MIGRATION_APPLICATION_ROLES_SETTING = "opengeni.migration_application_roles"',
     );
-    expect(migratorSource).toContain("!applied.has(ATOMIC_CONNECTED_MACHINE_CUTOVER_MIGRATION)");
+    expect(migratorSource).toContain("source.includes(MIGRATION_APPLICATION_ROLES_SETTING)");
   });
 
   test("attaches a selected personal machine once and reuses it on turn recovery", async () => {

--- a/packages/db/test/migration-0356-set-based-insights-session-visibility.test.ts
+++ b/packages/db/test/migration-0356-set-based-insights-session-visibility.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
-import { readFile } from "node:fs/promises";
+import {
+  acquireBlankTestDatabase,
+  acquireSharedTestDatabase,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { readdir, readFile } from "node:fs/promises";
 import postgres from "postgres";
 
 import {
@@ -27,11 +31,11 @@ import {
   type DbClient,
 } from "../src";
 import { LOSSLESS_CONTENT_WRITER_APPLICATION_NAME } from "../src/lossless-json";
+import { migrate } from "../src/migrate";
 
-const migrationUrl = new URL(
-  "../drizzle/0356_set_based_insights_session_visibility.sql",
-  import.meta.url,
-);
+const migrationName = "0356_set_based_insights_session_visibility.sql";
+const migrationUrl = new URL(`../drizzle/${migrationName}`, import.meta.url);
+const migrationsDirectoryUrl = new URL("../drizzle/", import.meta.url);
 
 setDefaultTimeout(60_000);
 
@@ -200,6 +204,72 @@ function executionTimeMs(plan: unknown): number {
 }
 
 describe("migration 0356 set-based Insights session visibility", () => {
+  test("initializes application roles when upgrading a database recorded through 0355", async () => {
+    const blank = await acquireBlankTestDatabase("migration-0356-upgrade-roles");
+    if (!blank) return;
+    const admin = postgres(blank.databaseUrl, {
+      max: 1,
+      prepare: false,
+      onnotice: () => undefined,
+    });
+    try {
+      await admin.unsafe(`create table schema_migrations (
+        name text primary key,
+        applied_at timestamptz not null default now()
+      )`);
+      const heldMigrations = (await readdir(migrationsDirectoryUrl))
+        .filter((file) => file.endsWith(".sql") && file >= migrationName)
+        .sort();
+      expect(heldMigrations[0]).toBe(migrationName);
+      for (const file of heldMigrations) {
+        await admin`insert into schema_migrations (name) values (${file})`;
+      }
+
+      await migrate(blank.databaseUrl);
+      await admin`delete from schema_migrations where name >= ${migrationName}`;
+
+      const [before] = await admin<
+        Array<{ latest: string | null; visibilityFunction: string | null }>
+      >`
+        select
+          (select max(name) from schema_migrations) as latest,
+          to_regprocedure(
+            'opengeni_private.visible_workspace_insights_model_call_facts(uuid,timestamptz,timestamptz)'
+          )::text as "visibilityFunction"
+      `;
+      expect(before).toEqual({
+        latest: "0355_automatic_session_title_quarantine.sql",
+        visibilityFunction: null,
+      });
+
+      await migrate(blank.databaseUrl);
+
+      const [after] = await admin<
+        Array<{ recorded: boolean; visibilityFunction: string | null; appCanExecute: boolean }>
+      >`
+        select
+          exists(select 1 from schema_migrations where name = ${migrationName}) as recorded,
+          to_regprocedure(
+            'opengeni_private.visible_workspace_insights_model_call_facts(uuid,timestamptz,timestamptz)'
+          )::text as "visibilityFunction",
+          has_function_privilege(
+            'opengeni_app',
+            'opengeni_private.visible_workspace_insights_model_call_facts(uuid,timestamptz,timestamptz)',
+            'EXECUTE'
+          ) as "appCanExecute"
+      `;
+      expect(after).toEqual({
+        recorded: true,
+        visibilityFunction:
+          "opengeni_private.visible_workspace_insights_model_call_facts(uuid,timestamp with time zone,timestamp with time zone)",
+        appCanExecute: true,
+      });
+    } finally {
+      await admin.end({ timeout: 5 });
+      await blank.release();
+    }
+  }, 180_000);
+
   test("installs bounded read-only functions without weakening ordinary fact-table RLS", async () => {
     const source = await readFile(migrationUrl, "utf8");
     expect(source.startsWith("-- deployment-mode: rolling\n")).toBe(true);


### PR DESCRIPTION
## Summary

- initialize the bounded application-role setting whenever a pending migration consumes it
- remove the stale filename checklist that stopped at migration 0353
- add a real PostgreSQL regression that physically migrates through 0355 and then applies 0356

## Why

The released 0356 Insights migration failed on normal existing installations with SQLSTATE 42704 because its application-role setting was absent. Fresh databases did not expose the problem because earlier pending migrations initialized the same setting.

## Safety

Released SQL migrations are unchanged. The repair preserves explicit application-role validation for dedicated-schema and custom-role deployments and does not broaden any database grant.

## Verification

- migration 0356 suite: 6 passed, 67 assertions
- migration 0338 migrator contract: passed
- migration 0257 explicit-role behavior: passed
- database package typecheck: passed
- focused lint and formatting: passed

Linear: OPE-370