### PR TITLE
test(react): await timeline jump control exit

### DIFF
--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -543,6 +543,11 @@ describe("timeline scroll ownership browser regression", () => {
 
     expect(immediate.maxScroll - immediate.scrollTop).toBeLessThan(2);
     expect(immediate.liveTailGap).toBeLessThan(48);
+    expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("true");
+    // Pin intent changes synchronously, while AnimatePresence retains the
+    // exiting control for its 150 ms fade. Wait for that visual lifecycle
+    // instead of treating the retained exit node as stale scroll state.
+    await page.getByRole("button", { name: "Jump to latest" }).waitFor({ state: "detached" });
     expect(await page.getByRole("button", { name: "Jump to latest" }).count()).toBe(0);
     expect(await page.evaluate(() => window.timelineCollapsedHistoryHarness!.loadCalls())).toBe(1);
   }, 30_000);


### PR DESCRIPTION
## Summary

- assert the timeline has synchronously returned to semantic bottom-follow state
- wait for the animated Jump to latest exit node to detach before checking its final absence

## Why

The browser regression observed the button during its intentional 150 ms AnimatePresence exit even though scroll geometry and bottom-follow state were already correct. The same test-only race failed an unrelated database PR twice on an identical head.

## Safety

No product code, timeout, or fixed sleep changes. The wait is state-based and bounded by the existing test deadline.

## Verification

- independent AI review approved exact head `830cdf429`
- focused case passed 6/6 reviewer runs and 10/10 implementation stress runs
- React typecheck, targeted lint, format, and diff checks clean