### PR TITLE
fix(react): keep composer projection on latest draft

### DIFF
--- a/.changeset/calm-composer-projection.md
+++ b/.changeset/calm-composer-projection.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep controlled composer inputs on the latest local draft while older autosave settlements render.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -2529,9 +2529,17 @@ export function useComposer(
     setError(null);
     setDraftConflict(null);
   }, [targetKey]);
+  // `valueRef` is the synchronous composer authority. React state exists to
+  // schedule renders, but a concurrent autosave settlement can render the
+  // previous state lane after a newer input event has already updated the ref.
+  // Projecting that stale state into a controlled textarea rewrites the old
+  // draft for one commit, which moves the caret and can briefly resurrect a
+  // submitted message. Never let an incidental render outrank the latest
+  // local lifecycle decision.
+  const visibleValue = identityMatches ? valueRef.current : "";
 
   return {
-    value: identityMatches ? value : "",
+    value: visibleValue,
     setValue: updateValue,
     annotations: identityMatches ? annotations : [],
     addAnnotation,
@@ -2561,7 +2569,7 @@ export function useComposer(
       sendBlockedRef.current?.() !== true &&
       annotationsComplete &&
       (hasPendingOperation ||
-        value.trim().length > 0 ||
+        visibleValue.trim().length > 0 ||
         hasReadyResources ||
         annotations.length > 0),
     pause,

--- a/packages/react/test/use-composer-embedding.test.tsx
+++ b/packages/react/test/use-composer-embedding.test.tsx
@@ -1,13 +1,50 @@
 import { describe, expect, test } from "bun:test";
 import type { SendMessageInput, SessionEvent } from "@opengeni/sdk";
+import { startTransition, useState } from "react";
+import { flushSync } from "react-dom";
 
 import { useComposer } from "../src/hooks/use-composer";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
-import { actRun, flush, registerDom, renderHook } from "./render-hook";
+import { actRun, flush, registerDom, renderComponent, renderHook } from "./render-hook";
 
 registerDom();
 
 describe("useComposer embedding policy", () => {
+  test("a synchronous host render cannot project an older composer state lane", async () => {
+    const projectedValues: string[] = [];
+    let setComposerValue!: (value: string) => void;
+    let forceHostRender!: () => void;
+
+    function Harness() {
+      const [, setHostRevision] = useState(0);
+      const composer = useComposer(SESSION_ID, {
+        client: fakeClient({}),
+        workspaceId: WORKSPACE_ID,
+        draftPersistence: "disabled",
+        initialPolicy: {
+          model: "scripted-model",
+          reasoningEffort: "medium",
+          latencyMode: "standard",
+        },
+      });
+      projectedValues.push(composer.value);
+      setComposerValue = composer.setValue;
+      forceHostRender = () => setHostRevision((revision) => revision + 1);
+      return null;
+    }
+
+    const rendered = await renderComponent(<Harness />);
+    projectedValues.length = 0;
+    await actRun(() => {
+      startTransition(() => setComposerValue("alpha Xbeta gamma"));
+      flushSync(forceHostRender);
+    });
+
+    expect(projectedValues).not.toContain("");
+    expect(projectedValues.at(-1)).toBe("alpha Xbeta gamma");
+    await rendered.unmount();
+  });
+
   test("ordinary Send clears the draft immediately and preserves rapid messages through handoff", async () => {
     const sessionId = crypto.randomUUID();
     const attempts: SendMessageInput[] = [];


### PR DESCRIPTION
## Summary
- project controlled composer text from the synchronous local authority instead of a lagging React state lane
- keep send eligibility aligned with that same visible value
- add a render-level regression for a transition edit interrupted by a synchronous host render

## Why
An autosave settlement or host update can synchronously render while a newer composer state update is still in a lower-priority lane. Rendering the older state briefly rewrites a controlled textarea, moving its caret to the end and allowing stale draft text to flash back.

## Verification
- `bun test packages/react/test/use-composer-embedding.test.tsx --test-name-pattern "synchronous host render"`
- mutation check: the regression fails against the previous state projection
- `bun run --cwd packages/react typecheck`