### PR TITLE
fix(react): preserve controller draft handoff

### DIFF
--- a/.changeset/tidy-composer-controller-value.md
+++ b/.changeset/tidy-composer-controller-value.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve the latest controlled composer edit across synchronous child-controller renders.

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -367,6 +367,20 @@ export function useChatComposerController({
   const submittingRef = useRef(false);
   const controlOperationRef = useRef(false);
   const mountedRef = useRef(true);
+  const deliveredValueRef = useRef(delivery.value);
+  const liveValueRef = useRef(delivery.value);
+  if (delivery.value !== deliveredValueRef.current) {
+    deliveredValueRef.current = delivery.value;
+    liveValueRef.current = delivery.value;
+  }
+  const setComposerValue = useCallback(
+    (next: string) => {
+      liveValueRef.current = next;
+      delivery.setValue(next);
+    },
+    [delivery.setValue],
+  );
+  const visibleValue = liveValueRef.current;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -468,7 +482,7 @@ export function useChatComposerController({
       applyComposerTextareaHeight(textarea, 220);
     });
   }, []);
-  useEffect(() => resizeInput(), [delivery.value, resizeInput]);
+  useEffect(() => resizeInput(), [resizeInput, visibleValue]);
   useEffect(
     () => () => {
       if (resizeInputRafRef.current !== null) {
@@ -505,8 +519,8 @@ export function useChatComposerController({
     commands,
     context: commandContext,
     handlers,
-    value: delivery.value,
-    setValue: delivery.setValue,
+    value: visibleValue,
+    setValue: setComposerValue,
   });
   const paletteEnabled = commandContext !== undefined;
   const commandDraftBlocked = paletteEnabled && palette.isCommandDraft;
@@ -696,8 +710,8 @@ export function useChatComposerController({
     handlePaste,
     handleFileChange,
     focusInput: () => textareaRef.current?.focus(),
-    setValue: delivery.setValue,
-    value: delivery.value,
+    setValue: setComposerValue,
+    value: visibleValue,
   };
 }
 

--- a/packages/react/test/composer-framework.test.tsx
+++ b/packages/react/test/composer-framework.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useRef, useState } from "react";
+import { act, startTransition, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import * as Composer from "../src/composer";
@@ -153,6 +154,34 @@ function ContainerDeliveryOnlyComposer() {
 }
 
 describe("compound composer framework", () => {
+  test("local controller renders retain a newer parent-delivery edit", async () => {
+    const projectedValues: string[] = [];
+    let controller!: Composer.ChatComposerController;
+
+    function Child({ value, setValue }: { value: string; setValue: (next: string) => void }) {
+      controller = Composer.useChatComposerController({
+        delivery: delivery(value, setValue),
+      });
+      projectedValues.push(controller.value);
+      return null;
+    }
+
+    function Parent() {
+      const [value, setValue] = useState("");
+      return <Child value={value} setValue={setValue} />;
+    }
+
+    mounted = await renderComponent(<Parent />);
+    projectedValues.length = 0;
+    await act(async () => {
+      startTransition(() => controller.setValue("alpha Xbeta gamma"));
+      flushSync(() => controller.setHelpOpen(true));
+    });
+
+    expect(projectedValues).not.toContain("");
+    expect(projectedValues.at(-1)).toBe("alpha Xbeta gamma");
+  });
+
   test("compound Root exposes the additive container basis", async () => {
     mounted = await renderComponent(<ContainerDeliveryOnlyComposer />);
     const root = mounted.container.querySelector(".og-composer");


### PR DESCRIPTION
## Summary
- keep the compound composer controller on its latest synchronous edit while a parent delivery update is pending
- reconcile the local value only when the parent actually delivers a new value
- use the same live value for slash commands, autosize, and the public controller projection

## Why
A child controller can synchronously rerender from palette/help/submit state before a parent commits its controlled composer update. Re-projecting the previous parent prop rewrites the textarea, moves the caret to the end, and can resurrect submitted text.

## Verification
- `bun test packages/react/test/composer-framework.test.tsx --test-name-pattern "local controller renders"`
- mutation check: the regression fails against the previous delivery-value projection
- `bun run --cwd packages/react typecheck`