### PR TITLE
fix(react): render composer edits synchronously

### DIFF
--- a/.changeset/fresh-composer-input-render.md
+++ b/.changeset/fresh-composer-input-render.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Render controlled composer edits synchronously before deferred host delivery settles.

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -20,6 +20,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -369,18 +370,27 @@ export function useChatComposerController({
   const mountedRef = useRef(true);
   const deliveredValueRef = useRef(delivery.value);
   const liveValueRef = useRef(delivery.value);
-  if (delivery.value !== deliveredValueRef.current) {
+  const [renderedValue, setRenderedValue] = useState(delivery.value);
+  const deliveryChanged = delivery.value !== deliveredValueRef.current;
+  if (deliveryChanged) {
     deliveredValueRef.current = delivery.value;
     liveValueRef.current = delivery.value;
   }
   const setComposerValue = useCallback(
     (next: string) => {
       liveValueRef.current = next;
+      setRenderedValue(next);
       delivery.setValue(next);
     },
     [delivery.setValue],
   );
-  const visibleValue = liveValueRef.current;
+  const visibleValue = deliveryChanged ? delivery.value : renderedValue;
+
+  useLayoutEffect(() => {
+    if (renderedValue !== liveValueRef.current) {
+      setRenderedValue(liveValueRef.current);
+    }
+  }, [delivery.value, renderedValue]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/packages/react/test/composer-framework.test.tsx
+++ b/packages/react/test/composer-framework.test.tsx
@@ -168,13 +168,18 @@ describe("compound composer framework", () => {
 
     function Parent() {
       const [value, setValue] = useState("");
-      return <Child value={value} setValue={setValue} />;
+      return (
+        <Child
+          value={value}
+          setValue={(next) => startTransition(() => setValue(next))}
+        />
+      );
     }
 
     mounted = await renderComponent(<Parent />);
     projectedValues.length = 0;
     await act(async () => {
-      startTransition(() => controller.setValue("alpha Xbeta gamma"));
+      controller.setValue("alpha Xbeta gamma");
       flushSync(() => controller.setHelpOpen(true));
     });
 


### PR DESCRIPTION
## Summary
- schedule a controller-local value render in the same input event as the host delivery update
- reconcile genuine parent value changes without allowing deferred host state to overwrite newer local input
- strengthen the parent/child transition regression to model controlled-input restoration

## Why
React restores a controlled textarea from its last rendered prop at the end of an input event. Updating only refs and deferred parent state leaves a window where the old prop is restored, moving the caret and flashing stale draft text.

## Verification
- `bun test packages/react/test/composer-framework.test.tsx --test-name-pattern "local controller renders"`
- mutation check: removing the synchronous local state update makes the regression fail
- `bun run --cwd packages/react typecheck`