### PR TITLE
fix(runtime): preserve native tool-search identity

### DIFF
--- a/.changeset/steady-tool-search-identities.md
+++ b/.changeset/steady-tool-search-identities.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Preserve provider-reported tool-search call identities across durable receipts, runtime events, and replay sanitization.

--- a/apps/worker/src/activities/agent-turn/history.ts
+++ b/apps/worker/src/activities/agent-turn/history.ts
@@ -1,4 +1,8 @@
-import { normalizeProtocolJsonValue, sanitizeHistoryItemsForModel } from "@opengeni/runtime";
+import {
+  normalizeProtocolJsonValue,
+  sanitizeHistoryItemsForModel,
+  toolCallIdFromSdkItem,
+} from "@opengeni/runtime";
 import { opaqueProviderArtifactFingerprint } from "@opengeni/codex";
 
 export function historyRowsToAppend(
@@ -149,7 +153,7 @@ export function pendingToolCallFromSdkEvent(event: unknown): {
   // never receives a separate function result and therefore must not enter the
   // pending function-call ledger.
   if (raw.type === "hosted_tool_call" && raw.name === "image_generation_call") return null;
-  const callId = raw.callId ?? raw.call_id ?? raw.id;
+  const callId = toolCallIdFromSdkItem(raw) ?? raw.id;
   const callType = raw.type;
   if (typeof callId !== "string" || callId.length === 0 || typeof callType !== "string") {
     return null;
@@ -182,7 +186,7 @@ export function completedToolCallFromSdkEvent(event: unknown): {
     item.rawItem && typeof item.rawItem === "object" && !Array.isArray(item.rawItem)
       ? (item.rawItem as Record<string, unknown>)
       : {};
-  const callId = raw.callId ?? raw.call_id ?? item.id;
+  const callId = toolCallIdFromSdkItem(raw) ?? item.id;
   if (typeof callId !== "string" || callId.length === 0) return null;
   return {
     callId,

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -626,6 +626,24 @@ describe("turn exact-content boundaries", () => {
     expect(Object.hasOwn(rawItem.output, "optional")).toBe(true);
   });
 
+  test("correlates native tool-search results whose id only survives in provider data", () => {
+    const rawItem = {
+      type: "tool_search_output",
+      tools: [{ name: "matching_tool" }],
+      providerData: { call_id: "tool-search-provider-id" },
+    };
+
+    expect(
+      completedToolCallFromSdkEvent({
+        type: "run_item_stream_event",
+        item: { type: "tool_search_output_item", rawItem },
+      }),
+    ).toEqual({
+      callId: "tool-search-provider-id",
+      resultItem: rawItem,
+    });
+  });
+
   test("keeps non-object undefined values fail-closed at the pending receipt boundary", () => {
     expect(() =>
       pendingToolCallFromSdkEvent({

--- a/packages/runtime/src/history-sanitizer.ts
+++ b/packages/runtime/src/history-sanitizer.ts
@@ -37,6 +37,7 @@ import {
   MODEL_ATTACHMENT_REFS_FIELD,
   MODEL_TIMELINE_ANNOTATIONS_FIELD,
 } from "@opengeni/contracts";
+import { toolCallIdFromSdkItem } from "./tool-call-identity";
 
 /** A history item is any JSON object; we only inspect a few discriminator fields. */
 export type HistoryItem = Record<string, unknown>;
@@ -88,35 +89,7 @@ function itemType(item: unknown): string | undefined {
  * `call_id`. Persisted rows are the SDK shape, but we accept either so a row
  * written by any code path (or hand-repaired) still correlates.
  */
-function callIdOf(item: unknown): string | undefined {
-  if (!item || typeof item !== "object") {
-    return undefined;
-  }
-  const record = item as { callId?: unknown; call_id?: unknown; providerData?: unknown };
-  if (typeof record.callId === "string" && record.callId.length > 0) {
-    return record.callId;
-  }
-  if (typeof record.call_id === "string" && record.call_id.length > 0) {
-    return record.call_id;
-  }
-  // tool_search items may carry their correlation id ONLY in providerData
-  // (mirrors the SDK's getToolSearchProviderCallId: providerData.call_id ??
-  // providerData.callId ?? call_id ?? callId). Harmless for other item kinds —
-  // their ids never live there.
-  const provider = record.providerData as
-    | { call_id?: unknown; callId?: unknown }
-    | null
-    | undefined;
-  if (provider && typeof provider === "object") {
-    if (typeof provider.call_id === "string" && provider.call_id.length > 0) {
-      return provider.call_id;
-    }
-    if (typeof provider.callId === "string" && provider.callId.length > 0) {
-      return provider.callId;
-    }
-  }
-  return undefined;
-}
+const callIdOf = toolCallIdFromSdkItem;
 
 /**
  * Sanitize a replayed history item list into a sequence the Responses API

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -442,6 +442,7 @@ export {
   serializeHumanInputRequests,
   serializeInteractionInterventionRequests,
 } from "./run-events";
+export { toolCallIdFromSdkItem } from "./tool-call-identity";
 export {
   compactMcpResultCustomDataRunState,
   OPENGENI_INNER_MCP_CUSTOM_DATA_KEY,

--- a/packages/runtime/src/run-events.ts
+++ b/packages/runtime/src/run-events.ts
@@ -346,7 +346,9 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.created",
       payload: {
-        id: toolCallIdFromSdkItem(raw) ?? raw.id ?? item.id ?? null,
+        // Preserve the native tool-search wire identity when both SDK aliases
+        // are present; provider metadata remains the additive fallback.
+        id: raw.call_id ?? toolCallIdFromSdkItem(raw) ?? raw.id ?? item.id ?? null,
         name: "tool_search",
         arguments: raw.arguments ?? null,
         raw,
@@ -362,7 +364,7 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.output",
       payload: {
-        id: toolCallIdFromSdkItem(raw) ?? item.id ?? null,
+        id: raw.call_id ?? toolCallIdFromSdkItem(raw) ?? item.id ?? null,
         output: {
           type: "text",
           text:

--- a/packages/runtime/src/run-events.ts
+++ b/packages/runtime/src/run-events.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeProtocolJsonValue } from "./protocol-json";
 import { mcpResultFromCustomData } from "./mcp-result-custom-data";
 import { isInternalGenericDispatchRegistrationItem } from "./lazy-tool-transport";
+import { toolCallIdFromSdkItem } from "./tool-call-identity";
 
 export type NormalizedRuntimeEvent = {
   type: SessionEventType;
@@ -313,7 +314,7 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.created",
       payload: {
-        id: raw.callId ?? raw.id ?? item.id ?? null,
+        id: toolCallIdFromSdkItem(raw) ?? raw.id ?? item.id ?? null,
         name: raw.name ?? raw.type ?? "tool",
         arguments: raw.arguments ?? raw.input ?? null,
         raw,
@@ -324,7 +325,7 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.output",
       payload: {
-        id: item.rawItem?.callId ?? item.id ?? null,
+        id: toolCallIdFromSdkItem(item.rawItem) ?? item.id ?? null,
         // Inline media becomes a content-free audit fact. Model history keeps
         // the provider's real structured image output on its separate path.
         output:
@@ -345,7 +346,7 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.created",
       payload: {
-        id: raw.call_id ?? raw.callId ?? raw.id ?? item.id ?? null,
+        id: toolCallIdFromSdkItem(raw) ?? raw.id ?? item.id ?? null,
         name: "tool_search",
         arguments: raw.arguments ?? null,
         raw,
@@ -361,7 +362,7 @@ export function normalizeSdkEvent(
     pushProtocolEvent({
       type: "agent.toolCall.output",
       payload: {
-        id: raw.call_id ?? raw.callId ?? item.id ?? null,
+        id: toolCallIdFromSdkItem(raw) ?? item.id ?? null,
         output: {
           type: "text",
           text:

--- a/packages/runtime/src/tool-call-identity.ts
+++ b/packages/runtime/src/tool-call-identity.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve the stable correlation id carried by an SDK tool call or result.
+ *
+ * Most SDK items expose the id directly as `callId` (or the wire-format
+ * `call_id`). Native tool-search items can instead keep their only stable id
+ * inside `providerData`, so every persistence and replay boundary must inspect
+ * both shapes before falling back to a stream-item id.
+ */
+export function toolCallIdFromSdkItem(item: unknown): string | undefined {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+  const record = item as { callId?: unknown; call_id?: unknown; providerData?: unknown };
+  if (typeof record.callId === "string" && record.callId.length > 0) {
+    return record.callId;
+  }
+  if (typeof record.call_id === "string" && record.call_id.length > 0) {
+    return record.call_id;
+  }
+  const provider = record.providerData as
+    | { call_id?: unknown; callId?: unknown }
+    | null
+    | undefined;
+  if (provider && typeof provider === "object") {
+    if (typeof provider.call_id === "string" && provider.call_id.length > 0) {
+      return provider.call_id;
+    }
+    if (typeof provider.callId === "string" && provider.callId.length > 0) {
+      return provider.callId;
+    }
+  }
+  return undefined;
+}

--- a/packages/runtime/test/runtime-module-boundaries.test.ts
+++ b/packages/runtime/test/runtime-module-boundaries.test.ts
@@ -18,6 +18,7 @@ const implementationModules = [
   "model-provider-routing",
   "model-provider-transport",
   "run-events",
+  "tool-call-identity",
 ] as const;
 
 type ImplementationModule = (typeof implementationModules)[number];
@@ -93,11 +94,12 @@ describe("runtime implementation module boundaries", () => {
   });
 
   test("the public facade re-exports each domain without wrappers", async () => {
-    const [barrel, modelInput, modelProvider, runEvents] = await Promise.all([
+    const [barrel, modelInput, modelProvider, runEvents, toolCallIdentity] = await Promise.all([
       import("../src/index"),
       import("../src/model-input"),
       import("../src/model-provider"),
       import("../src/run-events"),
+      import("../src/tool-call-identity"),
     ]);
 
     for (const name of [
@@ -121,5 +123,6 @@ describe("runtime implementation module boundaries", () => {
     ] as const) {
       expect(barrel[name]).toBe(runEvents[name]);
     }
+    expect(barrel.toolCallIdFromSdkItem).toBe(toolCallIdentity.toolCallIdFromSdkItem);
   });
 });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1328,6 +1328,44 @@ describe("runtime event normalization", () => {
     expect(Object.hasOwn(rawItem.action, "optional")).toBe(true);
   });
 
+  test("keeps native tool-search call and output events on one provider identity", () => {
+    const callId = "tool-search-provider-id";
+    const [created] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: {
+        type: "tool_search_call_item",
+        rawItem: {
+          type: "tool_search_call",
+          callId,
+          arguments: { query: "matching tools" },
+        },
+      },
+    } as any);
+    const [completed] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: {
+        type: "tool_search_output_item",
+        rawItem: {
+          type: "tool_search_output",
+          tools: [{ name: "matching_tool" }],
+          providerData: { call_id: callId },
+        },
+      },
+    } as any);
+
+    expect(created).toMatchObject({
+      type: "agent.toolCall.created",
+      payload: { id: callId, name: "tool_search" },
+    });
+    expect(completed).toEqual({
+      type: "agent.toolCall.output",
+      payload: {
+        id: callId,
+        output: { type: "text", text: "Disclosed tools: matching_tool" },
+      },
+    });
+  });
+
   test("normalizes tool outputs before durable event persistence", () => {
     const output = {
       type: "text",

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1336,7 +1336,8 @@ describe("runtime event normalization", () => {
         type: "tool_search_call_item",
         rawItem: {
           type: "tool_search_call",
-          callId,
+          call_id: callId,
+          callId: "conflicting-sdk-alias",
           arguments: { query: "matching tools" },
         },
       },


### PR DESCRIPTION
## Summary

- centralize SDK tool-call identity extraction across runtime events, durable receipts, and replay sanitization
- preserve native tool-search result identities when the provider reports the stable call id only in `providerData`
- add lifecycle regressions proving the created call and completed result retain one correlation key

## Testing

- [x] `bun test packages/runtime/test/runtime-module-boundaries.test.ts packages/runtime/test/history-sanitizer.test.ts packages/runtime/test/runtime.test.ts`
- [x] `bun test apps/worker/test/agent-turn.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [ ] full repository gates delegated to public PR CI

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advances, keep this candidate head frozen unless a real conflict or material incompatibility requires a source change.

## Notes

- The fallback is additive: existing top-level call-id precedence remains unchanged.

## Summary by Sourcery

Preserve native tool-search identities consistently across runtime event normalization, durable history, and replay handling.

Bug Fixes:
- Preserve native tool-search call identities when the stable correlation ID is available only in provider metadata.
- Ensure tool-search creation and completion events, durable receipts, and replay sanitization use a consistent correlation identity.

Enhancements:
- Centralize SDK tool-call identity extraction and expose it through the runtime public API.

Tests:
- Add regressions covering provider-metadata-only tool-search identities and matching creation/completion event IDs.
- Add runtime module-boundary coverage for the shared identity helper.