### PR TITLE
fix(worker): checkpoint tool results before provider dispatch

### DIFF
--- a/.changeset/calm-provider-dispatch-history.md
+++ b/.changeset/calm-provider-dispatch-history.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Checkpoint complete tool-call history before any follow-up model request reaches its provider dispatch boundary.

--- a/apps/worker/src/activities/agent-turn/provider-dispatch-barrier.ts
+++ b/apps/worker/src/activities/agent-turn/provider-dispatch-barrier.ts
@@ -2,9 +2,9 @@ import type { TurnHistorySink } from "./history-sink";
 
 /**
  * Persist the SDK's complete prior model/tool history before another provider
- * request can start. The first request is naturally a no-op because the stream
- * has not been installed on the history sink yet. Follow-up requests run only
- * after the preceding complete call/result batch is replay-safe.
+ * request can start. The first request has no prior model/tool rows to append.
+ * Follow-up requests run only after the preceding complete call/result batch is
+ * replay-safe.
  */
 export async function checkpointHistoryBeforeProviderDispatch(
   historySink: Pick<TurnHistorySink, "reconcileConversationTruth">,

--- a/apps/worker/src/activities/agent-turn/provider-dispatch-barrier.ts
+++ b/apps/worker/src/activities/agent-turn/provider-dispatch-barrier.ts
@@ -1,0 +1,13 @@
+import type { TurnHistorySink } from "./history-sink";
+
+/**
+ * Persist the SDK's complete prior model/tool history before another provider
+ * request can start. The first request is naturally a no-op because the stream
+ * has not been installed on the history sink yet. Follow-up requests run only
+ * after the preceding complete call/result batch is replay-safe.
+ */
+export async function checkpointHistoryBeforeProviderDispatch(
+  historySink: Pick<TurnHistorySink, "reconcileConversationTruth">,
+): Promise<void> {
+  await historySink.reconcileConversationTruth({ requireDurable: true });
+}

--- a/apps/worker/src/activities/agent-turn/run.ts
+++ b/apps/worker/src/activities/agent-turn/run.ts
@@ -44,6 +44,7 @@ import { ToolResultSpill } from "./tool-result-spill";
 import { createTurnCredentialLeases } from "./credential-leases";
 import { createTurnMediaArtifacts } from "./media-artifacts";
 import { createTurnHistorySink } from "./history-sink";
+import { checkpointHistoryBeforeProviderDispatch } from "./provider-dispatch-barrier";
 import { sandboxRunAs } from "@opengeni/runtime";
 import { randomUUID } from "node:crypto";
 import { createModelCheckpointMemoryCollector } from "../../model-checkpoint-memory-collector";
@@ -562,6 +563,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   if (!eventing.publish || !attempt.turnId) {
                     throw new Error("Codex model request started before the turn event producer");
                   }
+                  if (event.phase === "started") {
+                    await checkpointHistoryBeforeProviderDispatch(historySink);
+                  }
                   const shouldRecordStartedAudit =
                     event.phase === "started" && !firstModelRequestAuditRecorded;
                   if (shouldRecordStartedAudit) {
@@ -706,6 +710,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           onModelRequestEvent: async (event) => {
             if (!eventing.publish || !attempt.turnId) {
               throw new Error("SuperGrok model request started before the turn event producer");
+            }
+            if (event.phase === "started") {
+              await checkpointHistoryBeforeProviderDispatch(historySink);
             }
             const shouldRecordStartedAudit =
               event.phase === "started" && !firstModelRequestAuditRecorded;

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -101,6 +101,7 @@ import {
   toolCallProducesRetainableSessionImage,
   completedToolCallFromSdkEvent,
 } from "./history";
+import { checkpointHistoryBeforeProviderDispatch } from "./provider-dispatch-barrier";
 import {
   modelUsageSourceKey,
   recordCompletedModelCallBeforeOwnershipFences,
@@ -481,6 +482,7 @@ export async function runTurnStreamAttempt(
       resolvedModel?.provider.kind === "xai-subscription";
     let fallbackProviderRequestStartedAt: number | null = null;
     const recordFallbackProviderDispatchAtWire = async (): Promise<void> => {
+      await checkpointHistoryBeforeProviderDispatch(historySink);
       if (
         providerPublishesNativeRequestEvents ||
         eventing.firstModelRequestPreparationRecorded ||

--- a/apps/worker/test/provider-dispatch-barrier.test.ts
+++ b/apps/worker/test/provider-dispatch-barrier.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { checkpointHistoryBeforeProviderDispatch } from "../src/activities/agent-turn/provider-dispatch-barrier";
+
+describe("provider dispatch history barrier", () => {
+  test("awaits durable prior history before allowing provider work to continue", async () => {
+    const order: string[] = [];
+    let releaseCheckpoint!: () => void;
+    const checkpointReleased = new Promise<void>((resolve) => {
+      releaseCheckpoint = resolve;
+    });
+    const historySink = {
+      reconcileConversationTruth: mock(async () => {
+        order.push("checkpoint-started");
+        await checkpointReleased;
+        order.push("checkpoint-completed");
+      }),
+    };
+
+    const dispatch = checkpointHistoryBeforeProviderDispatch(historySink).then(() => {
+      order.push("provider-dispatch");
+    });
+    await Promise.resolve();
+
+    expect(order).toEqual(["checkpoint-started"]);
+    expect(historySink.reconcileConversationTruth).toHaveBeenCalledWith({
+      requireDurable: true,
+    });
+
+    releaseCheckpoint();
+    await dispatch;
+    expect(order).toEqual(["checkpoint-started", "checkpoint-completed", "provider-dispatch"]);
+  });
+
+  test("wires the barrier before generic and native provider started audits", async () => {
+    const runSource = await Bun.file(
+      new URL("../src/activities/agent-turn/run.ts", import.meta.url),
+    ).text();
+    const streamSource = await Bun.file(
+      new URL("../src/activities/agent-turn/stream-attempt.ts", import.meta.url),
+    ).text();
+
+    const genericCallback = streamSource.indexOf(
+      "const recordFallbackProviderDispatchAtWire = async",
+    );
+    const genericBarrier = streamSource.indexOf(
+      "await checkpointHistoryBeforeProviderDispatch(historySink);",
+      genericCallback,
+    );
+    const genericAudit = streamSource.indexOf('type: "agent.model.request"', genericBarrier);
+    expect(genericCallback).toBeGreaterThan(-1);
+    expect(genericBarrier).toBeGreaterThan(genericCallback);
+    expect(genericAudit).toBeGreaterThan(genericBarrier);
+
+    const nativeCallbacks = [...runSource.matchAll(/onModelRequestEvent: async \(event\) => \{/gu)];
+    expect(nativeCallbacks).toHaveLength(2);
+    for (const callback of nativeCallbacks) {
+      const callbackAt = callback.index!;
+      const nextCallbackAt = runSource.indexOf("onModelRequestEvent: async", callbackAt + 1);
+      const callbackEnd = nextCallbackAt === -1 ? runSource.length : nextCallbackAt;
+      const barrierAt = runSource.indexOf(
+        "await checkpointHistoryBeforeProviderDispatch(historySink);",
+        callbackAt,
+      );
+      const auditAt = runSource.indexOf("await eventing.publish([", callbackAt);
+      expect(barrierAt).toBeGreaterThan(callbackAt);
+      expect(barrierAt).toBeLessThan(callbackEnd);
+      expect(auditAt).toBeGreaterThan(barrierAt);
+    }
+  });
+});

--- a/apps/worker/test/provider-dispatch-barrier.test.ts
+++ b/apps/worker/test/provider-dispatch-barrier.test.ts
@@ -1,8 +1,64 @@
 import { describe, expect, mock, test } from "bun:test";
+import { Agent, Runner, tool, type ModelRequest, type StreamEvent } from "@openai/agents";
+import {
+  ScriptedModel,
+  assistantMessage,
+  functionCall,
+} from "../../../packages/testing/src/scripted-model";
 
 import { checkpointHistoryBeforeProviderDispatch } from "../src/activities/agent-turn/provider-dispatch-barrier";
 
 describe("provider dispatch history barrier", () => {
+  test("the SDK exposes complete tool history before its follow-up model call", async () => {
+    let activeStream: { state: { history?: unknown[] } } | null = null;
+    const dispatchSnapshots: Array<{ installed: boolean; history: unknown[] }> = [];
+    class DispatchObservedModel extends ScriptedModel {
+      override async *getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent> {
+        const history = activeStream?.state.history;
+        dispatchSnapshots.push({
+          installed: activeStream !== null,
+          history: Array.isArray(history) ? [...history] : [],
+        });
+        yield* super.getStreamedResponse(request);
+      }
+    }
+    const model = new DispatchObservedModel([
+      { output: [functionCall("echo", {}, "dispatch-call-1")] },
+      { output: [assistantMessage("done")] },
+    ]);
+    const echo = tool({
+      name: "echo",
+      description: "Return a fixed value.",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      strict: false,
+      execute: async () => "ok",
+    });
+    const agent = new Agent({
+      name: "dispatch-history-test",
+      instructions: "Use echo once.",
+      model,
+      tools: [echo],
+    });
+
+    const result = await new Runner().run(agent, "start", {
+      stream: true,
+      historyOwnership: "external",
+    });
+    activeStream = result as unknown as { state: { history?: unknown[] } };
+    for await (const _event of result.toStream()) {
+      // Drain the public stream while the SDK owns its background model/tool loop.
+    }
+    await result.completed;
+
+    expect(dispatchSnapshots.map((snapshot) => snapshot.installed)).toEqual([true, true]);
+    expect(dispatchSnapshots[1]?.history).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "function_call", callId: "dispatch-call-1" }),
+        expect.objectContaining({ type: "function_call_result", callId: "dispatch-call-1" }),
+      ]),
+    );
+  });
+
   test("awaits durable prior history before allowing provider work to continue", async () => {
     const order: string[] = [];
     let releaseCheckpoint!: () => void;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,7 +186,11 @@ and never silently repairs arbitrary callers. Completed pending tool receipts
 retain the model-facing SDK result item separately from the exact
 `agent.toolCall.output` audit value, allowing worker-death recovery to publish
 the same complete event projection as the live path without exposing its extra
-MCP fields to later model requests. A `requires_action` pause additionally
+MCP fields to later model requests. Before every follow-up provider request,
+the worker awaits a mandatory reconciliation of the SDK's complete prior
+history; native and generic provider dispatch therefore cannot overtake durable
+call/result truth. The first request naturally has no stream history to flush.
+A `requires_action` pause additionally
 stamps `interruption_kind` and `tied_reasoning_items` on those receipts so
 unpaired calls never enter model-facing history; resume promotes reasoning +
 call + bounded result as one pair. Side-effecting approvals invoke through the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,7 +189,8 @@ the same complete event projection as the live path without exposing its extra
 MCP fields to later model requests. Before every follow-up provider request,
 the worker awaits a mandatory reconciliation of the SDK's complete prior
 history; native and generic provider dispatch therefore cannot overtake durable
-call/result truth. The first request naturally has no stream history to flush.
+call/result truth. The first request naturally has no prior model/tool history
+to flush.
 A `requires_action` pause additionally
 stamps `interruption_kind` and `tied_reasoning_items` on those receipts so
 unpaired calls never enter model-facing history; resume promotes reasoning +

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1694,7 +1694,7 @@ Durable append/publish fencing and ordering therefore remain the source of audit
 truth. Every provider path first awaits a mandatory reconciliation of the SDK's
 complete prior history at the follow-up request boundary. A provider can
 therefore consume a completed tool batch only after its call/result pair is
-replay-safe; the first request is a no-op because no stream history exists yet.
+replay-safe; the first request has no prior model/tool history to append.
 For generic providers, an attempt-local async context then awaits the durable
 `started` checkpoint at the literal pre-fetch boundary; request bytes cannot
 reach the wire first. Model-preparation `started` is durable before

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1691,9 +1691,13 @@ Provider request lifecycle diagnostics are synchronous, bounded, and best-effort
 Native diagnostic observers run before the existing awaited
 `agent.model.request` durable audit callback and cannot block or change it.
 Durable append/publish fencing and ordering therefore remain the source of audit
-truth. For generic providers, an attempt-local async context instead awaits the
-durable `started` checkpoint at the literal pre-fetch boundary; request bytes
-cannot reach the wire first. Model-preparation `started` is durable before
+truth. Every provider path first awaits a mandatory reconciliation of the SDK's
+complete prior history at the follow-up request boundary. A provider can
+therefore consume a completed tool batch only after its call/result pair is
+replay-safe; the first request is a no-op because no stream history exists yet.
+For generic providers, an attempt-local async context then awaits the durable
+`started` checkpoint at the literal pre-fetch boundary; request bytes cannot
+reach the wire first. Model-preparation `started` is durable before
 `runStream` is invoked, including an immediately-calling native transport. A
 semantic terminal is latched before downstream stream cleanup; if the consumer
 cancels after parsing it, the audit remains `completed` rather than producing a


### PR DESCRIPTION
## Summary

- checkpoint complete SDK history before every follow-up provider request
- apply the awaited barrier to generic, Codex subscription, and xAI subscription dispatch paths
- document the provider-dispatch durability invariant and add a focused regression

## Why

The Agents SDK can prepare a follow-up model request as soon as a tool batch completes, before the worker's stream consumer has processed the corresponding result events. If the worker stops after that request reaches the provider but before history reconciliation, recovery can misclassify an already-consumed tool result as interrupted. The literal dispatch boundary now waits for the existing mandatory history reconciler, making the complete call/result pair replay-safe before request bytes can be sent.

## Validation

- `bun test apps/worker/test/provider-dispatch-barrier.test.ts`
- targeted `oxlint --deny-warnings` on changed TypeScript files
- targeted `oxfmt --check --threads=1` on changed files
- `git diff --check`

## Summary by Sourcery

Make follow-up provider dispatch wait for durable tool-call history reconciliation so completed call/result pairs are replay-safe before request bytes are sent.

Bug Fixes:
- Ensure completed tool-call history is durably reconciled before any follow-up provider request is dispatched, preventing recovery from misclassifying consumed tool results as interrupted.

Enhancements:
- Centralize the provider-dispatch history barrier across generic, Codex subscription, and xAI subscription request paths.
- Document the provider-dispatch durability invariant and add focused regression coverage.

Documentation:
- Document that follow-up provider requests must wait for durable reconciliation of the preceding model/tool history.

Tests:
- Add regression tests covering SDK history visibility, awaited durable reconciliation, and barrier placement across provider dispatch paths.