### PR TITLE
fix(runtime): accept sparse Responses output indices

### DIFF
--- a/.changeset/quiet-responses-indices.md
+++ b/.changeset/quiet-responses-indices.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Accept sparse Responses output indices while preserving numeric provider order and duplicate-index rejection.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,10 @@ projections use the same protocol-JSON boundary as canonical history before
 strict lossless storage. JavaScript-only `undefined` object properties are
 omitted without mutating the SDK item; undefined array entries and every other
 non-JSON graph still fail with an exact path. The database codec remains strict
-and never silently repairs arbitrary callers. Completed pending tool receipts
+and never silently repairs arbitrary callers. An empty Responses terminal is
+reconstructed from observed `output_item.done` events in numeric
+`output_index` order; provider index gaps do not create synthetic history items,
+while duplicate indices remain invalid. Completed pending tool receipts
 retain the model-facing SDK result item separately from the exact
 `agent.toolCall.output` audit value, allowing worker-death recovery to publish
 the same complete event projection as the live path without exposing its extra

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1695,6 +1695,10 @@ truth. Every provider path first awaits a mandatory reconciliation of the SDK's
 complete prior history at the follow-up request boundary. A provider can
 therefore consume a completed tool batch only after its call/result pair is
 replay-safe; the first request has no prior model/tool history to append.
+When a Responses terminal omits its output array, completed stream items are
+reassembled by numeric `output_index`; sparse provider positions are compacted
+to the observed items rather than treated as missing output, while duplicate
+indices still fail closed.
 For generic providers, an attempt-local async context then awaits the durable
 `started` checkpoint at the literal pre-fetch boundary; request bytes cannot
 reach the wire first. Model-preparation `started` is durable before

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -868,7 +868,13 @@ describe("pinned Responses protocol conformance", () => {
     const output = (terminalModel?.event as { response?: { output?: Array<{ id?: string }> } })
       ?.response?.output;
     expect(output?.map((item) => item.id)).toEqual(["message-two", "message-seven"]);
-    expect(result.events.filter((event) => event.type === "response_done")).toHaveLength(1);
+    const responseDone = result.events.find((event) => event.type === "response_done") as
+      | { response?: { output?: Array<{ id?: string }> } }
+      | undefined;
+    expect(responseDone?.response?.output?.map((item) => item.id)).toEqual([
+      "message-two",
+      "message-seven",
+    ]);
   });
 
   test("fails closed on duplicate output indices", async () => {
@@ -909,12 +915,12 @@ describe("pinned Responses protocol conformance", () => {
         response: {
           id: "completed",
           status: "completed",
-          output: [],
+          output: [responseMessage("terminal", "terminal")],
           usage: null,
         },
       },
     ]);
-    expect(String((result.error as Error).message)).toContain("invalid index");
+    expect(String((result.error as Error).message)).toContain("invalid index or missing item");
     expect(result.events.some((event) => event.type === "response_done")).toBe(false);
   });
 

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -837,6 +837,40 @@ describe("pinned Responses protocol conformance", () => {
     expect(result.events.filter((event) => event.type === "response_done")).toHaveLength(1);
   });
 
+  test("reconstructs sparse output indices without inventing missing items", async () => {
+    const result = await consumeDirectResponses([
+      {
+        type: "response.output_item.done",
+        output_index: 7,
+        item: responseMessage("message-seven", "seven"),
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 2,
+        item: responseMessage("message-two", "two"),
+      },
+      {
+        type: "response.completed",
+        response: {
+          id: "completed",
+          status: "completed",
+          output: [],
+          usage: null,
+        },
+      },
+    ]);
+    expect(result.error).toBeUndefined();
+    const terminalModel = result.events.find(
+      (event) =>
+        event.type === "model" &&
+        (event.event as { type?: unknown } | undefined)?.type === "response.completed",
+    );
+    const output = (terminalModel?.event as { response?: { output?: Array<{ id?: string }> } })
+      ?.response?.output;
+    expect(output?.map((item) => item.id)).toEqual(["message-two", "message-seven"]);
+    expect(result.events.filter((event) => event.type === "response_done")).toHaveLength(1);
+  });
+
   test("fails closed on duplicate output indices", async () => {
     const result = await consumeDirectResponses([
       {
@@ -860,6 +894,27 @@ describe("pinned Responses protocol conformance", () => {
       },
     ]);
     expect(String((result.error as Error).message)).toContain("duplicate output_item.done index");
+    expect(result.events.some((event) => event.type === "response_done")).toBe(false);
+  });
+
+  test("fails closed on invalid output indices", async () => {
+    const result = await consumeDirectResponses([
+      {
+        type: "response.output_item.done",
+        output_index: -1,
+        item: responseMessage("invalid", "invalid"),
+      },
+      {
+        type: "response.completed",
+        response: {
+          id: "completed",
+          status: "completed",
+          output: [],
+          usage: null,
+        },
+      },
+    ]);
+    expect(String((result.error as Error).message)).toContain("invalid index");
     expect(result.events.some((event) => event.type === "response_done")).toBe(false);
   });
 
@@ -999,22 +1054,6 @@ describe("pinned Responses protocol conformance", () => {
 
     const malformedCases: DirectResponsesEvent[][] = [
       [{ type: "response.created", response: { id: "unterminated" } }],
-      [
-        {
-          type: "response.output_item.done",
-          output_index: 2,
-          item: responseMessage("sparse", "sparse"),
-        },
-        {
-          type: "response.completed",
-          response: {
-            id: "sparse",
-            status: "completed",
-            output: [],
-            usage: null,
-          },
-        },
-      ],
       [
         {
           type: "response.output_item.done",

--- a/patches/@openai%2Fagents-openai@0.14.3.patch
+++ b/patches/@openai%2Fagents-openai@0.14.3.patch
@@ -57,11 +57,11 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
 +    if (completedOutputItemsByIndex.size === 0) {
 +        return response;
 +    }
-+    const orderedOutputItems = [...completedOutputItemsByIndex.entries()].sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex);
-+    if (orderedOutputItems.some(([index]) => !Number.isSafeInteger(index) || index < 0)) {
-+        throw new agents_core_1.ModelBehaviorError('Responses stream emitted output_item.done with an invalid index.');
-+    }
-+    const output = orderedOutputItems.map(([, item]) => item);
++    // Provider positions can be sparse; only numeric order is semantic.
++    // Every index was validated at output_item.done ingress.
++    const output = [...completedOutputItemsByIndex.entries()]
++        .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
++        .map(([, item]) => item);
 +    return { ...response, output };
 +}
  function getOpenAIResponseRequestId(response) {
@@ -123,8 +123,8 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
                  }
 +                if (eventType === 'response.output_item.done') {
 +                    const outputItemDone = event;
-+                    if (typeof outputItemDone.output_index !== 'number' || !outputItemDone.item) {
-+                        throw new agents_core_1.ModelBehaviorError('Responses stream emitted output_item.done without an indexed item.');
++                    if (!Number.isSafeInteger(outputItemDone.output_index) || outputItemDone.output_index < 0 || !outputItemDone.item) {
++                        throw new agents_core_1.ModelBehaviorError('Responses stream emitted output_item.done with an invalid index or missing item.');
 +                    }
 +                    if (completedOutputItemsByIndex.has(outputItemDone.output_index)) {
 +                        throw new agents_core_1.ModelBehaviorError('Responses stream emitted a duplicate output_item.done index.');
@@ -248,11 +248,11 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
 +    if (completedOutputItemsByIndex.size === 0) {
 +        return response;
 +    }
-+    const orderedOutputItems = [...completedOutputItemsByIndex.entries()].sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex);
-+    if (orderedOutputItems.some(([index]) => !Number.isSafeInteger(index) || index < 0)) {
-+        throw new ModelBehaviorError('Responses stream emitted output_item.done with an invalid index.');
-+    }
-+    const output = orderedOutputItems.map(([, item]) => item);
++    // Provider positions can be sparse; only numeric order is semantic.
++    // Every index was validated at output_item.done ingress.
++    const output = [...completedOutputItemsByIndex.entries()]
++        .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
++        .map(([, item]) => item);
 +    return { ...response, output };
 +}
  function getOpenAIResponseRequestId(response) {
@@ -314,8 +314,8 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
                  }
 +                if (eventType === 'response.output_item.done') {
 +                    const outputItemDone = event;
-+                    if (typeof outputItemDone.output_index !== 'number' || !outputItemDone.item) {
-+                        throw new ModelBehaviorError('Responses stream emitted output_item.done without an indexed item.');
++                    if (!Number.isSafeInteger(outputItemDone.output_index) || outputItemDone.output_index < 0 || !outputItemDone.item) {
++                        throw new ModelBehaviorError('Responses stream emitted output_item.done with an invalid index or missing item.');
 +                    }
 +                    if (completedOutputItemsByIndex.has(outputItemDone.output_index)) {
 +                        throw new ModelBehaviorError('Responses stream emitted a duplicate output_item.done index.');

--- a/patches/@openai%2Fagents-openai@0.14.3.patch
+++ b/patches/@openai%2Fagents-openai@0.14.3.patch
@@ -14,7 +14,7 @@ diff --git a/dist/openaiResponsesModel.js b/dist/openaiResponsesModel.js
 index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc2463568b684 100644
 --- a/dist/openaiResponsesModel.js
 +++ b/dist/openaiResponsesModel.js
-@@ -2262,14 +2262,55 @@ function convertToOutputItem(items) {
+@@ -2262,14 +2262,52 @@ function convertToOutputItem(items) {
  }
  const TERMINAL_RESPONSES_STREAM_EVENT_TYPES = new Set([
      'response.completed',
@@ -57,20 +57,17 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
 +    if (completedOutputItemsByIndex.size === 0) {
 +        return response;
 +    }
-+    const output = [];
-+    for (let index = 0; index < completedOutputItemsByIndex.size; index += 1) {
-+        const item = completedOutputItemsByIndex.get(index);
-+        if (!item) {
-+            throw new agents_core_1.ModelBehaviorError('Responses stream contained sparse output_item.done indices.');
-+        }
-+        output.push(item);
++    const orderedOutputItems = [...completedOutputItemsByIndex.entries()].sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex);
++    if (orderedOutputItems.some(([index]) => !Number.isSafeInteger(index) || index < 0)) {
++        throw new agents_core_1.ModelBehaviorError('Responses stream emitted output_item.done with an invalid index.');
 +    }
++    const output = orderedOutputItems.map(([, item]) => item);
 +    return { ...response, output };
 +}
  function getOpenAIResponseRequestId(response) {
      const requestId = response
          ?._request_id;
-@@ -2345,6 +2386,16 @@ class OpenAIResponsesModel {
+@@ -2345,6 +2383,16 @@ class OpenAIResponsesModel {
      _shouldEmitRawModelEvent(_event) {
          return true;
      }
@@ -87,7 +84,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
      /**
       * @internal
       */
-@@ -2419,7 +2470,7 @@ class OpenAIResponsesModel {
+@@ -2419,7 +2467,7 @@ class OpenAIResponsesModel {
          return response;
      }
      _buildResponsesCreateRequest(request, stream) {
@@ -96,7 +93,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
          const prompt = getPrompt(request.prompt);
          // When a prompt template already declares a model, skip sending the agent's default model.
          // If the caller explicitly requests an override, include the resolved model name in the request.
-@@ -2540,6 +2591,12 @@ class OpenAIResponsesModel {
+@@ -2540,6 +2588,12 @@ class OpenAIResponsesModel {
      async getResponse(request) {
          const response = await (0, agents_core_1.withResponseSpan)(async (span) => {
              const response = await this._fetchResponse(request, false);
@@ -109,7 +106,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
              if (request.tracing) {
                  span.spanData.response_id = response.id;
                  span.spanData._input = request.input;
-@@ -2576,7 +2633,10 @@ class OpenAIResponsesModel {
+@@ -2576,7 +2630,10 @@ class OpenAIResponsesModel {
              }
              const response = await this._fetchResponse(request, true);
              let finalResponse;
@@ -120,7 +117,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
              for await (const event of response) {
                  const eventType = event.type;
                  const shouldEmitRawModelEvent = this._shouldEmitRawModelEvent(event);
-@@ -2587,6 +2647,16 @@ class OpenAIResponsesModel {
+@@ -2587,6 +2644,16 @@ class OpenAIResponsesModel {
                          outputItemsByIndex.set(outputItemAdded.output_index, outputItemAdded.item);
                      }
                  }
@@ -137,7 +134,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
                  if (eventType === 'response.created') {
                      yield {
                          type: 'response_started',
-@@ -2596,22 +2666,11 @@ class OpenAIResponsesModel {
+@@ -2596,22 +2663,11 @@ class OpenAIResponsesModel {
                      };
                  }
                  else if (isTerminalResponsesStreamEventType(eventType)) {
@@ -165,7 +162,7 @@ index 07012f1f42b1e29b0daf915ac965e7e79142ffb7..67b49b785b52de3e982b9e27f21bc246
                  }
                  else if (eventType === 'response.output_text.delta') {
                      const { delta, ...remainingEvent } = event;
-@@ -2638,6 +2697,32 @@ class OpenAIResponsesModel {
+@@ -2638,6 +2694,32 @@ class OpenAIResponsesModel {
                      };
                  }
              }
@@ -208,7 +205,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
  import OpenAI from 'openai';
  import logger from "./logger.mjs";
  import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE } from "./rawModelEvents.mjs";
-@@ -2253,14 +2253,55 @@ function convertToOutputItem(items) {
+@@ -2253,14 +2253,52 @@ function convertToOutputItem(items) {
  export { getToolChoice, convertTool, getInputItems, convertToOutputItem };
  const TERMINAL_RESPONSES_STREAM_EVENT_TYPES = new Set([
      'response.completed',
@@ -251,20 +248,17 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
 +    if (completedOutputItemsByIndex.size === 0) {
 +        return response;
 +    }
-+    const output = [];
-+    for (let index = 0; index < completedOutputItemsByIndex.size; index += 1) {
-+        const item = completedOutputItemsByIndex.get(index);
-+        if (!item) {
-+            throw new ModelBehaviorError('Responses stream contained sparse output_item.done indices.');
-+        }
-+        output.push(item);
++    const orderedOutputItems = [...completedOutputItemsByIndex.entries()].sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex);
++    if (orderedOutputItems.some(([index]) => !Number.isSafeInteger(index) || index < 0)) {
++        throw new ModelBehaviorError('Responses stream emitted output_item.done with an invalid index.');
 +    }
++    const output = orderedOutputItems.map(([, item]) => item);
 +    return { ...response, output };
 +}
  function getOpenAIResponseRequestId(response) {
      const requestId = response
          ?._request_id;
-@@ -2336,6 +2377,16 @@ export class OpenAIResponsesModel {
+@@ -2336,6 +2374,16 @@ export class OpenAIResponsesModel {
      _shouldEmitRawModelEvent(_event) {
          return true;
      }
@@ -281,7 +275,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
      /**
       * @internal
       */
-@@ -2410,7 +2461,7 @@ export class OpenAIResponsesModel {
+@@ -2410,7 +2458,7 @@ export class OpenAIResponsesModel {
          return response;
      }
      _buildResponsesCreateRequest(request, stream) {
@@ -290,7 +284,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
          const prompt = getPrompt(request.prompt);
          // When a prompt template already declares a model, skip sending the agent's default model.
          // If the caller explicitly requests an override, include the resolved model name in the request.
-@@ -2531,6 +2582,12 @@ export class OpenAIResponsesModel {
+@@ -2531,6 +2579,12 @@ export class OpenAIResponsesModel {
      async getResponse(request) {
          const response = await withResponseSpan(async (span) => {
              const response = await this._fetchResponse(request, false);
@@ -303,7 +297,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
              if (request.tracing) {
                  span.spanData.response_id = response.id;
                  span.spanData._input = request.input;
-@@ -2567,7 +2624,10 @@ export class OpenAIResponsesModel {
+@@ -2567,7 +2621,10 @@ export class OpenAIResponsesModel {
              }
              const response = await this._fetchResponse(request, true);
              let finalResponse;
@@ -314,7 +308,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
              for await (const event of response) {
                  const eventType = event.type;
                  const shouldEmitRawModelEvent = this._shouldEmitRawModelEvent(event);
-@@ -2578,6 +2638,16 @@ export class OpenAIResponsesModel {
+@@ -2578,6 +2635,16 @@ export class OpenAIResponsesModel {
                          outputItemsByIndex.set(outputItemAdded.output_index, outputItemAdded.item);
                      }
                  }
@@ -331,7 +325,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
                  if (eventType === 'response.created') {
                      yield {
                          type: 'response_started',
-@@ -2587,22 +2657,11 @@ export class OpenAIResponsesModel {
+@@ -2587,22 +2654,11 @@ export class OpenAIResponsesModel {
                      };
                  }
                  else if (isTerminalResponsesStreamEventType(eventType)) {
@@ -359,7 +353,7 @@ index 3bc6e0a9335690a97120570c4d6355ac4447caf3..57889914542217a8ad595631d32b7eda
                  }
                  else if (eventType === 'response.output_text.delta') {
                      const { delta, ...remainingEvent } = event;
-@@ -2629,6 +2688,32 @@ export class OpenAIResponsesModel {
+@@ -2629,6 +2685,32 @@ export class OpenAIResponsesModel {
                      };
                  }
              }


### PR DESCRIPTION
## Summary

- reconstruct empty Responses terminals from observed completed items in numeric `output_index` order
- accept gaps in provider index positions without inventing synthetic output entries
- retain duplicate-index and invalid-index rejection
- update the pinned SDK patch, protocol regression coverage, and lifecycle documentation

## Why

The terminal reconstruction path used the number of observed items as the expected largest index, which incorrectly required provider indices to be dense from zero. A valid stream containing completed items at sparse positions therefore failed even though every observed item was complete. Reconstruction now sorts the observed `(output_index, item)` entries and emits only those items.

## Validation

- `bun install --frozen-lockfile --ignore-scripts` (verifies the pinned dependency patch applies)
- `bun test packages/runtime/test/model-providers.test.ts -t 'sparse output indices|duplicate output indices|invalid output indices'`
- targeted `oxlint --deny-warnings`
- targeted `oxfmt --check --threads=1`
- patch hunk integrity check
- `git diff --check`

## Summary by Sourcery

Accept sparse Responses output indices while preserving numeric ordering and fail-closed validation.

Bug Fixes:
- Allow empty Responses terminal outputs to be reconstructed from sparse completed item indices without requiring dense provider positions.
- Continue rejecting duplicate and invalid output indices.

Documentation:
- Document sparse Responses output reconstruction and its duplicate-index validation behavior in the architecture and lifecycle guides.

Tests:
- Add protocol regression coverage for sparse output reconstruction and invalid output indices while retaining duplicate-index coverage.

Chores:
- Update the pinned Responses SDK patch and add a runtime patch changeset.