### PR TITLE
fix(react): expose jump during timeline catch-up

### DIFF
--- a/.changeset/quick-session-tip-jump.md
+++ b/.changeset/quick-session-tip-jump.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Show the timeline's Jump to latest control while a pinned session is catching up from meaningful pre-existing tip debt.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -238,6 +238,13 @@ export type MessageTimelineProps = {
  */
 const PIN_THRESHOLD_PX = 48;
 /**
+ * A pinned timeline can still have meaningful pre-existing debt while the
+ * tip-follow camera catches up. Surface the existing explicit jump once that
+ * debt is large enough to be useful, without flashing the control for ordinary
+ * line-sized streaming movement.
+ */
+const JUMP_TO_LATEST_CATCHUP_DEBT_PX = 240;
+/**
  * Prefetch older history when the top sentinel is this far from the viewport.
  * After a page loads we stay cool until the reader leaves this band (scrolls
  * down into content) — never re-fire from continued scroll toward y=0.
@@ -432,6 +439,8 @@ export function MessageTimeline({
   const bottomSentinelRef = useRef<HTMLDivElement | null>(null);
   const previousBulkFirstKeyRef = useRef<string | null | undefined>(undefined);
   const [pinned, setPinned] = useState(true);
+  const [canSkipTipCatchup, setCanSkipTipCatchup] = useState(false);
+  const canSkipTipCatchupRef = useRef(false);
   const [bulkActive, setBulkActive] = useState(true);
   // Older history prefetch is user-driven: a window shorter than the viewport
   // + rootMargin would otherwise keep the top sentinel intersecting and fetch
@@ -545,15 +554,28 @@ export function MessageTimeline({
     previousBulkFirstKeyRef.current !== firstGroupKey;
   const bulkRender = allGroups.length > 0 && (bulkActive || firstKeyChangedForBulk);
 
+  const applyCanSkipTipCatchup = useCallback((value: boolean) => {
+    if (canSkipTipCatchupRef.current !== value) {
+      canSkipTipCatchupRef.current = value;
+      setCanSkipTipCatchup(value);
+    }
+  }, []);
+
   // The ONLY writer of the pinned flag. Ref and state move together, so
   // behavior (refs read by rAF callbacks) and rendering (the anchor class,
   // the Jump-to-latest button) can never desync.
-  const applyPinned = useCallback((value: boolean) => {
-    if (pinnedRef.current !== value) {
-      pinnedRef.current = value;
-      setPinned(value);
-    }
-  }, []);
+  const applyPinned = useCallback(
+    (value: boolean) => {
+      if (pinnedRef.current !== value) {
+        pinnedRef.current = value;
+        setPinned(value);
+      }
+      if (!value) {
+        applyCanSkipTipCatchup(false);
+      }
+    },
+    [applyCanSkipTipCatchup],
+  );
 
   const rearmOlderPrefetchAfterLeavingTop = useCallback((node: HTMLElement) => {
     if (node.scrollTop > OLDER_PREFETCH_MARGIN_PX) {
@@ -757,8 +779,9 @@ export function MessageTimeline({
         lastClientHeight: node.clientHeight,
         cameraTop: null,
       };
+      applyCanSkipTipCatchup(false);
     },
-    [cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
+    [applyCanSkipTipCatchup, cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
   );
 
   const beginUserMessageDisclosureChange = useCallback(
@@ -965,6 +988,10 @@ export function MessageTimeline({
       followRef.current = result.state;
       writeScrollTop(node, result.scrollTop);
       syncScrollBaseline(node);
+      applyCanSkipTipCatchup(
+        result.state.running &&
+          maxScrollOf(node) - node.scrollTop >= JUMP_TO_LATEST_CATCHUP_DEBT_PX,
+      );
       if (result.state.running) {
         cancelLeaveFallback();
         if (followFrameRef.current == null) {
@@ -981,7 +1008,7 @@ export function MessageTimeline({
         followFrameRef.current = null;
       }
     },
-    [cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
+    [applyCanSkipTipCatchup, cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
   );
   driveFollowRef.current = driveFollow;
 
@@ -1825,9 +1852,10 @@ export function MessageTimeline({
                     ) : null}
                   </AnimatePresence>
                   <AnimatePresence>
-                    {((!pinned && autoFollow) || hasNewer) && autoFollow ? (
+                    {((!pinned && autoFollow) || hasNewer || canSkipTipCatchup) && autoFollow ? (
                       <motion.button
                         type="button"
+                        data-og-jump-to-latest=""
                         initial={{ opacity: 0, y: 8 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: 8 }}

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -3679,6 +3679,35 @@ describe("MessageTimeline pagination affordances", () => {
     }
   }
 
+  test("large pinned catch-up offers an immediate jump to the live tip", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const { r, scroller, layout, initial } = await renderPinnedAtTip(frames);
+
+    // Returning to a long-lived surface may expose pre-existing camera debt
+    // (for example, from a prior hot follow frame). Keep the smooth follower,
+    // but let the reader skip the remaining travel immediately.
+    scroller.scrollTop -= 320;
+    await r.rerender(<MessageTimeline events={initial} status="running" />);
+    await flush();
+
+    expect(distanceFromBottom(scroller)).toBeGreaterThan(240);
+    const button = r.container.querySelector<HTMLButtonElement>("[data-og-jump-to-latest]");
+    expect(button?.textContent).toContain("Jump to latest");
+
+    await actRun(() => button?.click());
+    expect(distanceFromBottom(scroller)).toBe(0);
+
+    await drainFrames(frames);
+    layout.restore();
+    await r.unmount();
+  });
+
   test("same-commit settle-fold + chrome dock glues BOTH shrinks in one write", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {


### PR DESCRIPTION
## Summary

- show the existing Jump to latest control when a pinned timeline still has at least 240 px of pre-existing catch-up debt
- let readers snap directly to the live tip without changing normal feed-forward streaming or manual history navigation
- add a focused regression test and React patch changeset

## Testing

- [x] `bun run --cwd packages/react typecheck`
- [x] `bun x oxlint --deny-warnings packages/react/src/components/message-timeline.tsx packages/react/test/message-timeline-pagination.test.tsx`
- [x] `bun test packages/react/test/tip-follow.test.ts packages/react/test/message-timeline-pagination.test.tsx` (101 pass)
- [x] targeted format check and `git diff --check`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate was created from current `origin/main`; a fresh merge-tree check completed without conflicts before push.

## Notes

- This preserves the feed-forward pinned-streaming behavior from #1879. The shortcut appears only for meaningful debt that already existed before the current growth frame.

## Summary by Sourcery

Expose a Jump to latest shortcut for pinned timelines with meaningful catch-up debt while preserving existing follow behavior.

New Features:
- Expose the existing Jump to latest control when a pinned timeline has substantial pre-existing catch-up debt.

Enhancements:
- Allow readers to skip directly to the live tip without changing normal pinned streaming or manual history navigation behavior.

Tests:
- Add a regression test covering immediate jumping from a large pinned catch-up backlog.