### PR TITLE
test(db): stabilize learning-policy interruption fence proof

### DIFF
--- a/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
+++ b/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
@@ -288,6 +288,14 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
 
       interruptionCall = interruptionWriter.begin(async (tx) => {
         await tx`
+          select id from session_turn_attempts
+          where account_id = ${fixture.accountId}
+            and workspace_id = ${fixture.workspaceId}
+            and session_id = ${fixture.sessionId}
+            and turn_id = ${fixture.turnId}
+            and id = ${fixture.attemptId}
+          for update`;
+        await tx`
           insert into session_command_receipts (
             id, account_id, workspace_id, actor_type, actor_subject_id,
             action, target_session_id, target_turn_id, operation_key,
@@ -299,14 +307,6 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
             ${`learning-policy-interruption-${operationId}`}, ${"a".repeat(64)}
           )`;
         await tx`
-          select id from session_turn_attempts
-          where account_id = ${fixture.accountId}
-            and workspace_id = ${fixture.workspaceId}
-            and session_id = ${fixture.sessionId}
-            and turn_id = ${fixture.turnId}
-            and id = ${fixture.attemptId}
-          for update`;
-        await tx`
           insert into session_attempt_interruptions (
             account_id, workspace_id, session_id, operation_id,
             attempt_id, kind, control_revision
@@ -316,7 +316,12 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
           )`;
       });
       void interruptionCall.catch(() => undefined);
-      await waitForApplicationLock(interruptionApplicationName);
+      await Promise.race([
+        waitForApplicationLock(interruptionApplicationName),
+        interruptionCall.then(() => {
+          throw new Error("Interruption writer completed before reaching the attempt fence");
+        }),
+      ]);
 
       const [beforeCommit] = await shared!.admin<Array<{ count: number }>>`
         select count(*)::int as count

--- a/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
+++ b/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
@@ -32,6 +32,14 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+function deferredValue<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 async function within<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   return await Promise.race([
     promise,
@@ -53,6 +61,20 @@ async function waitForApplicationLock(applicationName: string): Promise<void> {
     await Bun.sleep(10);
   }
   throw new Error(`Timed out waiting for ${applicationName} to block on a row lock`);
+}
+
+async function waitForBackendLock(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    const [activity] = await shared!.admin<Array<{ waitEventType: string | null }>>`
+      select wait_event_type as "waitEventType"
+      from pg_stat_activity
+      where datname = current_database()
+        and pid = ${pid}
+      limit 1`;
+    if (activity?.waitEventType === "Lock") return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for backend ${pid} to block on a row lock`);
 }
 
 async function deadlockCount(): Promise<number> {
@@ -252,15 +274,11 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
   test("holds the attempt fence through commit so interruption creation cannot cross revalidation", async () => {
     if (!available) return;
     const fixture = await seedAttempt();
-    const interruptionApplicationName = `learning-policy-interruption-${crypto.randomUUID()}`;
     const snapshot = postgres(shared!.appUrl, { max: 1, prepare: false });
-    const interruptionWriter = postgres(shared!.adminUrl, {
-      max: 1,
-      prepare: false,
-      connection: { application_name: interruptionApplicationName },
-    });
+    const interruptionWriter = postgres(shared!.adminUrl, { max: 1, prepare: false });
     const snapshotCreated = deferred();
     const releaseSnapshot = deferred();
+    const interruptionBackend = deferredValue<number>();
     const operationId = crypto.randomUUID();
     let snapshotCall: Promise<Array<{ snapshotId: string }>> | undefined;
     let interruptionCall: Promise<unknown> | undefined;
@@ -287,6 +305,10 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
       await within(snapshotCreated.promise, 10_000, "Snapshot transaction did not reach commit");
 
       interruptionCall = interruptionWriter.begin(async (tx) => {
+        const [backend] = await tx<Array<{ pid: number }>>`
+          select pg_backend_pid()::int as pid`;
+        if (!backend) throw new Error("Interruption writer has no PostgreSQL backend");
+        interruptionBackend.resolve(backend.pid);
         await tx`
           select id from session_turn_attempts
           where account_id = ${fixture.accountId}
@@ -316,8 +338,13 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
           )`;
       });
       void interruptionCall.catch(() => undefined);
+      const interruptionBackendPid = await within(
+        interruptionBackend.promise,
+        10_000,
+        "Interruption writer did not establish a PostgreSQL backend",
+      );
       await Promise.race([
-        waitForApplicationLock(interruptionApplicationName),
+        waitForBackendLock(interruptionBackendPid),
         interruptionCall.then(() => {
           throw new Error("Interruption writer completed before reaching the attempt fence");
         }),


### PR DESCRIPTION
## Summary

- acquire the exact attempt `FOR UPDATE` before creating the synthetic interruption receipt
- fail immediately if the writer exits before reaching the expected lock wait
- keep the regression focused on the snapshot transaction retaining its attempt `SHARE` fence through commit

## Context

This is the focused test-harness follow-up to #1917. The migration and runtime behavior are unchanged; the first public exact-head run showed that the synthetic writer could exit before reaching the lock the test intended to observe.

## Verification

- focused `oxfmt --check`
- `git diff --check`
- `bun scripts/check-migration-test-budgets.ts`

The real PostgreSQL proof runs on the public PR unit matrix.

## Summary by Sourcery

Stabilize the learning-policy interruption lock-order regression proof by explicitly synchronizing on the writer’s backend lock wait.

Enhancements:
- Strengthen the learning-policy interruption regression test so it observes the exact attempt lock fence and verifies the snapshot transaction retains its share lock through commit.

Tests:
- Make the PostgreSQL lock-order test fail immediately when the synthetic interruption writer completes before reaching the expected row-lock wait.