### PR TITLE
test(db): keep lock probe application name exact

### DIFF
--- a/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
+++ b/packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts
@@ -252,7 +252,9 @@ describe("migration 0364 workspace learning-policy snapshot lock order", () => {
   test("holds the attempt fence through commit so interruption creation cannot cross revalidation", async () => {
     if (!available) return;
     const fixture = await seedAttempt();
-    const interruptionApplicationName = `learning-policy-interruption-${crypto.randomUUID()}`;
+    // PostgreSQL truncates application_name to NAMEDATALEN - 1 (63 bytes).
+    // Keep this probe below that limit so pg_stat_activity can match it exactly.
+    const interruptionApplicationName = `lp-interruption-${crypto.randomUUID()}`;
     const snapshot = postgres(shared!.appUrl, { max: 1, prepare: false });
     const interruptionWriter = postgres(shared!.adminUrl, {
       max: 1,


### PR DESCRIPTION
## Summary
- keep the migration 0364 pg_stat_activity probe below PostgreSQL's 63-byte application_name limit
- preserve the exact blocked-row-lock assertion instead of timing out on the truncated identifier

## Verification
- OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 180000 packages/db/test/migration-0364-workspace-learning-policy-snapshot-lock-order.test.ts (3 consecutive passes)

## Summary by Sourcery

Bug Fixes:
- Ensure the migration lock probe's application name remains within PostgreSQL's length limit so the blocked-row-lock assertion matches reliably.