### PR TITLE
fix(control): preserve desired-state no-op truth

### DIFF
--- a/.changeset/truthful-session-control-receipts.md
+++ b/.changeset/truthful-session-control-receipts.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+Make session and workspace Pause/Resume desired-state mutations report authoritative changed, unchanged, and replayed outcomes. Represented no-ops no longer allocate control revisions, events, interruptions, or wakes, while newer descendant overrides and missing lifecycle repairs still produce real mutations. First-party MCP session control now returns the same versioned mutation receipt for agent-bound and sessionless callers.

--- a/apps/api/src/mcp/receipts.ts
+++ b/apps/api/src/mcp/receipts.ts
@@ -26,6 +26,40 @@ export function mcpMutationReceipt(input: McpMutationReceiptInput): McpMutationR
   });
 }
 
+export function sessionControlMutationReceipt(input: {
+  operation: "session_pause" | "session_resume";
+  sessionId: string;
+  state: string;
+  receiptId: string;
+  timestamp: string;
+  outcome: "changed" | "unchanged" | "replayed";
+  interruptionCount: number;
+}): McpMutationReceiptType {
+  return mcpMutationReceipt({
+    operation: input.operation,
+    committed: true,
+    outcome:
+      input.outcome === "changed"
+        ? "updated"
+        : input.outcome === "unchanged"
+          ? "unchanged"
+          : "replayed",
+    changed: input.outcome === "changed",
+    resource: {
+      type: "session",
+      id: input.sessionId,
+      state: input.state,
+    },
+    relatedResources: [{ type: "session_command_receipt", id: input.receiptId }],
+    timestamp: input.timestamp,
+    idempotency: {
+      status: input.outcome === "replayed" ? "replayed" : "applied",
+    },
+    facts: { interruptionCount: input.interruptionCount },
+    nextAction: { tool: "session_get", arguments: { sessionId: input.sessionId } },
+  });
+}
+
 export type SessionCreateReceiptResult = {
   session: {
     id: string;

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -186,7 +186,7 @@ import {
 import {
   acceptSessionUserMessageWithOutcome,
   controlAgentSessionWorkstream,
-  controlHumanSessionWorkstream,
+  controlHumanSessionWorkstreamWithOutcome,
   createSessionForRequestWithOutcome,
   SessionSpawnDeniedError,
   sessionSpawnDenialEnvelope,
@@ -223,7 +223,11 @@ import {
   SESSION_WAIT_MAX_TARGETS,
   waitForSessionChanges,
 } from "./session-wait";
-import { mcpMutationReceipt, sessionCreateMutationReceipt } from "./receipts";
+import {
+  mcpMutationReceipt,
+  sessionControlMutationReceipt,
+  sessionCreateMutationReceipt,
+} from "./receipts";
 import {
   boundScheduledTaskDetailMcp,
   boundScheduledTaskMcpPage,
@@ -4537,27 +4541,18 @@ function registerWorkspaceOrchestrationTools(
             controlled.authorization?.relatedSessionAccess ?? "root",
           );
           return json(
-            mcpMutationReceipt({
+            sessionControlMutationReceipt({
               operation: "session_pause",
-              committed: true,
-              outcome: controlled.replay ? "replayed" : "updated",
-              changed: !controlled.replay,
-              resource: {
-                type: "session",
-                id: sessionId,
-                state: effectiveControl.state,
-              },
-              relatedResources: [{ type: "session_command_receipt", id: controlled.receipt.id }],
+              sessionId,
+              state: effectiveControl.state,
+              receiptId: controlled.receipt.id,
               timestamp: controlled.receipt.createdAt.toISOString(),
-              idempotency: {
-                status: controlled.replay ? "replayed" : "applied",
-              },
-              facts: { interruptionCount: controlled.interruptionCount },
-              nextAction: { tool: "session_get", arguments: { sessionId } },
+              outcome: controlled.outcome,
+              interruptionCount: controlled.interruptionCount,
             }),
           );
         }
-        const controlled = await controlHumanSessionWorkstream(
+        const controlled = await controlHumanSessionWorkstreamWithOutcome(
           deps,
           {
             accountId: grant.accountId,
@@ -4572,7 +4567,17 @@ function registerWorkspaceOrchestrationTools(
             ...(reason ? { reason } : {}),
           },
         );
-        return json(controlled);
+        return json(
+          sessionControlMutationReceipt({
+            operation: "session_pause",
+            sessionId,
+            state: controlled.response.effectiveControl.state,
+            receiptId: controlled.response.receipt.id,
+            timestamp: controlled.response.receipt.createdAt,
+            outcome: controlled.outcome,
+            interruptionCount: controlled.response.interruptionCount,
+          }),
+        );
       },
     );
 
@@ -4605,27 +4610,18 @@ function registerWorkspaceOrchestrationTools(
             controlled.authorization?.relatedSessionAccess ?? "root",
           );
           return json(
-            mcpMutationReceipt({
+            sessionControlMutationReceipt({
               operation: "session_resume",
-              committed: true,
-              outcome: controlled.replay ? "replayed" : "updated",
-              changed: !controlled.replay,
-              resource: {
-                type: "session",
-                id: sessionId,
-                state: effectiveControl.state,
-              },
-              relatedResources: [{ type: "session_command_receipt", id: controlled.receipt.id }],
+              sessionId,
+              state: effectiveControl.state,
+              receiptId: controlled.receipt.id,
               timestamp: controlled.receipt.createdAt.toISOString(),
-              idempotency: {
-                status: controlled.replay ? "replayed" : "applied",
-              },
-              facts: { interruptionCount: controlled.interruptionCount },
-              nextAction: { tool: "session_get", arguments: { sessionId } },
+              outcome: controlled.outcome,
+              interruptionCount: controlled.interruptionCount,
             }),
           );
         }
-        const controlled = await controlHumanSessionWorkstream(
+        const controlled = await controlHumanSessionWorkstreamWithOutcome(
           deps,
           {
             accountId: grant.accountId,
@@ -4640,7 +4636,17 @@ function registerWorkspaceOrchestrationTools(
             ...(reason ? { reason } : {}),
           },
         );
-        return json(controlled);
+        return json(
+          sessionControlMutationReceipt({
+            operation: "session_resume",
+            sessionId,
+            state: controlled.response.effectiveControl.state,
+            receiptId: controlled.response.receipt.id,
+            timestamp: controlled.response.receipt.createdAt,
+            outcome: controlled.outcome,
+            interruptionCount: controlled.response.interruptionCount,
+          }),
+        );
       },
     );
 

--- a/apps/api/test/mcp-receipts.test.ts
+++ b/apps/api/test/mcp-receipts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   mcpMutationReceipt,
+  sessionControlMutationReceipt,
   sessionCreateMutationReceipt,
   type SessionCreateReceiptResult,
 } from "../src/mcp/receipts";
@@ -80,6 +81,33 @@ describe("first-party MCP receipt builder", () => {
       rootSessionId: sessionCreateResult.session.rootSessionId,
       nestedAgentDepth: 0,
       effectiveMaxNestedAgentDepth: 3,
+    });
+  });
+
+  test("maps session control persistence outcomes without caller-shape drift", () => {
+    const base = {
+      operation: "session_pause" as const,
+      sessionId: "00000000-0000-4000-8000-000000000005",
+      state: "paused",
+      receiptId: "00000000-0000-4000-8000-000000000006",
+      timestamp: "2026-08-27T00:00:00.000Z",
+      interruptionCount: 0,
+    };
+
+    expect(sessionControlMutationReceipt({ ...base, outcome: "changed" })).toMatchObject({
+      outcome: "updated",
+      changed: true,
+      idempotency: { status: "applied" },
+    });
+    expect(sessionControlMutationReceipt({ ...base, outcome: "unchanged" })).toMatchObject({
+      outcome: "unchanged",
+      changed: false,
+      idempotency: { status: "applied" },
+    });
+    expect(sessionControlMutationReceipt({ ...base, outcome: "replayed" })).toMatchObject({
+      outcome: "replayed",
+      changed: false,
+      idempotency: { status: "replayed" },
     });
   });
 

--- a/apps/api/test/session-authorization-routes.test.ts
+++ b/apps/api/test/session-authorization-routes.test.ts
@@ -1596,12 +1596,47 @@ describe("embedding host session authorization routes", () => {
       sessionId: target.id,
       idempotencyKey: crypto.randomUUID(),
     });
-    expect(paused.resource.state).toBe("paused");
+    expect(paused).toMatchObject({
+      operation: "session_pause",
+      outcome: "updated",
+      changed: true,
+      resource: { type: "session", id: target.id, state: "paused" },
+      idempotency: { status: "applied" },
+    });
+    const unchangedPauseKey = crypto.randomUUID();
+    const unchangedPause = await callMcpTool<McpMutationReceiptType>(server, "session_pause", {
+      sessionId: target.id,
+      idempotencyKey: unchangedPauseKey,
+    });
+    expect(unchangedPause).toMatchObject({
+      operation: "session_pause",
+      outcome: "unchanged",
+      changed: false,
+      resource: { type: "session", id: target.id, state: "paused" },
+      idempotency: { status: "applied" },
+    });
+    const replayedPause = await callMcpTool<McpMutationReceiptType>(server, "session_pause", {
+      sessionId: target.id,
+      idempotencyKey: unchangedPauseKey,
+    });
+    expect(replayedPause).toMatchObject({
+      operation: "session_pause",
+      outcome: "replayed",
+      changed: false,
+      resource: { type: "session", id: target.id, state: "paused" },
+      idempotency: { status: "replayed" },
+    });
+    expect(replayedPause.relatedResources).toEqual(unchangedPause.relatedResources);
     const resumed = await callMcpTool<McpMutationReceiptType>(server, "session_resume", {
       sessionId: target.id,
       idempotencyKey: crypto.randomUUID(),
     });
-    expect(resumed.resource.state).toBe("active");
+    expect(resumed).toMatchObject({
+      operation: "session_resume",
+      outcome: "updated",
+      changed: true,
+      resource: { type: "session", id: target.id, state: "active" },
+    });
     const steered = await callMcpTool<{ updateId: string }>(server, "session_steer", {
       sessionId: target.id,
       instruction: "Take the newest direction exactly once",
@@ -1613,22 +1648,51 @@ describe("embedding host session authorization routes", () => {
       ...value.grant,
       permissions: ["workspace:read", "sessions:read", "sessions:control"],
     });
-    const operatorPaused = await callMcpTool<{
-      effectiveControl: { state: string };
-    }>(operatorServer, "session_pause", {
-      sessionId: target.id,
-      idempotencyKey: crypto.randomUUID(),
+    const operatorPaused = await callMcpTool<McpMutationReceiptType>(
+      operatorServer,
+      "session_pause",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(operatorPaused).toMatchObject({
+      receiptVersion: "mcp-mutation-receipt.v1",
+      operation: "session_pause",
+      outcome: "updated",
+      changed: true,
+      resource: { type: "session", id: target.id, state: "paused" },
+      relatedResources: [{ type: "session_command_receipt" }],
     });
-    expect(operatorPaused.effectiveControl.state).toBe("paused");
-    const operatorResumed = await callMcpTool<{
-      effectiveControl: { state: string };
-    }>(operatorServer, "session_resume", {
-      sessionId: target.id,
-      idempotencyKey: crypto.randomUUID(),
+    expect(operatorPaused).not.toHaveProperty("effectiveControl");
+    const operatorResumed = await callMcpTool<McpMutationReceiptType>(
+      operatorServer,
+      "session_resume",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(operatorResumed).toMatchObject({
+      receiptVersion: "mcp-mutation-receipt.v1",
+      operation: "session_resume",
+      outcome: "updated",
+      changed: true,
+      resource: { type: "session", id: target.id, state: "active" },
     });
-    expect(operatorResumed.effectiveControl.state).toBe("active");
+    expect(operatorResumed).not.toHaveProperty("effectiveControl");
 
     expect(decisions).toEqual([
+      {
+        operation: "session.control",
+        surface: "first_party_mcp",
+        sessionId: target.id,
+      },
+      {
+        operation: "session.control",
+        surface: "first_party_mcp",
+        sessionId: target.id,
+      },
       {
         operation: "session.control",
         surface: "first_party_mcp",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,6 +480,14 @@ through the claim transaction. Pause blocks admission without pretending that
 physical execution has already stopped. Cancel fences a session subtree and is
 terminal for the affected sessions.
 
+Pause and Resume are desired-state commands with durable semantic receipts. A
+fresh key allocates a control revision, events, interruptions, and wakes only
+when it changes direct blocker/override truth or repairs an uncovered lifecycle
+effect. Effective state alone is insufficient: a later ancestor Pause must
+invalidate newer descendant Resume overrides, and a narrower child Pause under
+an inherited blocker remains a real change. Exact idempotency retries stay
+`replayed`; represented intent with no repair stays `unchanged`.
+
 Failed sessions can be revived by new accepted work. Cancellation remains the
 terminal boundary.
 

--- a/docs/mcp-response-contracts.md
+++ b/docs/mcp-response-contracts.md
@@ -168,6 +168,11 @@ JSON escape expansion.
 - **No-op is not replay.** An already-paused task, a deduplicated memory write,
   or another mutation that commits no new state can return `unchanged` with the
   applicable non-replay idempotency status.
+- **Session control uses persistence truth on every caller shape.** Agent-bound
+  and sessionless/operator `session_pause` and `session_resume` calls both return
+  this v1 receipt. A fresh desired-state no-op is `unchanged`; only an exact
+  operation-receipt retry is `replayed`. The REST session-control body remains
+  its separate compatibility contract.
 - **Partial failure means partial commit.** The receipt says which stage failed,
   whether a retry is safe, and what resource identity remains authoritative. A
   scheduled-task database change followed by failed schedule synchronization is

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -819,6 +819,21 @@ logical turn `recovering`; Steer closes it as `superseded`, makes the steered
 human prompt first, and does not revive the old turn. A missing or already
 closed owner is an event-free stale no-op. This prevents a superseded activity
 that keeps running from publishing contradictory history or terminal truth.
+
+Pause/Resume command persistence distinguishes `changed`, `unchanged`, and
+`replayed` before allocating a control revision. A fresh Pause is unchanged
+only when the selected direct recursive blocker is already represented, no
+newer descendant run override must be invalidated, every live attempt is
+already covered by an actionable Pause interruption, and no adopted command is
+still running. A fresh Resume is unchanged only when the selected branch has no
+undefeated blocker and every currently continuable descendant already has an
+undelivered workflow wake; otherwise it advances the override and repairs wake
+delivery. Workspace Pause/Resume applies the same rules across the workspace.
+An unchanged result writes only its operation receipt: no control revision,
+control/session event, audit event, child notice, interruption, command stop,
+or workflow wake. Reusing that exact operation key remains `replayed`, not
+`unchanged`.
+
 If provider failure races with an accepted exact-attempt Pause or Steer, that
 control request owns the attempt: recovery returns stale and the normal
 settlement/quiescence path completes the transition. The workspace-control lock

--- a/packages/core/src/application/session-commands.ts
+++ b/packages/core/src/application/session-commands.ts
@@ -511,26 +511,38 @@ export async function controlAgentSessionWorkstream(
     },
   );
   scheduleSessionCommandPostCommit(deps, "agent_control", [
-    {
-      kind: "session_event_fanout",
-      run: async () =>
-        await publishSessionEventIds(deps, context.workspaceId, input.targetSessionId, [
-          result.sessionControlEventId,
-        ]),
-    },
-    {
-      kind: "workspace_control_fanout",
-      run: async () =>
-        await publishWorkspaceControlEvent(
-          deps,
-          context.workspaceId,
-          result.workspaceControlEventId,
-        ),
-    },
-    {
-      kind: "workflow_wake",
-      run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
-    },
+    ...(result.sessionControlEventId
+      ? [
+          {
+            kind: "session_event_fanout" as const,
+            run: async () =>
+              await publishSessionEventIds(deps, context.workspaceId, input.targetSessionId, [
+                result.sessionControlEventId!,
+              ]),
+          },
+        ]
+      : []),
+    ...(result.workspaceControlEventId
+      ? [
+          {
+            kind: "workspace_control_fanout" as const,
+            run: async () =>
+              await publishWorkspaceControlEvent(
+                deps,
+                context.workspaceId,
+                result.workspaceControlEventId!,
+              ),
+          },
+        ]
+      : []),
+    ...(result.wakeCount > 0
+      ? [
+          {
+            kind: "workflow_wake" as const,
+            run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
+          },
+        ]
+      : []),
     {
       kind: "workflow_wake",
       run: async () => {
@@ -832,7 +844,11 @@ export async function controlHumanSessionWorkstreamWithOutcome(
   } & SessionCommandPostCommitDeps,
   context: HumanSessionCommandContext,
   input: SessionControlRequest,
-): Promise<{ response: SessionControlResponse; replay: boolean }> {
+): Promise<{
+  response: SessionControlResponse;
+  outcome: "changed" | "unchanged" | "replayed";
+  replay: boolean;
+}> {
   const authorization = await authorizeHumanSessionCommand(deps, context, "session.control");
   const result = await runSessionCommandPersistenceTransaction(
     deps,
@@ -879,19 +895,27 @@ export async function controlHumanSessionWorkstreamWithOutcome(
           affected.eventIds,
         ),
     })),
-    {
-      kind: "workspace_control_fanout",
-      run: async () =>
-        await publishWorkspaceControlEvent(
-          deps,
-          context.workspaceId,
-          result.workspaceControlEventId,
-        ),
-    },
-    {
-      kind: "workflow_wake",
-      run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
-    },
+    ...(result.workspaceControlEventId
+      ? [
+          {
+            kind: "workspace_control_fanout" as const,
+            run: async () =>
+              await publishWorkspaceControlEvent(
+                deps,
+                context.workspaceId,
+                result.workspaceControlEventId!,
+              ),
+          },
+        ]
+      : []),
+    ...(result.wakeCount > 0
+      ? [
+          {
+            kind: "workflow_wake" as const,
+            run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
+          },
+        ]
+      : []),
     {
       kind: "workflow_wake",
       run: async () => {
@@ -909,7 +933,7 @@ export async function controlHumanSessionWorkstreamWithOutcome(
       },
     },
   ]);
-  return { response, replay: result.replay };
+  return { response, outcome: result.outcome, replay: result.replay };
 }
 
 /** Backward-compatible response path used by the REST control route. */
@@ -952,19 +976,27 @@ export async function controlHumanWorkspace(
     wakeCount: result.wakeCount,
   };
   scheduleSessionCommandPostCommit(deps, "human_workspace_control", [
-    {
-      kind: "workspace_control_fanout",
-      run: async () =>
-        await publishWorkspaceControlEvent(
-          deps,
-          context.workspaceId,
-          result.workspaceControlEventId,
-        ),
-    },
-    {
-      kind: "workflow_wake",
-      run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
-    },
+    ...(result.workspaceControlEventId
+      ? [
+          {
+            kind: "workspace_control_fanout" as const,
+            run: async () =>
+              await publishWorkspaceControlEvent(
+                deps,
+                context.workspaceId,
+                result.workspaceControlEventId!,
+              ),
+          },
+        ]
+      : []),
+    ...(result.wakeCount > 0
+      ? [
+          {
+            kind: "workflow_wake" as const,
+            run: async () => await requestControlWakeDispatch(deps, result.wakeCount),
+          },
+        ]
+      : []),
   ]);
   return response;
 }

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -2224,8 +2224,8 @@ export async function updateSessionCommandReceiptResult(
 export type SessionControlMutationResult = {
   receipt: SessionCommandReceiptRow;
   control: EffectiveSessionControl;
-  sessionControlEventId: string;
-  workspaceControlEventId: string;
+  sessionControlEventId: string | null;
+  workspaceControlEventId: string | null;
   interruptionCount: number;
   backgroundCommandCount: number;
   wakeCount: number;
@@ -2233,6 +2233,7 @@ export type SessionControlMutationResult = {
   cancelledTurnCount: number;
   affectedSessionEvents: Array<{ sessionId: string; eventIds: string[] }>;
   workflowWake: SessionControlWorkflowWake | null;
+  outcome: "changed" | "unchanged" | "replayed";
   replay: boolean;
 };
 
@@ -2276,6 +2277,115 @@ async function pendingSessionControlWorkflowWake(
     temporalWorkflowId: wake.temporalWorkflowId,
     wakeRevision: wake.wakeRevision,
   };
+}
+
+async function sessionPauseEffectsNeeded(
+  db: Database,
+  input: { workspaceId: string; sessionId: string; directPauseRevision: number },
+): Promise<boolean> {
+  const rows = await db.execute<{ needed: boolean }>(sql`
+    with recursive subtree(id, path, cycle) as (
+      select session.id, array[session.id]::uuid[], false
+      from ${schema.sessions} session
+      where session.workspace_id = ${input.workspaceId}
+        and session.id = ${input.sessionId}
+      union all
+      select child.id, parent.path || child.id, child.id = any(parent.path)
+      from subtree parent
+      join ${schema.sessions} child
+        on child.workspace_id = ${input.workspaceId}
+       and child.parent_session_id = parent.id
+      where not parent.cycle
+        and cardinality(parent.path) <= ${SESSION_ANCESTRY_LIMIT}
+    ), scoped_sessions as (
+      select session.id, session.subtree_run_override_revision
+      from subtree
+      join ${schema.sessions} session
+        on session.workspace_id = ${input.workspaceId}
+       and session.id = subtree.id
+      where not subtree.cycle
+    )
+    select exists (
+      select 1
+      from scoped_sessions session
+      where session.subtree_run_override_revision > ${input.directPauseRevision}
+      union all
+      select 1
+      from ${schema.sessionTurnAttempts} attempt
+      join scoped_sessions session on session.id = attempt.session_id
+      where attempt.workspace_id = ${input.workspaceId}
+        and attempt.state in ('claimed', 'running')
+        and not exists (
+          select 1
+          from ${schema.sessionAttemptInterruptions} interruption
+          where interruption.workspace_id = attempt.workspace_id
+            and interruption.attempt_id = attempt.id
+            and interruption.kind in ('session_pause', 'workspace_pause')
+            and interruption.state in ('pending', 'delivered', 'acknowledged')
+        )
+      union all
+      select 1
+      from ${schema.sessionBackgroundCommands} command
+      join scoped_sessions session on session.id = command.session_id
+      where command.workspace_id = ${input.workspaceId}
+        and command.state = 'running'
+    ) as needed
+  `);
+  return rows[0]?.needed ?? false;
+}
+
+async function workspacePauseEffectsNeeded(
+  db: Database,
+  input: { workspaceId: string; workspacePauseRevision: number },
+): Promise<boolean> {
+  const rows = await db.execute<{ needed: boolean }>(sql`
+    select exists (
+      select 1
+      from ${schema.sessions} session
+      where session.workspace_id = ${input.workspaceId}
+        and session.subtree_run_override_revision > ${input.workspacePauseRevision}
+      union all
+      select 1
+      from ${schema.sessionTurnAttempts} attempt
+      where attempt.workspace_id = ${input.workspaceId}
+        and attempt.state in ('claimed', 'running')
+        and not exists (
+          select 1
+          from ${schema.sessionAttemptInterruptions} interruption
+          where interruption.workspace_id = attempt.workspace_id
+            and interruption.attempt_id = attempt.id
+            and interruption.kind in ('session_pause', 'workspace_pause')
+            and interruption.state in ('pending', 'delivered', 'acknowledged')
+        )
+      union all
+      select 1
+      from ${schema.sessionBackgroundCommands} command
+      where command.workspace_id = ${input.workspaceId}
+        and command.state = 'running'
+    ) as needed
+  `);
+  return rows[0]?.needed ?? false;
+}
+
+async function continuableWakeRepairNeeded(
+  db: Database,
+  input: { workspaceId: string; rootSessionId: string | null },
+): Promise<boolean> {
+  const rows = await db.execute<{ needed: boolean }>(sql`
+    select exists (
+      select 1
+      from opengeni_private.list_continuable_sessions(
+        ${input.workspaceId}::uuid,
+        ${input.rootSessionId}::uuid
+      ) eligible
+      left join ${schema.sessionWorkflowWakeOutbox} wake
+        on wake.workspace_id = eligible.workspace_id
+       and wake.session_id = eligible.session_id
+      where wake.session_id is null
+        or wake.wake_revision <= wake.delivered_revision
+    ) as needed
+  `);
+  return rows[0]?.needed ?? false;
 }
 
 async function loadSessionSubtreeIds(
@@ -3017,13 +3127,23 @@ export async function mutateSessionControlInTransaction(
     operationKey: input.operationKey,
     canonicalRequestHash: hash,
   });
-  if (reserved.replay && reserved.receipt.appliedControlRevision !== null) {
-    const workspaceControlEventId = String(reserved.receipt.result.workspaceControlEventId ?? "");
-    if (!workspaceControlEventId) {
+  if (reserved.replay) {
+    const storedOutcome = reserved.receipt.result.outcome;
+    const unchanged =
+      storedOutcome === "unchanged" && reserved.receipt.appliedControlRevision === null;
+    if (!unchanged && reserved.receipt.appliedControlRevision === null) {
+      throw new SessionControlInvariantError(
+        "Replayed session control receipt has no applied control revision",
+      );
+    }
+    const workspaceControlEventId = unchanged
+      ? null
+      : String(reserved.receipt.result.workspaceControlEventId ?? "");
+    if (!unchanged && !workspaceControlEventId) {
       throw new SessionControlInvariantError("Replayed session control receipt has no event");
     }
-    const sessionControlEventId = String(reserved.receipt.result.eventId ?? "");
-    if (!sessionControlEventId) {
+    const sessionControlEventId = unchanged ? null : String(reserved.receipt.result.eventId ?? "");
+    if (!unchanged && !sessionControlEventId) {
       throw new SessionControlInvariantError(
         "Replayed session control receipt has no session event",
       );
@@ -3046,13 +3166,16 @@ export async function mutateSessionControlInTransaction(
             sessionId: string;
             eventIds: string[];
           }>)
-        : [{ sessionId: input.sessionId, eventIds: [sessionControlEventId] }],
+        : sessionControlEventId
+          ? [{ sessionId: input.sessionId, eventIds: [sessionControlEventId] }]
+          : [],
       workflowWake: await pendingSessionControlWorkflowWake(
         db,
         input.workspaceId,
         input.sessionId,
         wakeCount,
       ),
+      outcome: "replayed",
       replay: true,
     };
   }
@@ -3072,6 +3195,59 @@ export async function mutateSessionControlInTransaction(
   });
   if (input.expectedControlEtag && input.expectedControlEtag !== before.controlEtag) {
     throw new SessionControlConflictError();
+  }
+
+  if (input.action !== "cancel") {
+    const targetSession = locks.sessions.find((session) => session.id === input.sessionId);
+    if (!targetSession) {
+      throw new SessionControlInvariantError(`Session ${input.sessionId} disappeared`);
+    }
+    const directPauseRevision = asSafeRevision(
+      targetSession.directPauseRevision,
+      "direct pause revision",
+    );
+    const changed =
+      input.action === "pause"
+        ? targetSession.directControlState !== "paused" ||
+          directPauseRevision === null ||
+          (await sessionPauseEffectsNeeded(db, {
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            directPauseRevision,
+          }))
+        : before.state === "paused" ||
+          (await continuableWakeRepairNeeded(db, {
+            workspaceId: input.workspaceId,
+            rootSessionId: input.sessionId,
+          }));
+    if (!changed) {
+      const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
+        result: {
+          outcome: "unchanged",
+          interruptionCount: 0,
+          backgroundCommandCount: 0,
+          wakeCount: 0,
+          cancelledSessionCount: 0,
+          cancelledTurnCount: 0,
+          affectedSessionEvents: [],
+        },
+      });
+      return {
+        receipt,
+        control: before,
+        sessionControlEventId: null,
+        workspaceControlEventId: null,
+        interruptionCount: 0,
+        backgroundCommandCount: 0,
+        wakeCount: 0,
+        cancelledSessionCount: 0,
+        cancelledTurnCount: 0,
+        affectedSessionEvents: [],
+        workflowWake: null,
+        outcome: "unchanged",
+        replay: false,
+      };
+    }
   }
 
   const revision = nextRevision(workspace);
@@ -3281,6 +3457,7 @@ export async function mutateSessionControlInTransaction(
   const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
     controlRevision: revision,
     result: {
+      outcome: "changed",
       interruptionCount,
       backgroundCommandCount,
       wakeCount,
@@ -3311,6 +3488,7 @@ export async function mutateSessionControlInTransaction(
       input.sessionId,
       wakeCount,
     ),
+    outcome: "changed",
     replay: false,
   };
 }
@@ -3406,11 +3584,12 @@ export async function autoResumeSessionBranchInTransaction(
 export type WorkspaceControlMutationResult = {
   receipt: SessionCommandReceiptRow;
   revision: number;
-  workspaceControlEventId: string;
+  workspaceControlEventId: string | null;
   workspaceState: EffectiveControlState;
   interruptionCount: number;
   backgroundCommandCount: number;
   wakeCount: number;
+  outcome: "changed" | "unchanged" | "replayed";
   replay: boolean;
 };
 
@@ -3449,24 +3628,77 @@ export async function mutateWorkspaceControlInTransaction(
     operationKey: input.operationKey,
     canonicalRequestHash: hash,
   });
-  if (reserved.replay && reserved.receipt.appliedControlRevision !== null) {
-    const workspaceControlEventId = String(reserved.receipt.result.workspaceControlEventId ?? "");
-    if (!workspaceControlEventId) {
+  if (reserved.replay) {
+    const storedOutcome = reserved.receipt.result.outcome;
+    const unchanged =
+      storedOutcome === "unchanged" && reserved.receipt.appliedControlRevision === null;
+    if (!unchanged && reserved.receipt.appliedControlRevision === null) {
+      throw new SessionControlInvariantError(
+        "Replayed workspace control receipt has no applied control revision",
+      );
+    }
+    const workspaceControlEventId = unchanged
+      ? null
+      : String(reserved.receipt.result.workspaceControlEventId ?? "");
+    if (!unchanged && !workspaceControlEventId) {
       throw new SessionControlInvariantError("Replayed workspace control receipt has no event");
     }
     return {
       receipt: reserved.receipt,
-      revision: Number(reserved.receipt.appliedControlRevision),
-      workspaceControlEventId,
-      workspaceState: input.action === "pause" ? "paused" : "active",
+      revision:
+        reserved.receipt.appliedControlRevision === null
+          ? currentRevision
+          : Number(reserved.receipt.appliedControlRevision),
+      workspaceControlEventId: workspaceControlEventId || null,
+      workspaceState: workspace.workspaceState === "paused" ? "paused" : "active",
       interruptionCount: Number(reserved.receipt.result.interruptionCount ?? 0),
       backgroundCommandCount: Number(reserved.receipt.result.backgroundCommandCount ?? 0),
       wakeCount: Number(reserved.receipt.result.wakeCount ?? 0),
+      outcome: "replayed",
       replay: true,
     };
   }
   if (input.expectedRevision !== null && input.expectedRevision !== undefined) {
     if (input.expectedRevision !== currentRevision) throw new SessionControlConflictError();
+  }
+
+  const workspacePauseRevision = asSafeRevision(
+    workspace.workspacePauseRevision,
+    "workspace pause revision",
+  );
+  const changed =
+    input.action === "pause"
+      ? workspace.workspaceState !== "paused" ||
+        workspacePauseRevision === null ||
+        (await workspacePauseEffectsNeeded(db, {
+          workspaceId: input.workspaceId,
+          workspacePauseRevision,
+        }))
+      : workspace.workspaceState !== "active" ||
+        (await continuableWakeRepairNeeded(db, {
+          workspaceId: input.workspaceId,
+          rootSessionId: null,
+        }));
+  if (!changed) {
+    const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
+      result: {
+        outcome: "unchanged",
+        interruptionCount: 0,
+        backgroundCommandCount: 0,
+        wakeCount: 0,
+      },
+    });
+    return {
+      receipt,
+      revision: currentRevision,
+      workspaceControlEventId: null,
+      workspaceState: workspace.workspaceState === "paused" ? "paused" : "active",
+      interruptionCount: 0,
+      backgroundCommandCount: 0,
+      wakeCount: 0,
+      outcome: "unchanged",
+      replay: false,
+    };
   }
 
   const revision = nextRevision(workspace);
@@ -3533,7 +3765,13 @@ export async function mutateWorkspaceControlInTransaction(
         });
   const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
     controlRevision: revision,
-    result: { interruptionCount, backgroundCommandCount, wakeCount, workspaceControlEventId },
+    result: {
+      outcome: "changed",
+      interruptionCount,
+      backgroundCommandCount,
+      wakeCount,
+      workspaceControlEventId,
+    },
   });
   return {
     receipt,
@@ -3543,6 +3781,7 @@ export async function mutateWorkspaceControlInTransaction(
     interruptionCount,
     backgroundCommandCount,
     wakeCount,
+    outcome: "changed",
     replay: false,
   };
 }

--- a/packages/db/test/session-control-algebra.test.ts
+++ b/packages/db/test/session-control-algebra.test.ts
@@ -228,7 +228,8 @@ describe("recursive session control algebra", () => {
       ),
     ).toMatchObject({ state: "paused" });
 
-    await control(value, value.root.id, "pause");
+    const pausedAgain = await control(value, value.root.id, "pause");
+    expect(pausedAgain.outcome).toBe("changed");
     expect(
       await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
         evaluateSessionControl(db, value.grant.workspaceId!, value.child.id),
@@ -237,6 +238,74 @@ describe("recursive session control algebra", () => {
       state: "paused",
       primaryBlocker: { kind: "session", sessionId: value.root.id },
     });
+  });
+
+  test("a child Pause under inherited Pause installs a narrower blocker", async () => {
+    const value = await fixture();
+    await control(value, value.root.id, "pause");
+
+    const childPause = await control(value, value.child.id, "pause");
+    expect(childPause).toMatchObject({
+      outcome: "changed",
+      control: {
+        state: "paused",
+        directState: "paused",
+        primaryBlocker: { kind: "session", sessionId: value.child.id },
+      },
+    });
+
+    await control(value, value.root.id, "resume");
+    expect(
+      await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
+        evaluateSessionControl(db, value.grant.workspaceId!, value.child.id),
+      ),
+    ).toMatchObject({
+      state: "paused",
+      primaryBlocker: { kind: "session", sessionId: value.child.id },
+    });
+  });
+
+  test("fresh desired-state repeats are unchanged and exact retries stay replayed", async () => {
+    const value = await fixture();
+
+    const firstPause = await control(value, value.root.id, "pause");
+    expect(firstPause.outcome).toBe("changed");
+    const repeatedPauseKey = crypto.randomUUID();
+    const repeatedPause = await control(value, value.root.id, "pause", repeatedPauseKey);
+    expect(repeatedPause).toMatchObject({
+      outcome: "unchanged",
+      replay: false,
+      sessionControlEventId: null,
+      workspaceControlEventId: null,
+      interruptionCount: 0,
+      wakeCount: 0,
+    });
+    expect(repeatedPause.receipt.appliedControlRevision).toBeNull();
+    const replayedPause = await control(value, value.root.id, "pause", repeatedPauseKey);
+    expect(replayedPause).toMatchObject({
+      outcome: "replayed",
+      replay: true,
+      sessionControlEventId: null,
+      workspaceControlEventId: null,
+    });
+    expect(replayedPause.receipt.id).toBe(repeatedPause.receipt.id);
+
+    const firstResume = await control(value, value.root.id, "resume");
+    expect(firstResume.outcome).toBe("changed");
+    const repeatedResume = await control(value, value.root.id, "resume");
+    expect(repeatedResume).toMatchObject({
+      outcome: "unchanged",
+      replay: false,
+      sessionControlEventId: null,
+      workspaceControlEventId: null,
+      wakeCount: 0,
+    });
+
+    expect(
+      (await listWorkspaceControlEvents(client.db, value.grant.workspaceId!, 0, 10)).map(
+        (event) => event.action,
+      ),
+    ).toEqual(["pause", "resume"]);
   });
 
   test("Pause creates exact live-attempt interruptions without application-side descendant IDs", async () => {
@@ -327,6 +396,21 @@ describe("recursive session control algebra", () => {
       state: "pending",
     });
 
+    const repeatedPause = await control(value, value.root.id, "pause");
+    expect(repeatedPause).toMatchObject({
+      outcome: "unchanged",
+      interruptionCount: 0,
+      wakeCount: 0,
+    });
+    expect(
+      await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
+        db
+          .select()
+          .from(schema.sessionAttemptInterruptions)
+          .where(eq(schema.sessionAttemptInterruptions.attemptId, attemptId)),
+      ),
+    ).toHaveLength(1);
+
     const settled = await settleSessionAttemptInterruptions(
       client.db,
       value.grant.workspaceId!,
@@ -416,7 +500,14 @@ describe("recursive session control algebra", () => {
         }),
       );
 
-    await workspaceControl("pause");
+    const firstPause = await workspaceControl("pause");
+    expect(firstPause.outcome).toBe("changed");
+    const repeatedPause = await workspaceControl("pause");
+    expect(repeatedPause).toMatchObject({
+      outcome: "unchanged",
+      workspaceControlEventId: null,
+      wakeCount: 0,
+    });
     expect(
       await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
         evaluateSessionControl(db, value.grant.workspaceId!, value.child.id),
@@ -434,7 +525,8 @@ describe("recursive session control algebra", () => {
       ),
     ).toMatchObject({ state: "paused", primaryBlocker: { kind: "workspace" } });
 
-    await workspaceControl("pause");
+    const invalidatingPause = await workspaceControl("pause");
+    expect(invalidatingPause.outcome).toBe("changed");
     expect(
       await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
         evaluateSessionControl(db, value.grant.workspaceId!, value.child.id),


### PR DESCRIPTION
## Summary

- classify session and workspace Pause/Resume persistence as `changed`, `unchanged`, or `replayed` before allocating a control revision
- suppress events, audits, interruptions, adopted-command stops, and workflow wakes for represented desired-state no-ops while preserving newer descendant override invalidation and narrower child blockers
- repair uncovered live attempts, running adopted commands, and missing continuability wakes as real changes
- return the same versioned MCP mutation receipt for agent-bound and sessionless/operator `session_pause` and `session_resume` callers

## Tests

- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-algebra.test.ts` (9 passed)
- `bun test apps/api/test/mcp-receipts.test.ts` (6 passed)
- `bun scripts/check-docs-refs.ts`
- `git diff --check`

The focused MCP authorization integration test could not run locally because Bun 1.4.0 aborted before executing assertions; public CI is the authoritative integration run.

## Summary by Sourcery

Make session and workspace Pause/Resume mutations report truthful outcomes and avoid side effects for represented no-ops.

New Features:
- Return consistent versioned MCP mutation receipts for agent-bound and sessionless/operator session Pause and Resume operations, including changed, unchanged, and replayed outcomes.

Bug Fixes:
- Prevent represented desired-state no-ops from allocating control revisions or emitting unnecessary events, audits, interruptions, command stops, and workflow wakes.
- Repair uncovered live attempts, running adopted commands, descendant overrides, and missing workflow wakes as real control changes.

Enhancements:
- Make session and workspace control persistence distinguish fresh unchanged requests from exact idempotency replays while preserving descendant override invalidation and narrower child blockers.

Documentation:
- Document desired-state control semantics and the unified MCP session-control receipt contract.

Tests:
- Expand database and API coverage for no-op classification, replay behavior, lifecycle repairs, nested blockers, and receipt consistency.

Chores:
- Add a changeset for the session-control receipt and persistence behavior updates.