### PR TITLE
fix(api): retain fatal process diagnostics

### DIFF
--- a/.changeset/safe-api-fatal-diagnostics.md
+++ b/.changeset/safe-api-fatal-diagnostics.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/observability": patch
+---
+
+Attribute fatal API startup and runtime failures with secret-safe structural diagnostics, drain pending OTLP exports for a bounded interval, and preserve the required nonzero process exit.

--- a/apps/api/src/fatal-process-boundary.ts
+++ b/apps/api/src/fatal-process-boundary.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+import type { Attributes, Observability, Span } from "@opengeni/observability";
+
+export type ApiFatalEvent = "startup_failure" | "unhandled_rejection" | "uncaught_exception";
+export type ApiFatalPhase = "startup" | "running";
+export type ApiFatalReasonKind =
+  | "bigint"
+  | "boolean"
+  | "error"
+  | "function"
+  | "null"
+  | "number"
+  | "object"
+  | "string"
+  | "symbol"
+  | "undefined";
+
+type ApiFatalObservability = Pick<Observability, "error" | "flush" | "startSpan">;
+
+type ApiFatalProcess = {
+  on: (
+    event: "unhandledRejection" | "uncaughtException",
+    listener: (reason: unknown) => void,
+  ) => void;
+  off: (
+    event: "unhandledRejection" | "uncaughtException",
+    listener: (reason: unknown) => void,
+  ) => void;
+  exit: (code: number) => void;
+};
+
+export type ApiFatalProcessBoundaryOptions = {
+  process?: ApiFatalProcess;
+  observability?: ApiFatalObservability;
+  flushTimeoutMs?: number;
+  correlationId?: () => string;
+  fallbackLog?: (message: string) => void;
+};
+
+export type ApiFatalProcessBoundary = {
+  attachObservability: (observability: ApiFatalObservability) => void;
+  markRunning: () => void;
+  reportStartupFailure: (reason: unknown) => Promise<void>;
+  dispose: () => void;
+};
+
+const API_FATAL_FLUSH_TIMEOUT_MS = 1_000;
+const API_FATAL_CORRELATION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+const FATAL_ERROR_CODES = {
+  startup_failure: "api_startup_failed",
+  unhandled_rejection: "api_unhandled_rejection",
+  uncaught_exception: "api_uncaught_exception",
+} as const;
+
+export function installApiFatalProcessBoundary(
+  options: ApiFatalProcessBoundaryOptions = {},
+): ApiFatalProcessBoundary {
+  const runtimeProcess = options.process ?? defaultProcessBoundary();
+  const flushTimeoutMs = options.flushTimeoutMs ?? API_FATAL_FLUSH_TIMEOUT_MS;
+  const correlationId = options.correlationId ?? (() => `api-fatal.${randomUUID()}`);
+  const fallbackLog = options.fallbackLog ?? ((message: string) => console.error(message));
+  let observability = options.observability;
+  let phase: ApiFatalPhase = "startup";
+  let reporting = false;
+
+  const report = async (event: ApiFatalEvent, reason: unknown): Promise<void> => {
+    if (reporting) return;
+    reporting = true;
+
+    const diagnostic = apiFatalDiagnostic(event, phase, reason, correlationId);
+    const message = apiFatalMessage(diagnostic);
+    const activeObservability = observability;
+    try {
+      if (activeObservability) {
+        let logged = false;
+        try {
+          activeObservability.error(message, diagnostic);
+          logged = true;
+        } catch {
+          // The fatal boundary must still report and terminate if logging is unhealthy.
+        }
+        if (!logged) {
+          safeFallbackLog(fallbackLog, message);
+        }
+        try {
+          const span: Span = activeObservability.startSpan("api.process.fatal", diagnostic);
+          span.end({ error: true });
+        } catch {
+          // The synchronous log remains authoritative when span creation fails.
+        }
+        await flushWithin(activeObservability, flushTimeoutMs);
+      } else {
+        safeFallbackLog(fallbackLog, message);
+      }
+    } finally {
+      runtimeProcess.exit(1);
+    }
+  };
+
+  const onUnhandledRejection = (reason: unknown): void => {
+    void report("unhandled_rejection", reason);
+  };
+  const onUncaughtException = (reason: unknown): void => {
+    void report("uncaught_exception", reason);
+  };
+  runtimeProcess.on("unhandledRejection", onUnhandledRejection);
+  runtimeProcess.on("uncaughtException", onUncaughtException);
+
+  return {
+    attachObservability: (value) => {
+      observability = value;
+    },
+    markRunning: () => {
+      phase = "running";
+    },
+    reportStartupFailure: async (reason) => {
+      await report("startup_failure", reason);
+    },
+    dispose: () => {
+      runtimeProcess.off("unhandledRejection", onUnhandledRejection);
+      runtimeProcess.off("uncaughtException", onUncaughtException);
+    },
+  };
+}
+
+function apiFatalDiagnostic(
+  event: ApiFatalEvent,
+  phase: ApiFatalPhase,
+  reason: unknown,
+  correlationId: () => string,
+): Attributes & {
+  errorClass: "ApiFatalOperationError";
+  errorCode: (typeof FATAL_ERROR_CODES)[ApiFatalEvent];
+  origin: "api";
+  phase: ApiFatalPhase;
+  reasonKind: ApiFatalReasonKind;
+  correlationId: string;
+} {
+  let safeCorrelationId = "api-fatal.fallback";
+  try {
+    const candidate = correlationId();
+    if (API_FATAL_CORRELATION_ID_PATTERN.test(candidate)) {
+      safeCorrelationId = candidate;
+    }
+  } catch {
+    // A fixed valid fallback preserves the fatal report and nonzero exit.
+  }
+  return {
+    errorClass: "ApiFatalOperationError",
+    errorCode: FATAL_ERROR_CODES[event],
+    origin: "api",
+    phase,
+    reasonKind: apiFatalReasonKind(reason),
+    correlationId: safeCorrelationId,
+  };
+}
+
+function apiFatalReasonKind(reason: unknown): ApiFatalReasonKind {
+  if (reason === null) return "null";
+  const kind = typeof reason;
+  if (kind !== "object") return kind;
+  try {
+    return reason instanceof Error ? "error" : "object";
+  } catch {
+    return "object";
+  }
+}
+
+function apiFatalMessage(diagnostic: ReturnType<typeof apiFatalDiagnostic>): string {
+  return (
+    `OpenGeni API fatal process failure (${diagnostic.errorCode}; ` +
+    `phase=${diagnostic.phase}; reason_kind=${diagnostic.reasonKind}; ` +
+    `correlation_id=${diagnostic.correlationId})`
+  );
+}
+
+async function flushWithin(
+  observability: Pick<Observability, "flush">,
+  timeoutMs: number,
+): Promise<void> {
+  let flush: Promise<void>;
+  try {
+    flush = Promise.resolve(observability.flush()).catch(() => undefined);
+  } catch {
+    return;
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      flush,
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function safeFallbackLog(fallbackLog: (message: string) => void, message: string): void {
+  try {
+    fallbackLog(message);
+  } catch {
+    // Process termination remains mandatory even when every diagnostic sink fails.
+  }
+}
+
+function defaultProcessBoundary(): ApiFatalProcess {
+  return {
+    on: (event, listener) => {
+      if (event === "unhandledRejection") {
+        process.on("unhandledRejection", listener);
+      } else {
+        process.on("uncaughtException", listener);
+      }
+    },
+    off: (event, listener) => {
+      if (event === "unhandledRejection") {
+        process.off("unhandledRejection", listener);
+      } else {
+        process.off("uncaughtException", listener);
+      }
+    },
+    exit: (code) => {
+      process.exit(code);
+    },
+  };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,7 +21,11 @@ import {
   type Database,
 } from "@opengeni/db";
 import { createNatsEventBus, type ResponderConnection } from "@opengeni/events";
-import { createObservability, logStartupDependencyRetry } from "@opengeni/observability";
+import {
+  createObservability,
+  logStartupDependencyRetry,
+  type Observability,
+} from "@opengeni/observability";
 import { createObjectStorage } from "@opengeni/storage";
 import { isArtifactRuntimeConfigured } from "@opengeni/artifact-tool/runtime/development";
 import { SESSION_WORKFLOW_WAKE_DISPATCHER_SCHEDULE_ID } from "@opengeni/core";
@@ -51,6 +55,7 @@ import {
   createStandaloneEditableArtifactApplication,
   type StandaloneEditableArtifactApplication,
 } from "./editable-artifact-production";
+import { installApiFatalProcessBoundary } from "./fatal-process-boundary";
 
 /**
  * A REJECT_DUPLICATE start collides on the deterministic workflowId when the
@@ -299,9 +304,15 @@ export async function createTemporalWorkflowClient(
   };
 }
 
-export async function startApi() {
-  const settings = getSettings();
-  const observability = createObservability(settings, { component: "api" });
+export async function startApi(
+  options: {
+    settings?: ReturnType<typeof getSettings>;
+    observability?: Observability;
+  } = {},
+) {
+  const settings = options.settings ?? getSettings();
+  const observability =
+    options.observability ?? createObservability(settings, { component: "api" });
   // Step I: standalone → dbSchema unset → searchPath undefined → today's plain
   // handle (public). Embedded → scoped to the dedicated schema + the host's RLS
   // strategy.
@@ -531,7 +542,16 @@ export async function startApi() {
 }
 
 if (import.meta.main) {
-  await startApi();
+  const fatalBoundary = installApiFatalProcessBoundary();
+  try {
+    const settings = getSettings();
+    const observability = createObservability(settings, { component: "api" });
+    fatalBoundary.attachObservability(observability);
+    await startApi({ settings, observability });
+    fatalBoundary.markRunning();
+  } catch (error) {
+    await fatalBoundary.reportStartupFailure(error);
+  }
 }
 
 export function temporalOverlapPolicy(policy: ScheduledTaskOverlapPolicy): ScheduleOverlapPolicy {

--- a/apps/api/test/fatal-process-boundary.test.ts
+++ b/apps/api/test/fatal-process-boundary.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import type { Attributes } from "@opengeni/observability";
+import { installApiFatalProcessBoundary } from "../src/fatal-process-boundary";
+
+type FatalEvent = "unhandledRejection" | "uncaughtException";
+
+function fakeProcess() {
+  const listeners = new Map<FatalEvent, (reason: unknown) => void>();
+  const exits: number[] = [];
+  let resolveExit: ((code: number) => void) | undefined;
+  const exit = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+  return {
+    process: {
+      on: (event: FatalEvent, listener: (reason: unknown) => void) => {
+        listeners.set(event, listener);
+      },
+      off: (event: FatalEvent, listener: (reason: unknown) => void) => {
+        if (listeners.get(event) === listener) listeners.delete(event);
+      },
+      exit: (code: number) => {
+        exits.push(code);
+        resolveExit?.(code);
+      },
+    },
+    emit: (event: FatalEvent, reason: unknown) => {
+      listeners.get(event)?.(reason);
+    },
+    listeners,
+    exits,
+    exit,
+  };
+}
+
+describe("API fatal process boundary", () => {
+  test("reports an unhandled rejection with closed structural facts and no rejection content", async () => {
+    const sentinel = "API_FATAL_PRIVATE_SENTINEL_76d324";
+    const runtime = fakeProcess();
+    const logs: Array<{ message: string; attributes: Attributes }> = [];
+    const spans: Array<{
+      name: string;
+      attributes: Attributes;
+      endInput?: { attributes?: Attributes; error?: unknown };
+    }> = [];
+    let flushes = 0;
+    const boundary = installApiFatalProcessBoundary({
+      process: runtime.process,
+      correlationId: () => "api-fatal.test-unhandled",
+      observability: {
+        error: (message, attributes = {}) => {
+          logs.push({ message, attributes });
+        },
+        startSpan: (name, attributes = {}) => {
+          const recorded: (typeof spans)[number] = {
+            name,
+            attributes,
+          };
+          spans.push(recorded);
+          return {
+            traceId: "0".repeat(32),
+            spanId: "0".repeat(16),
+            end: (input = {}) => {
+              recorded.endInput = input;
+            },
+          };
+        },
+        flush: async () => {
+          flushes += 1;
+        },
+      },
+    });
+    boundary.markRunning();
+    const hostileReason = new Proxy(
+      { privateValue: sentinel },
+      {
+        get: () => {
+          throw new Error(sentinel);
+        },
+        getPrototypeOf: () => {
+          throw new Error(sentinel);
+        },
+      },
+    );
+
+    runtime.emit("unhandledRejection", hostileReason);
+    expect(await runtime.exit).toBe(1);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]!.attributes).toMatchObject({
+      errorClass: "ApiFatalOperationError",
+      errorCode: "api_unhandled_rejection",
+      origin: "api",
+      phase: "running",
+      reasonKind: "object",
+      correlationId: "api-fatal.test-unhandled",
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toMatchObject({
+      name: "api.process.fatal",
+      attributes: logs[0]!.attributes,
+      endInput: { error: true },
+    });
+    expect(flushes).toBe(1);
+    expect(runtime.exits).toEqual([1]);
+    expect(JSON.stringify({ logs, spans })).not.toContain(sentinel);
+
+    boundary.dispose();
+    expect(runtime.listeners.size).toBe(0);
+  });
+
+  test("uses a safe startup fallback when observability is not available", async () => {
+    const sentinel = "API_STARTUP_PRIVATE_SENTINEL_2aa957";
+    const runtime = fakeProcess();
+    const fallbackLogs: string[] = [];
+    const boundary = installApiFatalProcessBoundary({
+      process: runtime.process,
+      correlationId: () => `private correlation ${sentinel}`,
+      fallbackLog: (message) => fallbackLogs.push(message),
+    });
+
+    await boundary.reportStartupFailure(`private startup failure ${sentinel}`);
+
+    expect(runtime.exits).toEqual([1]);
+    expect(fallbackLogs).toHaveLength(1);
+    expect(fallbackLogs[0]).toContain("api_startup_failed");
+    expect(fallbackLogs[0]).toContain("phase=startup");
+    expect(fallbackLogs[0]).toContain("reason_kind=string");
+    expect(fallbackLogs[0]).toContain("correlation_id=api-fatal.fallback");
+    expect(fallbackLogs[0]).not.toContain(sentinel);
+  });
+
+  test("bounds a hung telemetry flush and reports only the first fatal event", async () => {
+    const runtime = fakeProcess();
+    const logs: Array<{ message: string; attributes: Attributes }> = [];
+    const boundary = installApiFatalProcessBoundary({
+      process: runtime.process,
+      flushTimeoutMs: 5,
+      correlationId: () => "api-fatal.test-timeout",
+      observability: {
+        error: (message, attributes = {}) => logs.push({ message, attributes }),
+        startSpan: () => ({
+          traceId: "0".repeat(32),
+          spanId: "0".repeat(16),
+          end: () => undefined,
+        }),
+        flush: async () => await new Promise<void>(() => undefined),
+      },
+    });
+
+    runtime.emit("uncaughtException", new Error("first private failure"));
+    runtime.emit("unhandledRejection", new Error("second private failure"));
+    const exitCode = await Promise.race([
+      runtime.exit,
+      Bun.sleep(200).then(() => {
+        throw new Error("fatal boundary did not exit after the flush deadline");
+      }),
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(runtime.exits).toEqual([1]);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]!.attributes).toMatchObject({
+      errorCode: "api_uncaught_exception",
+      phase: "startup",
+      reasonKind: "error",
+    });
+    expect(JSON.stringify(logs)).not.toContain("private failure");
+    boundary.dispose();
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -627,6 +627,15 @@ metadata.
 | `apps/web` | `opengeni-web` | Stock React/Vite operator console consuming the public SDK and React packages |
 | `apps/browser-extension` | `@opengeni/browser-extension` | Browser attachment extension and its control-plane protocol; a leaf client, not session authority |
 
+The standalone `apps/api` entrypoint installs a one-shot fatal process
+boundary before configuration or dependency startup. Startup failures,
+unhandled promise rejections, and uncaught exceptions emit only reviewed
+structural diagnostics plus an opaque correlation id, drain accepted OTLP
+exports for a bounded interval, and then exit nonzero. Exception messages,
+stacks, enumerable fields, and arbitrary rejection values never cross the
+public telemetry boundary. Embedded API composition does not install process
+handlers because its host owns process lifecycle.
+
 ### 6.2 Packages
 
 | Path | Package | Owns |

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -340,6 +340,20 @@ const PUBLIC_CHANNEL_A_FAILURE_REASONS = new Set([
   "unexpected",
 ]);
 
+const PUBLIC_API_FATAL_PHASES = new Set(["startup", "running"]);
+const PUBLIC_API_FATAL_REASON_KINDS = new Set([
+  "bigint",
+  "boolean",
+  "error",
+  "function",
+  "null",
+  "number",
+  "object",
+  "string",
+  "symbol",
+  "undefined",
+]);
+
 /**
  * Public diagnostic values are protocol constants, never values inferred from
  * an exception's name, constructor, code, message, or enumerable properties.
@@ -347,6 +361,7 @@ const PUBLIC_CHANNEL_A_FAILURE_REASONS = new Set([
  * are omitted rather than copied through based on syntax.
  */
 const PUBLIC_TELEMETRY_ERROR_CLASSES = new Set([
+  "ApiFatalOperationError",
   "OperationError",
   "CodexCheckpointOperationError",
   "CodexFleetShadowOperationError",
@@ -380,6 +395,9 @@ const PUBLIC_TELEMETRY_ERROR_CLASSES = new Set([
 
 const PUBLIC_TELEMETRY_ERROR_CODES = new Set([
   "agent_command_wake_failed",
+  "api_startup_failed",
+  "api_uncaught_exception",
+  "api_unhandled_rejection",
   "artifact_materializer_native_input_framing_failed",
   "artifact_materializer_native_snapshot_open_failed",
   "artifact_materializer_native_state_mismatch",
@@ -484,6 +502,7 @@ export class Observability {
   private readonly gauges = new Map<string, Gauge<string>>();
   private readonly histograms = new Map<string, Histogram<string>>();
   private readonly registrations = new Map<string, MetricRegistration>();
+  private readonly pendingExports = new Set<Promise<void>>();
   private readonly now: () => number;
   private readonly exporter: (
     url: string,
@@ -774,6 +793,13 @@ export class Observability {
     return await this.registry.metrics();
   }
 
+  /** Wait for every OTLP export accepted before or during this drain. */
+  async flush(): Promise<void> {
+    while (this.pendingExports.size > 0) {
+      await Promise.allSettled([...this.pendingExports]);
+    }
+  }
+
   private counter(name: string, help: string, labelNames: string[]): Counter<string> {
     const existing = this.counters.get(name);
     if (existing) {
@@ -882,15 +908,22 @@ export class Observability {
         },
       ],
     };
-    void this.exporter(endpoint, body, parseHeaders(this.settings.observabilityOtlpHeaders)).catch(
-      () => {
+    let pendingExport: Promise<void>;
+    pendingExport = Promise.resolve()
+      .then(() =>
+        this.exporter(endpoint, body, parseHeaders(this.settings.observabilityOtlpHeaders)),
+      )
+      .catch(() => {
         this.warn("OTLP span export failed", {
           errorClass: "TelemetryExportError",
           errorCode: "otlp_export_failed",
           origin: "observability",
         });
-      },
-    );
+      })
+      .finally(() => {
+        this.pendingExports.delete(pendingExport);
+      });
+    this.pendingExports.add(pendingExport);
   }
 }
 
@@ -1167,6 +1200,7 @@ function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
     return {
       ...projectStartupDependencyAttributes(attributes),
       ...projectPublicChannelADiagnosticAttributes(attributes),
+      ...projectApiFatalDiagnosticAttributes(attributes),
       ...projectPublicDiagnosticAttributes(attributes),
     };
   }
@@ -1178,6 +1212,18 @@ function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
       return typeof value === "string" && pattern?.test(value) === true;
     }),
   );
+}
+
+function projectApiFatalDiagnosticAttributes(attributes: Attributes): Attributes {
+  if (attributes.errorClass !== "ApiFatalOperationError") return {};
+  const phase = attributes.phase;
+  const reasonKind = attributes.reasonKind;
+  return {
+    ...(typeof phase === "string" && PUBLIC_API_FATAL_PHASES.has(phase) ? { phase } : {}),
+    ...(typeof reasonKind === "string" && PUBLIC_API_FATAL_REASON_KINDS.has(reasonKind)
+      ? { reasonKind }
+      : {}),
+  };
 }
 
 function projectStartupDependencyAttributes(attributes: Attributes): Attributes {

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -30,6 +30,7 @@ describe("observability", () => {
     expect(typeof obs.incrementCounter).toBe("function");
     expect(typeof obs.observeHistogram).toBe("function");
     expect(typeof obs.debug).toBe("function");
+    expect(typeof obs.flush).toBe("function");
   });
 
   test("renders prometheus metrics with resource and request labels", async () => {
@@ -376,6 +377,36 @@ describe("observability", () => {
     }
   });
 
+  test("flush waits for every accepted OTLP export", async () => {
+    let releaseExport: (() => void) | undefined;
+    let markExportStarted: (() => void) | undefined;
+    const exportStarted = new Promise<void>((resolve) => {
+      markExportStarted = resolve;
+    });
+    const obs = createObservability(settings, {
+      component: "api",
+      exporter: async () => {
+        markExportStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseExport = resolve;
+        });
+      },
+    });
+
+    obs.startSpan("api.pending_export").end();
+    await exportStarted;
+    let flushed = false;
+    const flush = obs.flush().then(() => {
+      flushed = true;
+    });
+    await Bun.sleep(0);
+
+    expect(flushed).toBe(false);
+    releaseExport?.();
+    await flush;
+    expect(flushed).toBe(true);
+  });
+
   test("projects span errors and drops unknown attributes before OTLP export", async () => {
     const exported: Array<{ body: any }> = [];
     const obs = createObservability(settings, {
@@ -633,6 +664,50 @@ describe("observability", () => {
       status: 502,
     });
     expect(JSON.parse(observed[0]!)).not.toHaveProperty("workspaceId");
+    expect(JSON.parse(observed[1]!)).not.toHaveProperty("correlationId");
+  });
+
+  test("public fatal diagnostics retain only closed structural fields", () => {
+    const sentinel = "PUBLIC_FATAL_DIAGNOSTIC_SENTINEL_1c3f91";
+    const observed: string[] = [];
+    const originalError = console.error;
+    console.error = (message?: unknown) => observed.push(String(message));
+    try {
+      const obs = createObservability(settings, { component: "api", now: () => 1 });
+      obs.error("fixed fatal diagnostic", {
+        errorClass: "ApiFatalOperationError",
+        errorCode: "api_unhandled_rejection",
+        origin: "api",
+        phase: "running",
+        reasonKind: "object",
+        correlationId: "api-fatal.test-public",
+        rejection: sentinel,
+      });
+      obs.error("invalid fatal diagnostic", {
+        errorClass: "ApiFatalOperationError",
+        errorCode: "api_uncaught_exception",
+        origin: "api",
+        phase: sentinel,
+        reasonKind: sentinel,
+        correlationId: `invalid correlation ${sentinel}`,
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(observed).toHaveLength(2);
+    expect(JSON.parse(observed[0]!)).toMatchObject({
+      message: "fixed fatal diagnostic",
+      errorClass: "ApiFatalOperationError",
+      errorCode: "api_unhandled_rejection",
+      origin: "api",
+      phase: "running",
+      reasonKind: "object",
+      correlationId: "api-fatal.test-public",
+    });
+    expect(observed.join("\n")).not.toContain(sentinel);
+    expect(JSON.parse(observed[1]!)).not.toHaveProperty("phase");
+    expect(JSON.parse(observed[1]!)).not.toHaveProperty("reasonKind");
     expect(JSON.parse(observed[1]!)).not.toHaveProperty("correlationId");
   });
 


### PR DESCRIPTION
## Summary

- install a one-shot fatal boundary before standalone API configuration and startup
- classify startup failures, unhandled rejections, and uncaught exceptions with closed structural fields and an opaque correlation id without serializing rejection content
- track accepted OTLP exports, drain them for a bounded interval, and preserve the required exit code 1
- keep embedded API composition process-neutral

## Verification

- bun test apps/api/test/fatal-process-boundary.test.ts
- bun test packages/observability/test/observability.test.ts
- tsc --noEmit for packages/observability
- strict standalone TypeScript compile for apps/api/src/fatal-process-boundary.ts
- oxlint --deny-warnings on changed TypeScript files
- oxfmt --check on changed files
- bun scripts/check-docs-refs.ts
- git diff --check

## Scope

This restores attributable, secret-safe fatal process evidence and bounded telemetry delivery. It does not identify or suppress the application rejection that triggers the boundary.

## Summary by Sourcery

Preserve secret-safe fatal API diagnostics and bounded telemetry delivery while maintaining required nonzero process termination.

New Features:
- Add secret-safe structural diagnostics for standalone API startup failures, unhandled rejections, and uncaught exceptions with correlation identifiers.
- Add bounded draining of accepted OTLP exports before fatal API process termination.

Bug Fixes:
- Preserve attributable fatal API process evidence while ensuring fatal paths exit with status 1.

Enhancements:
- Keep embedded API composition process-neutral by limiting fatal process handling to the standalone entrypoint.
- Restrict public fatal telemetry to approved diagnostic fields and reason categories.

Documentation:
- Document standalone API fatal-process handling, telemetry sanitization, bounded export draining, and embedded composition behavior.

Tests:
- Add coverage for fatal diagnostics, privacy-safe telemetry projection, bounded flush behavior, and one-shot process termination.

Chores:
- Publish patch releases for the API router and observability packages.