### PR TITLE
fix(db): settle native tool-search recovery

### DIFF
--- a/.changeset/clean-native-tool-search-settlement.md
+++ b/.changeset/clean-native-tool-search-settlement.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Settle interrupted native tool-search calls with the provider correlation identity retained in provider metadata.

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -985,6 +985,33 @@ describe("conversation-truth reconcile (orphaned tool output guard)", () => {
     ).toBeNull();
   });
 
+  test("settles native tool_search identity retained only in providerData", () => {
+    const callId = "call_native_search_1";
+    const call = {
+      id: "tsc_provider_item_1",
+      type: "tool_search_call",
+      status: "in_progress",
+      arguments: { query: "mail" },
+      providerData: { call_id: callId, execution: "client" },
+    };
+    const result = interruptedToolCallResult({
+      callType: "tool_search_call",
+      callId,
+      callItem: call,
+      reason: "worker_shutdown",
+    });
+
+    expect(result).toEqual({
+      type: "tool_search_output",
+      providerData: { call_id: callId, execution: "client" },
+      status: "incomplete",
+      tools: [],
+    });
+    const pair = [call, result!] as Array<Record<string, unknown>>;
+    expect(ModelItem.array().parse(pair)).toEqual(pair);
+    expect(sanitizeHistoryItemsForModel(pair)).toEqual(pair);
+  });
+
   test("never persists a function_call_result whose function_call was pruned mid-batch", () => {
     // Reproduces the live orphan: a parallel tool-call batch where the SDK's
     // computed history is non-monotonic across reconciles, then an abnormal

--- a/packages/db/src/session-tool-call-settlement.ts
+++ b/packages/db/src/session-tool-call-settlement.ts
@@ -20,10 +20,15 @@ export function historyCallId(item: Record<string, unknown>): string | null {
       ? (item.providerData as Record<string, unknown>)
       : null;
   // Native tool-search `id` is the provider item id, not the call correlation
-  // id. Prefer its providerData identity before the generic item-id fallback.
-  const value =
-    item.callId ?? item.call_id ?? providerData?.callId ?? providerData?.call_id ?? item.id;
-  return typeof value === "string" && value.length > 0 ? value : null;
+  // id. Validate direct and provider identities before the item-id fallback.
+  const value = [
+    item.callId,
+    item.call_id,
+    providerData?.callId,
+    providerData?.call_id,
+    item.id,
+  ].find((candidate): candidate is string => typeof candidate === "string" && candidate.length > 0);
+  return value ?? null;
 }
 
 export function historyItemType(item: Record<string, unknown>): string | null {
@@ -70,13 +75,33 @@ export function interruptedToolCallResult(input: {
   }
   if (input.callType === "computer_call") return null;
   if (input.callType === "tool_search_call") {
+    const providerData =
+      input.callItem.providerData &&
+      typeof input.callItem.providerData === "object" &&
+      !Array.isArray(input.callItem.providerData)
+        ? (input.callItem.providerData as Record<string, unknown>)
+        : null;
+    const execution =
+      input.callItem.execution === "client" || input.callItem.execution === "server"
+        ? input.callItem.execution
+        : providerData?.execution === "client" || providerData?.execution === "server"
+          ? providerData.execution
+          : null;
+    const providerIdentity =
+      typeof providerData?.call_id === "string" || typeof providerData?.callId === "string";
     const snakeId = typeof input.callItem.call_id === "string";
     return {
       type: "tool_search_output",
-      ...(snakeId ? { call_id: input.callId } : { callId: input.callId }),
-      ...(input.callItem.execution === "client" || input.callItem.execution === "server"
-        ? { execution: input.callItem.execution }
-        : {}),
+      ...(providerIdentity
+        ? {
+            providerData: {
+              call_id: input.callId,
+              ...(execution ? { execution } : {}),
+            },
+          }
+        : snakeId
+          ? { call_id: input.callId, ...(execution ? { execution } : {}) }
+          : { callId: input.callId, ...(execution ? { execution } : {}) }),
       status: "incomplete",
       tools: [],
     };

--- a/packages/db/test/session-tool-call-settlement.test.ts
+++ b/packages/db/test/session-tool-call-settlement.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { historyCallId } from "../src/session-tool-call-settlement";
+import { historyCallId, interruptedToolCallResult } from "../src/session-tool-call-settlement";
 
 describe("session tool-call settlement identity", () => {
   test("accepts native tool-search ids carried only in provider data", () => {
@@ -31,5 +31,34 @@ describe("session tool-call settlement identity", () => {
         providerData: ["provider-id"],
       }),
     ).toBe("item-id");
+  });
+
+  test("falls back when a provider id is not a non-empty string", () => {
+    expect(
+      historyCallId({
+        type: "tool_search_output",
+        id: "item-id",
+        providerData: { call_id: 42 },
+      }),
+    ).toBe("item-id");
+  });
+
+  test("uses one provider id for an interrupted native tool-search pair", () => {
+    const callId = "call_native_search_1";
+    const call = {
+      id: "tsc_provider_item_1",
+      type: "tool_search_call",
+      arguments: { query: "mail" },
+      providerData: { call_id: callId, execution: "client" },
+    };
+    const result = interruptedToolCallResult({
+      callType: "tool_search_call",
+      callId,
+      callItem: call,
+      reason: "worker_shutdown",
+    });
+
+    expect(historyCallId(call)).toBe(callId);
+    expect(historyCallId(result!)).toBe(callId);
   });
 });


### PR DESCRIPTION
## Summary

- resolve native `tool_search` calls by the stable provider call ID retained in `providerData`, rather than the provider item ID
- synthesize interrupted native tool-search outputs with the same provider identity and execution mode expected by Responses
- add database settlement and worker history regressions for the exact staging failure shape

## Root cause

Native tool-search calls can carry an item ID in `id` while their stable correlation ID lives in `providerData.call_id`. Durable pending-call settlement fell back to the item ID, then terminal recovery emitted a top-level `callId` result. That produced an unmatched call/output pair which poisoned subsequent provider requests.

## Testing

- [x] `bun test apps/worker/test/agent-turn.test.ts packages/db/test/session-tool-call-settlement.test.ts --timeout 30000` (214 passed)
- [x] `bun run typecheck` (31 projects)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx changeset status --output <temp-file>`
- [ ] full repository gates delegated to public PR CI

## Delivery integrity

- [x] Candidate is based on current `main`.
- [x] Candidate head represents substantive source changes and remains frozen unless CI identifies a source defect or conflict.

## Notes

- No schema migration is required.
- The affected staging session was repaired separately through the existing audited history-repair path. This PR prevents recurrence.

## Summary by Sourcery

Prevent native tool-search recovery from producing unmatched provider call/output pairs.

Bug Fixes:
- Fix settlement and recovery of interrupted native tool-search calls by using their stable provider correlation identity and preserving the expected provider output shape.

Tests:
- Add database and worker regressions covering provider-metadata-only identities, invalid provider IDs, and valid recovered call/output pairs.