### PR TITLE
fix(browser): honor native placement control

### DIFF
--- a/.changeset/fix-native-browser-placement.md
+++ b/.changeset/fix-native-browser-placement.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Use native Connected Machine browser control without bootstrapping a Linux display stack, and accept Modal's workspace-root diagnostic when selecting the secure streamed private-write fallback.

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -3435,7 +3435,14 @@ async function ensureHeadedBrowserDisplayStack(
   headless: boolean,
   linkedComputer: boolean,
 ): Promise<void> {
-  if (!browserNeedsStandaloneDisplayStack({ headless, linkedComputer })) return;
+  if (
+    !browserNeedsStandaloneDisplayStack({
+      headless,
+      linkedComputer,
+      nativeBrowserControl: typeof session.ensureBrowserControl === "function",
+    })
+  )
+    return;
   if (typeof session.exec !== "function" && typeof session.execCommand !== "function") return;
   await ensureDisplayStack(session, {
     telemetryContext: { callerKind: "viewer" },
@@ -3445,8 +3452,9 @@ async function ensureHeadedBrowserDisplayStack(
 export function browserNeedsStandaloneDisplayStack(input: {
   headless: boolean;
   linkedComputer: boolean;
+  nativeBrowserControl: boolean;
 }): boolean {
-  return !input.headless && !input.linkedComputer;
+  return !input.headless && !input.linkedComputer && !input.nativeBrowserControl;
 }
 
 async function ensureLinkedComputerController(

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -354,21 +354,40 @@ describe("BrowserSession route discipline", () => {
     expect(binding).toContain("isMissingLinkedComputerControllerSession(error)");
   });
 
-  test("uses a linked ComputerSession display without bootstrapping a standalone desktop", async () => {
-    expect(browserNeedsStandaloneDisplayStack({ headless: false, linkedComputer: true })).toBe(
-      false,
-    );
-    expect(browserNeedsStandaloneDisplayStack({ headless: false, linkedComputer: false })).toBe(
-      true,
-    );
-    expect(browserNeedsStandaloneDisplayStack({ headless: true, linkedComputer: false })).toBe(
-      false,
-    );
+  test("uses linked and native displays without bootstrapping a standalone desktop", async () => {
+    expect(
+      browserNeedsStandaloneDisplayStack({
+        headless: false,
+        linkedComputer: true,
+        nativeBrowserControl: false,
+      }),
+    ).toBe(false);
+    expect(
+      browserNeedsStandaloneDisplayStack({
+        headless: false,
+        linkedComputer: false,
+        nativeBrowserControl: true,
+      }),
+    ).toBe(false);
+    expect(
+      browserNeedsStandaloneDisplayStack({
+        headless: false,
+        linkedComputer: false,
+        nativeBrowserControl: false,
+      }),
+    ).toBe(true);
+    expect(
+      browserNeedsStandaloneDisplayStack({
+        headless: true,
+        linkedComputer: false,
+        nativeBrowserControl: false,
+      }),
+    ).toBe(false);
 
     const source = await readFile(routeUrl, "utf8");
     expect(source.match(/linkedComputer !== null,/gu)).toHaveLength(3);
     expect(source).toContain(
-      "if (!browserNeedsStandaloneDisplayStack({ headless, linkedComputer })) return;",
+      'nativeBrowserControl: typeof session.ensureBrowserControl === "function"',
     );
   });
 

--- a/packages/runtime/src/sandbox/browser-control-client.ts
+++ b/packages/runtime/src/sandbox/browser-control-client.ts
@@ -2062,7 +2062,9 @@ function requirePlacementRequestSurface(session: BrowserControlPlacementSession)
 function isWorkspaceConfinedWrite(error: unknown): boolean {
   return (
     error instanceof Error &&
-    /must stay within|confines|workspace mount|within \/workspace/iu.test(error.message)
+    /must stay within|confines|workspace mount|within \/workspace|escapes? the workspace(?: root)?/iu.test(
+      error.message,
+    )
   );
 }
 

--- a/packages/runtime/test/browser-control-client.test.ts
+++ b/packages/runtime/test/browser-control-client.test.ts
@@ -971,6 +971,41 @@ describe("BrowserControlClient", () => {
     }
   });
 
+  test("falls back to streamed private writes for the Modal workspace-escape diagnostic", async () => {
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        if (request.headers.get("authorization") !== `Bearer ${adminToken}`) {
+          return failure(401, "permission_denied", "no authority");
+        }
+        const body = (await request.json()) as { origins: string[] };
+        return success({ origins: body.origins });
+      },
+    });
+    const placement = await localPlacement({
+      fakeControllerStartup: true,
+      streamWrites: true,
+    });
+    placement.session.writeFile = async () => {
+      throw new Error('Sandbox path "/tmp" escapes the workspace root.');
+    };
+    const tokenFile = join(placement.root, "modal-authority", "admin-token");
+    try {
+      await provisionBrowserControlClient(placement.session, {
+        adminToken,
+        adminTokenFile: tokenFile,
+        allowedOrigins: ["https://app.opengeni.test"],
+        port: server.port,
+      });
+
+      expect((await readFile(tokenFile, "utf8")).trim()).toBe(adminToken);
+      expect(placement.stdinWrites).toHaveLength(1);
+      expect(placement.commands.every((command) => !command.includes(adminToken))).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
   test("uses the SDK execCommand banner and writeStdin surface when exec is unavailable", async () => {
     const server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## Summary

- skip the standalone Linux display-stack bootstrap when a sandbox exposes native browser placement control
- recognize Modal workspace-root confinement diagnostics and use the existing streamed private-write fallback
- add focused coverage for native placement and exact Modal diagnostics

This is the browser-only replacement for the corresponding portion of #1878.

## Root cause

Browser startup treated every headed, non-linked browser as needing Xvfb/noVNC, even when Connected Machine sessions supplied native browser placement control. Separately, Modal changed the wording of its workspace confinement diagnostic, so the already-supported private-file streaming fallback was not selected.

## Validation

- bun test apps/api/test/browser-session-routes.test.ts packages/runtime/test/browser-control-client.test.ts (37 passed)
- bun run typecheck
- bun run lint
- bun run format:check
- bunx changeset status --since=origin/main

## Summary by Sourcery

Use native browser placement when available and preserve private-write fallback compatibility with Modal workspace confinement errors.

Bug Fixes:
- Honor native Connected Machine browser placement control without starting a standalone Linux display stack.
- Recognize Modal workspace-root confinement diagnostics so secure streamed private-write fallback is selected.

Tests:
- Add focused coverage for native browser placement handling and the updated Modal diagnostic.