### PR TITLE
fix(sandbox): restore machine-to-managed switching

### DIFF
--- a/.changeset/fix-machine-managed-switch.md
+++ b/.changeset/fix-machine-managed-switch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/core": patch
+---
+
+Route explicit Connected Machine-to-session sandbox switches through the deployment's managed backend consistently across fleet projection, readiness, viewers, direct operations, worker manifests, and turns.

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -86,6 +86,8 @@ import {
   type RoutingSandboxSession,
 } from "@opengeni/runtime/sandbox";
 import {
+  managedSessionGroupBackend,
+  managedSessionGroupOs,
   providerSettingsForSessionSandboxRuntime,
   relayConfigFromSettings,
   resolveSessionSandboxRuntime,
@@ -643,15 +645,19 @@ async function withChannelAOperation<T>(
         // A machine-home session with no selected machine uses the deployment's
         // managed group box, exactly like the worker turn path. Keep the durable
         // home label honest; only this request's effective backend changes.
-        if (settings.sandboxBackend !== "none" && settings.sandboxBackend !== "selfhosted") {
+        const groupBackend = managedSessionGroupBackend(
+          settings.sandboxBackend,
+          session.sandboxBackend,
+        );
+        if (groupBackend) {
           return await withChannelAOperation(
             services,
             {
               ...ctx,
               session: {
                 ...session,
-                sandboxBackend: settings.sandboxBackend,
-                sandboxOs: "linux",
+                sandboxBackend: groupBackend,
+                sandboxOs: managedSessionGroupOs(session.sandboxBackend, session.sandboxOs),
               },
             },
             readOnly,
@@ -659,7 +665,7 @@ async function withChannelAOperation<T>(
           );
         }
         throw new HTTPException(409, {
-          message: "machine-home session has no active Connected Machine",
+          message: "machine-home session has no active Connected Machine or managed sandbox",
         });
       }
       const sandbox = await getSandbox(

--- a/apps/api/src/sandbox/machines.ts
+++ b/apps/api/src/sandbox/machines.ts
@@ -9,8 +9,9 @@
 //     heartbeat), projected to the contract's MetricSample;
 //   * sharedSessionCount — the lease refcount (how many sessions share this one
 //     whole machine, the maxSandboxes:1 disclosure).
-// PLUS, when a session context is supplied, the session's synthetic Modal group
-// box (isSessionGroup:true) + the active-sandbox pointer (activeSandboxId/Epoch).
+// PLUS, when a session context is supplied, the session's synthetic managed
+// group box (isSessionGroup:true) + the active-sandbox pointer
+// (activeSandboxId/Epoch).
 //
 // This is workspace-scoped (perm enrollments:read) and flag-gated upstream
 // (sandboxSelfhostedEnabled). It deliberately does NOT depend on a FleetContext
@@ -32,6 +33,7 @@ import {
   type MachineMetricsRow,
 } from "@opengeni/db";
 import { MachineView, MetricSample, type MachinesResponse } from "@opengeni/contracts";
+import { managedSessionGroupBackend } from "@opengeni/core";
 import { selfhostedHeartbeatLiveness } from "@opengeni/runtime/sandbox";
 
 export type MachinesServices = {
@@ -244,10 +246,15 @@ export async function listMachines(
   }
 
   const machines: MachineView[] = [];
+  const groupBackend = session
+    ? managedSessionGroupBackend(services.settings.sandboxBackend, session.sandboxBackend)
+    : null;
 
-  // The session's own group box (synthetic): the default/home sandbox a null
-  // active pointer routes to. A backend:none session has no home box.
-  if (session && session.sandboxBackend !== "none") {
+  // The session's own managed group box (synthetic): the sandbox a null active
+  // pointer routes to. A machine-home session uses the deployment's managed
+  // backend only after an explicit switch; none/selfhosted-only deployments do
+  // not invent a group they cannot establish.
+  if (session && groupBackend) {
     const groupActive = activeSandboxId === null;
     const groupLease = await readLease(db, workspaceId, session.sandboxGroupId);
     machines.push(
@@ -255,7 +262,7 @@ export async function listMachines(
         sandboxId: session.sandboxGroupId,
         enrollmentId: null,
         name: "session sandbox",
-        kind: session.sandboxBackend === "selfhosted" ? "selfhosted" : "modal",
+        kind: groupBackend === "opensandbox" ? "opensandbox" : "modal",
         state: "online",
         active: groupActive,
         isSessionGroup: true,

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -81,6 +81,8 @@ import {
   type NatsRequestConnection,
 } from "@opengeni/runtime/sandbox";
 import {
+  managedSessionGroupBackend,
+  managedSessionGroupOs,
   providerSettingsForSessionSandboxRuntime,
   relayConfigFromSettings,
   resolveSessionSandboxRuntime,
@@ -246,7 +248,24 @@ export async function attachViewer(
   },
 ): Promise<ViewerAttachResult> {
   const { db, settings } = services;
-  const { accountId, workspaceId, session } = input;
+  const { accountId, workspaceId } = input;
+  const groupBackend = managedSessionGroupBackend(
+    settings.sandboxBackend,
+    input.session.sandboxBackend,
+  );
+  if (!groupBackend) {
+    throw new HTTPException(409, {
+      message: "session has no managed sandbox group to attach",
+    });
+  }
+  const session =
+    groupBackend === input.session.sandboxBackend
+      ? input.session
+      : {
+          ...input.session,
+          sandboxBackend: groupBackend,
+          sandboxOs: managedSessionGroupOs(input.session.sandboxBackend, input.session.sandboxOs),
+        };
   const viewerId = input.viewerId ?? crypto.randomUUID();
   const attachSubjectId = claimableSubjectId(input.viewerSubjectId ?? null);
   const attachAuthorityEpoch = attachSubjectId

--- a/apps/api/test/fleet-tools.test.ts
+++ b/apps/api/test/fleet-tools.test.ts
@@ -180,7 +180,7 @@ async function seedFleet(
   opts: {
     online?: boolean;
     hostname?: string;
-    sandboxBackend?: "modal" | "none";
+    sandboxBackend?: "modal" | "none" | "selfhosted";
   } = {},
 ) {
   const { accountId, workspaceId } = await freshWorkspace();
@@ -544,6 +544,48 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
     expect((await readActiveSandbox(db, ctx.workspaceId, ctx.sessionId))?.activeSandboxId).toBe(
       sandbox.id,
     );
+  }, 60_000);
+
+  test("a machine-home session exposes and switches to the deployment-managed group", async () => {
+    if (!available) return;
+    const { ctx, services, session, sandbox } = await seedFleet({
+      sandboxBackend: "selfhosted",
+    });
+    const attached = await swapActiveSandbox(services, ctx, sandbox.id);
+    expect(attached).toMatchObject({ swapped: true, activeSandboxId: sandbox.id });
+
+    const listed = await listFleet(services, ctx);
+    const group = listed.sandboxes.find((entry) => entry.isSessionGroup);
+    expect(group).toMatchObject({
+      id: session.sandboxGroupId,
+      kind: "modal",
+      active: false,
+      operationAvailability: "wakeable",
+    });
+
+    let readinessChecks = 0;
+    let releases = 0;
+    const switched = await swapActiveSandbox(
+      {
+        ...services,
+        ensureSessionGroupReady: async () => {
+          readinessChecks += 1;
+          return {
+            release: async () => {
+              releases += 1;
+            },
+          };
+        },
+      },
+      ctx,
+      "session",
+    );
+    expect(switched).toMatchObject({ swapped: true, activeSandboxId: null });
+    expect(readinessChecks).toBe(1);
+    expect(releases).toBe(1);
+    expect(await readActiveSandbox(db, ctx.workspaceId, ctx.sessionId)).toMatchObject({
+      activeSandboxId: null,
+    });
   }, 60_000);
 
   test("sandboxes_list: the session Modal box + the enrolled machine, each with liveness + active marker", async () => {

--- a/apps/api/test/fleet-tools.test.ts
+++ b/apps/api/test/fleet-tools.test.ts
@@ -551,10 +551,14 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
     const { ctx, services, session, sandbox } = await seedFleet({
       sandboxBackend: "selfhosted",
     });
-    const attached = await swapActiveSandbox(services, ctx, sandbox.id);
+    const managedServices = {
+      ...services,
+      settings: testSettings({ ...services.settings, sandboxBackend: "modal" }),
+    };
+    const attached = await swapActiveSandbox(managedServices, ctx, sandbox.id);
     expect(attached).toMatchObject({ swapped: true, activeSandboxId: sandbox.id });
 
-    const listed = await listFleet(services, ctx);
+    const listed = await listFleet(managedServices, ctx);
     const group = listed.sandboxes.find((entry) => entry.isSessionGroup);
     expect(group).toMatchObject({
       id: session.sandboxGroupId,
@@ -567,7 +571,7 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
     let releases = 0;
     const switched = await swapActiveSandbox(
       {
-        ...services,
+        ...managedServices,
         ensureSessionGroupReady: async () => {
           readinessChecks += 1;
           return {

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -450,7 +450,9 @@ describe("M10 GET /machines — dashboard list + states + metrics", () => {
     const { accountId, workspaceId, session, sandbox, bus } = await seed({
       sandboxBackend: "selfhosted",
     });
-    const app = appFor(bus);
+    const app = appFor(bus, {
+      settings: testSettings({ ...settings, sandboxBackend: "modal" }),
+    });
     const auth = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
 
     const response = await app.request(

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -381,7 +381,7 @@ type SeedOpts = {
   online?: boolean;
   hasDisplay?: boolean;
   allowScreenControl?: boolean;
-  sandboxBackend?: "modal" | "none";
+  sandboxBackend?: "modal" | "none" | "selfhosted";
 };
 async function seed(opts: SeedOpts = {}) {
   const { accountId, workspaceId } = await freshWorkspace();
@@ -443,6 +443,48 @@ describe("M10 GET /machines — dashboard list + states + metrics", () => {
     expect(body.machines).toEqual([
       expect.objectContaining({ sandboxId: sandbox.id, active: false, isSessionGroup: false }),
     ]);
+  }, 60_000);
+
+  test("a machine-home session exposes the deployment-managed fallback group", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, session, sandbox, bus } = await seed({
+      sandboxBackend: "selfhosted",
+    });
+    const app = appFor(bus);
+    const auth = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
+
+    const response = await app.request(
+      `/v1/workspaces/${workspaceId}/machines?sessionId=${session.id}`,
+      { headers: { authorization: auth } },
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      activeSandboxId: string | null;
+      machines: Array<{
+        sandboxId: string;
+        kind: string;
+        active: boolean;
+        isSessionGroup: boolean;
+      }>;
+    };
+    expect(body.activeSandboxId).toBeNull();
+    expect(body.machines).toHaveLength(2);
+    expect(body.machines).toContainEqual(
+      expect.objectContaining({
+        sandboxId: session.sandboxGroupId,
+        kind: "modal",
+        active: true,
+        isSessionGroup: true,
+      }),
+    );
+    expect(body.machines).toContainEqual(
+      expect.objectContaining({
+        sandboxId: sandbox.id,
+        kind: "selfhosted",
+        active: false,
+        isSessionGroup: false,
+      }),
+    );
   }, 60_000);
 
   test("an online machine returns the contract shape with latest metrics; ?sessionId adds the synthetic group + active pointer", async () => {

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -1334,6 +1334,36 @@ describe("P1.4 API-direct viewer-holder lifecycle (real lease + reaper)", () => 
     expect(released).toMatchObject({ liveness: "draining", viewerHolders: 0, refcount: 0 });
   }, 60_000);
 
+  test("machine-home readiness attaches the deployment-managed group backend", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { sandboxGroupId, sessionId } = await seedWarmBox(accountId, workspaceId);
+    await admin`
+      update sessions
+      set sandbox_backend = 'selfhosted', sandbox_os = 'macos'
+      where workspace_id = ${workspaceId} and id = ${sessionId}
+    `;
+    const session = await getSession(db, workspaceId, sessionId);
+    const managedSettings = testSettings({
+      ...settings,
+      sandboxBackend: "local",
+      sandboxOwnershipEnabled: true,
+    });
+
+    const hold = await ensureSessionGroupReady(
+      { db, settings: managedSettings },
+      { accountId, workspaceId, session: session! },
+    );
+    expect(hold.lease).toMatchObject({
+      sandboxGroupId,
+      backend: "local",
+      liveness: "warm",
+      viewerHolders: 1,
+    });
+
+    await hold.release();
+  }, 60_000);
+
   test("releasing the viewer → the reaper drains the box (liveness = turn OR viewer)", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/apps/worker/src/activities/agent-turn/run-credentials.ts
+++ b/apps/worker/src/activities/agent-turn/run-credentials.ts
@@ -56,6 +56,7 @@ import {
   sandboxEstablishPolicyDecision,
   ensureTurnModalRegistryImage,
   sandboxArtifactRuntimeAdmission,
+  sandboxSettingsForRoute,
 } from "./sandbox-route";
 import type { ClaimTurnOk } from "./claim";
 import type { GovernanceModelOk } from "./governance-model";
@@ -105,18 +106,6 @@ export type PrepareRunCredentialsDeps = {
   runWorkspaceMutationForSandbox: SandboxTurnRuntime["runWorkspaceMutationForSandbox"];
 };
 
-export function sandboxEnvironmentSettingsForRoute(input: {
-  runSettings: Settings;
-  machinePrimary: boolean;
-  groupBoxBackend: Settings["sandboxBackend"];
-}): Settings {
-  return input.runSettings.sandboxBackend === "selfhosted" &&
-    !input.machinePrimary &&
-    input.groupBoxBackend !== "selfhosted"
-    ? { ...input.runSettings, sandboxBackend: input.groupBoxBackend }
-    : input.runSettings;
-}
-
 export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
   const {
     input,
@@ -151,7 +140,7 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
   // manifest environment with that effective provider just as Channel-A and
   // viewer readiness do; otherwise the verified managed box and the agent can
   // disagree on backend-aware HOME/token-file paths.
-  const sandboxEnvironmentSettings = sandboxEnvironmentSettingsForRoute({
+  const sandboxEnvironmentSettings = sandboxSettingsForRoute({
     runSettings,
     machinePrimary,
     groupBoxBackend,

--- a/apps/worker/src/activities/agent-turn/run-credentials.ts
+++ b/apps/worker/src/activities/agent-turn/run-credentials.ts
@@ -105,6 +105,18 @@ export type PrepareRunCredentialsDeps = {
   runWorkspaceMutationForSandbox: SandboxTurnRuntime["runWorkspaceMutationForSandbox"];
 };
 
+export function sandboxEnvironmentSettingsForRoute(input: {
+  runSettings: Settings;
+  machinePrimary: boolean;
+  groupBoxBackend: Settings["sandboxBackend"];
+}): Settings {
+  return input.runSettings.sandboxBackend === "selfhosted" &&
+    !input.machinePrimary &&
+    input.groupBoxBackend !== "selfhosted"
+    ? { ...input.runSettings, sandboxBackend: input.groupBoxBackend }
+    : input.runSettings;
+}
+
 export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
   const {
     input,
@@ -134,6 +146,16 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
     connectionScope,
     runWorkspaceMutationForSandbox,
   } = deps;
+  // A machine-home row carries selfhosted path defaults, but clearing its
+  // pointer explicitly selects the deployment-managed group. Build the stable
+  // manifest environment with that effective provider just as Channel-A and
+  // viewer readiness do; otherwise the verified managed box and the agent can
+  // disagree on backend-aware HOME/token-file paths.
+  const sandboxEnvironmentSettings = sandboxEnvironmentSettingsForRoute({
+    runSettings,
+    machinePrimary,
+    groupBoxBackend,
+  });
 
   const runCredentialResolver =
     effectiveRunCredentialBackend === "none"
@@ -321,7 +343,7 @@ export async function prepareRunCredentials(deps: PrepareRunCredentialsDeps) {
     codemodeTokenExpiresAt: sandboxCodemodeTokenExpiresAt,
   } = await waitForTurnOperation(
     sandboxEnvironmentForRun(
-      runSettings,
+      sandboxEnvironmentSettings,
       turnResources,
       // Rig default sets merged BELOW the session set (session wins); rig-less
       // turns pass exactly workspaceVariableSet?.values (byte-for-byte today).

--- a/apps/worker/src/activities/agent-turn/sandbox-establish.ts
+++ b/apps/worker/src/activities/agent-turn/sandbox-establish.ts
@@ -22,6 +22,7 @@ import {
   resolveConnectedMachineWorkspaceRoot,
 } from "@opengeni/runtime";
 import { type Settings } from "@opengeni/config";
+import { managedSessionGroupBackend, managedSessionGroupOs } from "@opengeni/core";
 import { mergeResourceRefs } from "../common";
 import {
   mintSandboxCodemodeToken,
@@ -249,10 +250,10 @@ export async function resolveSandboxRoute(deps: SandboxRouteDeps): Promise<Sandb
   // common path this is runSettings.sandboxBackend. A selfhosted home turn
   // that is NOT machine-primary falls back to the deployment cloud backend
   // so swap-away / flag-off degrade to a real group box.
-  const groupBoxBackend: Settings["sandboxBackend"] =
-    runSettings.sandboxBackend === "selfhosted" && !machinePrimary
-      ? settings.sandboxBackend
-      : runSettings.sandboxBackend;
+  const groupBoxBackend: Settings["sandboxBackend"] = !machinePrimary
+    ? (managedSessionGroupBackend(settings.sandboxBackend, runSettings.sandboxBackend) ??
+      runSettings.sandboxBackend)
+    : runSettings.sandboxBackend;
   sandboxState.startupMilestoneBackend = activeSandboxBackend ?? groupBoxBackend;
   media.sandboxFileDownloadBackend = sandboxState.startupMilestoneBackend;
   // Durable lease identity is always the logical OCI/base image. A provider
@@ -315,6 +316,7 @@ export async function establishTurnSandbox(deps: EstablishTurnSandboxDeps): Prom
     rigVersion,
     turnResources,
   } = deps;
+  const groupBoxOs = managedSessionGroupOs(runSettings.sandboxBackend, session.sandboxOs);
   const {
     releaseLateSandbox,
     onHomeSandboxRebound,
@@ -577,7 +579,7 @@ export async function establishTurnSandbox(deps: EstablishTurnSandboxDeps): Prom
                 sandboxGroupId: lazyGroupId,
                 sessionId: input.sessionId,
                 backend: groupBoxBackend,
-                os: session.sandboxOs,
+                os: groupBoxOs,
                 environment: sandboxEnvironment,
                 ...(groupBoxImage
                   ? {
@@ -656,7 +658,7 @@ export async function establishTurnSandbox(deps: EstablishTurnSandboxDeps): Prom
                 // deployment default), never a "selfhosted" box (which would throw
                 // for lack of a bound agentId).
                 backend: groupBoxBackend,
-                os: session.sandboxOs,
+                os: groupBoxOs,
                 environment: sandboxEnvironment,
                 // IMAGE IS SHARED STATE (B3): the container image
                 // this run resolves. The lease stamps it + conflicts on a live shared box

--- a/apps/worker/src/activities/agent-turn/sandbox-establish.ts
+++ b/apps/worker/src/activities/agent-turn/sandbox-establish.ts
@@ -63,6 +63,7 @@ import {
   sandboxEstablishPolicyDecision,
   shouldPrefetchManagedSandbox,
   reconcileActiveSandboxPointer,
+  sandboxSettingsForRoute,
 } from "./sandbox-route";
 import type { ClaimTurnOk } from "./claim";
 import type { GovernanceModelOk } from "./governance-model";
@@ -254,16 +255,28 @@ export async function resolveSandboxRoute(deps: SandboxRouteDeps): Promise<Sandb
     ? (managedSessionGroupBackend(settings.sandboxBackend, runSettings.sandboxBackend) ??
       runSettings.sandboxBackend)
     : runSettings.sandboxBackend;
+  const groupRouteSettings = sandboxSettingsForRoute({
+    runSettings,
+    machinePrimary,
+    groupBoxBackend,
+  });
+  if (groupRouteSettings !== runSettings) {
+    // `modelRunSettings` drives SandboxAgent manifest construction and the
+    // legacy SDK-owned client path. Keep its provider/model context overrides,
+    // but replace the stale durable machine-home label with the route that will
+    // actually execute.
+    eventing.modelRunSettings = {
+      ...eventing.modelRunSettings,
+      sandboxBackend: groupRouteSettings.sandboxBackend,
+    };
+  }
   sandboxState.startupMilestoneBackend = activeSandboxBackend ?? groupBoxBackend;
   media.sandboxFileDownloadBackend = sandboxState.startupMilestoneBackend;
   // Durable lease identity is always the logical OCI/base image. A provider
   // image id in runSettings is only a physical cold-create optimization and
   // must never become cross-surface shared-state fencing.
   const groupBoxImage = rigProviderImageSourceImage(logicalSandboxSettings, groupBoxBackend);
-  const sandboxCreationBackend: Settings["sandboxBackend"] =
-    settings.sandboxOwnershipEnabled && runSettings.sandboxBackend !== "none"
-      ? groupBoxBackend
-      : runSettings.sandboxBackend;
+  const sandboxCreationBackend: Settings["sandboxBackend"] = groupRouteSettings.sandboxBackend;
   const effectiveRunCredentialBackend = activeSandboxBackend ?? groupBoxBackend;
 
   return {

--- a/apps/worker/src/activities/agent-turn/sandbox-route.ts
+++ b/apps/worker/src/activities/agent-turn/sandbox-route.ts
@@ -64,6 +64,27 @@ export function managedSandboxOwnershipForTurn(
   };
 }
 
+/**
+ * Bind backend-aware runtime settings to the route that will actually execute.
+ *
+ * A machine-home turn keeps `selfhosted` as its durable policy. After an
+ * explicit clear-to-default, however, both the ownership-inverted path and the
+ * legacy SDK-owned path must construct manifests and clients for the resolved
+ * managed group backend. Machine-primary and ordinary session routes preserve
+ * their existing settings object.
+ */
+export function sandboxSettingsForRoute(input: {
+  runSettings: Settings;
+  machinePrimary: boolean;
+  groupBoxBackend: Settings["sandboxBackend"];
+}): Settings {
+  return input.runSettings.sandboxBackend === "selfhosted" &&
+    !input.machinePrimary &&
+    input.groupBoxBackend !== "selfhosted"
+    ? { ...input.runSettings, sandboxBackend: input.groupBoxBackend }
+    : input.runSettings;
+}
+
 /** A sandboxless home still establishes an explicitly attached Connected Machine. */
 export function shouldEstablishSandboxForTurn(
   sandboxOwnershipEnabled: boolean,

--- a/apps/worker/test/machine-managed-route-settings.test.ts
+++ b/apps/worker/test/machine-managed-route-settings.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import { sandboxEnvironmentSettingsForRoute } from "../src/activities/agent-turn/run-credentials";
+
+describe("machine-home managed-group settings", () => {
+  test("uses the managed provider for fallback manifests and preserves machine-primary settings", () => {
+    const machineHome = testSettings({ sandboxBackend: "selfhosted" });
+
+    const managed = sandboxEnvironmentSettingsForRoute({
+      runSettings: machineHome,
+      machinePrimary: false,
+      groupBoxBackend: "modal",
+    });
+    expect(managed).not.toBe(machineHome);
+    expect(managed.sandboxBackend).toBe("modal");
+
+    expect(
+      sandboxEnvironmentSettingsForRoute({
+        runSettings: machineHome,
+        machinePrimary: true,
+        groupBoxBackend: "selfhosted",
+      }),
+    ).toBe(machineHome);
+
+    const modalHome = testSettings({ sandboxBackend: "modal" });
+    expect(
+      sandboxEnvironmentSettingsForRoute({
+        runSettings: modalHome,
+        machinePrimary: false,
+        groupBoxBackend: "modal",
+      }),
+    ).toBe(modalHome);
+  });
+});

--- a/apps/worker/test/machine-managed-route-settings.test.ts
+++ b/apps/worker/test/machine-managed-route-settings.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { testSettings } from "@opengeni/testing";
-import { sandboxEnvironmentSettingsForRoute } from "../src/activities/agent-turn/run-credentials";
+import { sandboxSettingsForRoute } from "../src/activities/agent-turn/sandbox-route";
 
 describe("machine-home managed-group settings", () => {
   test("uses the managed provider for fallback manifests and preserves machine-primary settings", () => {
     const machineHome = testSettings({ sandboxBackend: "selfhosted" });
 
-    const managed = sandboxEnvironmentSettingsForRoute({
+    const managed = sandboxSettingsForRoute({
       runSettings: machineHome,
       machinePrimary: false,
       groupBoxBackend: "modal",
@@ -15,7 +15,7 @@ describe("machine-home managed-group settings", () => {
     expect(managed.sandboxBackend).toBe("modal");
 
     expect(
-      sandboxEnvironmentSettingsForRoute({
+      sandboxSettingsForRoute({
         runSettings: machineHome,
         machinePrimary: true,
         groupBoxBackend: "selfhosted",
@@ -24,7 +24,7 @@ describe("machine-home managed-group settings", () => {
 
     const modalHome = testSettings({ sandboxBackend: "modal" });
     expect(
-      sandboxEnvironmentSettingsForRoute({
+      sandboxSettingsForRoute({
         runSettings: modalHome,
         machinePrimary: false,
         groupBoxBackend: "modal",

--- a/apps/worker/test/sandbox-route-image-identity.test.ts
+++ b/apps/worker/test/sandbox-route-image-identity.test.ts
@@ -39,4 +39,41 @@ describe("managed sandbox logical image identity", () => {
     expect(route.groupBoxImage).toBe(logicalImage);
     expect(runSettings.modalImageId).toBe("im-01M0X53D38C3458D71F48QH2T1");
   });
+
+  test("binds a machine-home default route to the deployment-managed runtime", async () => {
+    const settings = testSettings({
+      sandboxBackend: "modal",
+      sandboxSelfhostedEnabled: false,
+      sandboxOwnershipEnabled: false,
+    });
+    const runSettings: Settings = { ...settings, sandboxBackend: "selfhosted" };
+    const modelRunSettings: Settings = {
+      ...runSettings,
+      modelContextWindowTokens: 123_456,
+    };
+    const eventing = { modelRunSettings };
+
+    const route = await resolveSandboxRoute({
+      input: {
+        accountId: "11111111-1111-4111-8111-111111111111",
+        workspaceId: "22222222-2222-4222-8222-222222222222",
+        sessionId: "33333333-3333-4333-8333-333333333333",
+      } as never,
+      settings,
+      db: {} as never,
+      eventing: eventing as never,
+      sandboxState: {} as never,
+      media: {} as never,
+      fileAuthoritySubjectId: null,
+      runSettings,
+      logicalSandboxSettings: settings,
+    });
+
+    expect(route.groupBoxBackend).toBe("modal");
+    expect(route.sandboxCreationBackend).toBe("modal");
+    expect(eventing.modelRunSettings).not.toBe(modelRunSettings);
+    expect(eventing.modelRunSettings.sandboxBackend).toBe("modal");
+    expect(eventing.modelRunSettings.modelContextWindowTokens).toBe(123_456);
+    expect(runSettings.sandboxBackend).toBe("selfhosted");
+  });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,6 +271,15 @@ outcome; text-only reasoning can still begin without contacting it. OpenGeni
 never interprets an offline machine as permission to cold-create a rival box,
 snapshot it, or provider-terminate the user's computer.
 
+A machine-home session does not pre-provision a hidden managed box. When the
+deployment has a managed sandbox backend, its fleet nevertheless exposes the
+session's synthetic managed group as a separate explicit target. Selecting
+`session`/`default` clears the active machine pointer, verifies that managed
+group through the ordinary viewer/lease lifecycle, and lets the next operation
+or turn use it. This is an intentional user route change, not an
+offline-machine fallback; deployments configured with only `none` or
+`selfhosted` expose no managed group.
+
 Canonical: `packages/runtime/src/sandbox/selfhosted/`,
 `apps/worker/src/activities/agent-turn/sandbox-establish.ts`,
 `agent/proto/opengeni_agent.proto`, [`connected-machines.md`](connected-machines.md),
@@ -294,6 +303,12 @@ operation to be replayed.
 Lease liveness, provider existence, route attachment, archive availability,
 workspace readiness, and operation availability are separate facts. A warm row
 or selected pointer alone is not proof that a command can run.
+
+The effective backend behind a synthetic managed group is resolved once from
+the session policy and deployment backend. Fleet projection, swap readiness,
+viewer attachment, API-direct operations, and worker turns must use that same
+answer so a route cannot be advertised under one backend and established under
+another.
 
 The canonical backend enum currently contains `docker`, `modal`, `local`,
 `none`, `daytona`, `runloop`, `e2b`, `blaxel`, `cloudflare`, `vercel`,

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -455,6 +455,13 @@ tool result, and source frame references are then released.
 A session points at one active sandbox at a time. `swapActiveSandbox` re-points
 it — the user-authenticated equivalent of the agent's `sandbox_swap` MCP tool.
 
+A machine-home session does not create a cloud box while its Connected Machine
+is selected. When the deployment has a managed backend, the fleet also exposes
+the session's synthetic managed group as an explicit fallback target. Choosing
+`"session"` or `"default"` verifies that group through the normal lease path and
+then clears the active machine pointer. A deployment configured with only
+`selfhosted` or `none` has no managed group to select.
+
 ```ts
 // Point the session at a machine…
 const swap = await client.swapActiveSandbox(workspaceId, sessionId, {
@@ -476,8 +483,8 @@ comes back as `swapped: false` with a `reason` rather than throwing. The next
 turn runs on whatever the pointer resolves to.
 
 An agent turn that started on a Connected Machine does not pre-lease a managed
-home sandbox. If that turn explicitly swaps a managed-home session back to
-`"session"`/`"default"`, OpenGeni preserves the successful pointer change,
+group. If that turn explicitly swaps back to `"session"`/`"default"`, OpenGeni
+preserves the successful pointer change,
 checkpoints completed model/tool truth, and continues the same logical turn in a
 fresh home-primary attempt. The handoff requires no new user message, never
 silently runs a post-swap operation on the old machine, and never provisions a

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -1,6 +1,6 @@
 // apps/api/src/sandbox/fleet.ts — the FLEET service backing the fleet MCP tools
 // (M7): list / attach / swap / run_on / provision over the heterogeneous fleet
-// (the session's Modal group box + the workspace's enrolled selfhosted machines).
+// (the session's managed group box + the workspace's enrolled selfhosted machines).
 //
 // Each operation is workspace-scoped (the caller's grant) and, for the
 // session-pointer mutations (attach/swap), session-scoped (the worker-signed
@@ -12,6 +12,7 @@
 // single op WITHOUT touching the active pointer.
 
 import type { Settings } from "@opengeni/config";
+import type { SandboxBackend } from "@opengeni/contracts";
 import {
   authorizePersonalMachineForAttempt,
   getEnrollment,
@@ -45,6 +46,7 @@ import {
   type SelfhostedOperationResourcePolicy,
 } from "@opengeni/runtime/sandbox";
 import { relayConfigFromSettings } from "./routing";
+import { managedSessionGroupBackend } from "./runtime-settings";
 
 export type FleetServices = {
   db: Database;
@@ -74,8 +76,8 @@ export type FleetContext = {
   /** The calling session (the pointer the attach/swap mutates + whose group box
    *  is the default fleet member). */
   sessionId: string;
-  /** The session's own group sandbox backend (modal/selfhosted/…). */
-  sessionBackend: string;
+  /** The session's durable home-compute policy. */
+  sessionBackend: SandboxBackend;
   /** The session's own group sandbox id (the lease group). */
   sessionGroupId: string;
 };
@@ -264,8 +266,9 @@ async function probeEnrollment(
  * List the fleet: the session's own group box when it has one (a synthetic
  * entry) + the workspace's first-class selfhosted sandboxes (each probed for
  * liveness), each with an `active` marker derived from the session's active
- * pointer. A backend:none session has no synthetic home entry; a null pointer
- * then means no compute is attached.
+ * pointer. A backend:none session and a machine-home session on a deployment
+ * without a managed provider have no synthetic group entry; a null pointer then
+ * means no compute is attached.
  */
 export async function listFleet(
   services: FleetServices,
@@ -285,8 +288,12 @@ export async function listFleet(
   };
 
   const entries: FleetSandboxEntry[] = [];
+  const groupBackend = managedSessionGroupBackend(
+    services.settings.sandboxBackend,
+    ctx.sessionBackend,
+  );
 
-  if (ctx.sessionBackend !== "none") {
+  if (groupBackend) {
     // The session's own group box (the default/home sandbox; null active pointer ==
     // this box). A session/group row is not provider existence. Online requires a
     // warm lease, observed provider existence, and verified workspace readiness.
@@ -317,17 +324,10 @@ export async function listFleet(
         ? "unavailable"
         : groupRecovering
           ? "recovering"
-          : ctx.sessionBackend === "selfhosted"
-            ? "unavailable"
-            : "wakeable";
+          : "wakeable";
     entries.push({
       id: ctx.sessionGroupId,
-      kind:
-        ctx.sessionBackend === "selfhosted"
-          ? "selfhosted"
-          : ctx.sessionBackend === "opensandbox"
-            ? "opensandbox"
-            : "modal",
+      kind: groupBackend === "opensandbox" ? "opensandbox" : "modal",
       name: "session sandbox",
       liveness: groupOnline ? "online" : groupRecovering ? "reconnecting" : "offline",
       active: groupActive,
@@ -467,10 +467,13 @@ async function resolveTarget(
 > {
   // The session's own group box → the default pointer (null).
   if (target === ctx.sessionGroupId || target === "session" || target === "default") {
-    if (ctx.sessionBackend === "none") {
+    if (!managedSessionGroupBackend(services.settings.sandboxBackend, ctx.sessionBackend)) {
       return {
         ok: false,
-        reason: "this session has no home sandbox; attach a Connected Machine",
+        reason:
+          ctx.sessionBackend === "none"
+            ? "this session has no home sandbox; attach a Connected Machine"
+            : "this deployment has no managed session sandbox; select an enrolled machine",
         code: "unsupported_backend_context",
       };
     }

--- a/packages/core/src/sandbox/runtime-settings.ts
+++ b/packages/core/src/sandbox/runtime-settings.ts
@@ -4,6 +4,7 @@ import {
   type RigVersion,
   type Session,
   type SandboxBackend,
+  type SandboxOs,
 } from "@opengeni/contracts";
 import {
   getRigVersion,
@@ -17,6 +18,37 @@ import {
   rigProviderImageMatchesDefinition,
   rigProviderImageProviderBindingKeyHash,
 } from "../rigs/provider-images";
+
+export type ManagedSessionGroupBackend = Exclude<SandboxBackend, "none" | "selfhosted">;
+
+/**
+ * Resolve the provider backend behind a session's synthetic managed group.
+ *
+ * A machine-home session keeps `selfhosted` as its durable policy while a
+ * non-null active pointer selects the enrolled machine. Clearing that pointer
+ * is an explicit switch to the deployment's managed group, so API readiness,
+ * viewer attachment, Channel-A, and worker turns must all select the same
+ * provider. Deployments configured with `none` or `selfhosted` have no managed
+ * fallback to expose.
+ */
+export function managedSessionGroupBackend(
+  deploymentBackend: SandboxBackend,
+  sessionBackend: SandboxBackend,
+): ManagedSessionGroupBackend | null {
+  if (sessionBackend === "none") return null;
+  const backend = sessionBackend === "selfhosted" ? deploymentBackend : sessionBackend;
+  return backend === "none" || backend === "selfhosted" ? null : backend;
+}
+
+/** A machine-home row carries the machine's host OS; its managed group uses the
+ * platform's canonical managed-sandbox OS instead. Ordinary sessions preserve
+ * their explicitly selected OS. */
+export function managedSessionGroupOs(
+  sessionBackend: SandboxBackend,
+  sessionOs: SandboxOs,
+): SandboxOs {
+  return sessionBackend === "selfhosted" ? "linux" : sessionOs;
+}
 
 /** Pre-V2 Packs are the sole compatibility path where a Pack can still own a
  * sandbox image. V2 installations select a Rig instead. Keep this predicate at

--- a/packages/core/test/sandbox-routing.test.ts
+++ b/packages/core/test/sandbox-routing.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import { directRetainedProcessMatchesBackend } from "../src/sandbox/routing";
+import { managedSessionGroupBackend, managedSessionGroupOs } from "../src/sandbox/runtime-settings";
+
+describe("managed session-group backend", () => {
+  test("uses the deployment provider only for an explicit machine-home fallback", () => {
+    expect(managedSessionGroupBackend("modal", "selfhosted")).toBe("modal");
+    expect(managedSessionGroupBackend("opensandbox", "selfhosted")).toBe("opensandbox");
+    expect(managedSessionGroupBackend("local", "modal")).toBe("modal");
+    expect(managedSessionGroupBackend("modal", "none")).toBeNull();
+    expect(managedSessionGroupBackend("none", "selfhosted")).toBeNull();
+    expect(managedSessionGroupBackend("selfhosted", "selfhosted")).toBeNull();
+    expect(managedSessionGroupOs("selfhosted", "macos")).toBe("linux");
+    expect(managedSessionGroupOs("modal", "windows")).toBe("windows");
+  });
+});
 
 describe("API-direct retained-process route identity", () => {
   test("accepts the default active pointer without misclassifying it as a home route", () => {


### PR DESCRIPTION
## Summary

- expose a managed session-group target for machine-home sessions only when the deployment has a real managed backend
- resolve the effective managed backend consistently across fleet projection, swap readiness, viewers, Channel-A operations, and worker turns
- normalize machine-host OS and backend-aware credential paths when explicitly switching from a Connected Machine to the managed group
- preserve the no-automatic-fallback invariant: an offline machine never provisions cloud compute without an explicit route change
- document the routing contract and add focused API/core/worker coverage

This is the sandbox-switching replacement for the corresponding portion of #1878. Unlike that PR, it does not hide or reject the managed target; it makes the intended route executable.

## Root cause

A machine-home session intentionally persists sandboxBackend=selfhosted, while clearing its active machine pointer means use the deployment-managed session group. Fleet readiness and viewer attachment interpreted that durable label literally and attempted to establish a phantom selfhosted group. The worker had a partial backend fallback, but still carried the machine OS and selfhosted environment defaults into the managed box. These surfaces therefore disagreed about the effective route.

## Validation

- bun test packages/core/test/sandbox-routing.test.ts apps/worker/test/machine-managed-route-settings.test.ts apps/worker/test/sandbox-route-image-identity.test.ts apps/worker/test/agent-turn.test.ts (216 passed)
- API-focused suite (88 passed, 1 opt-in skip; Docker-backed setup unavailable locally, so CI is the integration proof)
- bun run typecheck
- bun run lint
- bun run format:check
- bunx changeset status --since=origin/main

## Summary by Sourcery

Restore explicit Connected Machine-to-managed sandbox switching with consistent backend-aware routing across the API and worker paths.

New Features:
- Enable machine-home sessions to explicitly switch to a deployment-managed sandbox group when a managed backend is available.

Bug Fixes:
- Ensure fleet views, readiness checks, viewer attachment, Channel-A operations, and worker turns resolve the same effective managed backend instead of treating the durable selfhosted label as an executable group.
- Prevent managed fallback routes from inheriting Connected Machine host OS and backend-specific credential paths.
- Preserve the invariant that offline machines do not automatically provision managed compute without an explicit route change.

Enhancements:
- Centralize managed session-group backend and operating-system resolution across API and worker routing.

Documentation:
- Document explicit machine-to-managed switching, managed-group availability, and the no-automatic-fallback routing contract.

Tests:
- Add focused core, API, and worker coverage for managed-group projection, switching, readiness, viewer attachment, route settings, and image identity.