### PR TITLE
fix(db): keep recovery quiescence durably wakeable

### DIFF
--- a/.changeset/durable-recovery-quiescence-wake.md
+++ b/.changeset/durable-recovery-quiescence-wake.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Keep recoverable sessions durably wakeable until exact attempt quiescence, including when a retained process settles after the workflow's final reconciliation check.

--- a/apps/worker/test/retained-process-reconciliation.test.ts
+++ b/apps/worker/test/retained-process-reconciliation.test.ts
@@ -20,6 +20,7 @@ import {
   readLease,
   recordRetainedProcessReconciliationProof,
   releaseLeaseHolder,
+  requestSessionTurnRecovery,
   retainedProcessSettlementIdentity,
   retainWorkspaceMutationProcess,
   SandboxRetainedProcessPromotionFencedError,
@@ -89,6 +90,7 @@ type WorkspaceIds = {
 type TurnFixture = {
   sessionId: string;
   turnId: string;
+  triggerEventId: string;
   attemptId: string;
   executionGeneration: number;
   holderId: `turn-attempt:${string}`;
@@ -155,6 +157,7 @@ async function freshTurn(ids: WorkspaceIds): Promise<TurnFixture> {
   return {
     sessionId: session.id,
     turnId: claim.turn.id,
+    triggerEventId: claim.turn.triggerEventId,
     attemptId,
     executionGeneration: claim.turn.executionGeneration,
     holderId: sandboxLeaseHolderIdForAttempt(attemptId),
@@ -1312,6 +1315,73 @@ describe("retained-process terminal-owner reconciliation", () => {
     expect(metrics).toMatch(
       /opengeni_retained_process_reconciliation_total\{[^}]*outcome="settled_exited"[^}]*\} 1/,
     );
+  }, 60_000);
+
+  test("retained-process settlement atomically advances a recoverable attempt wake", async () => {
+    if (!available) return;
+    const fixture = await promoteTurnProcess();
+    expect(fixture.attempt).toBeDefined();
+    const attempt = fixture.attempt!;
+    expect(
+      await requestSessionTurnRecovery(db, fixture.workspaceId, {
+        sessionId: fixture.sessionId,
+        turnId: attempt.turnId,
+        triggerEventId: attempt.triggerEventId,
+        attemptId: attempt.attemptId,
+        reason: "worker_shutdown",
+      }),
+    ).toMatchObject({ action: "recovering" });
+    const [before] = await admin<
+      { wakeRevision: number; deliveredRevision: number; reason: string }[]
+    >`
+      select wake_revision::int as "wakeRevision",
+        delivered_revision::int as "deliveredRevision", reason
+      from session_workflow_wake_outbox
+      where workspace_id = ${fixture.workspaceId} and session_id = ${fixture.sessionId}`;
+    expect(before?.reason).toBe("turn_recovery_requested");
+
+    const settled = await settleRetainedProcess(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      sessionId: fixture.sessionId,
+      processId: fixture.process.id,
+      expected: retainedProcessSettlementIdentity(fixture.process),
+      outcome: "exited",
+      exitCode: 0,
+      reason: "provider_exit_banner",
+      idleGraceMs: SETTINGS.sandboxIdleGraceMs,
+    });
+    expect(settled.settled).toBe(true);
+    const [after] = await admin<
+      { wakeRevision: number; deliveredRevision: number; reason: string }[]
+    >`
+      select wake_revision::int as "wakeRevision",
+        delivered_revision::int as "deliveredRevision", reason
+      from session_workflow_wake_outbox
+      where workspace_id = ${fixture.workspaceId} and session_id = ${fixture.sessionId}`;
+    expect(after).toEqual({
+      wakeRevision: before!.wakeRevision + 1,
+      deliveredRevision: before!.deliveredRevision,
+      reason: "retained_process_settled_quiescence",
+    });
+
+    const replay = await settleRetainedProcess(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      sessionId: fixture.sessionId,
+      processId: fixture.process.id,
+      expected: retainedProcessSettlementIdentity(settled.process),
+      outcome: "exited",
+      exitCode: 0,
+      reason: "provider_exit_banner",
+      idleGraceMs: SETTINGS.sandboxIdleGraceMs,
+    });
+    expect(replay.settled).toBe(false);
+    const [afterReplay] = await admin<{ wakeRevision: number }[]>`
+      select wake_revision::int as "wakeRevision"
+      from session_workflow_wake_outbox
+      where workspace_id = ${fixture.workspaceId} and session_id = ${fixture.sessionId}`;
+    expect(afterReplay?.wakeRevision).toBe(after!.wakeRevision);
   }, 60_000);
 
   test("copied identity, claim, and admission fences reject; durable proof safely removes a superseded holder", async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,13 @@ Temporal cancellation is a delivery mechanism, not proof that tools and
 sandbox work have physically stopped; durable quiescence evidence gates
 replacement admission.
 
+A recoverable activity shutdown creates a transactional workflow-wake
+obligation in Postgres. Delivery remains unacknowledged until the exact closed
+attempt has durable quiescence, and every attempt-owned retained-process
+settlement advances that same outbox row in its settlement transaction. A
+workflow close or a writer exit racing the final reconciliation check therefore
+cannot orphan a session in recovery.
+
 A background command becomes session-owned only after its exact provider
 identity is durably adopted. Before adoption it remains attempt-owned. After
 adoption, ordinary turn completion and Steer detach from it, while explicit

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1001,13 +1001,18 @@ best-effort live fanout; a NATS failure cannot trigger proof recovery or undo a
 committed receipt.
 
 Settling or stale-rejecting an interruption atomically commits its own durable
-control wake. While the receipt is absent, wake acknowledgement remains pending,
+control wake. Activity-owned recoverable shutdown commits an ordinary durable
+wake in the same transaction as `turn.recovery.requested`. While the receipt is
+absent, wake acknowledgement remains pending for either recovery form,
 `peekSessionWork` returns `cancellation-wait`, and every claim path remains
 `control-pending` from the interruption ledger alone—queue presentation metadata
 is never admission authority. The workflow waits up to five seconds for a wake
 and may then close without running another turn activity; the outbox continues
-bounded redelivery until the exact activity disappears or supplies its proof. A
-proof accepted at that timeout boundary is persisted before close. Once the
+bounded redelivery until the exact activity disappears or supplies its proof.
+When an attempt-owned retained process was the final writer, its terminal
+settlement advances that outbox revision atomically, so settlement racing the
+workflow's last reconciliation check cannot be lost. A proof accepted at that
+timeout boundary is persisted before close. Once the
 receipt commits, its coalescing outbox wake uses immediate `signalWithStart` on
 the same stable workflow id, which restarts the exact
 session and admits the replacement once. This event-driven path needs no

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -42286,6 +42286,51 @@ async function lockWorkspaceMutationSessionTx(
   return session;
 }
 
+/** True while an exact closed attempt still owns the physical-quiescence gate.
+ * Both user control interruptions and activity-owned recoverable shutdowns use
+ * this predicate so wake delivery cannot turn an unfinished writer drain into
+ * an acknowledged edge-trigger. */
+async function hasPendingSessionAttemptQuiescenceTx(
+  tx: Database,
+  input: { workspaceId: string; sessionId: string; attemptId?: string },
+): Promise<boolean> {
+  const [row] = await tx.execute<{ pending: boolean }>(sql`
+    select exists (
+      select 1
+      from session_turn_attempts attempt
+      where attempt.workspace_id = ${input.workspaceId}
+        and attempt.session_id = ${input.sessionId}
+        ${input.attemptId ? sql`and attempt.id = ${input.attemptId}` : sql``}
+        and attempt.state = 'closed'
+        and attempt.quiesced_at is null
+        and (
+          exists (
+            select 1
+            from session_attempt_interruptions interruption
+            where interruption.workspace_id = attempt.workspace_id
+              and interruption.session_id = attempt.session_id
+              and interruption.attempt_id = attempt.id
+              and interruption.state in ('settled', 'rejected_stale')
+          )
+          or (
+            attempt.outcome = 'interrupted_recoverable'
+            and exists (
+              select 1
+              from session_events event
+              where event.account_id = attempt.account_id
+                and event.workspace_id = attempt.workspace_id
+                and event.session_id = attempt.session_id
+                and event.turn_id = attempt.turn_id
+                and event.turn_attempt_id = attempt.id
+                and event.type = 'turn.recovery.requested'
+            )
+          )
+        )
+    ) as pending
+  `);
+  return row?.pending === true;
+}
+
 /**
  * Resolve the organization grant identity behind a causal human, and refuse the
  * operation when that grant has been revoked or suspended.
@@ -44263,7 +44308,11 @@ export async function settleRetainedProcess(
     async (scopedDb) =>
       await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;
-        await lockWorkspaceMutationSessionTx(tx, input.workspaceId, input.sessionId);
+        const session = await lockWorkspaceMutationSessionTx(
+          tx,
+          input.workspaceId,
+          input.sessionId,
+        );
         const [process] = await tx
           .select()
           .from(schema.sandboxRetainedProcesses)
@@ -44470,6 +44519,22 @@ export async function settleRetainedProcess(
           where id = ${process.leaseId}
             and sandbox_group_id = ${process.sandboxGroupId}
         `);
+        if (
+          process.ownerAttemptId &&
+          (await hasPendingSessionAttemptQuiescenceTx(tx, {
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            attemptId: process.ownerAttemptId,
+          }))
+        ) {
+          await enqueueSessionWorkflowWakeInTransaction(tx, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            temporalWorkflowId: session.temporalWorkflowId ?? `session-${input.sessionId}`,
+            reason: "retained_process_settled_quiescence",
+          });
+        }
         return { settled: true, process: mapRetainedProcess(updated) };
       }),
   );
@@ -62866,6 +62931,13 @@ export async function requestSessionTurnRecovery(
       if (!updatedSession) {
         throw new Error(`Active session turn changed while locked: ${input.turnId}`);
       }
+      await enqueueSessionWorkflowWakeInTransaction(tx as unknown as Database, {
+        accountId: session.accountId,
+        workspaceId,
+        sessionId: input.sessionId,
+        temporalWorkflowId: session.temporalWorkflowId ?? `session-${input.sessionId}`,
+        reason: "turn_recovery_requested",
+      });
       return {
         action: "recovering" as const,
         events: [...closedTools.events, ...inserted.map(mapEvent)],
@@ -64610,33 +64682,12 @@ export async function markSessionWorkflowWakeDelivered(
               blocker: "pending_agent_steer",
             } as const;
           }
-          const [pendingQuiescence] = await tx
-            .select({ id: schema.sessionTurnAttempts.id })
-            .from(schema.sessionTurnAttempts)
-            .innerJoin(
-              schema.sessionAttemptInterruptions,
-              and(
-                eq(
-                  schema.sessionAttemptInterruptions.workspaceId,
-                  schema.sessionTurnAttempts.workspaceId,
-                ),
-                eq(
-                  schema.sessionAttemptInterruptions.sessionId,
-                  schema.sessionTurnAttempts.sessionId,
-                ),
-                eq(schema.sessionAttemptInterruptions.attemptId, schema.sessionTurnAttempts.id),
-              ),
-            )
-            .where(
-              and(
-                eq(schema.sessionTurnAttempts.workspaceId, input.workspaceId),
-                eq(schema.sessionTurnAttempts.sessionId, input.sessionId),
-                isNull(schema.sessionTurnAttempts.quiescedAt),
-                inArray(schema.sessionAttemptInterruptions.state, ["settled", "rejected_stale"]),
-              ),
-            )
-            .limit(1);
-          if (pendingQuiescence) {
+          if (
+            await hasPendingSessionAttemptQuiescenceTx(tx as unknown as Database, {
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+            })
+          ) {
             return {
               action: "pending_admission",
               blocker: "pending_quiescence",

--- a/packages/db/test/session-workflow-wake-outbox.test.ts
+++ b/packages/db/test/session-workflow-wake-outbox.test.ts
@@ -574,6 +574,84 @@ describe("transactional session workflow wake outbox", () => {
     });
   });
 
+  test("recoverable activity shutdown retains a durable wake until quiescence", async () => {
+    const ctx = await fixture();
+    const started = await initializeSessionStartAtomically(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    await markSessionWorkflowWakeDelivered(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      temporalWorkflowId: started.temporalWorkflowId,
+      wakeRevision: started.workflowWakeRevision!,
+    });
+    const attemptId = crypto.randomUUID();
+    const workflowRunId = crypto.randomUUID();
+    const activityId = crypto.randomUUID();
+    const claimed = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
+      sessionId: ctx.session.id,
+      workflowId: started.temporalWorkflowId,
+      workflowRunId,
+      attemptId,
+      dispatchId: activityId,
+      trigger: { kind: "next" },
+    });
+    expect(claimed.action).toBe("claimed");
+    if (claimed.action !== "claimed") throw new Error("turn was not claimed");
+
+    expect(
+      await requestSessionTurnRecovery(client.db, ctx.grant.workspaceId!, {
+        sessionId: ctx.session.id,
+        turnId: claimed.turn.id,
+        triggerEventId: claimed.turn.triggerEventId,
+        attemptId,
+        reason: "worker_shutdown",
+      }),
+    ).toMatchObject({ action: "recovering" });
+    const recoveryWake = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
+      (entry) => entry.sessionId === ctx.session.id,
+    );
+    expect(recoveryWake).toMatchObject({
+      wakeRevision: started.workflowWakeRevision! + 1,
+      interruptionRequested: false,
+    });
+    expect(await wakeRow(ctx.grant.workspaceId!, ctx.session.id)).toMatchObject({
+      reason: "turn_recovery_requested",
+      deliveredRevision: started.workflowWakeRevision,
+    });
+
+    expect(await markSessionWorkflowWakeDelivered(client.db, recoveryWake!)).toEqual({
+      action: "pending_admission",
+      blocker: "pending_quiescence",
+    });
+    expect(await wakeRow(ctx.grant.workspaceId!, ctx.session.id)).toMatchObject({
+      wakeRevision: recoveryWake!.wakeRevision,
+      deliveredRevision: started.workflowWakeRevision,
+    });
+
+    await markSessionAttemptQuiesced(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      attemptId,
+      temporalWorkflowId: started.temporalWorkflowId,
+      temporalWorkflowRunId: workflowRunId,
+      temporalActivityId: activityId,
+    });
+    const settledWake = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
+      (entry) => entry.sessionId === ctx.session.id,
+    );
+    expect(settledWake!.wakeRevision).toBe(recoveryWake!.wakeRevision + 1);
+    expect(await markSessionWorkflowWakeDelivered(client.db, settledWake!)).toEqual({
+      action: "acknowledged",
+    });
+  });
+
   test("fully quiesced historical interruptions do not upgrade ordinary wakes to control", async () => {
     const ctx = await fixture();
     const queued = await send(ctx, "run");
@@ -741,14 +819,19 @@ describe("transactional session workflow wake outbox", () => {
       interruptionRequested: true,
     });
 
-    await markSessionWorkflowWakeDelivered(client.db, claimed!);
+    expect(await markSessionWorkflowWakeDelivered(client.db, claimed!)).toEqual({
+      action: "pending_admission",
+      blocker: "pending_quiescence",
+    });
     const ordinary = await send(ctx, "ordinary follow-up");
     const ordinaryClaim = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
       (entry) => entry.sessionId === ctx.session.id,
     );
     expect(ordinaryClaim).toMatchObject({
       wakeRevision: ordinary.wakeRevision,
-      interruptionRequested: false,
+      // The closed recoverable predecessor still lacks physical quiescence, so
+      // the older control revision cannot be acknowledged away yet.
+      interruptionRequested: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- commit a workflow-wake obligation with recoverable activity shutdown
- keep wake delivery pending until exact attempt quiescence
- atomically advance the wake when an attempt-owned retained process settles
- document and regression-test the worker-shutdown/final-writer race

## Verification
- OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-workflow-wake-outbox.test.ts apps/worker/test/retained-process-reconciliation.test.ts
- bun x oxlint --deny-warnings packages/db/src/index.ts packages/db/test/session-workflow-wake-outbox.test.ts apps/worker/test/retained-process-reconciliation.test.ts
- bun x oxfmt --check packages/db/src/index.ts packages/db/test/session-workflow-wake-outbox.test.ts apps/worker/test/retained-process-reconciliation.test.ts docs/architecture.md docs/run-lifecycle.md .changeset/durable-recovery-quiescence-wake.md
- bun run typecheck

## Summary by Sourcery

Ensure recoverable workflow wakes remain pending and durably advance through exact attempt quiescence.

Bug Fixes:
- Keep recoverable sessions durably wakeable until the exact attempt reaches physical quiescence, preventing worker-shutdown and final-writer races from orphaning recovery.

Enhancements:
- Centralize attempt-quiescence detection and atomically advance workflow wake revisions when attempt-owned retained processes settle.

Documentation:
- Document durable wake obligations for recoverable shutdowns and retained-process settlement races.

Tests:
- Add database and worker regression coverage for pending recovery wakes, quiescence delivery, atomic retained-process settlement, and idempotent replay.