### PR TITLE
fix(react): stop composer draft request feedback loops

### DIFF
--- a/.changeset/quiet-composer-draft-retries.md
+++ b/.changeset/quiet-composer-draft-retries.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Bound composer draft read retries and ignore unchanged soft-reload projections to prevent request feedback loops during reconnects and transient gateway failures.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -139,7 +139,10 @@ function composerDraftRetryDelay(failures: number): number {
   );
   // Independent tabs should not retry on the same millisecond after ingress
   // maintenance ends.
-  return Math.round(exponential * (0.8 + Math.random() * 0.4));
+  return Math.min(
+    COMPOSER_DRAFT_RETRY_MAX_MS,
+    Math.round(exponential * (0.8 + Math.random() * 0.4)),
+  );
 }
 
 // A remount must not manufacture a new operation while the previous mutation

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -115,6 +115,32 @@ type StoredOptimisticSendOperation = Omit<OptimisticSendOperation, "input" | "ca
 
 const PENDING_COMPOSER_STORAGE_PREFIX = "opengeni.pending-composer.v1:";
 const OPTIMISTIC_SEND_STORAGE_PREFIX = "opengeni.optimistic-sends.v1:";
+const COMPOSER_DRAFT_RETRY_BASE_MS = 1_000;
+const COMPOSER_DRAFT_RETRY_MAX_MS = 30_000;
+
+function isRetryableDraftReadError(error: unknown): boolean {
+  if (
+    typeof DOMException !== "undefined" &&
+    error instanceof DOMException &&
+    error.name === "AbortError"
+  ) {
+    return false;
+  }
+  if (error && typeof error === "object" && "retryable" in error) {
+    return error.retryable === true;
+  }
+  return error instanceof TypeError;
+}
+
+function composerDraftRetryDelay(failures: number): number {
+  const exponential = Math.min(
+    COMPOSER_DRAFT_RETRY_MAX_MS,
+    COMPOSER_DRAFT_RETRY_BASE_MS * 2 ** Math.max(0, failures - 1),
+  );
+  // Independent tabs should not retry on the same millisecond after ingress
+  // maintenance ends.
+  return Math.round(exponential * (0.8 + Math.random() * 0.4));
+}
 
 // A remount must not manufacture a new operation while the previous mutation
 // is still outcome-unknown. Keep only non-credential request fields here; the
@@ -697,6 +723,17 @@ export function useComposer(
   const localEditRevision = useRef(initialShadow ? 1 : 0);
   const targetGeneration = useRef(0);
   const draftReadGeneration = useRef(0);
+  const draftReadInFlightRef = useRef<{
+    targetKey: string;
+    promise: Promise<void>;
+  } | null>(null);
+  const draftReadRetryRef = useRef<{
+    targetKey: string;
+    failures: number;
+    notBefore: number;
+    timer: ReturnType<typeof setTimeout> | null;
+  }>({ targetKey, failures: 0, notBefore: 0, timer: null });
+  const latestLoadDraftRef = useRef<(replaceLocal: boolean) => Promise<void>>(async () => {});
   const lastSavedSignature = useRef<string | null>(null);
   const saveChain = useRef<Promise<void>>(Promise.resolve());
   const onSent = options.onSent;
@@ -725,6 +762,10 @@ export function useComposer(
   const targetKeyRef = useRef(targetKey);
   useLayoutEffect(() => {
     if (targetKeyRef.current === targetKey) return;
+    if (draftReadRetryRef.current.timer !== null) {
+      clearTimeout(draftReadRetryRef.current.timer);
+    }
+    draftReadRetryRef.current = { targetKey, failures: 0, notBefore: 0, timer: null };
     targetKeyRef.current = targetKey;
     targetGeneration.current += 1;
     draftReadGeneration.current += 1;
@@ -777,6 +818,14 @@ export function useComposer(
     setDraftConflict(null);
     setRestoredResources(shadow?.resources ?? []);
   }, [durableDrafts, options.initialPolicy, pendingOperationKey, sessionId, targetKey]);
+  useEffect(
+    () => () => {
+      if (draftReadRetryRef.current.timer !== null) {
+        clearTimeout(draftReadRetryRef.current.timer);
+      }
+    },
+    [],
+  );
 
   const setOptimisticDraftShadow = useCallback(
     (shadow: ComposerDraftShadow): void => {
@@ -886,6 +935,41 @@ export function useComposer(
         setDraftLoading(false);
         return;
       }
+      let retry = draftReadRetryRef.current;
+      if (retry.targetKey !== targetKey) {
+        if (retry.timer !== null) clearTimeout(retry.timer);
+        retry = { targetKey, failures: 0, notBefore: 0, timer: null };
+        draftReadRetryRef.current = retry;
+      }
+      const scheduleRetry = (): void => {
+        if (retry.timer !== null || retry.notBefore <= 0) return;
+        retry.timer = setTimeout(
+          () => {
+            if (draftReadRetryRef.current !== retry || targetKeyRef.current !== targetKey) return;
+            retry.timer = null;
+            void latestLoadDraftRef.current(false);
+          },
+          Math.max(0, retry.notBefore - Date.now()),
+        );
+      };
+      if (!replaceLocal && Date.now() < retry.notBefore) {
+        scheduleRetry();
+        return;
+      }
+      const currentRead = draftReadInFlightRef.current;
+      if (currentRead?.targetKey === targetKey) {
+        await currentRead.promise;
+        return;
+      }
+      if (retry.timer !== null) {
+        clearTimeout(retry.timer);
+        retry.timer = null;
+      }
+      let settleInFlight: (() => void) | undefined;
+      const inFlight = new Promise<void>((resolve) => {
+        settleInFlight = resolve;
+      });
+      draftReadInFlightRef.current = { targetKey, promise: inFlight };
       const generation = targetGeneration.current;
       const readTicket = ++draftReadGeneration.current;
       const localAtStart = localEditRevision.current;
@@ -925,8 +1009,16 @@ export function useComposer(
         ) {
           return;
         }
+        if (retry.timer !== null) clearTimeout(retry.timer);
+        retry.failures = 0;
+        retry.notBefore = 0;
+        retry.timer = null;
         const currentRevision = draftRef.current?.revision ?? -1;
-        if (fetched.revision >= currentRevision) {
+        // Reconnect and client-generation effects can legitimately ask for the
+        // draft again. A same-revision response is not new authority: publishing
+        // its freshly decoded object back into React creates a response -> render
+        // -> read feedback loop. Hard reload remains the explicit exception.
+        if (replaceLocal || fetched.revision > currentRevision) {
           draftRef.current = fetched;
           setDraft(fetched);
           setDraftConflict(null);
@@ -978,6 +1070,16 @@ export function useComposer(
           readTicket === draftReadGeneration.current
         ) {
           setError(asError(cause));
+          if (isRetryableDraftReadError(cause)) {
+            retry.failures += 1;
+            retry.notBefore = Date.now() + composerDraftRetryDelay(retry.failures);
+            scheduleRetry();
+          } else {
+            if (retry.timer !== null) clearTimeout(retry.timer);
+            retry.failures = 0;
+            retry.notBefore = 0;
+            retry.timer = null;
+          }
         }
       } finally {
         if (
@@ -987,10 +1089,15 @@ export function useComposer(
         ) {
           setDraftLoading(false);
         }
+        settleInFlight?.();
+        if (draftReadInFlightRef.current?.promise === inFlight) {
+          draftReadInFlightRef.current = null;
+        }
       }
     },
     [client, durableDrafts, sessionId, targetKey, workspaceId],
   );
+  latestLoadDraftRef.current = loadDraft;
 
   useEffect(() => {
     if (!sessionId || !durableDrafts) {

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -115,36 +115,6 @@ type StoredOptimisticSendOperation = Omit<OptimisticSendOperation, "input" | "ca
 
 const PENDING_COMPOSER_STORAGE_PREFIX = "opengeni.pending-composer.v1:";
 const OPTIMISTIC_SEND_STORAGE_PREFIX = "opengeni.optimistic-sends.v1:";
-const COMPOSER_DRAFT_RETRY_BASE_MS = 1_000;
-const COMPOSER_DRAFT_RETRY_MAX_MS = 30_000;
-
-function isRetryableDraftReadError(error: unknown): boolean {
-  if (
-    typeof DOMException !== "undefined" &&
-    error instanceof DOMException &&
-    error.name === "AbortError"
-  ) {
-    return false;
-  }
-  if (error && typeof error === "object" && "retryable" in error) {
-    return error.retryable === true;
-  }
-  return error instanceof TypeError;
-}
-
-function composerDraftRetryDelay(failures: number): number {
-  const exponential = Math.min(
-    COMPOSER_DRAFT_RETRY_MAX_MS,
-    COMPOSER_DRAFT_RETRY_BASE_MS * 2 ** Math.max(0, failures - 1),
-  );
-  // Independent tabs should not retry on the same millisecond after ingress
-  // maintenance ends.
-  return Math.min(
-    COMPOSER_DRAFT_RETRY_MAX_MS,
-    Math.round(exponential * (0.8 + Math.random() * 0.4)),
-  );
-}
-
 // A remount must not manufacture a new operation while the previous mutation
 // is still outcome-unknown. Keep only non-credential request fields here; the
 // mounted hook retains the exact input, including any credential updates. The
@@ -726,17 +696,12 @@ export function useComposer(
   const localEditRevision = useRef(initialShadow ? 1 : 0);
   const targetGeneration = useRef(0);
   const draftReadGeneration = useRef(0);
-  const draftReadInFlightRef = useRef<{
-    targetKey: string;
-    promise: Promise<void>;
-  } | null>(null);
+  const draftReadInFlightRef = useRef<string | null>(null);
   const draftReadRetryRef = useRef<{
     targetKey: string;
     failures: number;
-    notBefore: number;
     timer: ReturnType<typeof setTimeout> | null;
-  }>({ targetKey, failures: 0, notBefore: 0, timer: null });
-  const latestLoadDraftRef = useRef<(replaceLocal: boolean) => Promise<void>>(async () => {});
+  }>({ targetKey, failures: 0, timer: null });
   const lastSavedSignature = useRef<string | null>(null);
   const saveChain = useRef<Promise<void>>(Promise.resolve());
   const onSent = options.onSent;
@@ -768,7 +733,7 @@ export function useComposer(
     if (draftReadRetryRef.current.timer !== null) {
       clearTimeout(draftReadRetryRef.current.timer);
     }
-    draftReadRetryRef.current = { targetKey, failures: 0, notBefore: 0, timer: null };
+    draftReadRetryRef.current = { targetKey, failures: 0, timer: null };
     targetKeyRef.current = targetKey;
     targetGeneration.current += 1;
     draftReadGeneration.current += 1;
@@ -941,38 +906,27 @@ export function useComposer(
       let retry = draftReadRetryRef.current;
       if (retry.targetKey !== targetKey) {
         if (retry.timer !== null) clearTimeout(retry.timer);
-        retry = { targetKey, failures: 0, notBefore: 0, timer: null };
+        retry = { targetKey, failures: 0, timer: null };
         draftReadRetryRef.current = retry;
       }
       const scheduleRetry = (): void => {
-        if (retry.timer !== null || retry.notBefore <= 0) return;
+        if (retry.timer !== null) return;
         retry.timer = setTimeout(
           () => {
             if (draftReadRetryRef.current !== retry || targetKeyRef.current !== targetKey) return;
             retry.timer = null;
-            void latestLoadDraftRef.current(false);
+            void loadDraft(false);
           },
-          Math.max(0, retry.notBefore - Date.now()),
+          Math.min(25_000, 1_000 * 2 ** (retry.failures - 1)) * (0.8 + Math.random() * 0.4),
         );
       };
-      if (!replaceLocal && Date.now() < retry.notBefore) {
-        scheduleRetry();
-        return;
-      }
-      const currentRead = draftReadInFlightRef.current;
-      if (currentRead?.targetKey === targetKey) {
-        await currentRead.promise;
-        return;
-      }
+      if (!replaceLocal && retry.timer !== null) return;
+      if (draftReadInFlightRef.current === targetKey) return;
       if (retry.timer !== null) {
         clearTimeout(retry.timer);
         retry.timer = null;
       }
-      let settleInFlight: (() => void) | undefined;
-      const inFlight = new Promise<void>((resolve) => {
-        settleInFlight = resolve;
-      });
-      draftReadInFlightRef.current = { targetKey, promise: inFlight };
+      draftReadInFlightRef.current = targetKey;
       const generation = targetGeneration.current;
       const readTicket = ++draftReadGeneration.current;
       const localAtStart = localEditRevision.current;
@@ -1014,7 +968,6 @@ export function useComposer(
         }
         if (retry.timer !== null) clearTimeout(retry.timer);
         retry.failures = 0;
-        retry.notBefore = 0;
         retry.timer = null;
         const currentRevision = draftRef.current?.revision ?? -1;
         // Reconnect and client-generation effects can legitimately ask for the
@@ -1073,14 +1026,15 @@ export function useComposer(
           readTicket === draftReadGeneration.current
         ) {
           setError(asError(cause));
-          if (isRetryableDraftReadError(cause)) {
+          if (
+            cause instanceof TypeError ||
+            (cause && typeof cause === "object" && "retryable" in cause && cause.retryable === true)
+          ) {
             retry.failures += 1;
-            retry.notBefore = Date.now() + composerDraftRetryDelay(retry.failures);
             scheduleRetry();
           } else {
             if (retry.timer !== null) clearTimeout(retry.timer);
             retry.failures = 0;
-            retry.notBefore = 0;
             retry.timer = null;
           }
         }
@@ -1092,15 +1046,13 @@ export function useComposer(
         ) {
           setDraftLoading(false);
         }
-        settleInFlight?.();
-        if (draftReadInFlightRef.current?.promise === inFlight) {
+        if (draftReadInFlightRef.current === targetKey) {
           draftReadInFlightRef.current = null;
         }
       }
     },
     [client, durableDrafts, sessionId, targetKey, workspaceId],
   );
-  latestLoadDraftRef.current = loadDraft;
 
   useEffect(() => {
     if (!sessionId || !durableDrafts) {

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -3241,6 +3241,42 @@ describe("useComposer durable draft and control binding", () => {
     await hook.unmount();
   });
 
+  test("same-revision soft reloads do not republish decoded draft state", async () => {
+    let reads = 0;
+    const authoritative: ComposerDraft = {
+      revision: 7,
+      text: "settled draft",
+      resources: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      latencyMode: "standard" as const,
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        return { ...authoritative, resources: [] };
+      },
+    });
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events }),
+      noEvents,
+    );
+    await flush();
+    const firstProjection = hook.result.current.draft;
+    expect(firstProjection?.revision).toBe(7);
+
+    await hook.rerender([makeEvent(1, "session.queue.changed", { operation: "edit" })]);
+    await flush();
+
+    expect(reads).toBe(2);
+    expect(hook.result.current.draft).toBe(firstProjection);
+    await hook.unmount();
+  });
+
   test("rerenders do not reload drafts outside target, explicit, or event triggers", async () => {
     const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const reads: string[] = [];
@@ -3888,6 +3924,33 @@ describe("useComposer durable draft and control binding", () => {
     expect(hook.result.current.error?.message).toBe(
       "OpenGeni is temporarily unavailable — retry. Reference: edge-503-safe.",
     );
+    await hook.unmount();
+  });
+
+  test("retryable draft hydrate failures stay bounded across client identity churn", async () => {
+    let reads = 0;
+    const failingClient = () =>
+      fakeClient({
+        getComposerDraft: async () => {
+          reads += 1;
+          throw gatewayError(503);
+        },
+      });
+    const hook = await renderHook(
+      (client: ReturnType<typeof failingClient>) =>
+        useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      failingClient(),
+    );
+    await flush();
+    expect(reads).toBe(1);
+
+    for (let index = 0; index < 10; index += 1) {
+      await hook.rerender(failingClient());
+    }
+    await flush();
+
+    expect(reads).toBe(1);
+    expect(hook.result.current.error).toMatchObject({ status: 503, retryable: true });
     await hook.unmount();
   });
 


### PR DESCRIPTION
## Summary
- ignore same-revision soft draft reload projections
- single-flight draft reads per session target
- back off retryable draft read failures with capped jitter

## Production evidence
Azure staging ingress showed 12-22 identical composer-draft GETs/sec per active tab/session, including both 200 and maintenance 503 responses. Repeated SDK reads minted new correlation IDs, producing the changing reference spam.

## Verification
- `bun test packages/react/test/hooks.test.tsx` (110 pass)
- `bun run typecheck`
- `bun run lint packages/react/src/hooks/use-composer.ts packages/react/test/hooks.test.tsx`
- `bun run --cwd packages/react build`
- `bun run format:check packages/react/src/hooks/use-composer.ts packages/react/test/hooks.test.tsx .changeset/quiet-composer-draft-retries.md`

## Summary by Sourcery

Stop composer draft request feedback loops during reconnects and transient gateway failures.

Bug Fixes:
- Prevent composer draft reads from republishing unchanged revisions and triggering response-to-render feedback loops.
- Limit duplicate in-flight draft requests per session target and bound retryable read failures with capped jittered backoff.

Tests:
- Add coverage for same-revision reload suppression and bounded retries during client identity churn.