### PR TITLE
fix(db): settle native tool-search results

### DIFF
--- a/.changeset/calm-tool-search-settlement.md
+++ b/.changeset/calm-tool-search-settlement.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Accept native tool-search results whose correlation id is carried only in provider metadata.

--- a/packages/db/src/session-tool-call-settlement.ts
+++ b/packages/db/src/session-tool-call-settlement.ts
@@ -15,7 +15,12 @@ export const TOOL_RESULT_TYPE_BY_CALL_TYPE: Readonly<Record<string, string>> = {
 };
 
 export function historyCallId(item: Record<string, unknown>): string | null {
-  const value = item.callId ?? item.call_id ?? item.id;
+  const providerData =
+    item.providerData && typeof item.providerData === "object" && !Array.isArray(item.providerData)
+      ? (item.providerData as Record<string, unknown>)
+      : null;
+  const value =
+    item.callId ?? item.call_id ?? providerData?.callId ?? providerData?.call_id ?? item.id;
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -240,6 +240,65 @@ async function claimTestSessionWork(
 }
 
 describe("clean session control plane", () => {
+  test("records native tool-search results whose id only survives in provider data", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "find matching tools");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    const callId = "tool-search-provider-id";
+
+    expect(
+      await registerPendingSessionToolCall(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+        callId,
+        callType: "tool_search_call",
+        callItem: {
+          type: "tool_search_call",
+          call_id: callId,
+          execution: "client",
+          arguments: { query: "matching tools" },
+        },
+      }),
+    ).toEqual({ accepted: true, registered: true });
+
+    const resultItem = {
+      type: "tool_search_output",
+      tools: [{ name: "matching_tool" }],
+      providerData: { call_id: callId },
+    };
+    expect(
+      await recordPendingSessionToolCallResult(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+        callId,
+        resultItem,
+      }),
+    ).toEqual({ accepted: true, recorded: true });
+
+    const [pending] = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db
+        .select({ resultItem: schema.sessionPendingToolCalls.resultItem })
+        .from(schema.sessionPendingToolCalls)
+        .where(eq(schema.sessionPendingToolCalls.callId, callId)),
+    );
+    expect(pending?.resultItem).toEqual(resultItem);
+  });
+
   test("provider-artifact shape constraints are rolling-safe and enforce new writes", async () => {
     const constraints = await shared.admin<
       Array<{ conname: string; convalidated: boolean }>

--- a/packages/db/test/session-tool-call-settlement.test.ts
+++ b/packages/db/test/session-tool-call-settlement.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { historyCallId } from "../src/session-tool-call-settlement";
+
+describe("session tool-call settlement identity", () => {
+  test("accepts native tool-search ids carried only in provider data", () => {
+    expect(
+      historyCallId({
+        type: "tool_search_output",
+        tools: [{ name: "matching_tool" }],
+        providerData: { call_id: "tool-search-provider-id" },
+      }),
+    ).toBe("tool-search-provider-id");
+  });
+
+  test("keeps direct SDK aliases ahead of provider metadata and item ids", () => {
+    expect(
+      historyCallId({
+        type: "tool_search_output",
+        callId: "direct-id",
+        id: "item-id",
+        providerData: { call_id: "provider-id" },
+      }),
+    ).toBe("direct-id");
+  });
+
+  test("ignores malformed provider metadata", () => {
+    expect(
+      historyCallId({
+        type: "tool_search_output",
+        id: "item-id",
+        providerData: ["provider-id"],
+      }),
+    ).toBe("item-id");
+  });
+});


### PR DESCRIPTION
## Summary
- accept tool-search correlation IDs carried only in SDK provider metadata at DB settlement
- add direct identity regression coverage
- add Postgres control-plane regression coverage for the exact failing transaction

## Verification
- bun test packages/db/test/session-tool-call-settlement.test.ts
- bun test packages/db/test/session-control-plane.test.ts --test-name-pattern 'records native tool-search results'
- bun run lint
- bun run format:check
- bun run typecheck

Fixes staging failures with: SDK tool result does not settle tool_search_call:<call-id>

## Summary by Sourcery

Settle native tool-search results using correlation IDs from provider metadata.

Bug Fixes:
- Allow native tool-search results to settle when their correlation ID is provided only through SDK provider metadata.

Tests:
- Add direct identity regression tests and Postgres control-plane coverage for provider-metadata tool-search settlement.