### PR TITLE
fix(db): bound historical recovery wake debt

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -42314,6 +42314,20 @@ async function hasPendingSessionAttemptQuiescenceTx(
           )
           or (
             attempt.outcome = 'interrupted_recoverable'
+            and not exists (
+              select 1
+              from session_turn_attempts successor
+              where successor.account_id = attempt.account_id
+                and successor.workspace_id = attempt.workspace_id
+                and successor.session_id = attempt.session_id
+                and (
+                  successor.started_at > attempt.started_at
+                  or (
+                    successor.started_at = attempt.started_at
+                    and successor.id > attempt.id
+                  )
+                )
+            )
             and exists (
               select 1
               from session_events event

--- a/packages/db/test/session-workflow-wake-outbox.test.ts
+++ b/packages/db/test/session-workflow-wake-outbox.test.ts
@@ -652,6 +652,96 @@ describe("transactional session workflow wake outbox", () => {
     });
   });
 
+  test("historical recovery-only debt cannot hold successor wakes unacknowledged", async () => {
+    const ctx = await fixture();
+    const started = await initializeSessionStartAtomically(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    await markSessionWorkflowWakeDelivered(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      temporalWorkflowId: started.temporalWorkflowId,
+      wakeRevision: started.workflowWakeRevision!,
+    });
+    const predecessorAttemptId = crypto.randomUUID();
+    const predecessorRunId = crypto.randomUUID();
+    const predecessorActivityId = crypto.randomUUID();
+    const predecessor = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
+      sessionId: ctx.session.id,
+      workflowId: started.temporalWorkflowId,
+      workflowRunId: predecessorRunId,
+      attemptId: predecessorAttemptId,
+      dispatchId: predecessorActivityId,
+      trigger: { kind: "next" },
+    });
+    expect(predecessor.action).toBe("claimed");
+    if (predecessor.action !== "claimed") throw new Error("predecessor was not claimed");
+    expect(
+      await requestSessionTurnRecovery(client.db, ctx.grant.workspaceId!, {
+        sessionId: ctx.session.id,
+        turnId: predecessor.turn.id,
+        triggerEventId: predecessor.turn.triggerEventId,
+        attemptId: predecessorAttemptId,
+        reason: "worker_shutdown",
+      }),
+    ).toMatchObject({ action: "recovering" });
+    await markSessionAttemptQuiesced(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      attemptId: predecessorAttemptId,
+      temporalWorkflowId: started.temporalWorkflowId,
+      temporalWorkflowRunId: predecessorRunId,
+      temporalActivityId: predecessorActivityId,
+    });
+    const recoveredWake = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
+      (entry) => entry.sessionId === ctx.session.id,
+    );
+    expect(await markSessionWorkflowWakeDelivered(client.db, recoveredWake!)).toEqual({
+      action: "acknowledged",
+    });
+
+    const successor = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
+      sessionId: ctx.session.id,
+      workflowId: started.temporalWorkflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    expect(successor.action).toBe("claimed");
+
+    // Model the durable pre-fix state: a successor was admitted even though the
+    // historical recovery-only predecessor has no physical receipt.
+    await withWorkspaceRls(client.db, ctx.grant.workspaceId!, async (db) => {
+      await db
+        .update(schema.sessionTurnAttempts)
+        .set({ quiescedAt: null })
+        .where(eq(schema.sessionTurnAttempts.id, predecessorAttemptId));
+    });
+    const ordinaryRevision = await enqueueSessionWorkflowWake(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      temporalWorkflowId: started.temporalWorkflowId,
+      reason: "successor_work",
+    });
+    expect(
+      await markSessionWorkflowWakeDelivered(client.db, {
+        accountId: ctx.grant.accountId,
+        workspaceId: ctx.grant.workspaceId!,
+        sessionId: ctx.session.id,
+        temporalWorkflowId: started.temporalWorkflowId,
+        wakeRevision: ordinaryRevision,
+      }),
+    ).toEqual({ action: "acknowledged" });
+  });
+
   test("fully quiesced historical interruptions do not upgrade ordinary wakes to control", async () => {
     const ctx = await fixture();
     const queued = await send(ctx, "run");


### PR DESCRIPTION
Follow-up review of #1931.

Recovery-only quiescence debt blocks wake acknowledgement only while the attempt is the newest session attempt, matching the existing admission/reconciliation rule. Historical pre-fix debt with an already-admitted successor remains operator-cleanup evidence and cannot poison future wake delivery.

Verification:
- 17 real-Postgres workflow wake tests
- 21 real-Postgres retained-process reconciliation tests
- all 31 TypeScript projects
- oxlint + oxfmt

## Summary by Sourcery

Bound recovery-only quiescence debt to the latest session attempt so stale historical debt cannot delay future workflow wakes.

Bug Fixes:
- Prevent historical recovery-only quiescence debt from blocking wake acknowledgement after a newer session attempt has been admitted.

Tests:
- Add a regression test covering successor wake acknowledgement when a predecessor retains stale recovery debt.