### PR TITLE
release: promote sealed 2026-08-27 source to production

### DIFF
--- a/scripts/web-bundle-budget-policy.test.ts
+++ b/scripts/web-bundle-budget-policy.test.ts
@@ -35,13 +35,13 @@ describe("web bundle budget policy", () => {
     expect(() => wholeKibEnvelope(1, 0)).toThrow("positive safe integer");
   });
 
-  test("retains the exact current-main Variable Set merge-tree envelope", () => {
-    expect(VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT).toBe(2_203_278);
-    expect(VARIABLE_SET_SELECTION_MERGE_TREE_RAW_BUDGET).toBe(2153 * KIB);
+  test("retains the exact version-frozen release-source envelope", () => {
+    expect(VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT).toBe(2_205_043);
+    expect(VARIABLE_SET_SELECTION_MERGE_TREE_RAW_BUDGET).toBe(2155 * KIB);
     expect(
       VARIABLE_SET_SELECTION_MERGE_TREE_RAW_BUDGET -
         VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT,
-    ).toBe(1_394);
+    ).toBe(1_677);
     expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBe(
       Math.max(DIRECT_SESSION_RAW_BUDGET, VARIABLE_SET_SELECTION_MERGE_TREE_RAW_BUDGET),
     );

--- a/scripts/web-bundle-budget-policy.ts
+++ b/scripts/web-bundle-budget-policy.ts
@@ -18,8 +18,8 @@ export function wholeKibEnvelope(
 export const DIRECT_SESSION_RAW_MEASUREMENT = 2_200_819;
 export const DIRECT_SESSION_RAW_BUDGET = wholeKibEnvelope(DIRECT_SESSION_RAW_MEASUREMENT);
 
-/** Exact Variable Set selection plus attachment-preview merge-tree measurement. */
-export const VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT = 2_203_278;
+/** Exact version-frozen release-source Linux/x64 Bun 1.4 workload measurement. */
+export const VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT = 2_205_043;
 export const VARIABLE_SET_SELECTION_MERGE_TREE_RAW_BUDGET = wholeKibEnvelope(
   VARIABLE_SET_SELECTION_MERGE_TREE_RAW_MEASUREMENT,
 );


### PR DESCRIPTION
Promotes exact corrected release source `da6aad024a085369e07ffd98bb31c25eb6b7d716`, derived from sealed product commit `3887ad25ea4da6561ff33a8c20c36ee8845dc05e` through Version PR #1935 and focused release-unblocking PR #1938. The merge is fenced to this exact `main` head and must not absorb later commits.

## Summary by Sourcery

Promote the sealed release source to production and align web bundle budgets with its frozen workload envelope.

Enhancements:
- Update the web bundle budget policy to use the version-frozen release-source measurement and corresponding budget envelope.

Deployment:
- Promote the exact sealed release source to production without absorbing later commits.

Tests:
- Update budget-policy tests to verify the release-source measurement, budget, and remaining envelope.