### PR TITLE
fix(worker): preserve provider recovery authority

### DIFF
--- a/.changeset/steady-provider-recovery-authority.md
+++ b/.changeset/steady-provider-recovery-authority.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Preserve the exact provider retry count when an operational database outage interrupts same-turn recovery, preventing stale replacement attempts from reopening an already-consumed retry generation.

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -320,14 +320,33 @@ export function postClaimDatabaseRecoveryFailure(input: {
   turnId: string;
   triggerEventId: string;
   executionGeneration: number;
+  providerRecovery?: {
+    failureCode: string;
+    providerRecoveryCount: number;
+  };
 }): ApplicationFailure | null {
   const code = retryableDatabaseFailureCode(input.error);
   if (!code || input.executionGeneration < 1) return null;
+  if (
+    input.providerRecovery &&
+    (!Number.isSafeInteger(input.providerRecovery.providerRecoveryCount) ||
+      input.providerRecovery.providerRecoveryCount <= 0 ||
+      input.providerRecovery.providerRecoveryCount > MAX_AUTOMATIC_PROVIDER_RECOVERIES ||
+      !/^[a-z][a-z0-9_]{0,63}$/.test(input.providerRecovery.failureCode))
+  ) {
+    return null;
+  }
   const detail: PostClaimDatabaseRecoveryDetail = {
     turnId: input.turnId,
     triggerEventId: input.triggerEventId,
     executionGeneration: input.executionGeneration,
     code,
+    ...(input.providerRecovery
+      ? {
+          providerFailureCode: input.providerRecovery.failureCode,
+          providerRecoveryCount: input.providerRecovery.providerRecoveryCount,
+        }
+      : {}),
   };
   return ApplicationFailure.create({
     message: POST_CLAIM_DATABASE_RECOVERY_FAILURE_MESSAGE,

--- a/apps/worker/src/activities/agent-turn/failure-settlement.ts
+++ b/apps/worker/src/activities/agent-turn/failure-settlement.ts
@@ -1388,6 +1388,25 @@ export async function settleTurnFailure(deps: TurnFailureDeps): Promise<RunAgent
         control.activityError = error;
         throw escaped;
       }
+      const postClaimRecovery =
+        recoveryResult.status === "recovering"
+          ? postClaimDatabaseRecoveryFailure({
+              error: recoveryError,
+              turnId: attempt.turnId,
+              triggerEventId: attempt.triggerEventId!,
+              executionGeneration: attempt.executionGeneration,
+              providerRecovery: {
+                failureCode: failure.code ?? "provider_unavailable",
+                providerRecoveryCount: nextProviderRecoveryCount,
+              },
+            })
+          : null;
+      if (postClaimRecovery) {
+        control.activityStatus = "recovering";
+        control.turnMetricOutcome = "recovering";
+        control.activityError = error;
+        throw postClaimRecovery;
+      }
       throw recoveryError;
     }
   }

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -189,6 +189,28 @@ export function createSessionStateActivities(
       turn.triggerEventId === postClaimRecovery.triggerEventId &&
       turn.executionGeneration === postClaimRecovery.executionGeneration,
     );
+    const providerRecoveryCount = postClaimIdentityMatches
+      ? postClaimRecovery?.providerRecoveryCount
+      : undefined;
+    const providerFailureCode = postClaimIdentityMatches
+      ? postClaimRecovery?.providerFailureCode
+      : undefined;
+    const hasProviderRecoveryCount = providerRecoveryCount !== undefined;
+    const hasProviderFailureCode = providerFailureCode !== undefined;
+    if (hasProviderRecoveryCount !== hasProviderFailureCode) {
+      return { action: "stale" };
+    }
+    if (
+      providerRecoveryCount !== undefined &&
+      (!Number.isSafeInteger(providerRecoveryCount) ||
+        providerRecoveryCount <= 0 ||
+        providerRecoveryCount !== providerRecoveryCountFromMetadata(turn.metadata ?? {}) + 1 ||
+        providerRecoveryCount > MAX_AUTOMATIC_PROVIDER_RECOVERIES ||
+        typeof providerFailureCode !== "string" ||
+        !/^[a-z][a-z0-9_]{0,63}$/.test(providerFailureCode))
+    ) {
+      return { action: "stale" };
+    }
     const recoveredClaimCode = postClaimIdentityMatches
       ? postClaimRecovery!.code
       : input.preClaimFailure?.disposition === "retryable" &&
@@ -201,10 +223,17 @@ export function createSessionStateActivities(
         turnId: turn.id,
         triggerEventId: turn.triggerEventId,
         attemptId: input.attemptId,
-        reason: "claimed_attempt_database_failure",
+        reason: providerFailureCode ?? "claimed_attempt_database_failure",
+        ...(providerRecoveryCount !== undefined ? { providerRecoveryCount } : {}),
         detail: {
-          code: recoveredClaimCode,
+          code: providerFailureCode ?? recoveredClaimCode,
           retryable: true,
+          ...(providerRecoveryCount !== undefined
+            ? {
+                databaseFailureCode: recoveredClaimCode,
+                providerRecoveryCount,
+              }
+            : {}),
           recoverySource: "workflow_activity_failure",
         },
         fromStatuses: ["running"],

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -276,6 +276,12 @@ export type PostClaimDatabaseRecoveryDetail = {
   triggerEventId: string;
   executionGeneration: number;
   code: "db_deadlock" | "db_serialization_failure" | "db_failure";
+  /** Present when the database outage interrupted a retryable provider
+   * recovery checkpoint. The control lane must advance this exact durable
+   * count instead of reopening the same recovery generation. */
+  providerRecoveryCount?: number;
+  /** Safe classified provider cause paired with providerRecoveryCount. */
+  providerFailureCode?: string;
 };
 
 export const POST_CLAIM_DATABASE_RECOVERY_FAILURE_TYPE = "OpenGeniPostClaimDatabaseRecovery";

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -275,6 +275,18 @@ export function postClaimDatabaseRecoveryDetail(
   ) {
     return null;
   }
+  const hasProviderRecoveryCount = detail.providerRecoveryCount !== undefined;
+  const hasProviderFailureCode = detail.providerFailureCode !== undefined;
+  if (
+    hasProviderRecoveryCount !== hasProviderFailureCode ||
+    (hasProviderRecoveryCount &&
+      (!Number.isSafeInteger(detail.providerRecoveryCount) ||
+        (detail.providerRecoveryCount ?? 0) <= 0 ||
+        typeof detail.providerFailureCode !== "string" ||
+        !/^[a-z][a-z0-9_]{0,63}$/.test(detail.providerFailureCode)))
+  ) {
+    return null;
+  }
   return detail as PostClaimDatabaseRecoveryDetail;
 }
 

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -4775,10 +4775,26 @@ describe("transient provider error classifier", () => {
       retryOutcome: "exhausted",
       database: { table: "session_turns" },
     });
-    expect(postClaimDatabaseRecoveryFailure({ error: deadlock, ...identity })).toMatchObject({
+    expect(
+      postClaimDatabaseRecoveryFailure({
+        error: deadlock,
+        ...identity,
+        providerRecovery: {
+          failureCode: "mcp_transport_unavailable",
+          providerRecoveryCount: 2,
+        },
+      }),
+    ).toMatchObject({
       type: "OpenGeniPostClaimDatabaseRecovery",
       nonRetryable: true,
-      details: [{ ...identity, code: "db_deadlock" }],
+      details: [
+        {
+          ...identity,
+          code: "db_deadlock",
+          providerFailureCode: "mcp_transport_unavailable",
+          providerRecoveryCount: 2,
+        },
+      ],
     });
     expect(
       postClaimDatabaseRecoveryFailure({
@@ -4801,6 +4817,16 @@ describe("transient provider error classifier", () => {
     expect(postClaimDatabaseRecoveryFailure({ error: constraint, ...identity })).toBeNull();
     expect(
       postClaimDatabaseRecoveryFailure({ error: new Error("SECRET invariant"), ...identity }),
+    ).toBeNull();
+    expect(
+      postClaimDatabaseRecoveryFailure({
+        error: deadlock,
+        ...identity,
+        providerRecovery: {
+          failureCode: "unsafe provider code",
+          providerRecoveryCount: 2,
+        },
+      }),
     ).toBeNull();
   });
 

--- a/apps/worker/test/session-activity-cancellation.test.ts
+++ b/apps/worker/test/session-activity-cancellation.test.ts
@@ -148,6 +148,21 @@ describe("post-claim database recovery wire classification", () => {
     expect(postClaimDatabaseRecoveryDetail(activityFailure(failure))).toEqual(detail);
   });
 
+  test("accepts a complete provider recovery authority pair", () => {
+    const providerDetail = {
+      ...detail,
+      providerFailureCode: "mcp_transport_unavailable",
+      providerRecoveryCount: 2,
+    };
+    const failure = ApplicationFailure.create({
+      message: POST_CLAIM_DATABASE_RECOVERY_FAILURE_MESSAGE,
+      type: POST_CLAIM_DATABASE_RECOVERY_FAILURE_TYPE,
+      nonRetryable: true,
+      details: [providerDetail],
+    });
+    expect(postClaimDatabaseRecoveryDetail(activityFailure(failure))).toEqual(providerDetail);
+  });
+
   test("rejects malformed identity, permanent codes, and unrelated activities", () => {
     const failure = (candidate: Record<string, unknown>) =>
       activityFailure(
@@ -162,6 +177,18 @@ describe("post-claim database recovery wire classification", () => {
     ).toBeNull();
     expect(
       postClaimDatabaseRecoveryDetail(failure({ ...detail, code: "claim_invariant" })),
+    ).toBeNull();
+    expect(
+      postClaimDatabaseRecoveryDetail(failure({ ...detail, providerRecoveryCount: 2 })),
+    ).toBeNull();
+    expect(
+      postClaimDatabaseRecoveryDetail(
+        failure({
+          ...detail,
+          providerFailureCode: "unsafe provider code",
+          providerRecoveryCount: 2,
+        }),
+      ),
     ).toBeNull();
     expect(
       postClaimDatabaseRecoveryDetail(

--- a/apps/worker/test/session-state-failure-dedupe.test.ts
+++ b/apps/worker/test/session-state-failure-dedupe.test.ts
@@ -78,7 +78,7 @@ describe("failSessionAttempt child-terminal identity", () => {
     );
   });
 
-  test("recovers an exact claimed turn after operational database failure", async () => {
+  test("preserves provider recovery authority after an operational database failure", async () => {
     const published: unknown[] = [];
     const recoveryCalls: unknown[] = [];
     const terminalSettlement = mock(async () => ({ action: "settled" as const, events: [] }));
@@ -100,6 +100,7 @@ describe("failSessionAttempt child-terminal identity", () => {
               id: "turn-1",
               triggerEventId: "trigger-1",
               executionGeneration: 4,
+              metadata: { providerRecoveryCount: 1 },
             }) as any,
         ),
         requestSessionTurnRecovery: mock(async (...args: unknown[]) => {
@@ -133,6 +134,8 @@ describe("failSessionAttempt child-terminal identity", () => {
           triggerEventId: "trigger-1",
           executionGeneration: 4,
           code: "db_failure",
+          providerFailureCode: "mcp_transport_unavailable",
+          providerRecoveryCount: 2,
         },
       }),
     ).toEqual({ action: "recovering" });
@@ -142,10 +145,13 @@ describe("failSessionAttempt child-terminal identity", () => {
         turnId: "turn-1",
         triggerEventId: "trigger-1",
         attemptId: "attempt-1",
-        reason: "claimed_attempt_database_failure",
+        reason: "mcp_transport_unavailable",
+        providerRecoveryCount: 2,
         detail: {
-          code: "db_failure",
+          code: "mcp_transport_unavailable",
           retryable: true,
+          databaseFailureCode: "db_failure",
+          providerRecoveryCount: 2,
           recoverySource: "workflow_activity_failure",
         },
         fromStatuses: ["running"],
@@ -154,6 +160,50 @@ describe("failSessionAttempt child-terminal identity", () => {
     expect(published).toEqual([{ id: "recovery-1", type: "turn.recovery.requested" }]);
     expect(terminalSettlement).not.toHaveBeenCalled();
     expect(parentWake).not.toHaveBeenCalled();
+
+    recoveryCalls.length = 0;
+    expect(
+      await activities.failSessionAttempt({
+        accountId: "account-1",
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        attemptId: "attempt-1",
+        workflowId: "session-session-1",
+        postClaimDatabaseRecovery: {
+          turnId: "turn-1",
+          triggerEventId: "trigger-1",
+          executionGeneration: 4,
+          code: "db_failure",
+          providerFailureCode: "mcp_transport_unavailable",
+          providerRecoveryCount: 1,
+        },
+      }),
+    ).toEqual({ action: "stale" });
+    expect(recoveryCalls).toHaveLength(0);
+
+    for (const malformedAuthority of [
+      { providerFailureCode: "mcp_transport_unavailable" },
+      { providerRecoveryCount: 2 },
+      { providerFailureCode: "unsafe provider code", providerRecoveryCount: 2 },
+    ]) {
+      expect(
+        await activities.failSessionAttempt({
+          accountId: "account-1",
+          workspaceId: "workspace-1",
+          sessionId: "session-1",
+          attemptId: "attempt-1",
+          workflowId: "session-session-1",
+          postClaimDatabaseRecovery: {
+            turnId: "turn-1",
+            triggerEventId: "trigger-1",
+            executionGeneration: 4,
+            code: "db_failure",
+            ...malformedAuthority,
+          },
+        } as any),
+      ).toEqual({ action: "stale" });
+    }
+    expect(recoveryCalls).toHaveLength(0);
   });
 
   test("recovers an ambiguously committed claim from retryable pre-claim truth", async () => {

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -474,7 +474,13 @@ replacement attempts may be scheduled, and a sixth retryable failure settles the
 same logical turn as failed with the original typed cause plus explicit recovery-
 exhaustion evidence. This is an infrastructure retry budget, not a goal,
 continuation, model-call, or run-length cap; a later human/API prompt may retry as
-new accepted work. Every Steer commits a control wake revision, including when
+new accepted work. If an operational database outage interrupts the recovery
+checkpoint itself, the existing post-claim failure wire carries the immutable
+turn identity, classified provider cause, and exact next recovery count into the
+DB-only control lane. That lane accepts the checkpoint only when the identity
+still owns the attempt and the count is exactly one beyond durable turn metadata;
+ambiguous commits and stale replays therefore cannot reset the retry budget.
+Every Steer commits a control wake revision, including when
 the recovering turn has no live attempt. A later coalesced Send cannot downgrade
 it to an ordinary queue signal, so the workflow interrupts the hold and processes
 the new direction immediately.

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -343,6 +343,8 @@ describe("Temporal workflow integration", () => {
                 triggerEventId: currentTurn.triggerEventId,
                 executionGeneration: 1,
                 code: "db_failure",
+                providerFailureCode: "mcp_transport_unavailable",
+                providerRecoveryCount: 2,
               },
             ],
           });
@@ -390,6 +392,8 @@ describe("Temporal workflow integration", () => {
             triggerEventId: turn.triggerEventId,
             executionGeneration: 1,
             code: "db_failure",
+            providerFailureCode: "mcp_transport_unavailable",
+            providerRecoveryCount: 2,
           },
         });
         expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900);


### PR DESCRIPTION
## Summary

- carry the classified provider failure and exact next recovery count through the existing post-claim database recovery wire
- require the provider recovery authority pair and fence it against the exact durable turn metadata before scheduling a replacement attempt
- preserve the dedicated escaped MCP timeout recovery path and its existing pacing behavior
- document the recovery checkpoint invariant and add a patch changeset for `@opengeni/worker-bundle`

## Verification

- `git diff --check` passed
- touched TypeScript files were formatted successfully with the repository's `oxfmt` engine in a single in-process pass
- merge-tree against current `origin/main` was clean
- focused Bun tests could not execute because the available dependency tree was incomplete (`nats` and `@temporalio/workflow` were missing)
- worker typecheck was likewise blocked by the incomplete dependency tree and reported broad missing-package fallout unrelated to this diff

CI should run the normal focused worker checks with a complete frozen install.

## Canary

A fresh `@opengeni/worker-bundle` canary is required if this fix needs pre-release consumer validation. Canary publication must happen only after merge from the exact protected `main` SHA; this PR does not publish or deploy anything.

## Summary by Sourcery

Preserve the exact provider retry authority when operational database failures interrupt same-turn recovery.

Bug Fixes:
- Preserve provider recovery authority across database outages so stale replacement attempts cannot reopen an already-consumed retry generation.

Enhancements:
- Validate the paired provider failure code and exact recovery count against durable turn metadata before scheduling recovery.
- Retain the existing escaped MCP timeout recovery path and pacing behavior.

Documentation:
- Document the recovery checkpoint invariant that prevents stale or ambiguous database recovery from resetting the provider retry budget.

Tests:
- Add coverage for valid, malformed, and stale provider recovery authority data across the recovery wire and session state handling.

Chores:
- Add a patch changeset for @opengeni/worker-bundle.