### PR TITLE
fix(release): unblock protected main verification

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -328,10 +328,12 @@ const budgets = {
   // boundary. The four browser-used SDK methods leave the exact Linux/x64 Bun
   // 1.4 direct-session graph at 2,210,226 raw bytes. The policy-derived 2,160-KiB
   // envelope retains 1,614 bytes of headroom; gzip and request count still fit.
-  // After integrating current main's Personal GitHub authority, the exact graph
-  // measures 2,220,970 raw / 620,262 gzip bytes across 30 files. Advance only
-  // the shared raw envelope to 2,170 KiB, retaining 1,110 bytes of headroom;
-  // gzip, request count, initial, lazy, and CSS caps remain fixed.
+  // After merging onto protected main with timeline paging, human-wait, and
+  // stream-recovery changes, repeated local builds measure 2,224,684 raw bytes
+  // and protected-main CI measures at most 2,224,726 across the supported build
+  // paths. Advance only the shared raw envelope to 2,174 KiB, retaining 1,450
+  // bytes of headroom above the high observation; gzip, request count, initial,
+  // lazy, and CSS caps remain fixed.
   directSessionRaw: EFFECTIVE_DIRECT_SESSION_RAW_BUDGET,
   directSessionGzip: 610 * kib,
   directSessionFiles: 31,

--- a/scripts/web-bundle-budget-policy.test.ts
+++ b/scripts/web-bundle-budget-policy.test.ts
@@ -98,11 +98,11 @@ describe("web bundle budget policy", () => {
   });
 
   test("retains the exact workspace-member administration current-main envelope", () => {
-    expect(WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT).toBe(2_220_970);
-    expect(WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_BUDGET).toBe(2170 * KIB);
+    expect(WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT).toBe(2_224_726);
+    expect(WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_BUDGET).toBe(2174 * KIB);
     expect(
       WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_BUDGET -
         WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT,
-    ).toBe(1_110);
+    ).toBe(1_450);
   });
 });

--- a/scripts/web-bundle-budget-policy.ts
+++ b/scripts/web-bundle-budget-policy.ts
@@ -48,8 +48,8 @@ export const WORKSPACE_MEMBER_ADMINISTRATION_RAW_BUDGET = wholeKibEnvelope(
   WORKSPACE_MEMBER_ADMINISTRATION_RAW_MEASUREMENT,
 );
 
-/** Exact workspace-member administration plus current-main Linux/x64 Bun 1.4 measurement. */
-export const WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT = 2_220_970;
+/** Exact workspace-member administration plus protected-main Linux/x64 Bun 1.4 measurement. */
+export const WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT = 2_224_726;
 export const WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_BUDGET = wholeKibEnvelope(
   WORKSPACE_MEMBER_ADMINISTRATION_CURRENT_MAIN_RAW_MEASUREMENT,
 );

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -425,7 +425,13 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     expect(await page.getByLabel(/workspace/i).count()).toBe(0);
     expect(await page.getByText(/create another organization/i).count()).toBe(0);
     await page.getByLabel("Organization name").fill("Onboarding Greenfield Org");
+    const setupSettled = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/v1/auth/organization-onboarding",
+    );
     await page.getByRole("button", { name: "Create organization" }).click();
+    expect((await setupSettled).ok()).toBe(true);
 
     const ownerCookie = await cookieHeader(context);
     const owner = sdk(ownerCookie);


### PR DESCRIPTION
## What changed

- recalibrate only the direct-session raw bundle envelope against the highest protected-main observation, retaining 1,450 bytes of headroom
- make onboarding acceptance wait for the exact committed setup response before reading memberships

## Why

Protected-main CI for 88c1155 failed because the merged UI graph was 556–598 bytes above the reviewed-head envelope. The same run exposed a race in the browser test: it read memberships immediately after clicking, before the asynchronous setup request had settled.

## Verification

- web production build passes with every other bundle cap unchanged
- bundle policy: 9 tests pass
- onboarding browser acceptance: 4 consecutive local passes with real PostgreSQL
- all 31 TypeScript projects pass typecheck
- changed files pass lint, formatting, and diff checks

This is a release-unblocking correction for the source that contains the completed personal GitHub integration.

## Summary by Sourcery

Unblock protected-main verification by aligning the direct-session bundle budget with observed output and eliminating the onboarding setup race.

Bug Fixes:
- Synchronize onboarding acceptance with the completed organization setup response before validating memberships.
- Update the direct-session raw bundle envelope to cover protected-main measurements while preserving headroom and leaving other caps unchanged.

Tests:
- Update bundle budget policy expectations for the protected-main measurement.