### PR TITLE
fix(auth): release rotated account streams

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -148,6 +148,38 @@ describe("web API auth helpers", () => {
     }
   });
 
+  test("aborts a live native transport when its consumer closes the wrapper", async () => {
+    const originalFetch = globalThis.fetch;
+    const observed: { cancelledWith?: unknown; signal?: AbortSignal | null } = {};
+    let source!: ReadableStream<Uint8Array>;
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      observed.signal = init?.signal ?? null;
+      source = new ReadableStream<Uint8Array>({
+        cancel(reason) {
+          observed.cancelledWith = reason;
+        },
+      });
+      return new Response(source, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("consumer-close");
+      const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
+      const reason = new DOMException("consumer finished", "AbortError");
+      await response.body!.cancel(reason);
+      await Promise.resolve();
+      expect(observed.signal?.aborted).toBe(true);
+      expect(observed.signal?.reason).toBe(reason);
+      expect(observed.cancelledWith).toBe(reason);
+      expect(source.locked).toBe(false);
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("drains finite JSON before exposing it and releases the native source lock", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { signal?: AbortSignal | null } = {};

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -107,7 +107,7 @@ describe("web API auth helpers", () => {
     }
   });
 
-  test("keeps an established response body actor-bound until the stream closes", async () => {
+  test("keeps a live response actor-bound and aborts its native transport on rotation", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { cancelledWith?: unknown; signal?: AbortSignal | null } = {};
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
@@ -136,7 +136,8 @@ describe("web API auth helpers", () => {
       await expect(read).resolves.toMatchObject({ done: false });
       const lateRead = reader.read();
       configureManagedActorEpoch("13");
-      expect(observed.signal?.aborted).toBe(false);
+      await Promise.resolve();
+      expect(observed.signal?.aborted).toBe(true);
       expect(observed.cancelledWith).toMatchObject({ name: "AbortError" });
       await expect(lateRead).rejects.toMatchObject({ name: "AbortError" });
       await Promise.resolve();

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -236,14 +236,22 @@ export async function managedActorFetch(
     // abort first so downstream consumption still fails closed with the same
     // AbortError, then release the native transport in the next microtask.
     const actorBodyController = new AbortController();
+    const abortNativeTransport = finiteJsonResponse
+      ? undefined
+      : (reason: unknown) => queueMicrotask(() => controller.abort(reason));
     abortTarget = finiteJsonResponse
       ? (reason) => actorBodyController.abort(reason)
       : (reason) => {
           actorBodyController.abort(reason);
-          queueMicrotask(() => controller.abort(reason));
+          abortNativeTransport?.(reason);
         };
     responseOwnsCleanup = true;
-    return managedActorTrackedResponse(actorResponse, actorBodyController.signal, cleanup);
+    return managedActorTrackedResponse(
+      actorResponse,
+      actorBodyController.signal,
+      cleanup,
+      abortNativeTransport,
+    );
   } finally {
     if (!responseOwnsCleanup) cleanup();
   }
@@ -258,6 +266,7 @@ function managedActorTrackedResponse(
   response: Response,
   signal: AbortSignal,
   cleanup: () => void,
+  abortNativeTransport?: (reason: unknown) => void,
 ): Response {
   const reader = response.body!.getReader();
   let settled = false;
@@ -328,11 +337,12 @@ function managedActorTrackedResponse(
         }
       },
       async cancel(reason) {
+        const ownsSettlement = settle();
+        if (ownsSettlement) abortNativeTransport?.(reason);
         try {
           await reader.cancel(reason);
         } finally {
           releaseReader();
-          settle();
         }
       },
     },

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -212,7 +212,8 @@ export async function managedActorFetch(
     // EOF. Draining here also guarantees the native body already has a
     // rejection consumer before any post-header actor abort.
     let actorResponse = response;
-    if (isFiniteJsonResponse(response)) {
+    const finiteJsonResponse = isFiniteJsonResponse(response);
+    if (finiteJsonResponse) {
       const bytes = await response.arrayBuffer();
       if (responseIsStale()) {
         throw new DOMException(
@@ -227,12 +228,20 @@ export async function managedActorFetch(
       });
     }
     // Before headers—and through a finite JSON drain—actor rotation aborts the
-    // native fetch. Once a streaming or detached body is admitted, transfer
-    // both actor and caller cancellation to the wrapper reader. WebKit otherwise
-    // reclassifies a post-header native abort as an unhandled access-control
-    // error. The downstream body remains fail-closed with the same AbortError.
+    // native fetch. A detached finite body no longer owns a network resource,
+    // so only its wrapper remains actor-bound. A live body must also abort its
+    // native fetch after admission: cancelling only the source reader can leave
+    // Chromium's HTTP/1 request open, eventually exhausting the per-origin
+    // connection pool across account switches and tabs. Publish the wrapper
+    // abort first so downstream consumption still fails closed with the same
+    // AbortError, then release the native transport in the next microtask.
     const actorBodyController = new AbortController();
-    abortTarget = (reason) => actorBodyController.abort(reason);
+    abortTarget = finiteJsonResponse
+      ? (reason) => actorBodyController.abort(reason)
+      : (reason) => {
+          actorBodyController.abort(reason);
+          queueMicrotask(() => controller.abort(reason));
+        };
     responseOwnsCleanup = true;
     return managedActorTrackedResponse(actorResponse, actorBodyController.signal, cleanup);
   } finally {


### PR DESCRIPTION
## Summary

- abort the native network request for admitted live actor-bound responses after first failing the downstream wrapper closed
- keep fully drained JSON responses detached so post-header actor changes do not regress WebKit
- prevent stale SSE requests from exhausting Chromium's HTTP/1 per-origin pool across multi-tab account switches

## Incident

The canonical main CI run `33155062761` and the first exact-head attempt for #1951 each left six obsolete SSE requests open in one Chromium browser context. A seventh finite `latestStarted` turn read remained queued indefinitely, so the strict account acceptance correctly failed.

## Verification

- web API transport unit tests: 21 passed / 78 assertions
- real migrated-PostgreSQL browser account acceptance: Chromium 3 isolated passes; Firefox pass; WebKit pass
- web typecheck
- production web + React demo build and bundle budgets
- changed-file lint, format, and diff checks

## Safety

The response wrapper is aborted before the native transport in a microtask, preserving consumer-owned `AbortError` handling. Only live/non-JSON responses retain and abort the native fetch after admission; finite JSON is drained and remains detached as before.

## Summary by Sourcery

Release native transports for rotated or closed live account-bound responses while preserving detached finite JSON behavior.

Bug Fixes:
- Abort native transports for admitted live responses when their consumer closes or the managed actor rotates, preventing stale SSE requests from exhausting per-origin connection pools.
- Preserve detached finite JSON responses while keeping downstream cancellation and actor-rotation failures fail-closed with the expected AbortError.

Tests:
- Add coverage for native transport cancellation on live-response actor rotation and consumer closure, including cancellation reasons and stream cleanup.