### PR TITLE
test(browser): contain response-loss injection

### DIFF
--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1853,18 +1853,14 @@ beforeAll(async () => {
           if (!completionResponseLoss.dropped && response.ok) {
             completionResponseLoss.dropped = true;
             await response.body?.cancel();
-            const body = new ReadableStream<Uint8Array>({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode('{"projection":'));
-                queueMicrotask(() =>
-                  controller.error(new Error("injected completion response body loss")),
-                );
-              },
-            });
-            return new Response(body, {
+            const headers = new Headers(response.headers);
+            headers.delete("content-length");
+            // Preserve an accepted response with an unreadable completion payload without
+            // throwing from Bun's server-side stream controller after the test has settled.
+            return new Response('{"projection":', {
               status: response.status,
               statusText: response.statusText,
-              headers: response.headers,
+              headers,
             });
           }
           return response;

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1854,6 +1854,7 @@ beforeAll(async () => {
             completionResponseLoss.dropped = true;
             await response.body?.cancel();
             const headers = new Headers(response.headers);
+            headers.delete("content-encoding");
             headers.delete("content-length");
             // Preserve an accepted response with an unreadable completion payload without
             // throwing from Bun's server-side stream controller after the test has settled.


### PR DESCRIPTION
Fixes the browser account acceptance harness so its intentionally unreadable accepted response does not escape as an unhandled Bun server-stream error after both assertions pass. The browser still receives a truncated JSON completion payload and exercises the exact retry/idempotency contract. Verified formatting, lint, diff checks, and all 31 TypeScript projects locally on Bun 1.4.0. The real-Postgres Chromium lane remains the protected CI proof because local Docker is unavailable.

## Summary by Sourcery

Contain the injected browser completion-response loss within the acceptance test harness.

Bug Fixes:
- Prevent the browser acceptance harness's intentionally truncated completion response from surfacing as an unhandled Bun server-stream error after assertions complete.

Enhancements:
- Continue exercising the accepted-response retry and idempotency contract with a truncated JSON completion payload.