### PR TITLE
fix(github): accept canonical clone URLs for app authority

### DIFF
--- a/apps/worker/src/github-rest-mcp.ts
+++ b/apps/worker/src/github-rest-mcp.ts
@@ -258,8 +258,11 @@ function appRepositoryAuthority(resources: ResourceRef[]): GitHubRestRepository[
     );
     const repositoryId = positiveSafeInteger(resource.githubRepositoryId ?? resource.repositoryId);
     const fullName = canonicalGitHubFullName(resource.uri);
-    if (!installationId || !repositoryId || !fullName) {
+    if (!installationId || !repositoryId) {
       throw new GitHubRestAuthorityError("GitHub App repository authority is incomplete");
+    }
+    if (!fullName) {
+      throw new GitHubRestAuthorityError("GitHub App repository URL is invalid");
     }
     return [
       {

--- a/apps/worker/src/github-rest-mcp.ts
+++ b/apps/worker/src/github-rest-mcp.ts
@@ -645,7 +645,8 @@ function githubConnectorBindings(
 function canonicalGitHubFullName(uri: string): string | null {
   try {
     const url = new URL(uri);
-    const path = url.pathname.replace(/^\/+|\/+$/gu, "");
+    const clonePath = url.pathname.replace(/^\/+|\/+$/gu, "");
+    const path = clonePath.endsWith(".git") ? clonePath.slice(0, -4) : clonePath;
     if (
       url.protocol !== "https:" ||
       url.hostname !== "github.com" ||
@@ -654,7 +655,6 @@ function canonicalGitHubFullName(uri: string): string | null {
       url.password ||
       url.search ||
       url.hash ||
-      path.endsWith(".git") ||
       !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(path)
     ) {
       return null;

--- a/apps/worker/test/github-rest-mcp.test.ts
+++ b/apps/worker/test/github-rest-mcp.test.ts
@@ -66,6 +66,15 @@ describe("buildGitHubRestMcpForTurn", () => {
     ).toBe(false);
   });
 
+  test("reports an invalid repository URL separately from missing App authority", async () => {
+    await expect(
+      build({
+        enabled: true,
+        resource: { ...appResource, uri: "https://github.com/Cloudgeni-ai/opengeni?ref=main" },
+      }),
+    ).rejects.toThrow("GitHub App repository URL is invalid");
+  });
+
   test("keeps the personal OAuth actor in a separate namespace", async () => {
     const connectionId = "11111111-1111-4111-8111-111111111111";
     const personalResource: ResourceRef = {
@@ -138,7 +147,7 @@ describe("buildGitHubRestMcpForTurn", () => {
   });
 });
 
-async function build(input: { enabled: boolean }) {
+async function build(input: { enabled: boolean; resource?: ResourceRef }) {
   return await buildGitHubRestMcpForTurn({
     db: {} as Database,
     settings: testSettings({ githubRestMcpEnabled: input.enabled }),
@@ -147,7 +156,7 @@ async function build(input: { enabled: boolean }) {
     sessionId: "00000000-0000-4000-8000-000000000003",
     attemptId: "00000000-0000-4000-8000-000000000004",
     turn: { personalConnectionDelegations: [] } as SessionTurn,
-    resources: [appResource],
+    resources: [input.resource ?? appResource],
     tools: [],
     resolveCredential: async () => ({
       status: "auth_needed",

--- a/apps/worker/test/github-rest-mcp.test.ts
+++ b/apps/worker/test/github-rest-mcp.test.ts
@@ -11,7 +11,7 @@ import { buildGitHubRestMcpForTurn } from "../src/github-rest-mcp";
 
 const appResource: ResourceRef = {
   kind: "repository",
-  uri: "https://github.com/Cloudgeni-ai/opengeni",
+  uri: "https://github.com/Cloudgeni-ai/opengeni.git",
   ref: "main",
   provider: "github",
   githubInstallationId: 71,


### PR DESCRIPTION
## Summary
- canonicalize the standard `.git` clone suffix before GitHub App repository validation
- cover persisted clone-form repository URLs in the worker regression test

## Verification
- `bun test apps/worker/test/github-rest-mcp.test.ts`
- staging worker image `sha256:8aa7a66a1d7ae83d2f63ab4badcfcaf558e15ddc940d575fa291f2cada57c5c2`
- 22 affected sessions redriven with exact `continue`; zero post-hotfix authority failures

## Summary by Sourcery

Allow GitHub App authority validation to canonicalize standard `.git` repository URLs while reporting malformed URLs clearly.

Bug Fixes:
- Accept canonical GitHub repository clone URLs with a trailing `.git` suffix for GitHub App repository authority validation.

Enhancements:
- Distinguish invalid repository URLs from incomplete GitHub App authority errors.

Tests:
- Add regression coverage for persisted `.git` clone-form repository URLs and invalid URL error classification.