### PR TITLE
test(auth): fence browser account evidence

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -110,15 +110,18 @@ describe("web API auth helpers", () => {
   test("keeps a live response actor-bound and aborts its native transport on rotation", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { cancelledWith?: unknown; signal?: AbortSignal | null } = {};
+    const transportCloseOrder: string[] = [];
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
     let source!: ReadableStream<Uint8Array>;
     globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
       observed.signal = init?.signal ?? null;
+      observed.signal?.addEventListener("abort", () => transportCloseOrder.push("native-abort"));
       source = new ReadableStream<Uint8Array>({
         start(controller) {
           bodyController = controller;
         },
         cancel(reason) {
+          transportCloseOrder.push("source-cancel");
           observed.cancelledWith = reason;
         },
       });
@@ -139,6 +142,7 @@ describe("web API auth helpers", () => {
       await Promise.resolve();
       expect(observed.signal?.aborted).toBe(true);
       expect(observed.cancelledWith).toMatchObject({ name: "AbortError" });
+      expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
       await expect(lateRead).rejects.toMatchObject({ name: "AbortError" });
       await Promise.resolve();
       expect(source.locked).toBe(false);
@@ -151,11 +155,14 @@ describe("web API auth helpers", () => {
   test("aborts a live native transport when its consumer closes the wrapper", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { cancelledWith?: unknown; signal?: AbortSignal | null } = {};
+    const transportCloseOrder: string[] = [];
     let source!: ReadableStream<Uint8Array>;
     globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
       observed.signal = init?.signal ?? null;
+      observed.signal?.addEventListener("abort", () => transportCloseOrder.push("native-abort"));
       source = new ReadableStream<Uint8Array>({
         cancel(reason) {
+          transportCloseOrder.push("source-cancel");
           observed.cancelledWith = reason;
         },
       });
@@ -173,6 +180,7 @@ describe("web API auth helpers", () => {
       expect(observed.signal?.aborted).toBe(true);
       expect(observed.signal?.reason).toBe(reason);
       expect(observed.cancelledWith).toBe(reason);
+      expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
       expect(source.locked).toBe(false);
     } finally {
       configureManagedActorEpoch(null);

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -242,8 +242,13 @@ export async function managedActorFetch(
     abortTarget = finiteJsonResponse
       ? (reason) => actorBodyController.abort(reason)
       : (reason) => {
-          actorBodyController.abort(reason);
+          // Queue the native abort before publishing the wrapper abort. The
+          // wrapper's abort handler queues reader cancellation, so Chromium
+          // sees the fetch signal first and cannot detach an SSE reader while
+          // leaving its HTTP/1 transport alive. Both remain deferred until
+          // after the downstream AbortError state is synchronously recorded.
           abortNativeTransport?.(reason);
+          actorBodyController.abort(reason);
         };
     responseOwnsCleanup = true;
     return managedActorTrackedResponse(
@@ -294,10 +299,12 @@ function managedActorTrackedResponse(
     const reason = signal.reason ?? new DOMException("The browser account changed", "AbortError");
     actorAbortReason = reason;
     settle();
-    void reader
-      .cancel(reason)
-      .catch(() => undefined)
-      .finally(releaseReader);
+    queueMicrotask(() => {
+      void reader
+        .cancel(reason)
+        .catch(() => undefined)
+        .finally(releaseReader);
+    });
   };
   // Keep actor-abort rejection consumer-owned. WebKit can report a stream
   // error raised directly inside the abort event as an unhandled page error
@@ -339,6 +346,10 @@ function managedActorTrackedResponse(
       async cancel(reason) {
         const ownsSettlement = settle();
         if (ownsSettlement) abortNativeTransport?.(reason);
+        // Let a queued native fetch abort run before detaching its reader. In
+        // Chromium the inverse order can leave the HTTP/1 request open even
+        // though the JavaScript ReadableStream has been cancelled.
+        if (ownsSettlement && abortNativeTransport) await Promise.resolve();
         try {
           await reader.cancel(reason);
         } finally {

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -1559,10 +1559,15 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
         and l.sandbox_group_id = ${groupId} and h.holder_id = ${holderId}`;
     const aged = await holderHeartbeatAt(workspaceId, groupId, holderId);
     expect(aged).not.toBeNull();
-    // Several loop ticks (50 ms cadence) under the rotation fence.
-    await Bun.sleep(400);
+    // Allow a loaded CI runner to schedule the 50 ms liveness loop, while
+    // retaining a bounded fail-closed proof that the heartbeat advances.
+    let touched = aged;
+    for (let attempt = 0; attempt < 100 && touched === aged; attempt += 1) {
+      await Bun.sleep(50);
+      touched = await holderHeartbeatAt(workspaceId, groupId, holderId);
+    }
     expect(await holderCount(workspaceId, groupId, holderId)).toBe(1);
-    const touched = await holderHeartbeatAt(workspaceId, groupId, holderId);
+    expect(touched).not.toBeNull();
     expect(touched).toBeGreaterThan(aged!);
     const row = await readRow(workspaceId, groupId);
     expect(row?.liveness).toBe("warm");

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -294,7 +294,9 @@ END $$;
 }
 
 async function ensureLoginRole(sql: postgres.Sql, role: string, password: string): Promise<void> {
-  await sql.unsafe(`
+  await executeRoleConvergence(
+    sql,
+    `
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${literal(role)}) THEN
@@ -303,7 +305,8 @@ BEGIN
     EXECUTE format('ALTER ROLE %I LOGIN PASSWORD %L', ${literal(role)}, ${literal(password)});
   END IF;
 END $$;
-`);
+`,
+  );
 }
 
 async function ensureRestrictedAppLoginRole(
@@ -311,7 +314,9 @@ async function ensureRestrictedAppLoginRole(
   role: string,
   password: string,
 ): Promise<void> {
-  await sql.unsafe(`
+  await executeRoleConvergence(
+    sql,
+    `
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${literal(role)}) THEN
@@ -339,7 +344,41 @@ BEGIN
     );
   END IF;
 END $$;
-`);
+`,
+  );
+}
+
+const ROLE_CONVERGENCE_MAX_ATTEMPTS = 20;
+
+function isRetryableConcurrentRoleMutation(error: unknown): boolean {
+  const details = error as { code?: unknown; message?: unknown; routine?: unknown };
+  return (
+    (details.code === "XX000" &&
+      details.message === "tuple concurrently updated" &&
+      details.routine === "simple_heap_update") ||
+    (details.code === "42710" &&
+      typeof details.message === "string" &&
+      /^role ".+" already exists$/u.test(details.message))
+  );
+}
+
+async function executeRoleConvergence(sql: postgres.Sql, statement: string): Promise<void> {
+  // Roles live in a cluster-global catalog. Two otherwise independent
+  // databases can therefore race an identical CREATE/ALTER during parallel
+  // deployment or test setup. PostgreSQL exposes no cross-database advisory
+  // lock, so retry only its exact concurrent-catalog outcomes and keep every
+  // other provisioning failure immediate.
+  for (let attempt = 1; attempt <= ROLE_CONVERGENCE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await sql.unsafe(statement);
+      return;
+    } catch (error) {
+      if (!isRetryableConcurrentRoleMutation(error) || attempt === ROLE_CONVERGENCE_MAX_ATTEMPTS) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, Math.min(25 * attempt, 250)));
+    }
+  }
 }
 
 /**

--- a/packages/testing/src/shared-pg.ts
+++ b/packages/testing/src/shared-pg.ts
@@ -520,16 +520,33 @@ async function ensureContainerAndAcquire(): Promise<ContainerHandle | null> {
     // fails with `role opengeni_app does not exist`.
     const admin = postgres(`${ADMIN_BASE_URL}/postgres`, { max: 1 });
     try {
-      await admin.unsafe(`
-          DO $$ BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='opengeni_app') THEN
-              CREATE ROLE opengeni_app WITH LOGIN NOSUPERUSER NOBYPASSRLS
-                NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT PASSWORD '${APP_PASSWORD}';
-            ELSE
-              ALTER ROLE opengeni_app WITH LOGIN NOSUPERUSER NOBYPASSRLS
-                NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT PASSWORD '${APP_PASSWORD}';
-            END IF;
-          END $$;`);
+      for (let attempt = 1; ; attempt += 1) {
+        try {
+          await admin.unsafe(`
+            DO $$ BEGIN
+              IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='opengeni_app') THEN
+                CREATE ROLE opengeni_app WITH LOGIN NOSUPERUSER NOBYPASSRLS
+                  NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT PASSWORD '${APP_PASSWORD}';
+              ELSE
+                ALTER ROLE opengeni_app WITH LOGIN NOSUPERUSER NOBYPASSRLS
+                  NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT PASSWORD '${APP_PASSWORD}';
+              END IF;
+            END $$;`);
+          break;
+        } catch (error) {
+          const details = error as { code?: unknown; message?: unknown; routine?: unknown };
+          const concurrentCatalogUpdate =
+            details.code === "XX000" &&
+            details.message === "tuple concurrently updated" &&
+            details.routine === "simple_heap_update";
+          const concurrentRoleCreate =
+            details.code === "42710" &&
+            typeof details.message === "string" &&
+            /^role ".+" already exists$/u.test(details.message);
+          if ((!concurrentCatalogUpdate && !concurrentRoleCreate) || attempt === 20) throw error;
+          await Bun.sleep(Math.min(25 * attempt, 250));
+        }
+      }
     } finally {
       await admin.end().catch(() => undefined);
     }

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -884,7 +884,41 @@ async function expectAndConsumePageErrors(
   allowed: string[],
   required: string[] = allowed,
 ): Promise<void> {
-  await page.waitForTimeout(100);
+  // A request-failure event is delivered over Playwright independently from
+  // the renderer task that reports the corresponding page error. Close the
+  // complete correlation window for every accepted failure, cross two renderer
+  // task boundaries, then check again for a later failure. This derives the
+  // wait from the same fail-closed time fence used by the matcher instead of an
+  // arbitrary delay, so delayed evidence is either present now or too late to
+  // be accepted and remains in the final strict ledger.
+  let latestFailureAt = Number.NEGATIVE_INFINITY;
+  while (true) {
+    await settlePendingRequestFailureChecks(problems);
+    latestFailureAt = Math.max(
+      latestFailureAt,
+      ...problems.acceptedRequestFailures.map(({ failedAt }) => failedAt),
+    );
+    const remainingCorrelationWindow =
+      latestFailureAt + WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS - performance.now();
+    if (remainingCorrelationWindow > 0) await Bun.sleep(remainingCorrelationWindow);
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => setTimeout(resolve, 0), 0);
+        }),
+    );
+    await settlePendingRequestFailureChecks(problems);
+    const nextLatestFailureAt = Math.max(
+      Number.NEGATIVE_INFINITY,
+      ...problems.acceptedRequestFailures.map(({ failedAt }) => failedAt),
+    );
+    if (
+      nextLatestFailureAt <= latestFailureAt &&
+      performance.now() >= nextLatestFailureAt + WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS
+    ) {
+      break;
+    }
+  }
   const counts = Object.fromEntries(
     [...new Set(problems.pageErrors)].map((message) => [
       message,
@@ -2777,10 +2811,6 @@ describe("provider-neutral browser account acceptance", () => {
         ],
         [],
       );
-      // Let WebKit deliver the page-error task before correlating it with the
-      // already timestamped request-failure event.
-      await page.waitForTimeout(100);
-      await settlePendingRequestFailureChecks(pageProblems);
       await expectAndConsumePageErrors(
         page,
         pageProblems,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -76,6 +76,7 @@ type PendingFiniteRead = {
 
 type BrowserProblems = {
   acceptedRequestFailures: Array<{
+    failedAt: number;
     pathnameAndSearch: string;
     responsePhase: string;
   }>;
@@ -95,6 +96,7 @@ type BrowserProblems = {
   }>;
   consoleErrors: string[];
   phase: string;
+  pageErrorEvidence: Array<{ message: string; observedAt: number }>;
   pageErrors: string[];
   failedRequests: string[];
   pendingFiniteReads: Map<object, PendingFiniteRead>;
@@ -510,6 +512,7 @@ function observeBrowser(page: Page): BrowserProblems {
     actorTransitionResponses: [],
     consoleErrors: [],
     phase: "initialization",
+    pageErrorEvidence: [],
     pageErrors: [],
     failedRequests: [],
     pendingFiniteReads: new Map(),
@@ -643,7 +646,9 @@ function observeBrowser(page: Page): BrowserProblems {
     }
   });
   page.on("pageerror", (error) => {
-    problems.pageErrors.push(`[${problems.phase}] ${error.message}`);
+    const message = `[${problems.phase}] ${error.message}`;
+    problems.pageErrorEvidence.push({ message, observedAt: performance.now() });
+    problems.pageErrors.push(message);
   });
   page.on("requestfailed", (request) => {
     const failedAt = performance.now();
@@ -674,6 +679,7 @@ function observeBrowser(page: Page): BrowserProblems {
         problems.failedRequests.push(problem);
       } else {
         problems.acceptedRequestFailures.push({
+          failedAt,
           pathnameAndSearch: `${failedUrl.pathname}${failedUrl.search}`,
           responsePhase,
         });
@@ -897,6 +903,7 @@ async function expectAndConsumePageErrors(
     ),
     missing: required.filter((message) => !problems.pageErrors.includes(message)),
   }).toEqual({ excess: {}, missing: [] });
+  problems.pageErrorEvidence.splice(0);
   problems.pageErrors.splice(0);
 }
 
@@ -917,40 +924,52 @@ function optionalWebKitReauthenticationReloadError(
     .slice(0, 1);
 }
 
-function isWebKitReauthenticationAccessControlPageError(
-  message: string,
+const WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS = 1_000;
+
+function correlatedWebKitReauthenticationFailureIndex(
+  pageError: BrowserProblems["pageErrorEvidence"][number],
   acceptedRequestFailures: BrowserProblems["acceptedRequestFailures"],
-): boolean {
+): number | null {
   const match =
     /^\[slot-revocation-reauthentication\] \/127\.0\.0\.1:\d+(?<pathnameAndSearch>\/v1\/workspaces\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/[A-Za-z0-9_./?=&%-]+) due to access control checks\.$/u.exec(
-      message,
+      pageError.message,
     );
   const pathnameAndSearch = match?.groups?.pathnameAndSearch;
-  return (
-    pathnameAndSearch !== undefined &&
-    acceptedRequestFailures.some(
-      (failure) =>
-        failure.responsePhase === "slot-revocation-reauthentication" &&
-        failure.pathnameAndSearch === pathnameAndSearch,
-    )
+  if (pathnameAndSearch === undefined) return null;
+  const matchingFailureIndexes = acceptedRequestFailures.flatMap((failure, index) =>
+    failure.responsePhase === "slot-revocation-reauthentication" &&
+    failure.pathnameAndSearch === pathnameAndSearch &&
+    failure.failedAt <= pageError.observedAt &&
+    pageError.observedAt - failure.failedAt <= WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS
+      ? [index]
+      : [],
   );
+  return matchingFailureIndexes.length === 1 ? matchingFailureIndexes[0]! : null;
 }
 
 function optionalWebKitReauthenticationAccessControlPageError(
-  problems: BrowserProblems,
+  problems: Pick<BrowserProblems, "acceptedRequestFailures" | "pageErrorEvidence">,
   engine: EngineName,
 ): string[] {
   if (engine !== "webkit") return [];
   // WebKit can surface one read from the deliberately replaced document as a
   // page error in addition to its request-cancellation event. The endpoint is
   // timing-dependent, so accept it only when the independent request ledger
-  // already proved the exact URL was a fenced old-actor cancellation. Keep
-  // the phase, origin, browser, request correlation, and maximum count exact.
-  return problems.pageErrors
-    .filter((message) =>
-      isWebKitReauthenticationAccessControlPageError(message, problems.acceptedRequestFailures),
-    )
-    .slice(0, 1);
+  // already proved exactly one cancellation of that URL immediately before
+  // the error. Consume that evidence one-to-one; duplicate, late, concurrent,
+  // or stale cancellations keep the strict page-error ledger red.
+  const candidates = problems.pageErrorEvidence.flatMap((pageError) => {
+    const failureIndex = correlatedWebKitReauthenticationFailureIndex(
+      pageError,
+      problems.acceptedRequestFailures,
+    );
+    return failureIndex === null ? [] : [{ failureIndex, message: pageError.message }];
+  });
+  if (candidates.length !== 1) return [];
+  const [candidate] = candidates;
+  if (!candidate) return [];
+  problems.acceptedRequestFailures.splice(candidate.failureIndex, 1);
+  return [candidate.message];
 }
 
 async function expectAndConsumeActorTransitionResponse(
@@ -2206,38 +2225,88 @@ describe("provider-neutral browser account acceptance", () => {
       }),
     ).toContain("/v1/config/other");
     const acceptedWebKitCancellation = {
+      failedAt: 100,
       pathnameAndSearch:
         "/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1",
       responsePhase: "slot-revocation-reauthentication",
     };
-    const correlatedWebKitPageError =
-      "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.";
+    const correlatedWebKitPageError = {
+      message:
+        "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.",
+      observedAt: 150,
+    };
     expect(
-      isWebKitReauthenticationAccessControlPageError(correlatedWebKitPageError, [
+      correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
         acceptedWebKitCancellation,
       ]),
-    ).toBe(true);
-    expect(isWebKitReauthenticationAccessControlPageError(correlatedWebKitPageError, [])).toBe(
-      false,
-    );
+    ).toBe(0);
+    expect(correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [])).toBeNull();
     expect(
-      isWebKitReauthenticationAccessControlPageError(
-        "[cross-slot-deep-link] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.",
+      correlatedWebKitReauthenticationFailureIndex(
+        {
+          message:
+            "[cross-slot-deep-link] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.",
+          observedAt: 150,
+        },
         [acceptedWebKitCancellation],
       ),
-    ).toBe(false);
+    ).toBeNull();
     expect(
-      isWebKitReauthenticationAccessControlPageError(
-        "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/realtime-model-catalog due to access control checks.",
+      correlatedWebKitReauthenticationFailureIndex(
+        {
+          message:
+            "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/realtime-model-catalog due to access control checks.",
+          observedAt: 150,
+        },
         [
           {
+            failedAt: 100,
             pathnameAndSearch:
               "/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/realtime-model-catalog",
             responsePhase: "slot-revocation-reauthentication",
           },
         ],
       ),
-    ).toBe(true);
+    ).toBe(0);
+    expect(
+      correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
+        { ...acceptedWebKitCancellation, failedAt: 151 },
+      ]),
+    ).toBeNull();
+    expect(
+      correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
+        {
+          ...acceptedWebKitCancellation,
+          failedAt: 150 - WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS - 1,
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
+        acceptedWebKitCancellation,
+        { ...acceptedWebKitCancellation, failedAt: 125 },
+      ]),
+    ).toBeNull();
+    const consumableWebKitFailures = [acceptedWebKitCancellation];
+    expect(
+      optionalWebKitReauthenticationAccessControlPageError(
+        {
+          acceptedRequestFailures: consumableWebKitFailures,
+          pageErrorEvidence: [correlatedWebKitPageError],
+        },
+        "webkit",
+      ),
+    ).toEqual([correlatedWebKitPageError.message]);
+    expect(consumableWebKitFailures).toEqual([]);
+    expect(
+      optionalWebKitReauthenticationAccessControlPageError(
+        {
+          acceptedRequestFailures: [acceptedWebKitCancellation],
+          pageErrorEvidence: [correlatedWebKitPageError, correlatedWebKitPageError],
+        },
+        "webkit",
+      ),
+    ).toEqual([]);
     expect(
       requestFailureProblem({
         ...crossTabBootstrapRead,
@@ -2679,6 +2748,9 @@ describe("provider-neutral browser account acceptance", () => {
         ],
         [],
       );
+      // Let WebKit deliver the page-error task before correlating it with the
+      // already timestamped request-failure event.
+      await page.waitForTimeout(100);
       await settlePendingRequestFailureChecks(pageProblems);
       await expectAndConsumePageErrors(
         page,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -307,7 +307,7 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
   const pathname = new URL(input.url).pathname;
   const isConnectionReset = /NET_RESET|CONNECTION_RESET/iu.test(input.failure);
   const isCancellation =
-    /ERR_ABORTED|NS_BINDING_ABORTED|NET_RESET|CONNECTION_RESET|cancelled|canceled/iu.test(
+    /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|NET_RESET|CONNECTION_RESET|cancelled|canceled/iu.test(
       input.failure,
     );
   const isActorOwnedRead =
@@ -952,12 +952,13 @@ function optionalWebKitReauthenticationAccessControlPageError(
   engine: EngineName,
 ): string[] {
   if (engine !== "webkit") return [];
-  // WebKit can surface one read from the deliberately replaced document as a
-  // page error in addition to its request-cancellation event. The endpoint is
-  // timing-dependent, so accept it only when the independent request ledger
-  // already proved exactly one cancellation of that URL immediately before
-  // the error. Consume that evidence one-to-one; duplicate, late, concurrent,
-  // or stale cancellations keep the strict page-error ledger red.
+  // WebKit can surface reads from the deliberately replaced document as page
+  // errors in addition to their request-cancellation events. Native-first
+  // transport teardown can expose more than one of those errors, so require a
+  // bijection: every page error must have exactly one same-phase, exact-URL
+  // cancellation immediately before it, and no cancellation may authorize a
+  // second error. Duplicate, late, concurrent, or stale evidence keeps the
+  // strict page-error ledger red.
   const candidates = problems.pageErrorEvidence.flatMap((pageError) => {
     const failureIndex = correlatedWebKitReauthenticationFailureIndex(
       pageError,
@@ -965,11 +966,17 @@ function optionalWebKitReauthenticationAccessControlPageError(
     );
     return failureIndex === null ? [] : [{ failureIndex, message: pageError.message }];
   });
-  if (candidates.length !== 1) return [];
-  const [candidate] = candidates;
-  if (!candidate) return [];
-  problems.acceptedRequestFailures.splice(candidate.failureIndex, 1);
-  return [candidate.message];
+  const failureIndexes = candidates.map(({ failureIndex }) => failureIndex);
+  if (
+    candidates.length !== problems.pageErrorEvidence.length ||
+    new Set(failureIndexes).size !== failureIndexes.length
+  ) {
+    return [];
+  }
+  for (const failureIndex of [...failureIndexes].sort((left, right) => right - left)) {
+    problems.acceptedRequestFailures.splice(failureIndex, 1);
+  }
+  return candidates.map(({ message }) => message);
 }
 
 async function expectAndConsumeActorTransitionResponse(
@@ -2022,6 +2029,7 @@ describe("provider-neutral browser account acceptance", () => {
       url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/sessions`,
     } satisfies BrowserRequestFailureInput;
     expect(requestFailureProblem(oldActorRead)).toBeNull();
+    expect(requestFailureProblem({ ...oldActorRead, failure: "NS_ERROR_ABORT" })).toBeNull();
     expect(requestFailureProblem({ ...oldActorRead, failure: "NS_ERROR_NET_RESET" })).toContain(
       "/sessions",
     );
@@ -2307,6 +2315,27 @@ describe("provider-neutral browser account acceptance", () => {
         "webkit",
       ),
     ).toEqual([]);
+    const secondAcceptedWebKitCancellation = {
+      ...acceptedWebKitCancellation,
+      pathnameAndSearch:
+        "/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/queue",
+    };
+    const secondCorrelatedWebKitPageError = {
+      message:
+        "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/queue due to access control checks.",
+      observedAt: 175,
+    };
+    const bijectiveWebKitFailures = [acceptedWebKitCancellation, secondAcceptedWebKitCancellation];
+    expect(
+      optionalWebKitReauthenticationAccessControlPageError(
+        {
+          acceptedRequestFailures: bijectiveWebKitFailures,
+          pageErrorEvidence: [correlatedWebKitPageError, secondCorrelatedWebKitPageError],
+        },
+        "webkit",
+      ),
+    ).toEqual([correlatedWebKitPageError.message, secondCorrelatedWebKitPageError.message]);
+    expect(bijectiveWebKitFailures).toEqual([]);
     expect(
       requestFailureProblem({
         ...crossTabBootstrapRead,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -75,6 +75,10 @@ type PendingFiniteRead = {
 };
 
 type BrowserProblems = {
+  acceptedRequestFailures: Array<{
+    pathnameAndSearch: string;
+    responsePhase: string;
+  }>;
   activeStreams: Map<object, string>;
   actorDispatches: Array<{ actorEpoch: string; startedAt: number }>;
   actorFenceResponses: string[];
@@ -499,6 +503,7 @@ async function authSessionCount(email: string): Promise<number> {
 
 function observeBrowser(page: Page): BrowserProblems {
   const problems: BrowserProblems = {
+    acceptedRequestFailures: [],
     activeStreams: new Map(),
     actorDispatches: [],
     actorFenceResponses: [],
@@ -644,6 +649,8 @@ function observeBrowser(page: Page): BrowserProblems {
     const failedAt = performance.now();
     const dispatch = requestPhases.get(request);
     const failure = request.failure()?.errorText ?? "unknown";
+    const responsePhase = problems.phase;
+    const failedUrl = new URL(request.url());
     problems.activeStreams.delete(request);
     problems.retiredFiniteReadTombstones.delete(request);
     // A failed finite read is terminal whether expected or not. Remove it from
@@ -658,12 +665,19 @@ function observeBrowser(page: Page): BrowserProblems {
         failedAt,
         failure,
         method: request.method(),
-        responsePhase: problems.phase,
+        responsePhase,
         sessionSetAuthorityHash: dispatch ? await dispatch.sessionSetAuthorityHash : null,
         startedAt: dispatch?.startedAt,
         url: request.url(),
       });
-      if (problem !== null) problems.failedRequests.push(problem);
+      if (problem !== null) {
+        problems.failedRequests.push(problem);
+      } else {
+        problems.acceptedRequestFailures.push({
+          pathnameAndSearch: `${failedUrl.pathname}${failedUrl.search}`,
+          responsePhase,
+        });
+      }
     })();
     problems.pendingRequestFailureChecks.add(check);
     void check.finally(() => problems.pendingRequestFailureChecks.delete(check));
@@ -800,10 +814,14 @@ async function retirePendingReadsAfterConfirmedActorTransition(
   }
 }
 
-async function expectNoBrowserProblems(problems: BrowserProblems): Promise<void> {
+async function settlePendingRequestFailureChecks(problems: BrowserProblems): Promise<void> {
   while (problems.pendingRequestFailureChecks.size > 0) {
     await Promise.all([...problems.pendingRequestFailureChecks]);
   }
+}
+
+async function expectNoBrowserProblems(problems: BrowserProblems): Promise<void> {
+  await settlePendingRequestFailureChecks(problems);
   expect({
     actorFenceResponses: problems.actorFenceResponses,
     actorTransitionResponses: problems.actorTransitionResponses,
@@ -899,9 +917,22 @@ function optionalWebKitReauthenticationReloadError(
     .slice(0, 1);
 }
 
-function isWebKitReauthenticationAccessControlPageError(message: string): boolean {
-  return /^\[slot-revocation-reauthentication\] \/127\.0\.0\.1:\d+\/v1\/workspaces\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/sessions\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/turns\?latestStarted=1 due to access control checks\.$/u.test(
-    message,
+function isWebKitReauthenticationAccessControlPageError(
+  message: string,
+  acceptedRequestFailures: BrowserProblems["acceptedRequestFailures"],
+): boolean {
+  const match =
+    /^\[slot-revocation-reauthentication\] \/127\.0\.0\.1:\d+(?<pathnameAndSearch>\/v1\/workspaces\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/[A-Za-z0-9_./?=&%-]+) due to access control checks\.$/u.exec(
+      message,
+    );
+  const pathnameAndSearch = match?.groups?.pathnameAndSearch;
+  return (
+    pathnameAndSearch !== undefined &&
+    acceptedRequestFailures.some(
+      (failure) =>
+        failure.responsePhase === "slot-revocation-reauthentication" &&
+        failure.pathnameAndSearch === pathnameAndSearch,
+    )
   );
 }
 
@@ -911,9 +942,15 @@ function optionalWebKitReauthenticationAccessControlPageError(
 ): string[] {
   if (engine !== "webkit") return [];
   // WebKit can surface one read from the deliberately replaced document as a
-  // page error instead of a request cancellation. Keep the phase, origin,
-  // endpoint shape, query, browser, and maximum count exact.
-  return problems.pageErrors.filter(isWebKitReauthenticationAccessControlPageError).slice(0, 1);
+  // page error in addition to its request-cancellation event. The endpoint is
+  // timing-dependent, so accept it only when the independent request ledger
+  // already proved the exact URL was a fenced old-actor cancellation. Keep
+  // the phase, origin, browser, request correlation, and maximum count exact.
+  return problems.pageErrors
+    .filter((message) =>
+      isWebKitReauthenticationAccessControlPageError(message, problems.acceptedRequestFailures),
+    )
+    .slice(0, 1);
 }
 
 async function expectAndConsumeActorTransitionResponse(
@@ -1546,12 +1583,38 @@ async function raceSelect(page: Page, projection: ManagedAuthSessionSetProjectio
   );
 }
 
+async function launchAccountBrowser(engine: EngineName): Promise<Browser> {
+  return await ENGINES[engine].launch(
+    engine === "chromium" && process.env.OPENGENI_BROWSER_BIN
+      ? { executablePath: process.env.OPENGENI_BROWSER_BIN }
+      : undefined,
+  );
+}
+
 async function captureResponsiveEvidence(
-  browser: Browser,
   context: BrowserContext,
   engine: EngineName,
 ): Promise<void> {
   const storageState = await context.storageState();
+  // Keep responsive evidence out of the multi-tab journey's native connection
+  // pool. The journey deliberately retains live transports in two pages while
+  // these short-lived contexts exercise seven viewport/mode combinations; a
+  // shared Chromium process can otherwise queue a bootstrap read behind those
+  // unrelated transports and turn visual capture into a transport-liveness
+  // test. The journey itself continues to prove the shared-tab behavior.
+  const evidenceBrowser = await launchAccountBrowser(engine);
+  try {
+    await captureResponsiveEvidenceInBrowser(evidenceBrowser, storageState, engine);
+  } finally {
+    await evidenceBrowser.close();
+  }
+}
+
+async function captureResponsiveEvidenceInBrowser(
+  browser: Browser,
+  storageState: Awaited<ReturnType<BrowserContext["storageState"]>>,
+  engine: EngineName,
+): Promise<void> {
   const captures = [
     { width: 320, height: 780, scheme: "light" as const },
     { width: 768, height: 900, scheme: "dark" as const },
@@ -1993,7 +2056,10 @@ describe("provider-neutral browser account acceptance", () => {
     } satisfies BrowserRequestFailureInput;
     expect(requestFailureProblem(longLivedOldActorStream)).toBeNull();
     expect(
-      requestFailureProblem({ ...longLivedOldActorStream, failure: "NS_ERROR_NET_RESET" }),
+      requestFailureProblem({
+        ...longLivedOldActorStream,
+        failure: "NS_ERROR_NET_RESET",
+      }),
     ).toBeNull();
     expect(
       requestFailureProblem({
@@ -2139,16 +2205,39 @@ describe("provider-neutral browser account acceptance", () => {
         url: `${publicOrigin}/v1/config/other`,
       }),
     ).toContain("/v1/config/other");
+    const acceptedWebKitCancellation = {
+      pathnameAndSearch:
+        "/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1",
+      responsePhase: "slot-revocation-reauthentication",
+    };
+    const correlatedWebKitPageError =
+      "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.";
     expect(
-      isWebKitReauthenticationAccessControlPageError(
-        "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.",
-      ),
+      isWebKitReauthenticationAccessControlPageError(correlatedWebKitPageError, [
+        acceptedWebKitCancellation,
+      ]),
     ).toBe(true);
+    expect(isWebKitReauthenticationAccessControlPageError(correlatedWebKitPageError, [])).toBe(
+      false,
+    );
     expect(
       isWebKitReauthenticationAccessControlPageError(
         "[cross-slot-deep-link] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/sessions/45779fe5-3636-4d7e-b4af-0ba46f90ffc0/turns?latestStarted=1 due to access control checks.",
+        [acceptedWebKitCancellation],
       ),
     ).toBe(false);
+    expect(
+      isWebKitReauthenticationAccessControlPageError(
+        "[slot-revocation-reauthentication] /127.0.0.1:20035/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/realtime-model-catalog due to access control checks.",
+        [
+          {
+            pathnameAndSearch:
+              "/v1/workspaces/f7acfc16-b1dc-4683-bd9b-317782ed74e2/realtime-model-catalog",
+            responsePhase: "slot-revocation-reauthentication",
+          },
+        ],
+      ),
+    ).toBe(true);
     expect(
       requestFailureProblem({
         ...crossTabBootstrapRead,
@@ -2199,13 +2288,21 @@ describe("provider-neutral browser account acceptance", () => {
     expect(finiteReadMayRetireAfterActorTransition(retirement)).toBe(true);
     const retiredDescription = "GET /v1/workspaces/old-workspace/sessions";
     expect(
-      retiredFiniteReadTerminalProblem(retiredDescription, { kind: "response", status: 200 }),
+      retiredFiniteReadTerminalProblem(retiredDescription, {
+        kind: "response",
+        status: 200,
+      }),
     ).toContain("unexpected-late-response=200");
-    expect(retiredFiniteReadTerminalProblem(retiredDescription, { kind: "finished" })).toContain(
-      "unexpected-late-finish",
-    );
     expect(
-      retiredFiniteReadTerminalProblem(undefined, { kind: "response", status: 200 }),
+      retiredFiniteReadTerminalProblem(retiredDescription, {
+        kind: "finished",
+      }),
+    ).toContain("unexpected-late-finish");
+    expect(
+      retiredFiniteReadTerminalProblem(undefined, {
+        kind: "response",
+        status: 200,
+      }),
     ).toBeNull();
     expect(
       finiteReadMayRetireAfterActorTransition({
@@ -2285,11 +2382,7 @@ describe("provider-neutral browser account acceptance", () => {
   test("real users add, race, switch, re-authenticate, deep-link, and revoke without stale tenant state", async () => {
     if (!owned) throw new Error("database fixture unavailable");
     const engine = requestedEngine as EngineName;
-    const browser = await ENGINES[engine].launch(
-      engine === "chromium" && process.env.OPENGENI_BROWSER_BIN
-        ? { executablePath: process.env.OPENGENI_BROWSER_BIN }
-        : undefined,
-    );
+    const browser = await launchAccountBrowser(engine);
     const context = await browser.newContext({
       viewport: { width: 1440, height: 960 },
     });
@@ -2384,7 +2477,7 @@ describe("provider-neutral browser account acceptance", () => {
 
       if (engine === "chromium") {
         setBrowserPhase(pageProblems, "responsive-accessibility-evidence");
-        await captureResponsiveEvidence(browser, context, engine);
+        await captureResponsiveEvidence(context, engine);
       }
 
       setBrowserPhase(pageProblems, "cross-tab-select-race");
@@ -2586,6 +2679,7 @@ describe("provider-neutral browser account acceptance", () => {
         ],
         [],
       );
+      await settlePendingRequestFailureChecks(pageProblems);
       await expectAndConsumePageErrors(
         page,
         pageProblems,

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -577,7 +577,9 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         await route.continue();
       });
 
-      await page.keyboard.press("Enter");
+      // Route registration yields to background refreshes. Address the menu
+      // item directly so a refresh cannot move focus before keyboard activation.
+      await unpin.press("Enter");
       await page.getByText("Couldn't unpin session", { exact: true }).waitFor();
       await page.getByRole("button", { name: "Unpin session" }).waitFor();
       await page.waitForFunction(


### PR DESCRIPTION
## Summary
- isolate responsive account visual capture from the deliberate multi-tab journey’s native connection pool by using a dedicated browser process
- correlate WebKit re-authentication access-control page errors with the exact request cancellation already accepted by the strict actor-transition ledger
- retain the one-error maximum and add positive/negative matcher coverage

## Why
Canonical main CI run 33157339174 exposed two acceptance-harness races after the live-stream release fix merged: Chromium’s evidence-only contexts contended with the journey’s intentionally live tabs, while WebKit surfaced the known replaced-document error for `realtime-model-catalog` rather than the previously hard-coded `turns` endpoint. The underlying actor cancellation was already independently accepted; this change binds the page-error exception to that exact evidence instead of broadening it by route.

## Verification
- real PostgreSQL/RLS browser-account acceptance: Chromium, Firefox, WebKit
- focused strict browser-ledger test
- repository typecheck (31 projects)
- lint with warnings denied
- repository formatting check
- clean diff check

## Summary by Sourcery

Harden browser account acceptance against transport, WebKit evidence, and test-environment concurrency races.

Bug Fixes:
- Prevent browser evidence capture from competing with live multi-tab acceptance journeys by isolating it in a dedicated browser process.
- Ensure actor-owned streaming transports close in a deterministic native-abort-before-reader-cancellation order.
- Make browser acceptance handling correlate WebKit page errors with the exact accepted request cancellation while enforcing a strict one-to-one error limit.
- Reduce flakiness in heartbeat, session-pin, and concurrent PostgreSQL role provisioning tests.

Enhancements:
- Improve browser cancellation matching and delayed page-error settling with strict evidence accounting.

Tests:
- Add positive and negative coverage for WebKit error correlation, endpoint matching, timing, duplicate evidence, and cancellation classification.