### PR TITLE
Remember session grouping preference

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -153,6 +153,11 @@ import {
   type SessionBrowseDateRange,
   type SessionBrowseGroupBy,
 } from "@/lib/sessions-group";
+import {
+  readSessionBrowseGroupBy,
+  sessionBrowsePreferenceStorageId,
+  writeSessionBrowseGroupBy,
+} from "@/lib/session-browse-preferences";
 import { railRowCreator } from "@/lib/creator-initials";
 import { formatWaitingSince } from "@/lib/format";
 import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
@@ -259,10 +264,29 @@ export function SessionList() {
   const [searchDraft, setSearchDraft] = useState("");
   const [search, setSearch] = useState("");
   const [archivedOpen, setArchivedOpen] = useState(false);
-  const [browseGroupBy, setBrowseGroupBy] = useState<SessionBrowseGroupBy>("activity");
+  const browsePreferenceStorageId = useMemo(
+    () => sessionBrowsePreferenceStorageId(context.accessContext.subjectId),
+    [context.accessContext.subjectId],
+  );
+  const previousBrowsePreferenceStorageId = useRef(browsePreferenceStorageId);
+  const [browseGroupBy, setBrowseGroupByState] = useState<SessionBrowseGroupBy>(() =>
+    readSessionBrowseGroupBy(browsePreferenceStorageId),
+  );
   const [browseDateField, setBrowseDateField] = useState<SessionBrowseDateField>("activity");
   const [browseDateRange, setBrowseDateRange] = useState<SessionBrowseDateRange>("any");
   const [browseCreator, setBrowseCreator] = useState<string | null>(null);
+  useEffect(() => {
+    if (previousBrowsePreferenceStorageId.current === browsePreferenceStorageId) return;
+    previousBrowsePreferenceStorageId.current = browsePreferenceStorageId;
+    setBrowseGroupByState(readSessionBrowseGroupBy(browsePreferenceStorageId));
+  }, [browsePreferenceStorageId]);
+  const setBrowseGroupBy = useCallback(
+    (groupBy: SessionBrowseGroupBy) => {
+      setBrowseGroupByState(groupBy);
+      writeSessionBrowseGroupBy(browsePreferenceStorageId, groupBy);
+    },
+    [browsePreferenceStorageId],
+  );
   useEffect(() => {
     const timer = window.setTimeout(() => setSearch(searchDraft.trim()), 200);
     return () => window.clearTimeout(timer);
@@ -275,7 +299,7 @@ export function SessionList() {
     setBrowseDateField("activity");
     setBrowseDateRange("any");
     setBrowseCreator(null);
-  }, []);
+  }, [setBrowseGroupBy]);
 
   const rootPage = useWorkspaceSessions({
     limit: 50,

--- a/apps/web/src/lib/session-browse-preferences.test.ts
+++ b/apps/web/src/lib/session-browse-preferences.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  readSessionBrowseGroupBy,
+  sessionBrowsePreferenceStorageId,
+  writeSessionBrowseGroupBy,
+} from "./session-browse-preferences";
+
+function memoryStorage(): Pick<Storage, "getItem" | "setItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("session browse preferences", () => {
+  test("isolates the grouping preference by subject", () => {
+    const first = sessionBrowsePreferenceStorageId("user:one");
+    const otherUser = sessionBrowsePreferenceStorageId("user:two");
+
+    expect(first).not.toBe(otherUser);
+    expect(first).toContain("user%3Aone");
+  });
+
+  test("round-trips each supported grouping", () => {
+    const storage = memoryStorage();
+    const id = sessionBrowsePreferenceStorageId("user:one");
+
+    expect(readSessionBrowseGroupBy(id, storage)).toBe("activity");
+    writeSessionBrowseGroupBy(id, "creator", storage);
+    expect(readSessionBrowseGroupBy(id, storage)).toBe("creator");
+    writeSessionBrowseGroupBy(id, "created", storage);
+    expect(readSessionBrowseGroupBy(id, storage)).toBe("created");
+  });
+
+  test("falls back safely when storage is stale or unavailable", () => {
+    const id = sessionBrowsePreferenceStorageId("user:one");
+    const stale = {
+      getItem: () => "removed-grouping",
+      setItem: () => undefined,
+    };
+    const blocked = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+
+    expect(readSessionBrowseGroupBy(id, stale)).toBe("activity");
+    expect(readSessionBrowseGroupBy(id, blocked)).toBe("activity");
+    expect(() => writeSessionBrowseGroupBy(id, "creator", blocked)).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/session-browse-preferences.ts
+++ b/apps/web/src/lib/session-browse-preferences.ts
@@ -1,0 +1,57 @@
+import type { SessionBrowseGroupBy } from "./sessions-group";
+
+const SESSION_BROWSE_PREFERENCE_VERSION = 1;
+const DEFAULT_SESSION_BROWSE_GROUP_BY: SessionBrowseGroupBy = "activity";
+
+type BrowsePreferenceStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function sessionBrowsePreferenceStorageId(subjectId: string): string {
+  return [
+    "og.session.browse",
+    `v${SESSION_BROWSE_PREFERENCE_VERSION}`,
+    encodeURIComponent(subjectId),
+  ].join(":");
+}
+
+export function readSessionBrowseGroupBy(
+  preferenceStorageId: string,
+  storage: BrowsePreferenceStorage | null = browserStorage(),
+): SessionBrowseGroupBy {
+  if (!storage) return DEFAULT_SESSION_BROWSE_GROUP_BY;
+  try {
+    const value = storage.getItem(groupByStorageKey(preferenceStorageId));
+    return isSessionBrowseGroupBy(value) ? value : DEFAULT_SESSION_BROWSE_GROUP_BY;
+  } catch {
+    return DEFAULT_SESSION_BROWSE_GROUP_BY;
+  }
+}
+
+export function writeSessionBrowseGroupBy(
+  preferenceStorageId: string,
+  groupBy: SessionBrowseGroupBy,
+  storage: BrowsePreferenceStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(groupByStorageKey(preferenceStorageId), groupBy);
+  } catch {
+    // The browse controls remain usable when storage is blocked or full.
+  }
+}
+
+function isSessionBrowseGroupBy(value: string | null): value is SessionBrowseGroupBy {
+  return value === "activity" || value === "created" || value === "creator";
+}
+
+function groupByStorageKey(preferenceStorageId: string): string {
+  return `${preferenceStorageId}:group-by`;
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -143,6 +143,34 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await shared?.release();
   }, 60_000);
 
+  test("keeps the selected session grouping after a page refresh", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      await createSessionThroughApi(page, apiBaseUrl, workspaceId, "Grouping preference proof");
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions`);
+      await page.getByRole("link", { name: /^Open Grouping preference proof/ }).waitFor();
+
+      await page.getByRole("button", { name: "Session filters" }).click();
+      await page.getByRole("menuitemradio", { name: "Creator" }).click();
+      await page.getByRole("button", { name: "Session filters, active" }).waitFor();
+
+      await page.reload();
+      await page.getByRole("link", { name: /^Open Grouping preference proof/ }).waitFor();
+      await page.getByRole("button", { name: "Session filters, active" }).click();
+      expect(
+        await page.getByRole("menuitemradio", { name: "Creator" }).getAttribute("aria-checked"),
+      ).toBe("true");
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+
   test("acknowledges later output without leaving and reopening the active chat", async () => {
     const context = await configuredContext(browser, {
       viewport: { width: 1280, height: 800 },


### PR DESCRIPTION
## Summary
- persist the selected session grouping for the current user
- restore it on refresh and authenticated-subject changes
- fall back to Last activity when browser storage is unavailable or stale

## Verification
- 146 focused web tests
- web typecheck
- formatting, lint, and diff checks
- production web build
- real-browser session/API/PostgreSQL refresh regression

Linear: OPE-397

## Summary by Sourcery

Remember each user’s selected session grouping across page refreshes while preserving safe defaults when preference storage cannot be used.

New Features:
- Persist the selected session grouping preference separately for each authenticated user and restore it when the session list is revisited or the user changes.

Bug Fixes:
- Safely fall back to grouping by last activity when the saved preference is invalid or browser storage is unavailable.

Tests:
- Add unit coverage for user-scoped preference storage, supported grouping round trips, and unavailable or stale storage.
- Add a real-browser regression test confirming the grouping preference survives a page refresh.