### PR TITLE
Improve staging session performance and runtime failure observability

### DIFF
--- a/.changeset/fast-runtime-failure-observability.md
+++ b/.changeset/fast-runtime-failure-observability.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Bound session-control settlement reads to the requested session subtrees, avoid redundant workspace refreshes for session-scoped control events, and add low-cardinality MCP lifecycle telemetry with failure, latency, and runtime reliability alerts and dashboards.

--- a/apps/web/src/routes/workspace-control-refresh.test.ts
+++ b/apps/web/src/routes/workspace-control-refresh.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { workspaceControlEventInvalidatesWorkspace } from "./workspace";
+
+describe("workspace control refresh", () => {
+  test("refetches the workspace only for workspace-wide control changes", () => {
+    expect(workspaceControlEventInvalidatesWorkspace({ scope: "workspace" })).toBe(true);
+    expect(workspaceControlEventInvalidatesWorkspace({ scope: "session" })).toBe(false);
+  });
+});

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -2,6 +2,7 @@
 // switcher, workspace nav, the session list) plus a slim canvas top strip for
 // session-contextual actions around every workspace-scoped route.
 import { OpenGeniProvider } from "@opengeni/react";
+import type { WorkspaceControlEvent } from "@opengeni/sdk";
 import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
@@ -37,6 +38,16 @@ type SlackAccessState = {
   error: string | null;
   busy: boolean;
 };
+
+export function workspaceControlEventInvalidatesWorkspace(
+  event: Pick<WorkspaceControlEvent, "scope">,
+): boolean {
+  // Session-scoped controls invalidate session projections through the React
+  // provider's live event. The workspace projection changes only for the
+  // workspace-wide scope, so refetching it for every descendant pause/resume
+  // turns orchestrator traffic into an unnecessary database read storm.
+  return event.scope === "workspace";
+}
 
 function emptySlackAccessState(): SlackAccessState {
   return { request: null, error: null, busy: false };
@@ -476,7 +487,11 @@ function AuthorizedWorkspaceShell({
     <OpenGeniProvider
       client={context.client}
       workspaceId={workspaceId}
-      onWorkspaceControlEvent={() => void context.refreshWorkspace(workspaceId)}
+      onWorkspaceControlEvent={(event) => {
+        if (workspaceControlEventInvalidatesWorkspace(event)) {
+          void context.refreshWorkspace(workspaceId);
+        }
+      }}
     >
       {usesOrganizationShell ? (
         children

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -163,6 +163,19 @@ export function runtimeMetricsHooksForObservability(
         value: durationSeconds,
       });
     },
+    onMcpLifecycle: ({ phase, policy, outcome, durationSeconds }) => {
+      observability.incrementCounter({
+        name: "opengeni_mcp_lifecycle_operations_total",
+        help: "Total physical MCP lifecycle operations by bounded phase, policy, and outcome.",
+        labels: { phase, policy, outcome },
+      });
+      observability.observeHistogram({
+        name: "opengeni_mcp_lifecycle_operation_duration_seconds",
+        help: "MCP lifecycle operation duration in seconds by bounded phase, policy, and outcome.",
+        labels: { phase, policy, outcome },
+        value: durationSeconds,
+      });
+    },
     onSandboxOp: ({ backend, op, outcome, code, healed, durationSeconds, replyBytes }) => {
       observability.incrementCounter({
         name: "opengeni_machine_op_total",

--- a/apps/worker/test/mcp-tool-call-metrics.test.ts
+++ b/apps/worker/test/mcp-tool-call-metrics.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test";
 import { createObservability } from "@opengeni/observability";
-import { MCP_TOOL_CALL_OUTCOMES } from "@opengeni/runtime";
+import {
+  MCP_LIFECYCLE_OUTCOMES,
+  MCP_LIFECYCLE_PHASES,
+  MCP_LIFECYCLE_POLICIES,
+  MCP_TOOL_CALL_OUTCOMES,
+} from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
 import { runtimeMetricsHooksForObservability } from "../src/observability-metrics";
 
@@ -22,6 +27,37 @@ test("MCP tool-call metrics expose only the closed structural outcome", async ()
         `opengeni_mcp_tool_call_duration_seconds_count\\{[^}]*outcome="${outcome}"[^}]*\\} 1\\b`,
       ),
     );
+  }
+  expect(metrics).not.toMatch(/server(_id)?=|tool(_name)?=|workspace(_id)?=|session(_id)?=/);
+});
+
+test("MCP lifecycle metrics expose only bounded structural dimensions", async () => {
+  const observability = createObservability(testSettings(), { component: "worker" });
+  const hooks = runtimeMetricsHooksForObservability(observability);
+
+  let durationSeconds = 0.25;
+  for (const phase of MCP_LIFECYCLE_PHASES) {
+    for (const policy of MCP_LIFECYCLE_POLICIES) {
+      for (const outcome of MCP_LIFECYCLE_OUTCOMES) {
+        hooks.onMcpLifecycle?.({ phase, policy, outcome, durationSeconds });
+        durationSeconds += 1;
+      }
+    }
+  }
+
+  const metrics = await observability.prometheusMetrics();
+  for (const phase of MCP_LIFECYCLE_PHASES) {
+    for (const policy of MCP_LIFECYCLE_POLICIES) {
+      for (const outcome of MCP_LIFECYCLE_OUTCOMES) {
+        const labels = `[^}]*outcome="${outcome}"[^}]*phase="${phase}"[^}]*policy="${policy}"[^}]*`;
+        expect(metrics).toMatch(
+          new RegExp(`opengeni_mcp_lifecycle_operations_total\\{${labels}\\} 1\\b`),
+        );
+        expect(metrics).toMatch(
+          new RegExp(`opengeni_mcp_lifecycle_operation_duration_seconds_count\\{${labels}\\} 1\\b`),
+        );
+      }
+    }
   }
   expect(metrics).not.toMatch(/server(_id)?=|tool(_name)?=|workspace(_id)?=|session(_id)?=/);
 });

--- a/apps/worker/test/sandbox-observability-contract.test.ts
+++ b/apps/worker/test/sandbox-observability-contract.test.ts
@@ -35,7 +35,7 @@ describe("sandbox observability contract", () => {
         condition?: string;
       }>;
     };
-    expect(chart.version).toBe("0.1.6");
+    expect(chart.version).toBe("0.1.7");
     expect(chart.dependencies).toEqual([
       {
         name: "kube-prometheus-stack",

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -233,6 +233,150 @@ spec:
           annotations:
             summary: A SuperGrok response stream stopped producing valid SSE events
             description: The accepted stream was cancelled after its configured valid-event silence interval and was not replayed. Correlate the durable agent.model.request terminal checkpoint with provider request metadata.
+        - alert: OpenGeniTurnFailureRatioHigh
+          expr: |
+            (
+              sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},outcome="failed"}[10m]))
+              /
+              clamp_min(sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])), 1)
+            ) > 0.2
+            and on()
+            sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni turn failures exceed 20%
+            description: Durable logical turns are terminalizing failed. Compare MCP lifecycle/tool outcomes, sandbox provision categories, provider terminals, and startup phases before changing retry policy.
+        - alert: OpenGeniTurnRecoveryRatioHigh
+          expr: |
+            (
+              sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},outcome="recovering"}[10m]))
+              /
+              clamp_min(sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])), 1)
+            ) > 0.2
+            and on()
+            sum(increase(opengeni_turns_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni same-turn recovery pressure exceeds 20%
+            description: Recovery is preserving logical turns but consuming capacity and adding latency. Inspect typed MCP transport, sandbox, provider, and worker-shutdown evidence for the dominant retryable boundary.
+        - alert: OpenGeniModelCallFailureRatioHigh
+          expr: |
+            (
+              sum by (provider) (increase(opengeni_model_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},outcome="failed"}[10m]))
+              /
+              clamp_min(sum by (provider) (increase(opengeni_model_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])), 1)
+            ) > 0.2
+            and on(provider)
+            sum by (provider) (increase(opengeni_model_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni model-call failures exceed 20% for {{ "{{ $labels.provider }}" }}
+            description: The provider request boundary is failing independently of sandbox and tool preparation. Correlate provider terminal phases and first-byte availability before retrying or rerouting work.
+        - alert: OpenGeniMcpStrictConnectFailed
+          expr: |
+            sum(increase(opengeni_mcp_lifecycle_operations_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},phase="connect",policy="strict",outcome="failed"}[5m])) > 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: A required OpenGeni MCP server failed to connect
+            description: A strict MCP dependency prevented a turn from reaching the model. Inspect the bounded McpLifecycleError code/status/origin log and the Runtime Failures dashboard; never copy transport bodies or credentials into incident evidence.
+        - alert: OpenGeniMcpCloseFailed
+          expr: |
+            sum by (policy) (increase(opengeni_mcp_lifecycle_operations_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},phase="close",outcome="failed"}[5m])) > 0
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni MCP cleanup failed for {{ "{{ $labels.policy }}" }} connections
+            description: A transport did not close cleanly and may retain resources. Inspect the bounded MCP lifecycle diagnostic and worker health; do not obscure the turn's original outcome with cleanup retries.
+        - alert: OpenGeniMcpBestEffortConnectFailureRatio
+          expr: |
+            (
+              sum(increase(opengeni_mcp_lifecycle_operations_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},phase="connect",policy="best_effort",outcome="failed"}[10m]))
+              /
+              clamp_min(sum(increase(opengeni_mcp_lifecycle_operations_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},phase="connect",policy="best_effort"}[10m])), 1)
+            ) > 0.2
+            and on()
+            sum(increase(opengeni_mcp_lifecycle_operations_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},phase="connect",policy="best_effort"}[10m])) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Optional or connector-backed MCP connection failures exceed 20%
+            description: Turns may continue with missing tools, but users are losing capabilities. Check connector authentication, endpoint health, and bounded MCP lifecycle logs.
+        - alert: OpenGeniMcpToolFailureRatio
+          expr: |
+            (
+              sum(increase(opengeni_mcp_tool_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},outcome=~"provider_declared_error|auth_needed|outcome_uncertain|timeout|thrown_transport_error|thrown_protocol_error"}[10m]))
+              /
+              clamp_min(sum(increase(opengeni_mcp_tool_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])), 1)
+            ) > 0.2
+            and on()
+            sum(increase(opengeni_mcp_tool_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni MCP tool-call failures exceed 20%
+            description: Includes provider-declared, authentication, timeout, uncertain, transport, and protocol outcomes. User cancellation remains visible in Grafana but does not page operators.
+        - alert: OpenGeniMcpToolOutcomeUncertain
+          expr: |
+            sum(increase(opengeni_mcp_tool_calls_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},outcome="outcome_uncertain"}[5m])) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: An MCP mutation ended with an uncertain outcome
+            description: Do not replay the operation automatically. Reconcile through the tool's durable provider receipt or idempotency boundary before retrying.
+        - alert: OpenGeniMcpToolLatencyHigh
+          expr: |
+            histogram_quantile(
+              0.95,
+              sum by (le) (rate(opengeni_mcp_tool_call_duration_seconds_bucket{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m]))
+            ) > 15
+            and on()
+            sum(increase(opengeni_mcp_tool_call_duration_seconds_count{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[10m])) >= 5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni MCP tool-call p95 exceeds 15 seconds
+            description: Tool latency is materially delaying turns. Split by structural outcome and compare MCP connect time before attributing this to model inference.
+        - alert: OpenGeniHttp5xxRatioHigh
+          expr: |
+            (
+              sum(increase(opengeni_http_requests_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},component="api",status=~"5.."}[5m]))
+              /
+              clamp_min(sum(increase(opengeni_http_requests_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},component="api"}[5m])), 1)
+            ) > 0.05
+            and on()
+            sum(increase(opengeni_http_requests_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},component="api"}[5m])) >= 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni API 5xx responses exceed 5%
+            description: Group the bounded route/status series in Grafana, then correlate the affected route with Postgres append latency and application logs.
+        - alert: OpenGeniCoreReadLatencyHigh
+          expr: |
+            histogram_quantile(
+              0.95,
+              sum by (le, route) (rate(opengeni_http_request_duration_seconds_bucket{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},component="api",method="GET",route=~"/v1/workspaces/:workspaceId|/v1/workspaces/:workspaceId/sessions|/v1/workspaces/:workspaceId/sessions/:id"}[10m]))
+            ) > 2
+            and on(route)
+            sum by (route) (increase(opengeni_http_request_duration_seconds_count{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},component="api",method="GET",route=~"/v1/workspaces/:workspaceId|/v1/workspaces/:workspaceId/sessions|/v1/workspaces/:workspaceId/sessions/:id"}[10m])) >= 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni core read p95 exceeds 2 seconds on {{ "{{ $labels.route }}" }}
+            description: Workspace or session reads are slow enough to degrade the interactive control plane. Inspect database CPU, active queries, event append latency, and request volume before scaling API pods.
         - alert: OpenGeniSandboxCreateFailureRatio
           expr: |
             (
@@ -615,6 +759,14 @@ spec:
           annotations:
             summary: OpenGeni session-event append p99 exceeds 1s (durable write path)
             description: appendSessionEvents p99 is above 1s for 10m — Postgres is the streaming bottleneck, not the model or NATS.
+        - alert: OpenGeniEventAppendLatencyCritical
+          expr: histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_append_seconds_bucket{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}}[5m]))) > 2
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: OpenGeni session-event append p99 exceeds 2s
+            description: The durable Postgres write path is critically saturated. Inspect database CPU, active sessions, hot statements, and application request pressure before scaling stateless pods.
         - alert: OpenGeniEventPublishLatencyHigh
           expr: histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[10m]))) > 0.5
           for: 10m

--- a/deploy/helm/opengeni/test/prometheusrule.test.ts
+++ b/deploy/helm/opengeni/test/prometheusrule.test.ts
@@ -94,6 +94,63 @@ describe("turn-capacity Prometheus alerts", () => {
     expect(idleTimeout).not.toContain("requestId");
   });
 
+  test("alerts on bounded runtime, tool, lifecycle, API, and recovery failures", async () => {
+    const template = await readFile(
+      new URL("../templates/prometheusrule.yaml", import.meta.url),
+      "utf8",
+    );
+    const expected = new Map([
+      ["OpenGeniTurnFailureRatioHigh", ["opengeni_turns_total", 'outcome="failed"']],
+      ["OpenGeniTurnRecoveryRatioHigh", ["opengeni_turns_total", 'outcome="recovering"']],
+      [
+        "OpenGeniModelCallFailureRatioHigh",
+        ["opengeni_model_calls_total", 'outcome="failed"', "sum by (provider)"],
+      ],
+      [
+        "OpenGeniMcpStrictConnectFailed",
+        ["opengeni_mcp_lifecycle_operations_total", 'policy="strict"', 'outcome="failed"'],
+      ],
+      [
+        "OpenGeniMcpCloseFailed",
+        ["opengeni_mcp_lifecycle_operations_total", 'phase="close"', 'outcome="failed"'],
+      ],
+      [
+        "OpenGeniMcpBestEffortConnectFailureRatio",
+        ["opengeni_mcp_lifecycle_operations_total", 'policy="best_effort"'],
+      ],
+      [
+        "OpenGeniMcpToolFailureRatio",
+        [
+          "opengeni_mcp_tool_calls_total",
+          'outcome=~"provider_declared_error|auth_needed|outcome_uncertain|timeout|thrown_transport_error|thrown_protocol_error"',
+        ],
+      ],
+      ["OpenGeniMcpToolOutcomeUncertain", ["outcome_uncertain"]],
+      ["OpenGeniMcpToolLatencyHigh", ["opengeni_mcp_tool_call_duration_seconds_bucket"]],
+      ["OpenGeniHttp5xxRatioHigh", ["opengeni_http_requests_total", 'status=~"5.."']],
+      [
+        "OpenGeniCoreReadLatencyHigh",
+        [
+          "opengeni_http_request_duration_seconds_bucket",
+          'method="GET"',
+          'route=~"/v1/workspaces/:workspaceId|/v1/workspaces/:workspaceId/sessions|/v1/workspaces/:workspaceId/sessions/:id"',
+        ],
+      ],
+    ]);
+
+    for (const [alert, signals] of expected) {
+      const expression = alertExpression(template, alert);
+      for (const signal of signals)
+        expect(expression, `${alert} missing ${signal}`).toContain(signal);
+      for (const selector of metricSelectors(expression))
+        expect(selector).toContain(DEPLOYMENT_SCOPE);
+      expect(expression).not.toMatch(/workspace_id|session_id|turn_id|tool_name|server_id/);
+      if (alert === "OpenGeniMcpToolFailureRatio") {
+        expect(expression).not.toContain("cancelled");
+      }
+    }
+  });
+
   test("correlates backlog and freshness before fleet aggregation", async () => {
     const template = await readFile(
       new URL("../templates/prometheusrule.yaml", import.meta.url),

--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opengeni-observability
 description: Optional self-hosted Prometheus and Grafana stack for OpenGeni.
 type: application
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/observability/dashboards/README.md
+++ b/deploy/observability/dashboards/README.md
@@ -1,6 +1,6 @@
 # OpenGeni Grafana dashboards
 
-Dashboards-as-code for the OpenGeni control plane. Six boards, each answering a
+Dashboards-as-code for the OpenGeni control plane. Seven boards, each answering a
 different "manage and fix problems as soon as they arise" question:
 
 | File | Board | Answers |
@@ -11,8 +11,9 @@ different "manage and fix problems as soon as they arise" question:
 | `sandbox-health.json` | **OpenGeni · Sandbox Health** | Are provider operations, creates, lease recovery, checkpoint GC, deadline rotation, draining, and retained-process reconciliation healthy? |
 | `turn-startup.json` | **OpenGeni · Turn Startup** | Where does queue-to-first-byte time go — worker queue, sandbox/rig/repository/file/tool/model preparation, provider dispatch, or provider response? |
 | `google-drive-sync.json` | **OpenGeni · Google Drive Sync** | Are scheduled Drive runs succeeding within their persisted quotas, or failing on provider retry, reconnect, and explicit resource limits? |
+| `runtime-failures.json` | **OpenGeni · Runtime Failures** | Are turns failing or recovering, are MCP connections or tool calls broken or slow, are sandboxes/providers failing, is the API returning 5xx, or is the durable write path saturated? |
 
-All six are theme-agnostic, tagged `opengeni` + `observability`, and carry a
+All seven are theme-agnostic, tagged `opengeni` + `observability`, and carry a
 `$datasource` template variable — pick your Prometheus datasource on import; no UID
 is hardcoded. The Turn Startup dashboard additionally requires one exact
 `$namespace`, `$environment`, and `$release` selection so a shared Prometheus
@@ -93,7 +94,9 @@ App series used here (non-exhaustive): `opengeni_stream_ttft_seconds`,
 `opengeni_sandbox_leases_expired_draining`, `opengeni_retained_processes_*`,
 `opengeni_opensandbox_batchsandboxes`, `opengeni_opensandbox_workload_pods`,
 `opengeni_opensandbox_cleanup_stuck`, `opengeni_opensandbox_expiration_overdue`,
-`opengeni_model_call_duration_seconds`,
+`opengeni_model_call_duration_seconds`, `opengeni_mcp_lifecycle_operations_total`,
+`opengeni_mcp_lifecycle_operation_duration_seconds`, `opengeni_mcp_tool_calls_total`,
+`opengeni_mcp_tool_call_duration_seconds`,
 `opengeni_knowledge_source_sync_*`, `opengeni_google_drive_provider_*`,
 `opengeni_turn_worker_memory_guard_utilization_ratio`,
 `opengeni_turn_worker_memory_guard_target_ratio`,

--- a/deploy/observability/dashboards/runtime-failures.json
+++ b/deploy/observability/dashboards/runtime-failures.json
@@ -1,0 +1,396 @@
+{
+  "uid": "opengeni-runtime-failures",
+  "title": "OpenGeni · Runtime Failures",
+  "description": "One exact deployment's turn, MCP, sandbox, API, provider, and durable-write failures. Identity and error content stay in authenticated logs and durable events, never metric labels.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {
+    "refresh_intervals": ["30s", "1m", "5m", "15m", "30m", "1h"],
+    "time_options": ["1h", "6h", "24h", "7d", "30d"]
+  },
+  "tags": ["opengeni", "observability", "failures", "runtime"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": {
+          "query": "label_values(opengeni_turns_total, namespace)",
+          "refId": "namespace"
+        },
+        "definition": "label_values(opengeni_turns_total, namespace)",
+        "current": {},
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "sort": 1
+      },
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": {
+          "query": "label_values(opengeni_turns_total{namespace=\"$namespace\"}, environment)",
+          "refId": "environment"
+        },
+        "definition": "label_values(opengeni_turns_total{namespace=\"$namespace\"}, environment)",
+        "current": {},
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "sort": 1
+      },
+      {
+        "name": "release",
+        "label": "Release",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": {
+          "query": "label_values(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\"}, release)",
+          "refId": "release"
+        },
+        "definition": "label_values(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\"}, release)",
+        "current": {},
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Turn health",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Turn outcomes",
+      "description": "Terminal failures and same-turn recovery pressure are separated so safe recovery is visible without being mistaken for success.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (rate(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 8 }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Turn failure and recovery ratios",
+      "description": "Failures and recoveries divided by all observed turn outcomes over the selected rate interval.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"failed\"}[$__rate_interval])) / clamp_min(sum(rate(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval])), 0.000000001)",
+          "legendFormat": "failed",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"recovering\"}[$__rate_interval])) / clamp_min(sum(rate(opengeni_turns_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval])), 0.000000001)",
+          "legendFormat": "recovering",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 8 }
+    },
+    {
+      "id": 4,
+      "type": "row",
+      "title": "MCP connections and tool use",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "MCP lifecycle operations",
+      "description": "Required failures are turn-blocking. Best-effort failures remove optional or connector-backed capabilities while allowing the turn to continue.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (phase, policy, outcome) (increase(opengeni_mcp_lifecycle_operations_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__range]))",
+          "legendFormat": "{{phase}} · {{policy}} · {{outcome}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 10, "w": 12, "h": 8 }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "MCP tool calls by outcome",
+      "description": "Every physical tool call lands in one closed structural outcome, including provider errors, auth, timeouts, cancellation, uncertainty, transport, and protocol failures.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (increase(opengeni_mcp_tool_calls_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__range]))",
+          "legendFormat": "{{outcome}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 10, "w": 12, "h": 8 }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "MCP tool-call p95 by outcome",
+      "description": "Separates slow successful tools from timeout and transport tails.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, outcome) (rate(opengeni_mcp_tool_call_duration_seconds_bucket{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval])))",
+          "legendFormat": "{{outcome}} p95",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 18, "w": 12, "h": 8 }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Failed startup phases",
+      "description": "The platform phase that failed before or around provider dispatch, with no session or turn identifiers in Prometheus.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (phase) (increase(opengeni_turn_startup_phase_duration_seconds_count{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"failed\"}[$__range]))",
+          "legendFormat": "{{phase}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 18, "w": 12, "h": 8 }
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "Sandbox, API, provider, and durable storage",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Logical sandbox provision failures",
+      "description": "Typed logical failures only. Internal lease transitions and attempts stay on the Sandbox Health dashboard.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (backend, category, stage) (increase(opengeni_sandbox_provisions_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"failed\"}[$__range]))",
+          "legendFormat": "{{backend}} · {{category}} · {{stage}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 27, "w": 12, "h": 8 }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "API 5xx by route and status",
+      "description": "Bounded route templates, never raw paths or request identifiers.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status) (rate(opengeni_http_requests_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",component=\"api\",status=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "{{status}} · {{route}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 27, "w": 12, "h": 8 }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Core workspace and session read p95",
+      "description": "The interactive workspace, session-list, and session-detail reads. These isolate database-backed control-plane degradation without mixing in long-lived streams or terminal operations.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(opengeni_http_request_duration_seconds_bucket{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",component=\"api\",method=\"GET\",route=~\"/v1/workspaces/:workspaceId|/v1/workspaces/:workspaceId/sessions|/v1/workspaces/:workspaceId/sessions/:id\"}[$__rate_interval])))",
+          "legendFormat": "{{route}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 35, "w": 12, "h": 8 }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Durable append and live publish p99",
+      "description": "High append latency points to Postgres. High publish latency with healthy append points to NATS or live delivery.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_append_seconds_bucket{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval])))",
+          "legendFormat": "append p99",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__rate_interval])))",
+          "legendFormat": "publish p99",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 35, "w": 12, "h": 8 }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Model call outcomes",
+      "description": "Provider-level success and failure pressure after platform preparation.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (provider, outcome) (increase(opengeni_model_calls_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}[$__range]))",
+          "legendFormat": "{{provider}} · {{outcome}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 0, "y": 43, "w": 12, "h": 8 }
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Incident delivery path",
+      "description": "Managed deployments route alerts through obs-incident-translator. Desired/available replicas below one or failed Alertmanager webhooks mean Grafana can see incidents but the incident agent cannot receive them.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(kube_deployment_spec_replicas{namespace=\"observability\",deployment=\"obs-incident-translator\"})",
+          "legendFormat": "translator desired replicas",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "max(kube_deployment_status_replicas_available{namespace=\"observability\",deployment=\"obs-incident-translator\"})",
+          "legendFormat": "translator available replicas",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "sum by (reason) (rate(alertmanager_notifications_failed_total{integration=\"webhook\"}[$__rate_interval]))",
+          "legendFormat": "failed webhooks · {{reason}}",
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "gridPos": { "x": 12, "y": 43, "w": 12, "h": 8 }
+    }
+  ]
+}

--- a/deploy/observability/dashboards/runtime-failures.test.ts
+++ b/deploy/observability/dashboards/runtime-failures.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+describe("runtime failures dashboard", () => {
+  test("puts bounded failure and latency signals on one deployment-scoped board", async () => {
+    const dashboard = JSON.parse(
+      await readFile(new URL("./runtime-failures.json", import.meta.url), "utf8"),
+    ) as RuntimeFailuresDashboard;
+    const titles = new Set(dashboard.panels.map((panel) => panel.title));
+    for (const title of [
+      "Turn outcomes",
+      "Turn failure and recovery ratios",
+      "MCP lifecycle operations",
+      "MCP tool calls by outcome",
+      "MCP tool-call p95 by outcome",
+      "Failed startup phases",
+      "Logical sandbox provision failures",
+      "API 5xx by route and status",
+      "Core workspace and session read p95",
+      "Durable append and live publish p99",
+      "Model call outcomes",
+      "Incident delivery path",
+    ]) {
+      expect(titles).toContain(title);
+    }
+
+    const serialized = JSON.stringify(dashboard);
+    for (const metric of [
+      "opengeni_turns_total",
+      "opengeni_mcp_lifecycle_operations_total",
+      "opengeni_mcp_tool_calls_total",
+      "opengeni_mcp_tool_call_duration_seconds_bucket",
+      "opengeni_turn_startup_phase_duration_seconds_count",
+      "opengeni_sandbox_provisions_total",
+      "opengeni_http_requests_total",
+      "opengeni_http_request_duration_seconds_bucket",
+      "opengeni_session_event_append_seconds_bucket",
+      "opengeni_session_event_publish_seconds_bucket",
+      "opengeni_model_calls_total",
+      "alertmanager_notifications_failed_total",
+      "kube_deployment_status_replicas_available",
+    ]) {
+      expect(serialized).toContain(metric);
+    }
+    expect(serialized).not.toMatch(/sessionId|turnId|requestId|toolName|serverId/);
+  });
+
+  test("pins every panel selector to one namespace, environment, and release", async () => {
+    const dashboard = JSON.parse(
+      await readFile(new URL("./runtime-failures.json", import.meta.url), "utf8"),
+    ) as RuntimeFailuresDashboard;
+    const variables = new Map(
+      dashboard.templating.list.map((variable) => [variable.name, variable]),
+    );
+    for (const name of ["namespace", "environment", "release"]) {
+      expect(variables.get(name)?.includeAll).toBe(false);
+      expect(variables.get(name)?.multi).toBe(false);
+    }
+
+    for (const panel of dashboard.panels) {
+      for (const target of panel.targets ?? []) {
+        for (const selector of metricSelectors(target.expr)) {
+          expect(selector).toContain('namespace="$namespace"');
+          expect(selector).toContain('environment="$environment"');
+          expect(selector).toContain('release="$release"');
+        }
+      }
+    }
+  });
+});
+
+interface RuntimeFailuresDashboard {
+  panels: Array<{ title?: string; targets?: Array<{ expr: string }> }>;
+  templating: {
+    list: Array<{
+      name: string;
+      includeAll?: boolean;
+      multi?: boolean;
+    }>;
+  };
+}
+
+function metricSelectors(expression: string): string[] {
+  return [...expression.matchAll(/opengeni_[a-zA-Z0-9_:]+\{([^}]*)\}/g)].map(
+    (match) => match[1] ?? "",
+  );
+}

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -1337,6 +1337,10 @@ async function settlementAttemptCounts(
   workspaceId: string,
   sessionIds: string[],
 ): Promise<Map<string, SettlementAttemptCounts>> {
+  // Drive the projection from the requested targets through the indexed
+  // parent_session_id edge. The inverse plan scanned every interruption in a
+  // workspace before walking upward, making one session read proportional to
+  // a high-volume orchestrator workspace's entire interruption history.
   const rows = await db.execute<{
     sessionId: string;
     attemptCount: number | string;
@@ -1344,9 +1348,24 @@ async function settlementAttemptCounts(
     quiescencePendingCount: number | string;
   }>(sql`
     with recursive targets(id) as (values ${targetValues(sessionIds)}),
-    interruptions as (
+    descendant_sessions(target_id, session_id, depth, path) as (
+      select target.id, target.id, 0::integer, array[target.id]::uuid[]
+      from targets target
+      union all
       select
-        interruption.session_id,
+        descendant.target_id,
+        child.id,
+        descendant.depth + 1,
+        descendant.path || child.id
+      from descendant_sessions descendant
+      join ${schema.sessions} child
+        on child.workspace_id = ${workspaceId}
+       and child.parent_session_id = descendant.session_id
+      where not child.id = any(descendant.path)
+        and descendant.depth < ${SESSION_ANCESTRY_LIMIT}
+    ), interruptions as (
+      select
+        descendant.target_id,
         interruption.attempt_id,
         bool_or(interruption.state in ('pending', 'delivered', 'acknowledged'))
           as interruption_pending,
@@ -1354,62 +1373,31 @@ async function settlementAttemptCounts(
           interruption.state in ('settled', 'rejected_stale')
           and attempt.quiesced_at is null
         ) as quiescence_pending
-      from ${schema.sessionAttemptInterruptions} interruption
+      from descendant_sessions descendant
+      join ${schema.sessionAttemptInterruptions} interruption
+        on interruption.workspace_id = ${workspaceId}
+       and interruption.session_id = descendant.session_id
       join ${schema.sessionTurnAttempts} attempt
         on attempt.workspace_id = interruption.workspace_id
        and attempt.id = interruption.attempt_id
-      where interruption.workspace_id = ${workspaceId}
-        and (
+      where (
           interruption.state in ('pending', 'delivered', 'acknowledged')
           or (
             interruption.state in ('settled', 'rejected_stale')
             and attempt.quiesced_at is null
           )
         )
-      group by interruption.session_id, interruption.attempt_id
-    ), interruption_ancestry(
-      session_id,
-      ancestor_id,
-      attempt_id,
-      interruption_pending,
-      quiescence_pending,
-      depth,
-      path
-    ) as (
-      select
-        interruption.session_id,
-        interruption.session_id,
-        interruption.attempt_id,
-        interruption.interruption_pending,
-        interruption.quiescence_pending,
-        0::integer,
-        array[interruption.session_id]::uuid[]
-      from interruptions interruption
-      union all
-      select
-        ancestry.session_id,
-        current.parent_session_id,
-        ancestry.attempt_id,
-        ancestry.interruption_pending,
-        ancestry.quiescence_pending,
-        ancestry.depth + 1,
-        ancestry.path || current.parent_session_id
-      from interruption_ancestry ancestry
-      join ${schema.sessions} current
-        on current.workspace_id = ${workspaceId} and current.id = ancestry.ancestor_id
-      where current.parent_session_id is not null
-        and not current.parent_session_id = any(ancestry.path)
-        and ancestry.depth < ${SESSION_ANCESTRY_LIMIT}
+      group by descendant.target_id, interruption.attempt_id
     )
     select
       target.id as "sessionId",
-      count(distinct ancestry.attempt_id)::integer as "attemptCount",
-      count(distinct ancestry.attempt_id)
-        filter (where ancestry.interruption_pending)::integer as "interruptionPendingCount",
-      count(distinct ancestry.attempt_id)
-        filter (where ancestry.quiescence_pending)::integer as "quiescencePendingCount"
+      count(interruption.attempt_id)::integer as "attemptCount",
+      count(interruption.attempt_id)
+        filter (where interruption.interruption_pending)::integer as "interruptionPendingCount",
+      count(interruption.attempt_id)
+        filter (where interruption.quiescence_pending)::integer as "quiescencePendingCount"
     from targets target
-    join interruption_ancestry ancestry on ancestry.ancestor_id = target.id
+    join interruptions interruption on interruption.target_id = target.id
     group by target.id
   `);
   return new Map(

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -2297,6 +2297,59 @@ describe("clean session control plane", () => {
     });
   });
 
+  test("settlement projection follows only the requested session subtrees", async () => {
+    const { grant, session: root } = await fixture();
+    const child = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "child with interrupted attempt",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium" as const,
+      latencyMode: "standard" as const,
+      sandboxBackend: "none",
+      parentSessionId: root.id,
+    });
+    const unrelated = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "unrelated root",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium" as const,
+      latencyMode: "standard" as const,
+      sandboxBackend: "none",
+    });
+    await send(grant, child.id, "run until the child is paused");
+    const attemptId = crypto.randomUUID();
+    const running = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      child.id,
+      `session-${child.id}`,
+      { attemptId },
+    );
+    expect(running?.status).toBe("running");
+    expect((await controlSession(grant, child.id, "pause")).interruptionCount).toBe(1);
+
+    const projected = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      evaluateSessionControls(db, grant.workspaceId!, [root.id, child.id, unrelated.id], {
+        lock: "share",
+      }),
+    );
+    const expectedSettlement = {
+      state: "stopping" as const,
+      attemptCount: 1,
+      interruptionPendingCount: 1,
+      quiescencePendingCount: 0,
+    };
+    expect(projected.get(root.id)?.settlement).toEqual(expectedSettlement);
+    expect(projected.get(child.id)?.settlement).toEqual(expectedSettlement);
+    expect(projected.get(unrelated.id)?.settlement).toBeNull();
+  });
+
   test("compact discovery control matches full blocker truth across pause overrides", async () => {
     const { grant, session: root } = await fixture();
     const child = await createSession(client.db, {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -252,6 +252,7 @@ import {
   buildOpenAIClientFromSettings,
   configureOpenAI,
   configureRuntimeMetricsHooks,
+  recordRuntimeMcpLifecycleMetric,
   recordRuntimeMcpToolCallMetric,
   resolveTurnModel,
 } from "./model-provider";
@@ -334,7 +335,13 @@ export {
 } from "./skill-library";
 
 export {
+  MCP_LIFECYCLE_OUTCOMES,
+  MCP_LIFECYCLE_PHASES,
+  MCP_LIFECYCLE_POLICIES,
   MCP_TOOL_CALL_OUTCOMES,
+  type McpLifecycleOutcome,
+  type McpLifecyclePhase,
+  type McpLifecyclePolicy,
   type McpToolCallOutcome,
   type RuntimeMetricsHooks,
 } from "./metrics";
@@ -5705,10 +5712,21 @@ export class PrefixedMcpServer implements MCPServer {
   }
 
   async connect(): Promise<void> {
+    await this.connectWithLifecycleMetric(true);
+  }
+
+  private async connectWithLifecycleMetric(recordMetric: boolean): Promise<void> {
+    const startedAt = recordMetric ? performance.now() : 0;
+    let outcome: "completed" | "failed" = "completed";
     try {
-      await this.inner.connect();
+      if (this.inner instanceof PrefixedMcpServer) {
+        await this.inner.connectWithLifecycleMetric(false);
+      } else {
+        await this.inner.connect();
+      }
       delete this.lifecycleFailures.connect;
     } catch (error) {
+      outcome = "failed";
       // The SDK logs its rejected Error directly. Keep exact internal truth
       // out-of-band and reject only a structural public lifecycle error.
       const exactError = exactMcpLifecycleError(error, {
@@ -5724,15 +5742,35 @@ export class PrefixedMcpServer implements MCPServer {
       };
       logPublicMcpLifecycleFailure(publicError);
       throw publicError;
+    } finally {
+      if (recordMetric) {
+        recordRuntimeMcpLifecycleMetric(
+          "connect",
+          this.bestEffort ? "best_effort" : "strict",
+          outcome,
+          startedAt,
+        );
+      }
     }
   }
 
   async close(): Promise<void> {
+    await this.closeWithLifecycleMetric(true);
+  }
+
+  private async closeWithLifecycleMetric(recordMetric: boolean): Promise<void> {
+    const startedAt = recordMetric ? performance.now() : 0;
+    let outcome: "completed" | "failed" = "completed";
     this.releaseAggregateBudget();
     try {
-      await this.inner.close();
+      if (this.inner instanceof PrefixedMcpServer) {
+        await this.inner.closeWithLifecycleMetric(false);
+      } else {
+        await this.inner.close();
+      }
       delete this.lifecycleFailures.close;
     } catch (error) {
+      outcome = "failed";
       const exactError = exactMcpLifecycleError(error);
       const publicError = publicMcpLifecycleError(exactError, "close", this.registryId);
       this.lifecycleFailures.close = {
@@ -5742,6 +5780,15 @@ export class PrefixedMcpServer implements MCPServer {
       };
       logPublicMcpLifecycleFailure(publicError);
       throw publicError;
+    } finally {
+      if (recordMetric) {
+        recordRuntimeMcpLifecycleMetric(
+          "close",
+          this.bestEffort ? "best_effort" : "strict",
+          outcome,
+          startedAt,
+        );
+      }
     }
   }
 

--- a/packages/runtime/src/metrics.ts
+++ b/packages/runtime/src/metrics.ts
@@ -11,6 +11,14 @@ export const MCP_TOOL_CALL_OUTCOMES = [
 
 export type McpToolCallOutcome = (typeof MCP_TOOL_CALL_OUTCOMES)[number];
 
+export const MCP_LIFECYCLE_PHASES = ["connect", "close"] as const;
+export const MCP_LIFECYCLE_POLICIES = ["strict", "best_effort"] as const;
+export const MCP_LIFECYCLE_OUTCOMES = ["completed", "failed"] as const;
+
+export type McpLifecyclePhase = (typeof MCP_LIFECYCLE_PHASES)[number];
+export type McpLifecyclePolicy = (typeof MCP_LIFECYCLE_POLICIES)[number];
+export type McpLifecycleOutcome = (typeof MCP_LIFECYCLE_OUTCOMES)[number];
+
 export type RuntimeMetricsHooks = {
   onModelCall?: (input: {
     provider: string;
@@ -45,6 +53,16 @@ export type RuntimeMetricsHooks = {
    * excludes server, tool, tenant, request, and error-content labels.
    */
   onMcpToolCall?: (input: { outcome: McpToolCallOutcome; durationSeconds: number }) => void;
+  /**
+   * One physical MCP connection lifecycle operation. Labels stay structural:
+   * no server, tenant, request, URL, or error-content dimensions are admitted.
+   */
+  onMcpLifecycle?: (input: {
+    phase: McpLifecyclePhase;
+    policy: McpLifecyclePolicy;
+    outcome: McpLifecycleOutcome;
+    durationSeconds: number;
+  }) => void;
   /**
    * One completed Connected Machine (selfhosted) control op — the out-of-band
    * telemetry twin of the in-band fault rendering. `code` is the typed wire-code

--- a/packages/runtime/src/model-provider-client.ts
+++ b/packages/runtime/src/model-provider-client.ts
@@ -6,7 +6,13 @@ import {
   xaiSubscriptionFetch,
 } from "@opengeni/xai-subscription";
 
-import type { McpToolCallOutcome, RuntimeMetricsHooks } from "./metrics";
+import type {
+  McpLifecycleOutcome,
+  McpLifecyclePhase,
+  McpLifecyclePolicy,
+  McpToolCallOutcome,
+  RuntimeMetricsHooks,
+} from "./metrics";
 import { WorkspaceGatewayUnavailableError } from "./model-provider-errors";
 import {
   azureModelRequestPolicy,
@@ -31,6 +37,20 @@ export function recordRuntimeMcpToolCallMetric(
     runtimeMetricsHooks?.onMcpToolCall?.({ outcome, durationSeconds });
   } catch {
     // Metrics emission must never affect an MCP call or rewrite its result.
+  }
+}
+
+export function recordRuntimeMcpLifecycleMetric(
+  phase: McpLifecyclePhase,
+  policy: McpLifecyclePolicy,
+  outcome: McpLifecycleOutcome,
+  startedAt: number,
+): void {
+  const durationSeconds = Math.max(0, (performance.now() - startedAt) / 1_000);
+  try {
+    runtimeMetricsHooks?.onMcpLifecycle?.({ phase, policy, outcome, durationSeconds });
+  } catch {
+    // Metrics emission must never affect MCP connection lifecycle behavior.
   }
 }
 

--- a/packages/runtime/src/model-provider.ts
+++ b/packages/runtime/src/model-provider.ts
@@ -23,6 +23,7 @@ export {
   buildOpenAIClientFromSettings,
   buildProviderClient,
   configureRuntimeMetricsHooks,
+  recordRuntimeMcpLifecycleMetric,
   recordRuntimeMcpToolCallMetric,
 } from "./model-provider-client";
 export {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -5452,8 +5452,12 @@ describe("runtime event normalization", () => {
   test("nested prefixed servers preserve one exact result marker and the innermost custom data", async () => {
     const observations: Array<Parameters<NonNullable<RuntimeMetricsHooks["onMcpToolCall"]>>[0]> =
       [];
+    const lifecycleObservations: Array<
+      Parameters<NonNullable<RuntimeMetricsHooks["onMcpLifecycle"]>>[0]
+    > = [];
     configureRuntimeMetricsHooks({
       onMcpToolCall: (input) => observations.push(input),
+      onMcpLifecycle: (input) => lifecycleObservations.push(input),
     });
     const fullResult = {
       content: [{ type: "text" as const, text: "nested model-visible content" }],
@@ -5489,7 +5493,10 @@ describe("runtime event normalization", () => {
       async invalidateToolsCache() {},
     };
     const inner = new PrefixedMcpServer(base, "inner");
-    const outer = new PrefixedMcpServer(inner, "outer");
+    // The outer registry entry owns effective connection policy. Nested
+    // wrappers are a transport implementation detail and must not double-count
+    // or report their inner policy as the physical operation's policy.
+    const outer = new PrefixedMcpServer(inner, "outer", undefined, true);
     const settings = testSettings({
       sandboxBackend: "none",
       webSearchEnabled: false,
@@ -5506,7 +5513,10 @@ describe("runtime event normalization", () => {
       mcpServers: [outer],
     });
 
+    let connected = false;
     try {
+      await outer.connect();
+      connected = true;
       const result = await runAgentStream(agent, "Inspect it", settings);
       const streamed: any[] = [];
       for await (const event of result.toStream()) streamed.push(event);
@@ -5522,7 +5532,16 @@ describe("runtime event normalization", () => {
         [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { baseReceipt: "base-1" },
       });
       expect(observations.map(({ outcome }) => outcome)).toEqual(["success"]);
+      await outer.close();
+      connected = false;
+      expect(
+        lifecycleObservations.map(({ phase, policy, outcome }) => ({ phase, policy, outcome })),
+      ).toEqual([
+        { phase: "connect", policy: "best_effort", outcome: "completed" },
+        { phase: "close", policy: "best_effort", outcome: "completed" },
+      ]);
     } finally {
+      if (connected) await outer.close();
       configureRuntimeMetricsHooks(null);
     }
   });
@@ -8568,7 +8587,13 @@ describe("runtime event normalization", () => {
       rpcMethod: "initialize",
       causeChainComplete: true,
     });
-    const makeFacade = () =>
+    const lifecycleObservations: Array<
+      Parameters<NonNullable<RuntimeMetricsHooks["onMcpLifecycle"]>>[0]
+    > = [];
+    configureRuntimeMetricsHooks({
+      onMcpLifecycle: (input) => lifecycleObservations.push(input),
+    });
+    const makeFacade = (bestEffort = false) =>
       new PrefixedMcpServer(
         {
           name: `inner-${registryId}`,
@@ -8586,6 +8611,8 @@ describe("runtime event normalization", () => {
           async invalidateToolsCache() {},
         } as MCPServer,
         registryId,
+        undefined,
+        bestEffort,
       );
     const warnings: unknown[][] = [];
     const errors: unknown[][] = [];
@@ -8594,7 +8621,7 @@ describe("runtime event normalization", () => {
     console.warn = (...args: unknown[]) => warnings.push(args);
     console.error = (...args: unknown[]) => errors.push(args);
     try {
-      const bestEffortFacade = makeFacade();
+      const bestEffortFacade = makeFacade(true);
       const bestEffort = await connectMcpServersInBatches([bestEffortFacade], {
         strict: false,
       });
@@ -8637,7 +8664,16 @@ describe("runtime event normalization", () => {
       expect(exactSourceError.message).toContain(sentinel);
       expect(exactSourceError.responseBody).toEqual({ sentinel });
       expect(exactSourceError.cause).toEqual({ exact: sentinel });
+      expect(
+        lifecycleObservations.map(({ phase, policy, outcome }) => ({ phase, policy, outcome })),
+      ).toEqual([
+        { phase: "connect", policy: "best_effort", outcome: "failed" },
+        { phase: "close", policy: "best_effort", outcome: "completed" },
+        { phase: "connect", policy: "strict", outcome: "failed" },
+        { phase: "close", policy: "strict", outcome: "completed" },
+      ]);
     } finally {
+      configureRuntimeMetricsHooks(null);
       console.warn = originalWarn;
       console.error = originalError;
     }

--- a/scripts/deployment-observability.test.ts
+++ b/scripts/deployment-observability.test.ts
@@ -29,7 +29,7 @@ describe("observability deployment plan", () => {
     });
 
     expect(plan.chartPath).toBe("deploy/observability");
-    expect(plan.chartVersion).toBe("0.1.6");
+    expect(plan.chartVersion).toBe("0.1.7");
     expect(plan.kubePrometheusStackVersion).toBe("87.16.1");
     expect(plan.opensandbox).toBe(true);
     expect(plan.valuesFiles).toEqual([

--- a/scripts/deployment-observability.ts
+++ b/scripts/deployment-observability.ts
@@ -19,7 +19,7 @@ export interface ObservabilityStackPlan {
   environment: string;
   opensandbox: boolean;
   chartPath: "deploy/observability";
-  chartVersion: "0.1.6";
+  chartVersion: "0.1.7";
   kubePrometheusStackVersion: "87.16.1";
   valuesFiles: string[];
   applicationValuesFile: "deploy/observability/opengeni.values.example.yaml";
@@ -112,7 +112,7 @@ export function observabilityStackPlanFor(
     environment,
     opensandbox,
     chartPath: "deploy/observability",
-    chartVersion: "0.1.6",
+    chartVersion: "0.1.7",
     kubePrometheusStackVersion: "87.16.1",
     valuesFiles,
     applicationValuesFile: "deploy/observability/opengeni.values.example.yaml",


### PR DESCRIPTION
## Summary

- bounds session-control settlement reads to requested session subtrees, using the existing workspace/parent index instead of scanning the full interruption history
- stops redundant workspace refetches for session-scoped pause and resume events
- adds low-cardinality MCP connect and close telemetry without server, tenant, request, URL, or error-content labels
- adds deployment-scoped alerts for turn, recovery, model, MCP, API, core-read, and durable event failures
- adds the OpenGeni Runtime Failures Grafana dashboard and bumps the observability wrapper to 0.1.7

## Why

Staging sampling showed settlementAttemptCounts dominating active database work. The previous plan made a one-session read proportional to the whole workspace interruption history. Staging also lacked the canonical Grafana dashboard bundle that production uses, and neither environment had a consolidated runtime failure board or MCP lifecycle signals.

## Validation

- 394 focused tests passed
- all 31 TypeScript projects passed type checking
- formatting, lint, changeset, JSON, and Helm rendering checks passed
- revised PromQL parsed and evaluated successfully against staging and production Prometheus
- alert selectors are exact deployment scoped and exclude high-cardinality identities
- MCP cancellation remains visible in Grafana but is excluded from the operational failure page

## Rollout

Merge and deploy this change to staging first. The companion private-ops PR provisions and verifies the complete dashboard and alert bundle from the exact deployed source revision. No live cluster state was changed from this branch.

## Summary by Sourcery

Improve staging session-control efficiency and consolidate deployment-scoped runtime failure observability.

New Features:
- Add low-cardinality MCP connection and closure telemetry covering lifecycle outcomes and latency.
- Provide a deployment-scoped Runtime Failures Grafana dashboard and alerts for turn, recovery, model, MCP, API, core-read, and durable event failures.

Bug Fixes:
- Limit session-control settlement projections to the requested sessions and their descendants instead of scanning unrelated workspace interruption history.
- Avoid refetching workspace data for session-scoped pause and resume control events.

Enhancements:
- Upgrade the observability chart and wrapper version to 0.1.7.

Deployment:
- Extend the observability deployment plan with the 0.1.7 dashboard and alert bundle.

Documentation:
- Document the new Runtime Failures dashboard and its MCP lifecycle and tool-call metrics.

Tests:
- Add coverage for subtree-scoped settlement projections, session control refresh behavior, MCP lifecycle metrics, runtime failure alerts, and dashboard scoping.