### PR TITLE
fix(db): detach variable sets before workspace deletion

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -518,6 +518,7 @@ import {
   setSubjectRlsContext,
   withAccountRls,
   withRlsContext,
+  withRestoredSessionActivityRlsContext,
   withSessionActivityRlsContext,
   withSessionActivitySavepoint,
   withWorkspaceRls,
@@ -3116,6 +3117,30 @@ export async function deleteWorkspaceIfQuiescent(
               ${input.workspaceId}::uuid
             )
           `);
+          // Variable-set attachment guards intentionally prevent deleting a set
+          // while any session still selects it. A workspace cascade owns both
+          // sides, so detach those selections through the activity gate before
+          // deleting the parent. Finalize the gate inside this transaction: the
+          // workspace activity counter disappears with the parent cascade.
+          await withRestoredSessionActivityRlsContext(
+            tx,
+            { accountId: input.accountId, workspaceId: input.workspaceId },
+            async (activityDb) => {
+              await activityDb
+                .update(schema.sessions)
+                .set({
+                  variableSetIds: [],
+                  variableSetId: null,
+                  updatedAt: new Date(),
+                })
+                .where(
+                  and(
+                    eq(schema.sessions.workspaceId, input.workspaceId),
+                    isNotNull(schema.sessions.variableSetId),
+                  ),
+                );
+            },
+          );
           const deleted = await tx
             .delete(schema.workspaces)
             .where(

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -15,6 +15,7 @@ import {
   confirmDrainCold,
   createDb,
   createSession,
+  createVariableSet,
   deleteWorkspaceIfQuiescent,
   failSandboxRematerialization,
   failWarmingToCold,
@@ -583,6 +584,29 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
       releaseLock();
       await blocker;
     }
+
+    // A workspace owns both the selected variable set and the selecting
+    // session. Deletion must detach that relationship through the session
+    // activity gate before the parent cascade reaches workspace_variable_sets.
+    const selectedVariableSet = await createVariableSet(db, {
+      accountId,
+      workspaceId,
+      name: "workspace deletion fixture",
+    });
+    await withWorkspaceSessionActivityRls(db, workspaceId, async (tx) => {
+      await tx.execute(sql`
+        update sessions
+        set variable_set_ids = ${JSON.stringify([selectedVariableSet.id])}::jsonb,
+            variable_set_id = ${selectedVariableSet.id}::uuid,
+            updated_at = now()
+        where workspace_id = ${workspaceId} and id = ${recoveringSessionId}
+      `);
+    });
+    const [attachmentBeforeDelete] = await admin<{ count: number }[]>`
+      select count(*)::int as count
+      from session_variable_set_attachments
+      where workspace_id = ${workspaceId}`;
+    expect(attachmentBeforeDelete?.count).toBe(1);
 
     const deleted = await deleteWorkspaceIfQuiescent(db, { accountId, workspaceId });
     expect(deleted.status).toBe("deleted");


### PR DESCRIPTION
## Summary
- detach session variable-set selections through the activity gate before workspace cascade deletion
- preserve atomic quiescence checks and cleanup ordering
- add regression coverage for deleting a workspace whose session selects a workspace variable set

## Verification
- `bun test packages/db/test/sandbox-leases.test.ts` (68 pass)
- `bun run typecheck`
- `bun run format:check -- packages/db/src/index.ts packages/db/test/sandbox-leases.test.ts`

## Summary by Sourcery

Allow quiescent workspace deletion to safely clean up session variable-set attachments before removing the workspace.

Bug Fixes:
- Ensure workspace deletion detaches session variable-set selections before cascading removal of the workspace and its variable sets.

Enhancements:
- Preserve transactional activity-gate handling during workspace cleanup.

Tests:
- Add regression coverage for deleting a workspace with a session-selected workspace variable set.