### PR TITLE
fix(web): keep core UI usable on private HTTP origins

### DIFF
--- a/apps/web/src/lib/crypto-random-uuid.test.ts
+++ b/apps/web/src/lib/crypto-random-uuid.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { createRandomUuid, installRandomUuidCompatibility } from "./crypto-random-uuid";
+
+const deterministicCrypto = {
+  getRandomValues<T extends ArrayBufferView | null>(array: T): T {
+    if (array instanceof Uint8Array) {
+      array.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+    return array;
+  },
+};
+
+describe("crypto.randomUUID compatibility", () => {
+  test("creates an RFC 4122 version 4 UUID with secure random bytes", () => {
+    expect(createRandomUuid(deterministicCrypto)).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+  });
+
+  test("installs an idempotent fallback when randomUUID is unavailable", () => {
+    const cryptoSource: typeof deterministicCrypto & { randomUUID?: Crypto["randomUUID"] } = {
+      ...deterministicCrypto,
+    };
+    installRandomUuidCompatibility(cryptoSource);
+    const installed = cryptoSource.randomUUID;
+    installRandomUuidCompatibility(cryptoSource);
+
+    expect(cryptoSource.randomUUID).toBe(installed);
+    expect(cryptoSource.randomUUID!()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+  });
+
+  test("preserves a browser-provided randomUUID implementation", () => {
+    const nativeRandomUuid = () =>
+      "native-uuid" as `${string}-${string}-${string}-${string}-${string}`;
+    const cryptoSource = { ...deterministicCrypto, randomUUID: nativeRandomUuid };
+    installRandomUuidCompatibility(cryptoSource);
+
+    expect(cryptoSource.randomUUID).toBe(nativeRandomUuid);
+  });
+});

--- a/apps/web/src/lib/crypto-random-uuid.ts
+++ b/apps/web/src/lib/crypto-random-uuid.ts
@@ -1,0 +1,36 @@
+type CryptoUuidSource = Pick<Crypto, "getRandomValues"> & {
+  randomUUID?: Crypto["randomUUID"];
+};
+
+/**
+ * Keep the core app usable on private HTTP origins where browsers expose
+ * getRandomValues but withhold the secure-context-only randomUUID helper.
+ * This does not make other secure-context-only features available.
+ */
+export function createRandomUuid(cryptoSource: Pick<Crypto, "getRandomValues">): string {
+  const bytes = cryptoSource.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+}
+
+export function installRandomUuidCompatibility(cryptoSource: CryptoUuidSource): void {
+  if (typeof cryptoSource.randomUUID === "function") return;
+
+  Object.defineProperty(cryptoSource, "randomUUID", {
+    configurable: true,
+    value: () => createRandomUuid(cryptoSource),
+  });
+}
+
+if (typeof globalThis.crypto !== "undefined") {
+  installRandomUuidCompatibility(globalThis.crypto);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "./lib/crypto-random-uuid";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";

--- a/apps/web/src/routes/machines-removal.test.tsx
+++ b/apps/web/src/routes/machines-removal.test.tsx
@@ -4,7 +4,11 @@ import type { RemoveEnrollmentResponse } from "@opengeni/sdk";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MachineRemovalBlockNotice, moveDependentSessionsToDefault } from "./machines";
+import {
+  MachineRemovalBlockNotice,
+  copyToClipboard,
+  moveDependentSessionsToDefault,
+} from "./machines";
 
 const blocked: RemoveEnrollmentResponse = {
   revoked: false,
@@ -128,5 +132,31 @@ describe("connected machine removal conflict", () => {
 
     await act(async () => root.unmount());
     container.remove();
+  });
+});
+
+describe("connected machine command copy", () => {
+  test("falls back when the Clipboard API is unavailable on private HTTP", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const copied: string[] = [];
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: (command: string) => {
+        if (command === "copy") {
+          copied.push(document.querySelector("textarea")?.value ?? "");
+          return true;
+        }
+        return false;
+      },
+    });
+
+    await expect(copyToClipboard("curl https://example.test/install", "Copied")).resolves.toBe(
+      true,
+    );
+    expect(copied).toEqual(["curl https://example.test/install"]);
+    expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -16,6 +16,7 @@ import {
   type MetricSample,
   type MetricWindow,
 } from "@opengeni/react/machines";
+import { copyTextToClipboard } from "@opengeni/react/clipboard";
 import { usePageLiveActivity } from "@opengeni/react";
 import {
   ArrowLeftIcon,
@@ -52,17 +53,15 @@ import {
 import { useAppContext } from "@/context";
 import type { MachineView } from "@opengeni/react/machines";
 
-/** Copy to the clipboard and toast the outcome — clipboard access can be denied
- *  (permissions, insecure context), so failures surface instead of vanishing. */
-async function copyToClipboard(text: string, successMessage: string) {
-  try {
-    await navigator.clipboard.writeText(text);
+/** Copy to the clipboard and toast the outcome. The shared helper falls back to
+ *  a temporary textarea when private HTTP origins cannot use navigator.clipboard. */
+export async function copyToClipboard(text: string, successMessage: string) {
+  if (await copyTextToClipboard(text)) {
     toast.success(successMessage);
     return true;
-  } catch {
-    toast.error("Couldn't copy to the clipboard", { description: "Copy it manually instead." });
-    return false;
   }
+  toast.error("Couldn't copy to the clipboard", { description: "Copy it manually instead." });
+  return false;
 }
 
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {

--- a/apps/web/test/crypto-random-uuid-fixture.ts
+++ b/apps/web/test/crypto-random-uuid-fixture.ts
@@ -1,0 +1,7 @@
+import "../src/lib/crypto-random-uuid";
+
+const uuid = globalThis.crypto.randomUUID();
+document.body.dataset.secureContext = String(globalThis.isSecureContext);
+document.body.dataset.randomUuidType = typeof globalThis.crypto.randomUUID;
+document.body.dataset.uuid = uuid;
+document.body.textContent = uuid;

--- a/apps/web/test/crypto-random-uuid.html
+++ b/apps/web/test/crypto-random-uuid.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HTTP UUID compatibility fixture</title>
+  </head>
+  <body>
+    <script type="module" src="/test/crypto-random-uuid-fixture.ts"></script>
+  </body>
+</html>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,6 +153,12 @@ API uses it when serving the installer, so an enrolled machine downloads the
 agent version baked into this deployment and connects back to that same external
 HTTPS origin rather than falling back to either public default.
 
+HTTPS/WSS is the supported private-edge posture. The web bootstrap retains a
+cryptographically random UUID compatibility path so a private HTTP origin can
+render the core workspace UI and useful diagnostics instead of crashing, but
+that fallback does not make HTTP feature-complete: browsers still withhold APIs
+used by voice, clipboard, and encrypted browser-side artifact operations.
+
 For a tailnet-only deployment, `OPENGENI_AUTH_REQUIRED=false` and
 `OPENGENI_PRODUCT_ACCESS_MODE=local` mean there is no shared deployment access
 key; tailnet membership is the outer access boundary. Internal database, NATS,

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -34,6 +34,7 @@ const ORGANIZATION_WORKSPACE_ADMINISTRATION_E2E =
   "test/e2e/organization-workspace-administration.browser.e2e.ts";
 const ORGANIZATION_RECOVERY_E2E = "test/e2e/organization-recovery.browser.e2e.ts";
 const PERSONAL_GITHUB_IDENTITY_E2E = "test/e2e/personal-github-identity.browser.e2e.ts";
+const CRYPTO_RANDOM_UUID_E2E = "test/e2e/crypto-random-uuid.browser.e2e.ts";
 const WORKSPACE_SWITCHER_TRIGGER_E2E = "test/e2e/workspace-switcher-trigger.browser.e2e.ts";
 const SESSION_RAIL_ROW_METADATA_E2E = "test/e2e/session-rail-row-metadata.browser.e2e.ts";
 const TIMELINE_SCROLL_BROWSER_E2E = "test/e2e/timeline-scroll.browser.e2e.ts";
@@ -94,6 +95,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/code-editor.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",
+      CRYPTO_RANDOM_UUID_E2E,
       ORGANIZATION_RECOVERY_E2E,
       ORGANIZATION_WORKSPACE_ADMINISTRATION_E2E,
       PERSONAL_GITHUB_IDENTITY_E2E,
@@ -319,6 +321,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/code-editor.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",
+      CRYPTO_RANDOM_UUID_E2E,
       ORGANIZATION_RECOVERY_E2E,
       ORGANIZATION_WORKSPACE_ADMINISTRATION_E2E,
       PERSONAL_GITHUB_IDENTITY_E2E,

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -188,6 +188,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
     "@opengeni/sdk",
     "@opengeni/testing",
   ],
+  "test/e2e/crypto-random-uuid.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/organization-workspace-administration.browser.e2e.ts": [
     "opengeni-web",
     "@opengeni/testing",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -11,6 +11,7 @@ const testFiles =
         "./test/e2e/editable-artifacts.browser.e2e.ts",
         "./test/e2e/browser.e2e.ts",
         "./test/e2e/connected-machine-removal.browser.e2e.ts",
+        "./test/e2e/crypto-random-uuid.browser.e2e.ts",
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/organization-workspace-administration.browser.e2e.ts",
         "./test/e2e/organization-recovery.browser.e2e.ts",

--- a/test/e2e/crypto-random-uuid.browser.e2e.ts
+++ b/test/e2e/crypto-random-uuid.browser.e2e.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Page } from "playwright";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+
+describe("private HTTP origin UUID compatibility", () => {
+  let browser: Browser;
+  let page: Page;
+  let web: StartedProcess;
+  let fixtureUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    const loopbackBaseUrl = `http://127.0.0.1:${port}`;
+    fixtureUrl = `http://insecure.opengeni.test:${port}/test/crypto-random-uuid.html`;
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        ".",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${repoRoot}/apps/web`,
+        env: { OPENGENI_WEB_ALLOWED_HOSTS: "insecure.opengeni.test" },
+        ready: async () =>
+          (
+            await fetch(`${loopbackBaseUrl}/test/crypto-random-uuid.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+    browser = await chromium.launch({
+      headless: true,
+      args: ["--host-resolver-rules=MAP insecure.opengeni.test 127.0.0.1"],
+    });
+    page = await browser.newPage();
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  }, 30_000);
+
+  test("boots before application code on a non-trustworthy HTTP hostname", async () => {
+    await page.goto(fixtureUrl, { waitUntil: "networkidle" });
+
+    const body = page.locator("body");
+    expect(await body.getAttribute("data-secure-context")).toBe("false");
+    expect(await body.getAttribute("data-random-uuid-type")).toBe("function");
+    expect(await body.getAttribute("data-uuid")).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- install an RFC 4122 v4 `crypto.randomUUID` compatibility layer before the web application graph loads
- preserve the browser-native implementation and use `crypto.getRandomValues` only when `randomUUID` is absent
- add a real Chromium regression on a non-trustworthy HTTP hostname
- document that HTTPS/WSS remains required for feature-complete deployments

## Reproduction

A deployed OpenGeni web bundle loaded over `http://homeserver:30079` received the app and `/v1/config/client` with HTTP 200, then stopped before workspace discovery with:

```
Failed to load workspace access
TypeError: crypto.randomUUID is not a function
```

The same production bundle loaded successfully through the Local workspace and session composer when the compatibility layer was installed. Chrome still withholds secure-context-only APIs such as `crypto.subtle`, media devices, and clipboard, so HTTPS remains the supported private edge.

## Verification

- `bun test apps/web/src/lib/crypto-random-uuid.test.ts`
- `bun scripts/run-browser-e2e.ts ./test/e2e/crypto-random-uuid.browser.e2e.ts`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`
- `bun run check:docs-refs`
- targeted `oxlint --deny-warnings`

Linear: OPE-400

## Summary by Sourcery

Keep the core web UI usable on private HTTP origins while preserving native browser APIs and documenting the remaining HTTPS requirements.

New Features:
- Add UUID generation compatibility for private HTTP origins where the browser lacks crypto.randomUUID.
- Add clipboard fallback support for environments without the Clipboard API.

Bug Fixes:
- Prevent the web application from failing during startup on non-secure HTTP origins.
- Allow connected-machine command copying to work when navigator.clipboard is unavailable.

CI:
- Add Chromium coverage for UUID compatibility on a non-trustworthy HTTP hostname and include it in browser test impact tracking.

Documentation:
- Document HTTPS/WSS as required for feature-complete private-edge deployments while noting limited HTTP compatibility.

Tests:
- Add unit coverage for UUID formatting, fallback installation, and preservation of native implementations.
- Add browser regression coverage for UUID initialization on private HTTP origins.
- Add coverage for clipboard fallback behavior.