### PR TITLE
fix(web): release stale actor transports on document teardown

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -140,8 +140,8 @@ describe("web API auth helpers", () => {
       await expect(read).resolves.toMatchObject({ done: false });
       const lateRead = reader.read();
       configureManagedActorEpoch("13");
-      await Promise.resolve();
       expect(observed.signal?.aborted).toBe(true);
+      await Promise.resolve();
       expect(observed.cancelledWith).toMatchObject({ name: "AbortError" });
       expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
       await expect(lateRead).rejects.toMatchObject({ name: "AbortError" });
@@ -176,9 +176,10 @@ describe("web API auth helpers", () => {
       configureManagedActorEpoch("consumer-close");
       const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
       const reason = new DOMException("consumer finished", "AbortError");
-      await response.body!.cancel(reason);
-      await Promise.resolve();
+      const cancel = response.body!.cancel(reason);
       expect(observed.signal?.aborted).toBe(true);
+      await cancel;
+      await Promise.resolve();
       expect(observed.signal?.reason).toBe(reason);
       expect(observed.cancelledWith).toBe(reason);
       expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
@@ -210,8 +211,8 @@ describe("web API auth helpers", () => {
       const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
       const read = response.body!.getReader().read();
       handleManagedActorPageHide(false);
-      await Promise.resolve();
       expect(observed.signal?.aborted).toBe(true);
+      await Promise.resolve();
       await expect(read).rejects.toMatchObject({ name: "AbortError" });
       // The old response must not retain a native body controller that can
       // continue publishing after document teardown.

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -6,6 +6,7 @@ import {
   configureManagedActorEpoch,
   configureClientAuth,
   createOpenGeniClient,
+  handleManagedActorPageHide,
   managedActorMutationBusySnapshot,
   managedActorFetch,
   redeemCodexResetCredit,
@@ -182,6 +183,72 @@ describe("web API auth helpers", () => {
       expect(observed.cancelledWith).toBe(reason);
       expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
       expect(source.locked).toBe(false);
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("aborts live native transports before a document is replaced", async () => {
+    const originalFetch = globalThis.fetch;
+    const observed: { signal?: AbortSignal | null } = {};
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      observed.signal = init?.signal ?? null;
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+        },
+      });
+      return new Response(source, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("document-old");
+      const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
+      const read = response.body!.getReader().read();
+      handleManagedActorPageHide(false);
+      await Promise.resolve();
+      expect(observed.signal?.aborted).toBe(true);
+      await expect(read).rejects.toMatchObject({ name: "AbortError" });
+      // The old response must not retain a native body controller that can
+      // continue publishing after document teardown.
+      expect(() => bodyController.enqueue(new Uint8Array([1]))).toThrow();
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("keeps live transports intact when the document enters the back-forward cache", async () => {
+    const originalFetch = globalThis.fetch;
+    const observed: { signal?: AbortSignal | null } = {};
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      observed.signal = init?.signal ?? null;
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+        },
+      });
+      return new Response(source, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("document-persisted");
+      const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
+      const reader = response.body!.getReader();
+      const read = reader.read();
+      handleManagedActorPageHide(true);
+      await Promise.resolve();
+      expect(observed.signal?.aborted).toBe(false);
+      bodyController.enqueue(new Uint8Array([1]));
+      await expect(read).resolves.toEqual({ done: false, value: new Uint8Array([1]) });
+      await reader.cancel();
     } finally {
       configureManagedActorEpoch(null);
       globalThis.fetch = originalFetch;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -250,21 +250,21 @@ export async function managedActorFetch(
     // so only its wrapper remains actor-bound. A live body must also abort its
     // native fetch after admission: cancelling only the source reader can leave
     // Chromium's HTTP/1 request open, eventually exhausting the per-origin
-    // connection pool across account switches and tabs. Publish the wrapper
-    // abort first so downstream consumption still fails closed with the same
-    // AbortError, then release the native transport in the next microtask.
+    // connection pool across account switches and tabs. Abort the native fetch
+    // synchronously so a pagehide cannot destroy the document before the
+    // transport is released. The native reader rejection is still delivered in
+    // a later microtask, after the wrapper records its fail-closed AbortError.
     const actorBodyController = new AbortController();
     const abortNativeTransport = finiteJsonResponse
       ? undefined
-      : (reason: unknown) => queueMicrotask(() => controller.abort(reason));
+      : (reason: unknown) => controller.abort(reason);
     abortTarget = finiteJsonResponse
       ? (reason) => actorBodyController.abort(reason)
       : (reason) => {
-          // Queue the native abort before publishing the wrapper abort. The
+          // Abort the native fetch before publishing the wrapper abort. The
           // wrapper's abort handler queues reader cancellation, so Chromium
           // sees the fetch signal first and cannot detach an SSE reader while
-          // leaving its HTTP/1 transport alive. Both remain deferred until
-          // after the downstream AbortError state is synchronously recorded.
+          // leaving its HTTP/1 transport alive.
           abortNativeTransport?.(reason);
           actorBodyController.abort(reason);
         };
@@ -387,7 +387,7 @@ function managedActorTrackedResponse(
       async cancel(reason) {
         const ownsSettlement = settle();
         if (ownsSettlement) abortNativeTransport?.(reason);
-        // Let a queued native fetch abort run before detaching its reader. In
+        // Let the native fetch abort propagate before detaching its reader. In
         // Chromium the inverse order can leave the HTTP/1 request open even
         // though the JavaScript ReadableStream has been cancelled.
         if (ownsSettlement && abortNativeTransport) await Promise.resolve();

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -35,6 +35,27 @@ let managedActorMutationCount = 0;
 const MANAGED_ACTOR_EPOCH_HEADER = "x-opengeni-actor-epoch";
 const MANAGED_ACTOR_STATE_HEADER = "x-opengeni-actor-state";
 
+function abortManagedActorRequests(reason: DOMException): void {
+  for (const managedRequest of [...managedActorRequests]) {
+    managedRequest.abortActor(reason);
+  }
+}
+
+export function handleManagedActorPageHide(persisted: boolean): void {
+  if (persisted) return;
+  abortManagedActorRequests(new DOMException("The document was replaced", "AbortError"));
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", (event) => {
+    // A persisted page can resume from the back/forward cache with its effects
+    // intact. A document that is actually being replaced cannot run React
+    // cleanup reliably after teardown begins, so synchronously release every
+    // actor-owned native transport before the old realm disappears.
+    handleManagedActorPageHide(event.persisted);
+  });
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -105,10 +126,7 @@ export function configureManagedActorEpoch(epoch: string | null): void {
   if (managedActorEpoch === epoch) return;
   managedActorEpoch = epoch;
   managedActorRevision += 1;
-  const reason = new DOMException("The browser account changed", "AbortError");
-  for (const managedRequest of managedActorRequests) {
-    managedRequest.abortActor(reason);
-  }
+  abortManagedActorRequests(new DOMException("The browser account changed", "AbortError"));
 }
 
 export function currentManagedActorEpoch(): string | null {

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1058,6 +1058,7 @@ async function expectAndConsumeActorTransitionResponse(
     phase: string;
     status: number;
     statusLabel: string;
+    allowedConsoleErrors?: readonly string[];
     workspaceId?: string;
     timing?: { kind: "direct-race-fence"; settledAt: number };
   },
@@ -1119,7 +1120,7 @@ async function expectAndConsumeActorTransitionResponse(
   await expectAndConsumeConsoleErrors(
     page,
     problems,
-    exactConsoleErrors,
+    [...exactConsoleErrors, ...(input.allowedConsoleErrors ?? [])],
     requestedEngine === "firefox" ? [] : exactConsoleErrors,
   );
   problems.actorTransitionResponses.splice(0);
@@ -2792,6 +2793,12 @@ describe("provider-neutral browser account acceptance", () => {
             kind: "direct-race-fence",
             settledAt: racedSelectionSettledAt,
           },
+          allowedConsoleErrors:
+            engine === "chromium"
+              ? [
+                  `[cross-tab-select-race] Failed to load resource: net::ERR_CONNECTION_RESET @ /v1/workspaces/${alpha.workspaceId}/live-events/stream`,
+                ]
+              : [],
         });
       }
       const racedSelectionAcceptance = actorMutationAcceptances

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -228,6 +228,7 @@ const DOCUMENT_WORKSPACE_CATALOG_CANCELLATION_PHASES = new Set([
 ]);
 
 const DOCUMENT_BOOTSTRAP_CANCELLATION_DISPATCH_PHASES = new Map<string, ReadonlySet<string>>([
+  ["late-old-epoch-primary-settled-before-old-release", new Set(["late-old-epoch-alpha-to-beta"])],
   ["slot-revocation-reauthentication", new Set(["cross-slot-deep-link"])],
 ]);
 
@@ -2317,6 +2318,48 @@ describe("provider-neutral browser account acceptance", () => {
         url: `${publicOrigin}/v1/auth/get-session`,
       }),
     ).toBeNull();
+    const lateOldActorBootstrapRead = {
+      ...crossTabBootstrapRead,
+      dispatchPhase: "late-old-epoch-alpha-to-beta",
+      responsePhase: "late-old-epoch-primary-settled-before-old-release",
+    };
+    expect(requestFailureProblem(lateOldActorBootstrapRead)).toBeNull();
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        url: `${publicOrigin}/v1/auth/get-session`,
+      }),
+    ).toBeNull();
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        dispatchPhase: "late-old-epoch-setup-beta-to-alpha",
+      }),
+    ).toContain("/v1/config/client");
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        responsePhase: "responsive-evidence-bootstrap",
+      }),
+    ).toContain("/v1/config/client");
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        failure: "NS_ERROR_NET_RESET",
+      }),
+    ).toContain("/v1/config/client");
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        method: "POST",
+      }),
+    ).toContain("POST");
+    expect(
+      requestFailureProblem({
+        ...lateOldActorBootstrapRead,
+        url: `${publicOrigin}/v1/config/other`,
+      }),
+    ).toContain("/v1/config/other");
     expect(
       requestFailureProblem({
         ...crossTabBootstrapRead,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -2320,6 +2320,7 @@ describe("provider-neutral browser account acceptance", () => {
     ).toBeNull();
     const lateOldActorBootstrapRead = {
       ...crossTabBootstrapRead,
+      actorEpoch: "old-actor-epoch",
       dispatchPhase: "late-old-epoch-alpha-to-beta",
       responsePhase: "late-old-epoch-primary-settled-before-old-release",
     };


### PR DESCRIPTION
## Summary
- release every actor-owned native transport before a non-persisted browser document is replaced, preventing stale SSE sockets from exhausting the per-origin connection pool
- preserve live transports when the page enters the back/forward cache
- permit only the exact Chromium connection-reset console signal caused by the intentional cross-tab document replacement
- permit only the exact stale-tab config/session bootstrap cancellation phase pair, with positive and fail-closed negative coverage

## Verification
- 5 consecutive full WebKit account journeys with required real PostgreSQL/RLS
- 3 full Chromium account journeys with required real PostgreSQL/RLS
- full Firefox account journey with required real PostgreSQL/RLS
- web API suite: 24 tests / 90 assertions
- focused strict browser ledger: 82 assertions
- repository typecheck: 31 projects
- formatting, lint, and diff checks

## Summary by Sourcery

Release stale actor transports during document replacement while preserving back/forward-cache sessions and tightening race-condition error handling.

Bug Fixes:
- Release actor-owned native transports when non-persisted documents are hidden or replaced, preventing stale live connections from exhausting browser connection pools.
- Preserve actor transports for pages entering the back/forward cache.
- Constrain accepted browser console errors and stale-tab bootstrap cancellations to the exact expected race conditions.

Enhancements:
- Centralize actor request abortion and make native transport cancellation synchronous while retaining fail-closed response behavior.

Tests:
- Add coverage for transport release during document teardown and transport preservation in the back/forward cache.
- Add positive and negative validation for narrowly scoped stale-tab cancellation and Chromium connection-reset signals.