### PR TITLE
fix(web): synchronously release rotated actor readers

### DIFF
--- a/.changeset/clean-revoked-streams.md
+++ b/.changeset/clean-revoked-streams.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Close authorization-revoked SSE responses cleanly so HTTP/1 clients release stale connections without receiving any post-revocation frame.

--- a/apps/api/src/http/sse.ts
+++ b/apps/api/src/http/sse.ts
@@ -463,7 +463,13 @@ export async function sseSessionStream(
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
+      // A clean authorization close must also retire the HTTP/1 transport.
+      // Reusing that socket can leave Chromium accounting the ended SSE as an
+      // active per-origin connection while a replacement document is already
+      // dispatching finite reads. HTTP/2 front doors strip this hop-by-hop
+      // header; direct Bun/self-hosted HTTP/1 clients receive an unambiguous
+      // connection end after the stream's terminal chunk.
+      Connection: "close",
       ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
     },
   });
@@ -637,7 +643,7 @@ export async function sseWorkspaceControlStream(
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
+      Connection: "close",
       ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
     },
   });
@@ -763,7 +769,7 @@ export async function sseWorkspaceLiveStream(
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
+      Connection: "close",
       ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
     },
   });
@@ -850,7 +856,7 @@ export async function sseWorkspaceInteractionRevisionStream(
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
+      Connection: "close",
       ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
     },
   });

--- a/apps/api/src/http/sse.ts
+++ b/apps/api/src/http/sse.ts
@@ -309,14 +309,14 @@ export async function sseSessionStream(
   const fail = (error: unknown) => {
     channel.fail(retryableSseFailure("session event stream delivery failed", error));
   };
-  stopReauthorization = startSseReauthorization(options, channel.stopped, fail);
+  stopReauthorization = startSseReauthorization(options, channel.stopped, channel.close);
   let writeTail = Promise.resolve();
   const writeFrame = (frame: string): Promise<void> => {
     const write = writeTail.then(async () => {
       // A periodic check closes an idle stream, while this exact pre-delivery
       // check prevents a buffered/replayed event from crossing a revocation
       // boundary merely because its timer has not fired yet.
-      await options.reauthorize?.();
+      await reauthorizeSseOrClose(options, channel);
       if (!(await channel.write(frame))) throw new SseStreamStoppedError();
     });
     writeTail = write.catch(() => {});
@@ -540,11 +540,11 @@ export async function sseWorkspaceControlStream(
   const fail = (error: unknown) => {
     channel.fail(retryableSseFailure("workspace control stream delivery failed", error));
   };
-  stopReauthorization = startSseReauthorization(options, channel.stopped, fail);
+  stopReauthorization = startSseReauthorization(options, channel.stopped, channel.close);
   let writeTail = Promise.resolve();
   const writeFrame = (frame: string): Promise<void> => {
     const write = writeTail.then(async () => {
-      await options.reauthorize?.();
+      await reauthorizeSseOrClose(options, channel);
       if (!(await channel.write(frame))) throw new SseStreamStoppedError();
     });
     writeTail = write.catch(() => {});
@@ -682,9 +682,7 @@ export async function sseWorkspaceLiveStream(
   };
   if (signal.aborted) abort();
   else signal.addEventListener("abort", abort, { once: true });
-  stopReauthorization = startSseReauthorization(options, channel.stopped, (error) => {
-    channel.fail(retryableSseFailure("workspace live stream authorization failed", error));
-  });
+  stopReauthorization = startSseReauthorization(options, channel.stopped, channel.close);
 
   const upstreamOptions: WorkspaceInteractionSseOptions = {
     ...options,
@@ -695,7 +693,7 @@ export async function sseWorkspaceLiveStream(
   let writeTail = Promise.resolve(true);
   const write = (frame: string): Promise<boolean> => {
     const pending = writeTail.then(async () => {
-      await options.reauthorize?.();
+      await reauthorizeSseOrClose(options, channel);
       return await channel.write(frame);
     });
     writeTail = pending.catch(() => false);
@@ -804,12 +802,10 @@ export async function sseWorkspaceInteractionRevisionStream(
     },
   });
   closeMetrics = observeSseConnection("workspace_interaction", after, options.observability);
-  stopReauthorization = startSseReauthorization(options, channel.stopped, (error) => {
-    channel.fail(retryableSseFailure("workspace interaction stream authorization failed", error));
-  });
+  stopReauthorization = startSseReauthorization(options, channel.stopped, channel.close);
 
   const write = async (frame: string): Promise<boolean> => {
-    await options.reauthorize?.();
+    await reauthorizeSseOrClose(options, channel);
     const accepted = await channel.write(frame);
     if (accepted) lastWriteAt = Date.now();
     return accepted;
@@ -917,6 +913,24 @@ async function replayWorkspaceControlEvents(
 }
 
 class SseStreamStoppedError extends Error {}
+
+async function reauthorizeSseOrClose(
+  options: SseDeliveryOptions,
+  channel: ByteBoundedSseStream,
+): Promise<void> {
+  try {
+    await options.reauthorize?.();
+  } catch {
+    // Authorization loss is an expected fail-closed terminal condition, not a
+    // delivery fault. End the HTTP response cleanly so Bun and Chromium retire
+    // the HTTP/1 socket even if the initiating document is being replaced.
+    // No frame crosses the failed check; a still-live SDK may reconnect and is
+    // fenced again at request admission, while a destroyed realm cannot leave
+    // an errored response occupying the per-origin connection pool.
+    channel.close();
+    throw new SseStreamStoppedError();
+  }
+}
 
 export type SseDeliveryOptions = {
   maxQueuedBytes?: number;

--- a/apps/api/test/sse-stream-bounds.test.ts
+++ b/apps/api/test/sse-stream-bounds.test.ts
@@ -475,7 +475,7 @@ test("idle session stream count does not multiply durable reads on heartbeat", a
   await Promise.all(readers.map(async (reader) => await reader.cancel()));
 });
 
-test("a session stream fails closed before its first frame when host authorization is revoked", async () => {
+test("a session stream closes cleanly before its first frame when host authorization is revoked", async () => {
   durableEvents = [];
   durableReads.length = 0;
   let released = 0;
@@ -501,12 +501,12 @@ test("a session stream fails closed before its first frame when host authorizati
     },
   );
   const reader = response.body!.getReader();
-  await expect(reader.read()).rejects.toBeInstanceOf(TypeError);
+  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
   expect(reauthorizations).toBe(1);
   expect(released).toBe(1);
 });
 
-test("rechecks current authority and suppresses a live event after revocation", async () => {
+test("rechecks current authority and closes before a live event after revocation", async () => {
   durableEvents = [];
   durableReads.length = 0;
   let allowed = true;
@@ -537,8 +537,9 @@ test("rechecks current authority and suppresses a live event after revocation", 
   const reader = response.body!.getReader();
   expect(new TextDecoder().decode((await reader.read()).value)).toBe(": connected\n\n");
   allowed = false;
+  durableEvents = [event(1)];
   publish?.([event(1)]);
-  await expect(reader.read()).rejects.toBeInstanceOf(TypeError);
+  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
 });
 
 test("emits the selected actor epoch and closes before a cross-tab actor event", async () => {
@@ -574,8 +575,9 @@ test("emits the selected actor epoch and closes before a cross-tab actor event",
   const reader = response.body!.getReader();
   expect(new TextDecoder().decode((await reader.read()).value)).toBe(": connected\n\n");
   currentEpoch = "8";
+  durableEvents = [event(1)];
   publish?.([event(1)]);
-  await expect(reader.read()).rejects.toBeInstanceOf(TypeError);
+  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
 });
 
 test("every long-lived SSE surface closes when its current workspace authority is revoked", async () => {
@@ -618,7 +620,7 @@ test("every long-lived SSE surface closes when its current workspace authority i
   const readers = responses.map((response) => response.body!.getReader());
   await Promise.all(
     readers.map(async (reader) => {
-      await expect(reader.read()).rejects.toBeInstanceOf(Error);
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
     }),
   );
 });

--- a/apps/api/test/sse-stream-bounds.test.ts
+++ b/apps/api/test/sse-stream-bounds.test.ts
@@ -617,6 +617,9 @@ test("every long-lived SSE surface closes when its current workspace authority i
       { ...revoked(), pollIntervalMs: 100 },
     ),
   ]);
+  for (const response of responses) {
+    expect(response.headers.get("connection")).toBe("close");
+  }
   const readers = responses.map((response) => response.body!.getReader());
   await Promise.all(
     readers.map(async (reader) => {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -141,9 +141,9 @@ describe("web API auth helpers", () => {
       const lateRead = reader.read();
       configureManagedActorEpoch("13");
       expect(observed.signal?.aborted).toBe(true);
-      await Promise.resolve();
       expect(observed.cancelledWith).toMatchObject({ name: "AbortError" });
       expect(transportCloseOrder).toEqual(["native-abort", "source-cancel"]);
+      await Promise.resolve();
       await expect(lateRead).rejects.toMatchObject({ name: "AbortError" });
       await Promise.resolve();
       expect(source.locked).toBe(false);
@@ -192,13 +192,16 @@ describe("web API auth helpers", () => {
 
   test("aborts live native transports before a document is replaced", async () => {
     const originalFetch = globalThis.fetch;
-    const observed: { signal?: AbortSignal | null } = {};
+    const observed: { cancelledWith?: unknown; signal?: AbortSignal | null } = {};
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
     globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
       observed.signal = init?.signal ?? null;
       const source = new ReadableStream<Uint8Array>({
         start(controller) {
           bodyController = controller;
+        },
+        cancel(reason) {
+          observed.cancelledWith = reason;
         },
       });
       return new Response(source, {
@@ -212,7 +215,7 @@ describe("web API auth helpers", () => {
       const read = response.body!.getReader().read();
       handleManagedActorPageHide(false);
       expect(observed.signal?.aborted).toBe(true);
-      await Promise.resolve();
+      expect(observed.cancelledWith).toMatchObject({ name: "AbortError" });
       await expect(read).rejects.toMatchObject({ name: "AbortError" });
       // The old response must not retain a native body controller that can
       // continue publishing after document teardown.

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -340,12 +340,17 @@ function managedActorTrackedResponse(
     const reason = signal.reason ?? new DOMException("The browser account changed", "AbortError");
     actorAbortReason = reason;
     settle();
-    queueMicrotask(() => {
-      void reader
-        .cancel(reason)
-        .catch(() => undefined)
-        .finally(releaseReader);
-    });
+    // The native fetch signal is aborted before this wrapper signal. Start
+    // cancelling its locked reader in the same task as well: a pagehide can
+    // destroy this realm before a queued microtask runs, leaving Chromium's
+    // old HTTP/1 stream alive and starving the replacement document's finite
+    // reads. The returned promise already owns any asynchronous rejection;
+    // the wrapper still publishes its AbortError only from the consumer's
+    // pull path below.
+    void reader
+      .cancel(reason)
+      .catch(() => undefined)
+      .finally(releaseReader);
   };
   // Keep actor-abort rejection consumer-owned. WebKit can report a stream
   // error raised directly inside the abort event as an unhandled page error

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1756,6 +1756,12 @@ async function captureResponsiveEvidenceInBrowser(
       });
       expect(screenshot.readUInt32BE(16)).toBe(capture.width);
       await closeResponsiveAccountMenu(evidencePage, capture.width);
+      // Menu open/close and accessibility inspection can trigger ordinary
+      // routed refreshes after the initial bootstrap has already settled.
+      // Close that second finite-read window before applying the strict final
+      // ledger; an in-flight successful read is neither a browser fault nor
+      // evidence that can be discarded by closing this short-lived context.
+      await waitForFiniteReadQuiescence(evidenceProblems);
       await expectNoBrowserProblems(evidenceProblems);
     } finally {
       await evidenceContext.close();
@@ -1798,6 +1804,7 @@ async function captureResponsiveEvidenceInBrowser(
     });
     expect(forcedColorsScreenshot.readUInt32BE(16)).toBe(768);
     await closeResponsiveAccountMenu(forcedColorsPage, 768);
+    await waitForFiniteReadQuiescence(forcedColorsProblems);
     await expectNoBrowserProblems(forcedColorsProblems);
   } finally {
     await forcedColors.close();
@@ -1827,6 +1834,7 @@ async function captureResponsiveEvidenceInBrowser(
     fullPage: true,
   });
   expect(zoomScreenshot.readUInt32BE(16)).toBe(768);
+  await waitForFiniteReadQuiescence(zoomProblems);
   await expectNoBrowserProblems(zoomProblems);
   await zoom.close();
 
@@ -1870,6 +1878,7 @@ async function captureResponsiveEvidenceInBrowser(
     fullPage: true,
   });
   expect(touchScreenshot.readUInt32BE(16)).toBe(320);
+  await waitForFiniteReadQuiescence(touchProblems);
   await expectNoBrowserProblems(touchProblems);
   await touch.close();
 }


### PR DESCRIPTION
## Summary
- cancel locked native stream readers in the same task as actor rotation or document teardown, after the native fetch signal is aborted
- terminate authorization-revoked SSE responses with a clean fail-closed close; ordinary delivery faults still terminate as errors
- explicitly retire every completed HTTP/1 SSE transport so direct Bun/Docker deployments do not retain stale streams in Chromium's six-connection per-origin pool
- wait for responsive account-menu refresh reads to settle before applying the strict final browser ledger
- correct SSE authorization tests so the candidate live event is durable before reauthorization blocks delivery

## Verification
- 39 focused web/API stream tests (158 assertions)
- final transport-retirement implementation: 4 complete Chromium real-PostgreSQL multi-account journeys, including 3 consecutive repetitions
- prior exact stream-close implementation also passed Firefox and WebKit; no browser-specific product behavior changed in the final patch
- all 31 TypeScript projects
- repository-wide formatting and lint

## Hosted failure evidence
Three exact hosted Chromium runs reproduced HTTP/1 connection-pool starvation. The ledgers showed authorization-fenced streams from replaced actors remained attached to reusable Bun HTTP/1 sockets while current-actor finite reads waited behind Chromium's per-origin connection cap. This head closes revoked bodies without a stale frame and marks all SSE responses `Connection: close`, making completion retire the HTTP/1 transport; HTTP/2 front doors strip the hop-by-hop header. The exact pressure journey is now repeatedly green locally. Merge remains blocked until this exact head is independently green and reviewed.
