### PR TITLE
fix(observability): correct runtime dashboard filters

### DIFF
--- a/apps/worker/test/sandbox-observability-contract.test.ts
+++ b/apps/worker/test/sandbox-observability-contract.test.ts
@@ -35,7 +35,7 @@ describe("sandbox observability contract", () => {
         condition?: string;
       }>;
     };
-    expect(chart.version).toBe("0.1.8");
+    expect(chart.version).toBe("0.1.9");
     expect(chart.dependencies).toEqual([
       {
         name: "kube-prometheus-stack",

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -34,6 +34,13 @@ metadata:
 spec:
   groups:
     - name: opengeni.rules
+      # Make every alert and recording rule self-identifying when one Prometheus
+      # evaluates more than one OpenGeni deployment. Dashboard and Alertmanager
+      # consumers can then select the exact release instead of matching globally.
+      labels:
+        namespace: {{ .Release.Namespace | quote }}
+        environment: {{ $environment | quote }}
+        release: {{ .Release.Name | quote }}
       rules:
         # These recording rules admit only a complete inventory projection whose
         # matching domain refreshed on the same scrape target within the configured

--- a/deploy/helm/opengeni/test/prometheusrule.test.ts
+++ b/deploy/helm/opengeni/test/prometheusrule.test.ts
@@ -6,6 +6,22 @@ const DEPLOYMENT_SCOPE =
   "namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }}";
 
 describe("turn-capacity Prometheus alerts", () => {
+  test("labels the complete rule group with exact deployment identity", async () => {
+    const template = await readFile(
+      new URL("../templates/prometheusrule.yaml", import.meta.url),
+      "utf8",
+    );
+
+    const groupStart = template.indexOf("    - name: opengeni.rules\n");
+    const rulesStart = template.indexOf("      rules:\n", groupStart);
+    expect(groupStart).toBeGreaterThanOrEqual(0);
+    expect(rulesStart).toBeGreaterThan(groupStart);
+    expect(template.slice(groupStart, rulesStart)).toContain(`      labels:
+        namespace: {{ .Release.Namespace | quote }}
+        environment: {{ $environment | quote }}
+        release: {{ .Release.Name | quote }}`);
+  });
+
   test("alerts on cumulative queue, provider-dispatch, and first-byte p95 SLOs", async () => {
     const template = await readFile(
       new URL("../templates/prometheusrule.yaml", import.meta.url),

--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opengeni-observability
 description: Optional self-hosted Prometheus and Grafana stack for OpenGeni.
 type: application
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/observability/dashboards/runtime-failures.json
+++ b/deploy/observability/dashboards/runtime-failures.json
@@ -117,7 +117,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=\"critical\"}) or vector(0)",
+          "expr": "count(ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=\"critical\",namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}) or vector(0)",
           "legendFormat": "critical",
           "editorMode": "code",
           "instant": true,
@@ -160,7 +160,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=\"warning\"}) or vector(0)",
+          "expr": "count(ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=\"warning\",namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}) or vector(0)",
           "legendFormat": "warning",
           "editorMode": "code",
           "instant": true,
@@ -367,7 +367,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=~\"warning|critical\"}",
+          "expr": "ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=~\"warning|critical\",namespace=\"$namespace\",environment=\"$environment\",release=\"$release\"}",
           "format": "table",
           "legendFormat": "{{severity}} · {{alertname}}",
           "editorMode": "code",
@@ -383,7 +383,10 @@
               "Time": true,
               "Value": true,
               "__name__": true,
-              "alertstate": true
+              "alertstate": true,
+              "environment": true,
+              "namespace": true,
+              "release": true
             },
             "indexByName": { "severity": 0, "alertname": 1 },
             "renameByName": { "alertname": "Alert", "severity": "Severity" }

--- a/deploy/observability/dashboards/runtime-failures.json
+++ b/deploy/observability/dashboards/runtime-failures.json
@@ -3,7 +3,7 @@
   "title": "OpenGeni · Runtime Failures",
   "description": "One exact deployment's turn, MCP, sandbox, API, provider, and durable-write failures. Identity and error content stay in authenticated logs and durable events, never metric labels.",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 3,
   "editable": true,
   "graphTooltip": 1,
   "timezone": "browser",
@@ -47,10 +47,10 @@
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
         "query": {
-          "query": "label_values(up{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, environment)",
+          "query": "label_values(opengeni_build_info{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, environment)",
           "refId": "environment"
         },
-        "definition": "label_values(up{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, environment)",
+        "definition": "label_values(opengeni_build_info{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, environment)",
         "current": {},
         "includeAll": false,
         "multi": false,
@@ -63,10 +63,10 @@
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
         "query": {
-          "query": "label_values(up{namespace=\"$namespace\",environment=\"$environment\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, release)",
+          "query": "label_values(up{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, release)",
           "refId": "release"
         },
-        "definition": "label_values(up{namespace=\"$namespace\",environment=\"$environment\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, release)",
+        "definition": "label_values(up{namespace=\"$namespace\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}, release)",
         "current": {},
         "includeAll": false,
         "multi": false,
@@ -87,12 +87,13 @@
     {
       "id": 17,
       "type": "stat",
-      "title": "Firing critical alerts",
+      "title": "Critical alerts",
       "description": "Current firing OpenGeni critical alerts. Zero is explicit because Prometheus omits the ALERTS series when no alert is firing.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "decimals": 0,
           "min": 0,
           "color": { "mode": "thresholds" },
           "thresholds": {
@@ -128,12 +129,13 @@
     {
       "id": 18,
       "type": "stat",
-      "title": "Firing warnings",
+      "title": "Warnings",
       "description": "Current firing OpenGeni warning alerts. The card turns amber immediately and red when several warnings overlap.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "decimals": 0,
           "min": 0,
           "color": { "mode": "thresholds" },
           "thresholds": {
@@ -170,7 +172,7 @@
     {
       "id": 19,
       "type": "stat",
-      "title": "App scrape health",
+      "title": "Scrape health",
       "description": "Percentage of selected OpenGeni application scrape targets currently reachable. No data is a telemetry outage, not a healthy zero.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
@@ -203,7 +205,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "100 * avg(up{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",opengeni_workload_component=~\"api|worker-control|worker-turns\"})",
+          "expr": "100 * avg(up{namespace=\"$namespace\",release=\"$release\",opengeni_workload_component=~\"api|worker-control|worker-turns\"})",
           "legendFormat": "healthy",
           "editorMode": "code",
           "instant": true,
@@ -215,7 +217,7 @@
     {
       "id": 20,
       "type": "stat",
-      "title": "Synthetic probe age",
+      "title": "Probe age",
       "description": "Seconds since the managed synthetic session probe last completed successfully. It runs every 30 minutes; missing or older than one hour is unhealthy.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
@@ -258,12 +260,13 @@
     {
       "id": 21,
       "type": "stat",
-      "title": "Turn-worker restarts · 15m",
+      "title": "Worker restarts · 15m",
       "description": "Container restarts from release-owned turn workers. Rollout replacement does not increment this signal; process exits and liveness failures do.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "decimals": 0,
           "min": 0,
           "noValue": "Missing",
           "color": { "mode": "thresholds" },
@@ -301,12 +304,13 @@
     {
       "id": 22,
       "type": "stat",
-      "title": "Recovery exhausted · range",
+      "title": "Recovery exhausted",
       "description": "Logical turns durably failed after losing four workers. Zero is explicit when application scrape health is present; each non-zero value is a critical session failure.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "decimals": 0,
           "min": 0,
           "color": { "mode": "thresholds" },
           "thresholds": {
@@ -330,7 +334,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(increase(opengeni_turn_worker_death_recoveries_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"exhausted\"}[$__range])) or on() (0 * count(up{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}))",
+          "expr": "sum(increase(opengeni_turn_worker_death_recoveries_total{namespace=\"$namespace\",environment=\"$environment\",release=\"$release\",outcome=\"exhausted\"}[$__range])) or on() (0 * count(up{namespace=\"$namespace\",release=\"$release\",opengeni_workload_component=~\"api|worker-control|worker-turns\"}))",
           "legendFormat": "exhausted",
           "editorMode": "code",
           "instant": true,
@@ -340,12 +344,61 @@
       "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 }
     },
     {
+      "id": 23,
+      "type": "table",
+      "title": "Firing OpenGeni alerts",
+      "description": "The exact warning and critical alert names behind the summary cards. Open Alerting for full annotations and runbook context.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Severity", "desc": false }]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "ALERTS{alertstate=\"firing\",alertname=~\"OpenGeni.*\",severity=~\"warning|critical\"}",
+          "format": "table",
+          "legendFormat": "{{severity}} · {{alertname}}",
+          "editorMode": "code",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "alertstate": true
+            },
+            "indexByName": { "severity": 0, "alertname": 1 },
+            "renameByName": { "alertname": "Alert", "severity": "Severity" }
+          }
+        }
+      ],
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 5 }
+    },
+    {
       "id": 1,
       "type": "row",
       "title": "Turn health",
       "collapsed": false,
       "panels": [],
-      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 }
+      "gridPos": { "x": 0, "y": 10, "w": 24, "h": 1 }
     },
     {
       "id": 2,
@@ -367,7 +420,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 11, "w": 12, "h": 8 }
     },
     {
       "id": 3,
@@ -396,7 +449,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 11, "w": 12, "h": 8 }
     },
     {
       "id": 4,
@@ -404,7 +457,7 @@
       "title": "MCP connections and tool use",
       "collapsed": false,
       "panels": [],
-      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 }
+      "gridPos": { "x": 0, "y": 19, "w": 24, "h": 1 }
     },
     {
       "id": 5,
@@ -426,7 +479,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 15, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 }
     },
     {
       "id": 6,
@@ -448,7 +501,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 15, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 8 }
     },
     {
       "id": 7,
@@ -470,7 +523,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 23, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 28, "w": 12, "h": 8 }
     },
     {
       "id": 8,
@@ -492,7 +545,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 23, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 28, "w": 12, "h": 8 }
     },
     {
       "id": 9,
@@ -500,7 +553,7 @@
       "title": "Sandbox, API, provider, and durable storage",
       "collapsed": false,
       "panels": [],
-      "gridPos": { "x": 0, "y": 31, "w": 24, "h": 1 }
+      "gridPos": { "x": 0, "y": 36, "w": 24, "h": 1 }
     },
     {
       "id": 10,
@@ -522,7 +575,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 37, "w": 12, "h": 8 }
     },
     {
       "id": 11,
@@ -544,7 +597,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 37, "w": 12, "h": 8 }
     },
     {
       "id": 15,
@@ -566,7 +619,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 40, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 45, "w": 12, "h": 8 }
     },
     {
       "id": 12,
@@ -595,7 +648,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 40, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 45, "w": 12, "h": 8 }
     },
     {
       "id": 13,
@@ -617,7 +670,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 0, "y": 48, "w": 12, "h": 8 }
+      "gridPos": { "x": 0, "y": 53, "w": 12, "h": 8 }
     },
     {
       "id": 14,
@@ -653,7 +706,7 @@
           "range": true
         }
       ],
-      "gridPos": { "x": 12, "y": 48, "w": 12, "h": 8 }
+      "gridPos": { "x": 12, "y": 53, "w": 12, "h": 8 }
     }
   ]
 }

--- a/deploy/observability/dashboards/runtime-failures.test.ts
+++ b/deploy/observability/dashboards/runtime-failures.test.ts
@@ -112,6 +112,13 @@ describe("runtime failures dashboard", () => {
     expect(variables.get("release")?.definition).not.toContain("environment=");
 
     const alertTable = dashboard.panels.find((panel) => panel.title === "Firing OpenGeni alerts");
+    for (const panelTitle of ["Critical alerts", "Warnings", "Firing OpenGeni alerts"]) {
+      const expression = dashboard.panels.find((panel) => panel.title === panelTitle)?.targets?.[0]
+        ?.expr;
+      expect(expression).toContain('namespace="$namespace"');
+      expect(expression).toContain('environment="$environment"');
+      expect(expression).toContain('release="$release"');
+    }
     expect(alertTable?.targets?.[0]?.expr).toContain('severity=~"warning|critical"');
   });
 

--- a/deploy/observability/dashboards/runtime-failures.test.ts
+++ b/deploy/observability/dashboards/runtime-failures.test.ts
@@ -8,12 +8,13 @@ describe("runtime failures dashboard", () => {
     ) as RuntimeFailuresDashboard;
     const titles = new Set(dashboard.panels.map((panel) => panel.title));
     for (const title of [
-      "Firing critical alerts",
-      "Firing warnings",
-      "App scrape health",
-      "Synthetic probe age",
-      "Turn-worker restarts · 15m",
-      "Recovery exhausted · range",
+      "Critical alerts",
+      "Warnings",
+      "Scrape health",
+      "Probe age",
+      "Worker restarts · 15m",
+      "Recovery exhausted",
+      "Firing OpenGeni alerts",
       "Turn outcomes",
       "Turn failure and recovery ratios",
       "MCP lifecycle operations",
@@ -62,15 +63,18 @@ describe("runtime failures dashboard", () => {
     ) as RuntimeFailuresDashboard;
     const panels = new Map(dashboard.panels.map((panel) => [panel.title, panel]));
 
-    expect(panels.get("Firing critical alerts")?.targets?.[0]?.expr).toContain("or vector(0)");
-    expect(panels.get("Firing warnings")?.targets?.[0]?.expr).toContain("or vector(0)");
-    const exhaustedRecovery = panels.get("Recovery exhausted · range")?.targets?.[0]?.expr ?? "";
+    expect(panels.get("Critical alerts")?.targets?.[0]?.expr).toContain("or vector(0)");
+    expect(panels.get("Warnings")?.targets?.[0]?.expr).toContain("or vector(0)");
+    const exhaustedRecovery = panels.get("Recovery exhausted")?.targets?.[0]?.expr ?? "";
     expect(exhaustedRecovery).toContain("or on() (0 * count(up{");
     expect(exhaustedRecovery).toContain("opengeni_workload_component");
-    const scrapeHealth = panels.get("App scrape health")?.targets?.[0]?.expr ?? "";
+    expect(exhaustedRecovery).not.toContain('up{namespace="$namespace",environment=');
+    expect(panels.get("Recovery exhausted")?.fieldConfig?.defaults?.decimals).toBe(0);
+    const scrapeHealth = panels.get("Scrape health")?.targets?.[0]?.expr ?? "";
     expect(scrapeHealth).not.toContain("or vector(0)");
     expect(scrapeHealth).toContain("opengeni_workload_component");
-    expect(panels.get("Synthetic probe age")?.targets?.[0]?.expr).not.toContain("or vector(0)");
+    expect(scrapeHealth).not.toContain('environment="$environment"');
+    expect(panels.get("Probe age")?.targets?.[0]?.expr).not.toContain("or vector(0)");
 
     const ratio = panels.get("Turn failure and recovery ratios");
     expect(ratio?.targets).toHaveLength(2);
@@ -84,13 +88,31 @@ describe("runtime failures dashboard", () => {
     const dashboard = JSON.parse(
       await readFile(new URL("./runtime-failures.json", import.meta.url), "utf8"),
     ) as RuntimeFailuresDashboard;
-    const restarts = dashboard.panels.find((panel) => panel.title === "Turn-worker restarts · 15m");
+    const restarts = dashboard.panels.find((panel) => panel.title === "Worker restarts · 15m");
     const expression = restarts?.targets?.[0]?.expr ?? "";
     expect(expression).toContain("kube_pod_container_status_restarts_total");
     expect(expression).toContain("kube_pod_labels");
     expect(expression).toContain('label_app_kubernetes_io_instance="$release"');
     expect(expression).toContain('label_app_kubernetes_io_component="worker-turns"');
     expect(expression).toContain("* on(namespace, pod) group_left()");
+    expect(restarts?.fieldConfig?.defaults?.decimals).toBe(0);
+  });
+
+  test("uses application identity for environment without breaking scrape health", async () => {
+    const dashboard = JSON.parse(
+      await readFile(new URL("./runtime-failures.json", import.meta.url), "utf8"),
+    ) as RuntimeFailuresDashboard;
+    const variables = new Map(
+      dashboard.templating.list.map((variable) => [variable.name, variable]),
+    );
+    expect(variables.get("environment")?.definition).toContain("opengeni_build_info");
+    expect(variables.get("environment")?.definition).toContain(
+      'opengeni_workload_component=~"api|worker-control|worker-turns"',
+    );
+    expect(variables.get("release")?.definition).not.toContain("environment=");
+
+    const alertTable = dashboard.panels.find((panel) => panel.title === "Firing OpenGeni alerts");
+    expect(alertTable?.targets?.[0]?.expr).toContain('severity=~"warning|critical"');
   });
 
   test("pins every panel selector to one namespace, environment, and release", async () => {
@@ -120,7 +142,11 @@ describe("runtime failures dashboard", () => {
 });
 
 interface RuntimeFailuresDashboard {
-  panels: Array<{ title?: string; targets?: Array<{ expr: string }> }>;
+  panels: Array<{
+    title?: string;
+    targets?: Array<{ expr: string }>;
+    fieldConfig?: { defaults?: { decimals?: number } };
+  }>;
   templating: {
     list: Array<{
       name: string;

--- a/scripts/deployment-observability.test.ts
+++ b/scripts/deployment-observability.test.ts
@@ -29,7 +29,7 @@ describe("observability deployment plan", () => {
     });
 
     expect(plan.chartPath).toBe("deploy/observability");
-    expect(plan.chartVersion).toBe("0.1.8");
+    expect(plan.chartVersion).toBe("0.1.9");
     expect(plan.kubePrometheusStackVersion).toBe("87.16.1");
     expect(plan.opensandbox).toBe(true);
     expect(plan.valuesFiles).toEqual([

--- a/scripts/deployment-observability.ts
+++ b/scripts/deployment-observability.ts
@@ -19,7 +19,7 @@ export interface ObservabilityStackPlan {
   environment: string;
   opensandbox: boolean;
   chartPath: "deploy/observability";
-  chartVersion: "0.1.8";
+  chartVersion: "0.1.9";
   kubePrometheusStackVersion: "87.16.1";
   valuesFiles: string[];
   applicationValuesFile: "deploy/observability/opengeni.values.example.yaml";
@@ -112,7 +112,7 @@ export function observabilityStackPlanFor(
     environment,
     opensandbox,
     chartPath: "deploy/observability",
-    chartVersion: "0.1.8",
+    chartVersion: "0.1.9",
     kubePrometheusStackVersion: "87.16.1",
     valuesFiles,
     applicationValuesFile: "deploy/observability/opengeni.values.example.yaml",


### PR DESCRIPTION
## Summary
- derive the dashboard environment from always-present application build metrics
- keep scrape-target queries independent of application-only labels
- add an exact firing-alert table and make top-level counts readable
- bump the observability chart to 0.1.9

## Verification
- focused dashboard and deployment tests
- Helm lint and render
- all dashboard PromQL expressions accepted by the live staging Prometheus API
- environment query resolves `azure-managed` from live staging targets

## Summary by Sourcery

Correct runtime observability dashboard filtering and alert identity across multiple OpenGeni deployments.

New Features:
- Add an exact firing-alert table to the runtime failures dashboard.

Bug Fixes:
- Correct runtime dashboard environment discovery and keep scrape-health queries independent of application-only labels.

Enhancements:
- Improve dashboard panel naming and readability for alert counts and numeric metrics.
- Add deployment identity labels to Prometheus rule groups so alerts and recording rules can be selected per namespace, environment, and release.

Build:
- Bump the observability chart and deployment plan from version 0.1.8 to 0.1.9.

Tests:
- Update dashboard and deployment contract tests for the corrected selectors, panel structure, and chart version.