### PR TITLE
fix(web): own bounded stream native lifetime

### DIFF
--- a/.changeset/clean-revoked-streams.md
+++ b/.changeset/clean-revoked-streams.md
@@ -2,4 +2,4 @@
 "@opengeni/api-router": patch
 ---
 
-Close authorization-revoked SSE responses cleanly and cycle browser streams on HTTP/1 so stale tabs cannot exhaust the shared connection pool or starve ordinary API reads.
+Close authorization-revoked SSE responses cleanly and cycle browser streams with server- and browser-owned HTTP/1 lifetimes so stale or orphaned native requests cannot exhaust the shared connection pool or starve ordinary API reads.

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, jest, test } from "bun:test";
 import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import {
   AuthApiError,
@@ -65,62 +65,84 @@ describe("web API auth helpers", () => {
   });
 
   test("forces a clean logical seam when a bounded native HTTP/1 stream outlives the server seam", async () => {
+    jest.useFakeTimers();
     let nativeAbort: unknown;
     let sourceCancel: unknown;
     let cleaned = 0;
-    const source = new ReadableStream<Uint8Array>({
-      cancel(reason) {
-        sourceCancel = reason;
-      },
+    let signalNativeAbort!: () => void;
+    const nativeAborted = new Promise<void>((resolve) => {
+      signalNativeAbort = resolve;
     });
-    const response = managedActorTrackedResponse(
-      new Response(source, { headers: { "content-type": "text/event-stream" } }),
-      new AbortController().signal,
-      () => {
-        cleaned += 1;
-      },
-      (reason) => {
-        nativeAbort = reason;
-      },
-      10,
-      5,
-    );
-    let settled = false;
-    const read = response
-      .body!.getReader()
-      .read()
-      .then((result) => {
-        settled = true;
-        return result;
+    try {
+      const source = new ReadableStream<Uint8Array>({
+        cancel(reason) {
+          sourceCancel = reason;
+        },
       });
-    await Bun.sleep(7);
-    expect(settled).toBe(false);
-    expect(nativeAbort).toMatchObject({ name: "AbortError" });
-    expect(sourceCancel).toBe(nativeAbort);
-    await expect(read).resolves.toEqual({ done: true, value: undefined });
-    expect(cleaned).toBe(1);
-    expect(source.locked).toBe(false);
+      const response = managedActorTrackedResponse(
+        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        new AbortController().signal,
+        () => {
+          cleaned += 1;
+        },
+        (reason) => {
+          nativeAbort = reason;
+          signalNativeAbort();
+        },
+        10,
+        5,
+      );
+      let settled = false;
+      const read = response
+        .body!.getReader()
+        .read()
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+      jest.advanceTimersByTime(5);
+      await nativeAborted;
+      expect(settled).toBe(false);
+      expect(nativeAbort).toMatchObject({ name: "AbortError" });
+      expect(sourceCancel).toBe(nativeAbort);
+      jest.advanceTimersByTime(10);
+      await expect(read).resolves.toEqual({ done: true, value: undefined });
+      expect(cleaned).toBe(1);
+      expect(source.locked).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("keeps actor rotation fail-closed while a native HTTP/1 seam is in grace", async () => {
-    const actor = new AbortController();
-    const source = new ReadableStream<Uint8Array>();
-    const response = managedActorTrackedResponse(
-      new Response(source, { headers: { "content-type": "text/event-stream" } }),
-      actor.signal,
-      () => undefined,
-      () => undefined,
-      30,
-      5,
-    );
-    const read = response.body!.getReader().read();
-    await Bun.sleep(8);
-    actor.abort(new DOMException("account changed during stream seam", "AbortError"));
-    await expect(read).rejects.toMatchObject({
-      name: "AbortError",
-      message: "account changed during stream seam",
+    jest.useFakeTimers();
+    let signalNativeAbort!: () => void;
+    const nativeAborted = new Promise<void>((resolve) => {
+      signalNativeAbort = resolve;
     });
-    expect(source.locked).toBe(false);
+    try {
+      const actor = new AbortController();
+      const source = new ReadableStream<Uint8Array>();
+      const response = managedActorTrackedResponse(
+        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        actor.signal,
+        () => undefined,
+        () => signalNativeAbort(),
+        30,
+        5,
+      );
+      const read = response.body!.getReader().read();
+      jest.advanceTimersByTime(5);
+      await nativeAborted;
+      actor.abort(new DOMException("account changed during stream seam", "AbortError"));
+      await expect(read).rejects.toMatchObject({
+        name: "AbortError",
+        message: "account changed during stream seam",
+      });
+      expect(source.locked).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("attaches the accepted actor epoch and rejects a late prior-actor response", async () => {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -64,6 +64,65 @@ describe("web API auth helpers", () => {
     expect(source.locked).toBe(false);
   });
 
+  test("forces a clean logical seam when a bounded native HTTP/1 stream outlives the server seam", async () => {
+    let nativeAbort: unknown;
+    let sourceCancel: unknown;
+    let cleaned = 0;
+    const source = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        sourceCancel = reason;
+      },
+    });
+    const response = managedActorTrackedResponse(
+      new Response(source, { headers: { "content-type": "text/event-stream" } }),
+      new AbortController().signal,
+      () => {
+        cleaned += 1;
+      },
+      (reason) => {
+        nativeAbort = reason;
+      },
+      10,
+      5,
+    );
+    let settled = false;
+    const read = response
+      .body!.getReader()
+      .read()
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await Bun.sleep(7);
+    expect(settled).toBe(false);
+    expect(nativeAbort).toMatchObject({ name: "AbortError" });
+    expect(sourceCancel).toBe(nativeAbort);
+    await expect(read).resolves.toEqual({ done: true, value: undefined });
+    expect(cleaned).toBe(1);
+    expect(source.locked).toBe(false);
+  });
+
+  test("keeps actor rotation fail-closed while a native HTTP/1 seam is in grace", async () => {
+    const actor = new AbortController();
+    const source = new ReadableStream<Uint8Array>();
+    const response = managedActorTrackedResponse(
+      new Response(source, { headers: { "content-type": "text/event-stream" } }),
+      actor.signal,
+      () => undefined,
+      () => undefined,
+      30,
+      5,
+    );
+    const read = response.body!.getReader().read();
+    await Bun.sleep(8);
+    actor.abort(new DOMException("account changed during stream seam", "AbortError"));
+    await expect(read).rejects.toMatchObject({
+      name: "AbortError",
+      message: "account changed during stream seam",
+    });
+    expect(source.locked).toBe(false);
+  });
+
   test("attaches the accepted actor epoch and rejects a late prior-actor response", async () => {
     const originalFetch = globalThis.fetch;
     let release!: (response: Response) => void;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -24,6 +24,11 @@ const deploymentReloadStoragePrefix = "opengeni.reloadForRevision:";
 const contractReloadStoragePrefix = "opengeni.reloadForApiContract:";
 const boundedHttp1SseTransport = "http1-bounded";
 const HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS = 2_000;
+// The API normally closes bounded HTTP/1 streams after five seconds. Keep a
+// browser-owned backstop as well: a server/runtime adapter can acknowledge a
+// Web Stream close without retiring Chromium's native request, and one such
+// orphan per tab is enough to exhaust the shared per-origin connection pool.
+const HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS = 9_000;
 let activeAuthConfig: ClientConfig["auth"] | null = null;
 let managedActorEpoch: string | null = null;
 let managedActorRevision = 0;
@@ -201,7 +206,11 @@ export async function managedActorFetch(
     typeof Request !== "undefined" && input instanceof Request ? input.headers : undefined,
   );
   new Headers(init.headers).forEach((value, key) => headers.set(key, value));
-  const [transportInput, cleanCloseDelayMs] = browserSseTransportInput(input, init, headers);
+  const [transportInput, cleanCloseDelayMs, nativeLifetimeMs] = browserSseTransportInput(
+    input,
+    init,
+    headers,
+  );
   if (acceptedEpoch && init.credentials !== "omit" && !headers.has(MANAGED_ACTOR_EPOCH_HEADER)) {
     headers.set(MANAGED_ACTOR_EPOCH_HEADER, acceptedEpoch);
   }
@@ -278,6 +287,7 @@ export async function managedActorFetch(
       cleanup,
       abortNativeTransport,
       finiteJsonResponse ? 0 : cleanCloseDelayMs,
+      finiteJsonResponse ? 0 : nativeLifetimeMs,
     );
   } finally {
     if (!responseOwnsCleanup) cleanup();
@@ -294,18 +304,22 @@ function browserSseTransportInput(
   input: string | URL | Request,
   init: RequestInit,
   headers: Headers,
-): readonly [input: string | URL | Request, cleanCloseDelayMs: number] {
+): readonly [input: string | URL | Request, cleanCloseDelayMs: number, nativeLifetimeMs: number] {
   if (
     requestMethod(input, init) !== "GET" ||
     !headers.get("accept")?.toLowerCase().includes("text/event-stream") ||
     (typeof Request !== "undefined" && input instanceof Request) ||
     !shouldBoundBrowserSseForProtocol(observedApiProtocol())
   ) {
-    return [input, 0];
+    return [input, 0, 0];
   }
   const url = new URL(String(input), window.location.href);
   url.searchParams.set("transport", boundedHttp1SseTransport);
-  return [typeof input === "string" ? url.toString() : url, HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS];
+  return [
+    typeof input === "string" ? url.toString() : url,
+    HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS,
+    HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS,
+  ];
 }
 
 function observedApiProtocol(): string | null {
@@ -362,11 +376,14 @@ export function managedActorTrackedResponse(
   cleanup: () => void,
   abortNativeTransport?: (reason: unknown) => void,
   cleanCloseDelayMs = 0,
+  nativeLifetimeMs = 0,
 ): Response {
   const reader = response.body!.getReader();
   let settled = false;
   let readerReleased = false;
   let actorAbortReason: unknown | null = null;
+  let cleanSeamGrace: Promise<void> | null = null;
+  let lifetimeTimer: ReturnType<typeof setTimeout> | null = null;
   const releaseReader = () => {
     if (readerReleased) return;
     try {
@@ -380,6 +397,10 @@ export function managedActorTrackedResponse(
   const settle = () => {
     if (settled) return false;
     settled = true;
+    if (lifetimeTimer !== null) {
+      clearTimeout(lifetimeTimer);
+      lifetimeTimer = null;
+    }
     signal.removeEventListener("abort", abortBody);
     cleanup();
     return true;
@@ -401,6 +422,31 @@ export function managedActorTrackedResponse(
       .catch(() => undefined)
       .finally(releaseReader);
   };
+  const beginCleanSeam = () => {
+    if (settled || cleanSeamGrace !== null) return;
+    const reason = new DOMException(
+      "The bounded HTTP/1 stream reached its native lifetime",
+      "AbortError",
+    );
+    cleanSeamGrace = abortableDelay(cleanCloseDelayMs, signal);
+    // The browser signal must be aborted before its locked reader is
+    // cancelled. This owns the native request lifecycle even when the API's
+    // clean terminal chunk never releases Chromium's connection accounting.
+    abortNativeTransport?.(reason);
+    void reader
+      .cancel(reason)
+      .catch(() => undefined)
+      .finally(releaseReader);
+  };
+  const closeCleanSeam = async (controller: ReadableStreamDefaultController<Uint8Array>) => {
+    await cleanSeamGrace;
+    if (actorAbortReason !== null) {
+      controller.error(actorAbortReason);
+      return;
+    }
+    releaseReader();
+    if (settle()) controller.close();
+  };
   // Keep actor-abort rejection consumer-owned. WebKit can report a stream
   // error raised directly inside the abort event as an unhandled page error
   // before the SDK has attached its body reader. Zero buffering also prevents
@@ -417,10 +463,18 @@ export function managedActorTrackedResponse(
           return;
         }
         if (settled) return;
+        if (cleanSeamGrace !== null) {
+          await closeCleanSeam(controller);
+          return;
+        }
         try {
           const next = await reader.read();
           if (actorAbortReason !== null) {
             controller.error(actorAbortReason);
+            return;
+          }
+          if (cleanSeamGrace !== null) {
+            await closeCleanSeam(controller);
             return;
           }
           if (next.done) {
@@ -444,6 +498,8 @@ export function managedActorTrackedResponse(
           releaseReader();
           if (actorAbortReason !== null) {
             controller.error(actorAbortReason);
+          } else if (cleanSeamGrace !== null) {
+            await closeCleanSeam(controller);
           } else if (settle()) {
             controller.error(error);
           }
@@ -465,6 +521,9 @@ export function managedActorTrackedResponse(
     },
     { highWaterMark: 0 },
   );
+  if (nativeLifetimeMs > 0 && abortNativeTransport) {
+    lifetimeTimer = setTimeout(beginCleanSeam, nativeLifetimeMs);
+  }
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,

--- a/scripts/web-bundle-budget-policy.test.ts
+++ b/scripts/web-bundle-budget-policy.test.ts
@@ -121,9 +121,9 @@ describe("web bundle budget policy", () => {
     ).toBe(1_756);
   });
 
-  test("retains the exact bounded HTTP/1 browser-stream envelope", () => {
-    expect(HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT).toBe(2_237_019);
-    expect(HTTP1_BROWSER_STREAMS_RAW_BUDGET).toBe(2186 * KIB);
-    expect(HTTP1_BROWSER_STREAMS_RAW_BUDGET - HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT).toBe(1_445);
+  test("retains the exact browser-owned HTTP/1 stream-lifetime envelope", () => {
+    expect(HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT).toBe(2_237_456);
+    expect(HTTP1_BROWSER_STREAMS_RAW_BUDGET).toBe(2187 * KIB);
+    expect(HTTP1_BROWSER_STREAMS_RAW_BUDGET - HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT).toBe(2_032);
   });
 });

--- a/scripts/web-bundle-budget-policy.ts
+++ b/scripts/web-bundle-budget-policy.ts
@@ -60,8 +60,8 @@ export const MANAGED_SOCIAL_SIGN_IN_MERGE_TREE_RAW_BUDGET = wholeKibEnvelope(
   MANAGED_SOCIAL_SIGN_IN_MERGE_TREE_RAW_MEASUREMENT,
 );
 
-/** Exact bounded HTTP/1 browser-stream Linux/x64 Bun 1.4 measurement. */
-export const HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT = 2_237_019;
+/** Exact browser-owned HTTP/1 stream-lifetime Linux/x64 Bun 1.4 measurement. */
+export const HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT = 2_237_456;
 export const HTTP1_BROWSER_STREAMS_RAW_BUDGET = wholeKibEnvelope(
   HTTP1_BROWSER_STREAMS_RAW_MEASUREMENT,
 );

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -425,10 +425,12 @@ function isExpectedBoundedHttp1NativeSeam(input: {
   }
   const url = new URL(input.url);
   const isStream = url.pathname.endsWith("/stream") || url.pathname.includes("/live-events/stream");
+  // Chromium and Firefox expose concrete abort codes; WebKit reports a bare
+  // cancellation word. Exact matching prevents an abort-shaped prefix from
+  // hiding a reset, timeout, DNS, or other transport failure.
   const isCancellation =
-    /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|cancelled|canceled/iu.test(input.failure) &&
-    !/(?:NET_RESET|CONNECTION_RESET|connection[\s_-]+reset|transport[\s_-]+(?:failure|failed|error|reset))/iu.test(
-      input.failure,
+    /^(?:(?:net::)?ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|(?:request (?:was )?)?(?:cancelled|canceled))$/iu.test(
+      input.failure.trim(),
     );
   const elapsedMs = input.failedAt - input.startedAt;
   // The browser-owned seam fires at nine seconds. Allow only the request-start

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -82,6 +82,7 @@ type BrowserProblems = {
   }>;
   activeStreams: Map<object, string>;
   boundedHttp1StreamDispatches: number;
+  boundedHttp1NativeSeams: number;
   actorDispatches: Array<{ actorEpoch: string; startedAt: number }>;
   actorFenceResponses: string[];
   actorTransitionResponses: Array<{
@@ -407,6 +408,38 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
   return `[dispatch=${input.dispatchPhase}; actor=${input.actorEpoch ?? "missing"}; response=${input.responsePhase}] ${input.method} ${input.url}: ${input.failure}`;
 }
 
+function isExpectedBoundedHttp1NativeSeam(input: {
+  failedAt: number;
+  failure: string;
+  method: string;
+  startedAt?: number;
+  url: string;
+}): boolean {
+  if (
+    input.method !== "GET" ||
+    typeof input.startedAt !== "number" ||
+    !Number.isFinite(input.startedAt) ||
+    !Number.isFinite(input.failedAt)
+  ) {
+    return false;
+  }
+  const url = new URL(input.url);
+  const isStream = url.pathname.endsWith("/stream") || url.pathname.includes("/live-events/stream");
+  const isCancellation =
+    /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|cancelled|canceled/iu.test(input.failure) &&
+    !/NET_RESET|CONNECTION_RESET/iu.test(input.failure);
+  const elapsedMs = input.failedAt - input.startedAt;
+  // The browser-owned seam fires at nine seconds. Allow bounded scheduling
+  // jitter while rejecting eager cancellations and genuinely stuck requests.
+  return (
+    isStream &&
+    isCancellation &&
+    url.searchParams.get("transport") === "http1-bounded" &&
+    elapsedMs >= 8_000 &&
+    elapsedMs <= 25_000
+  );
+}
+
 function retiredFiniteReadTerminalProblem(
   description: string | undefined,
   terminal: { kind: "finished" } | { kind: "response"; status: number },
@@ -543,6 +576,7 @@ function observeBrowser(page: Page): BrowserProblems {
     acceptedRequestFailures: [],
     activeStreams: new Map(),
     boundedHttp1StreamDispatches: 0,
+    boundedHttp1NativeSeams: 0,
     actorDispatches: [],
     actorFenceResponses: [],
     actorTransitionResponses: [],
@@ -702,6 +736,18 @@ function observeBrowser(page: Page): BrowserProblems {
     // quiescence tracking, but keep every non-transition failure in the strict
     // final ledger—including canceled product mutations.
     problems.pendingFiniteReads.delete(request);
+    if (
+      isExpectedBoundedHttp1NativeSeam({
+        failedAt,
+        failure,
+        method: request.method(),
+        startedAt: dispatch?.startedAt,
+        url: request.url(),
+      })
+    ) {
+      problems.boundedHttp1NativeSeams += 1;
+      return;
+    }
     const check = (async () => {
       const problem = requestFailureProblem({
         acceptedActorTransitions: actorMutationAcceptances,
@@ -2656,6 +2702,34 @@ describe("provider-neutral browser account acceptance", () => {
     ).toBe(false);
   });
 
+  test("the strict browser ledger bounds native HTTP/1 stream seams by URL, cause, and time", () => {
+    const expected = {
+      failedAt: 9_100,
+      failure: "net::ERR_ABORTED",
+      method: "GET",
+      startedAt: 100,
+      url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/live-events/stream?transport=http1-bounded`,
+    };
+    expect(isExpectedBoundedHttp1NativeSeam(expected)).toBe(true);
+    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 7_999 })).toBe(false);
+    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 25_101 })).toBe(false);
+    expect(
+      isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "net::ERR_CONNECTION_RESET" }),
+    ).toBe(false);
+    expect(
+      isExpectedBoundedHttp1NativeSeam({
+        ...expected,
+        url: `${publicOrigin}/v1/workspaces?transport=http1-bounded`,
+      }),
+    ).toBe(false);
+    expect(
+      isExpectedBoundedHttp1NativeSeam({
+        ...expected,
+        url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/live-events/stream`,
+      }),
+    ).toBe(false);
+  });
+
   test("real users add, race, switch, re-authenticate, deep-link, and revoke without stale tenant state", async () => {
     if (!owned) throw new Error("database fixture unavailable");
     const engine = requestedEngine as EngineName;
@@ -3218,6 +3292,11 @@ describe("provider-neutral browser account acceptance", () => {
               primary: pageProblems.boundedHttp1StreamDispatches,
               secondTab: secondTabProblems.boundedHttp1StreamDispatches,
               independentSet: otherProblems.boundedHttp1StreamDispatches,
+            },
+            boundedHttp1NativeSeams: {
+              primary: pageProblems.boundedHttp1NativeSeams,
+              secondTab: secondTabProblems.boundedHttp1NativeSeams,
+              independentSet: otherProblems.boundedHttp1NativeSeams,
             },
             sameSetSecondTabNeutralizedAfterLogoutAll: true,
             anotherBrowserSetSurvivedLogoutAll: true,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -429,14 +429,15 @@ function isExpectedBoundedHttp1NativeSeam(input: {
     /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|cancelled|canceled/iu.test(input.failure) &&
     !/NET_RESET|CONNECTION_RESET/iu.test(input.failure);
   const elapsedMs = input.failedAt - input.startedAt;
-  // The browser-owned seam fires at nine seconds. Allow bounded scheduling
-  // jitter while rejecting eager cancellations and genuinely stuck requests.
+  // The browser-owned seam fires at nine seconds. Allow only the request-start
+  // offset plus bounded scheduling jitter; the two-second logical reconnect
+  // grace does not extend the native request's cancellation deadline.
   return (
     isStream &&
     isCancellation &&
     url.searchParams.get("transport") === "http1-bounded" &&
     elapsedMs >= 8_000 &&
-    elapsedMs <= 25_000
+    elapsedMs <= 13_000
   );
 }
 
@@ -2712,7 +2713,7 @@ describe("provider-neutral browser account acceptance", () => {
     };
     expect(isExpectedBoundedHttp1NativeSeam(expected)).toBe(true);
     expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 7_999 })).toBe(false);
-    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 25_101 })).toBe(false);
+    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 13_101 })).toBe(false);
     expect(
       isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "net::ERR_CONNECTION_RESET" }),
     ).toBe(false);

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -427,7 +427,9 @@ function isExpectedBoundedHttp1NativeSeam(input: {
   const isStream = url.pathname.endsWith("/stream") || url.pathname.includes("/live-events/stream");
   const isCancellation =
     /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|cancelled|canceled/iu.test(input.failure) &&
-    !/NET_RESET|CONNECTION_RESET/iu.test(input.failure);
+    !/(?:NET_RESET|CONNECTION_RESET|connection[\s_-]+reset|transport[\s_-]+(?:failure|failed|error|reset))/iu.test(
+      input.failure,
+    );
   const elapsedMs = input.failedAt - input.startedAt;
   // The browser-owned seam fires at nine seconds. Allow only the request-start
   // offset plus bounded scheduling jitter; the two-second logical reconnect
@@ -2716,6 +2718,12 @@ describe("provider-neutral browser account acceptance", () => {
     expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 13_101 })).toBe(false);
     expect(
       isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "net::ERR_CONNECTION_RESET" }),
+    ).toBe(false);
+    expect(
+      isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "cancelled: connection reset" }),
+    ).toBe(false);
+    expect(
+      isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "canceled: transport failure" }),
     ).toBe(false);
     expect(
       isExpectedBoundedHttp1NativeSeam({


### PR DESCRIPTION
## Summary
- add a browser-owned nine-second lifetime to bounded HTTP/1 event streams, after the normal five-second server seam and two-second reconnect grace
- abort the native request before cancelling its reader so an orphaned Chromium request cannot retain a per-origin connection slot
- preserve fail-closed account rotation during the clean reconnect seam and record only tightly bounded expected cancellations in browser evidence
- recalibrate the reviewed production bundle envelope

## Why
The exact PR checks for #1990 passed, but post-merge Chromium account acceptance still reproduced native stream requests remaining active for more than 30 seconds and starving finite account reads. This closes the remaining browser/runtime-adapter lifecycle gap while leaving HTTP/2 and HTTP/3 streams unchanged.

Regression evidence: https://github.com/Cloudgeni-ai/opengeni/actions/runs/33188809083/job/98908858319

## Verification
- focused API and policy tests: 55 passing, 215 assertions
- typecheck: all 31 projects clean
- lint and format checks clean
- exact Chromium real-Postgres account journey: 3 passing, 205 assertions
- Firefox and WebKit real-Postgres account journeys passed on the same implementation path before the final nine-second calibration
- all 22 unrelated failures observed under the 1,429-file parallel unit sweep passed together on isolated rerun: 77 passing, 2 opt-in skips
- production web build and precompression clean
- direct-session bundle: 2,237,456 raw bytes against 2,239,488 budget; 627,020 gzip against 627,712 budget

## Safety
- the fallback is selected only after the browser has observed HTTP/1 for the API origin
- server-owned clean EOF remains the primary path
- account rotation wins over a pending clean seam and rejects the old actor stream
- the browser acceptance ledger rejects eager, reset, non-stream, unmarked, and stuck cancellations

## Summary by Sourcery

Bound browser-owned HTTP/1 event-stream lifetimes so orphaned native requests cannot exhaust per-origin connections or starve finite API reads.

Bug Fixes:
- Prevent orphaned browser-native HTTP/1 event-stream requests from retaining connection slots beyond their bounded lifetime.
- Preserve fail-closed actor rotation while streams transition through the clean reconnect seam.

Enhancements:
- Abort native stream requests before releasing their readers and narrowly classify expected bounded-stream cancellations in browser acceptance evidence.

Build:
- Recalibrate the reviewed production web bundle budget for the browser-owned HTTP/1 stream lifetime changes.

Tests:
- Add coverage for native HTTP/1 stream lifetime enforcement, clean-seam behavior, actor rotation, and strict cancellation classification.