### PR TITLE
fix(streams): prevent browser HTTP/1 connection starvation

### DIFF
--- a/.changeset/calm-http1-sse-batches.md
+++ b/.changeset/calm-http1-sse-batches.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/worker-bundle": patch
+---
+
+Return browser HTTP/1 event streams as capped, known-length batches so multiple tabs cannot retain ambiguous streaming requests and starve ordinary API reads.

--- a/apps/api/src/http/sse.ts
+++ b/apps/api/src/http/sse.ts
@@ -27,6 +27,7 @@ export const SSE_QUEUED_FRAME_MAX_COUNT = 1;
 export const SSE_WRITE_STALL_TIMEOUT_MS = 30_000;
 export const SSE_HEARTBEAT_INTERVAL_MS = 15_000;
 export const HTTP1_BROWSER_SSE_LIFETIME_MS = 5_000;
+export const HTTP1_BROWSER_SSE_BATCH_MAX_BYTES = 512 * 1024;
 type SseStreamKind = "session" | "workspace_control" | "workspace_interaction";
 const activeSseStreams: Record<SseStreamKind, number> = {
   session: 0,
@@ -477,20 +478,7 @@ export async function sseSessionStream(
     detachAbortListener = () => signal.removeEventListener("abort", abort);
   }
 
-  return new Response(channel.stream, {
-    headers: {
-      "Content-Type": "text/event-stream; charset=utf-8",
-      "Cache-Control": "no-cache, no-transform",
-      // A clean authorization close must also retire the HTTP/1 transport.
-      // Reusing that socket can leave Chromium accounting the ended SSE as an
-      // active per-origin connection while a replacement document is already
-      // dispatching finite reads. HTTP/2 front doors strip this hop-by-hop
-      // header; direct Bun/self-hosted HTTP/1 clients receive an unambiguous
-      // connection end after the stream's terminal chunk.
-      Connection: "close",
-      ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
-    },
-  });
+  return await sseHttpResponse(channel.stream, options);
 }
 
 export async function replaySessionEvents(
@@ -658,14 +646,7 @@ export async function sseWorkspaceControlStream(
     detachAbortListener = () => signal.removeEventListener("abort", abort);
   }
 
-  return new Response(channel.stream, {
-    headers: {
-      "Content-Type": "text/event-stream; charset=utf-8",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "close",
-      ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
-    },
-  });
+  return await sseHttpResponse(channel.stream, options);
 }
 
 export type WorkspaceInteractionSseOptions = SseDeliveryOptions & {
@@ -713,6 +694,7 @@ export async function sseWorkspaceLiveStream(
   const upstreamOptions: WorkspaceInteractionSseOptions = {
     ...options,
     connectionLifetimeMs: undefined,
+    finiteResponseMaxBytes: undefined,
     reauthorize: undefined,
     reauthorizeAfterMs: undefined,
   };
@@ -786,14 +768,7 @@ export async function sseWorkspaceLiveStream(
     }
   })();
 
-  return new Response(channel.stream, {
-    headers: {
-      "Content-Type": "text/event-stream; charset=utf-8",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "close",
-      ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
-    },
-  });
+  return await sseHttpResponse(channel.stream, options);
 }
 
 /**
@@ -844,7 +819,10 @@ export async function sseWorkspaceInteractionRevisionStream(
       if (!(await write(": connected\n\n"))) return;
       for (;;) {
         if (stopRequested || signal.aborted || channel.stopped()) return;
-        const state = await getWorkspaceInteractionRevisionState(db, { accountId, workspaceId });
+        const state = await getWorkspaceInteractionRevisionState(db, {
+          accountId,
+          workspaceId,
+        });
         if (state.revision > lastSent) {
           const event = WorkspaceInteractionRevisionEvent.parse({
             workspaceId,
@@ -874,14 +852,7 @@ export async function sseWorkspaceInteractionRevisionStream(
     detachAbortListener = () => signal.removeEventListener("abort", abort);
   }
 
-  return new Response(channel.stream, {
-    headers: {
-      "Content-Type": "text/event-stream; charset=utf-8",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "close",
-      ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
-    },
-  });
+  return await sseHttpResponse(channel.stream, options);
 }
 
 function observeSseConnection(
@@ -962,6 +933,8 @@ async function reauthorizeSseOrClose(
 
 export type SseDeliveryOptions = {
   connectionLifetimeMs?: number | undefined;
+  /** Return a known-length batch instead of a chunked response. HTTP/1 only. */
+  finiteResponseMaxBytes?: number | undefined;
   maxQueuedBytes?: number;
   stallTimeoutMs?: number;
   heartbeatIntervalMs?: number;
@@ -976,10 +949,82 @@ export type SseDeliveryOptions = {
 
 export function browserSseDeliveryOptions(
   transport: string | undefined,
-): Pick<SseDeliveryOptions, "connectionLifetimeMs"> {
+): Pick<SseDeliveryOptions, "connectionLifetimeMs" | "finiteResponseMaxBytes"> {
   return transport === "http1-bounded"
-    ? { connectionLifetimeMs: HTTP1_BROWSER_SSE_LIFETIME_MS }
+    ? {
+        connectionLifetimeMs: HTTP1_BROWSER_SSE_LIFETIME_MS,
+        finiteResponseMaxBytes: HTTP1_BROWSER_SSE_BATCH_MAX_BYTES,
+      }
     : {};
+}
+
+async function sseHttpResponse(
+  stream: ReadableStream<Uint8Array>,
+  options: SseDeliveryOptions,
+): Promise<Response> {
+  const maxBytes = options.finiteResponseMaxBytes;
+  let body: ReadableStream<Uint8Array> | ArrayBuffer = stream;
+  let contentLength: number | null = null;
+  if (maxBytes !== undefined) {
+    if (
+      !Number.isSafeInteger(maxBytes) ||
+      maxBytes < SESSION_EVENT_SSE_FRAME_MAX_BYTES ||
+      maxBytes > HTTP1_BROWSER_SSE_BATCH_MAX_BYTES
+    ) {
+      throw new RangeError(
+        `finite SSE batch limit must be between ${SESSION_EVENT_SSE_FRAME_MAX_BYTES} and ${HTTP1_BROWSER_SSE_BATCH_MAX_BYTES} bytes`,
+      );
+    }
+    body = await collectFiniteSseBatch(stream, maxBytes);
+    contentLength = body.byteLength;
+  }
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      // A clean authorization close must also retire the HTTP/1 transport.
+      // Reusing that socket can leave Chromium accounting the ended SSE as an
+      // active per-origin connection while a replacement document is already
+      // dispatching finite reads. HTTP/2 front doors strip this hop-by-hop
+      // header; direct Bun/self-hosted HTTP/1 clients receive an unambiguous
+      // connection end after the stream's terminal chunk.
+      Connection: "close",
+      ...(contentLength === null ? {} : { "Content-Length": String(contentLength) }),
+      ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
+    },
+  });
+}
+
+async function collectFiniteSseBatch(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<ArrayBuffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      // Each source chunk is one complete SSE frame. End before an overflowing
+      // frame so reconnect replay starts from the consumer's last whole cursor.
+      if (length + next.value.byteLength > maxBytes) {
+        await reader.cancel("finite SSE batch reached its byte limit");
+        break;
+      }
+      chunks.push(next.value);
+      length += next.value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes.buffer;
 }
 
 export type SessionSseDeliveryOptions = SseDeliveryOptions;

--- a/apps/api/test/sse-stream-bounds.test.ts
+++ b/apps/api/test/sse-stream-bounds.test.ts
@@ -119,7 +119,10 @@ afterAll(() => {
 });
 
 test("HTTP/1 browser streams cycle cleanly while HTTP/2 streams remain long-lived", async () => {
-  expect(browserSseDeliveryOptions("http1-bounded")).toEqual({ connectionLifetimeMs: 5_000 });
+  expect(browserSseDeliveryOptions("http1-bounded")).toEqual({
+    connectionLifetimeMs: 5_000,
+    finiteResponseMaxBytes: 512 * 1024,
+  });
   expect(browserSseDeliveryOptions(undefined)).toEqual({});
   expect(browserSseDeliveryOptions("h2")).toEqual({});
 
@@ -137,9 +140,35 @@ test("HTTP/1 browser streams cycle cleanly while HTTP/2 streams remain long-live
   expect(stopped).toBe(1);
 });
 
+test("HTTP/1 browser fallback returns a fully framed finite SSE batch", async () => {
+  interactionRevisionState = {
+    revision: 3,
+    updatedAt: new Date("2026-08-10T00:00:03.000Z"),
+  };
+  const response = await sseWorkspaceInteractionRevisionStream(
+    fakeDb as never,
+    "00000000-0000-4000-8000-000000000010",
+    WORKSPACE_ID,
+    1,
+    new AbortController().signal,
+    {
+      connectionLifetimeMs: 10,
+      finiteResponseMaxBytes: 96 * 1024,
+      pollIntervalMs: 100,
+      heartbeatIntervalMs: 1_000,
+    },
+  );
+  const bytes = await response.arrayBuffer();
+  expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
+  expect(new TextDecoder().decode(bytes)).toContain('"sequence":3');
+});
+
 test("workspace interaction SSE projects only the newest durable revision", async () => {
   interactionRevisionReads = 0;
-  interactionRevisionState = { revision: 3, updatedAt: new Date("2026-08-10T00:00:03.000Z") };
+  interactionRevisionState = {
+    revision: 3,
+    updatedAt: new Date("2026-08-10T00:00:03.000Z"),
+  };
   const controller = new AbortController();
   const response = await sseWorkspaceInteractionRevisionStream(
     fakeDb as never,
@@ -153,7 +182,10 @@ test("workspace interaction SSE projects only the newest durable revision", asyn
   expect(await readSequences(reader, 1)).toEqual([3]);
 
   // Intermediate revisions are cursor noise; the stream may deliver 7 directly.
-  interactionRevisionState = { revision: 7, updatedAt: new Date("2026-08-10T00:00:07.000Z") };
+  interactionRevisionState = {
+    revision: 7,
+    updatedAt: new Date("2026-08-10T00:00:07.000Z"),
+  };
   expect(await readSequences(reader, 1)).toEqual([7]);
   expect(interactionRevisionReads).toBeGreaterThanOrEqual(2);
 
@@ -164,7 +196,10 @@ test("workspace interaction SSE projects only the newest durable revision", asyn
 test("workspace live SSE carries both durable domains over one response", async () => {
   durableControlEvents = [controlEvent(2)];
   durableControlReads.length = 0;
-  interactionRevisionState = { revision: 7, updatedAt: new Date("2026-08-10T00:00:07.000Z") };
+  interactionRevisionState = {
+    revision: 7,
+    updatedAt: new Date("2026-08-10T00:00:07.000Z"),
+  };
   const controller = new AbortController();
   const response = await sseWorkspaceLiveStream(
     fakeDb as never,
@@ -211,7 +246,11 @@ test("a stalled SSE client is isolated, stops replay, and reconnects without gap
     queuedBytes: number;
   }> = [];
   const counters: Array<{ name: string; labels?: Record<string, unknown> }> = [];
-  const gauges: Array<{ name: string; labels?: Record<string, unknown>; value: number }> = [];
+  const gauges: Array<{
+    name: string;
+    labels?: Record<string, unknown>;
+    value: number;
+  }> = [];
   const observability = {
     incrementCounter: (input: { name: string; labels?: Record<string, unknown> }) =>
       counters.push(input),
@@ -254,7 +293,10 @@ test("a stalled SSE client is isolated, stops replay, and reconnects without gap
 
   // The non-reading connection cannot hold up a sibling subscription.
   expect(fastEvents.map((candidate) => candidate.sequence)).toEqual([1]);
-  expect(fastEvents[0]?.payload).toMatchObject({ text: "12", coalescedUntil: 2 });
+  expect(fastEvents[0]?.payload).toMatchObject({
+    text: "12",
+    coalescedUntil: 2,
+  });
   expect(released).toEqual([]);
 
   await waitFor(() => released.length === 1);
@@ -312,7 +354,10 @@ test("a stalled SSE client is isolated, stops replay, and reconnects without gap
   const resumedReader = resumed.body!.getReader();
   const resumedEvents = await readSessionEvents(resumedReader, 1);
   expect(resumedEvents.map((candidate) => candidate.sequence)).toEqual([1]);
-  expect(resumedEvents[0]?.payload).toMatchObject({ text: "12", coalescedUntil: 2 });
+  expect(resumedEvents[0]?.payload).toMatchObject({
+    text: "12",
+    coalescedUntil: 2,
+  });
 
   await resumedReader.cancel();
   await fastReader.cancel();
@@ -522,7 +567,10 @@ test("a session stream closes cleanly before its first frame when host authoriza
     },
   );
   const reader = response.body!.getReader();
-  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+  await expect(reader.read()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
   expect(reauthorizations).toBe(1);
   expect(released).toBe(1);
 });
@@ -560,7 +608,10 @@ test("rechecks current authority and closes before a live event after revocation
   allowed = false;
   durableEvents = [event(1)];
   publish?.([event(1)]);
-  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+  await expect(reader.read()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
 });
 
 test("emits the selected actor epoch and closes before a cross-tab actor event", async () => {
@@ -598,7 +649,10 @@ test("emits the selected actor epoch and closes before a cross-tab actor event",
   currentEpoch = "8";
   durableEvents = [event(1)];
   publish?.([event(1)]);
-  await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+  await expect(reader.read()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
 });
 
 test("every long-lived SSE surface closes when its current workspace authority is revoked", async () => {
@@ -644,7 +698,10 @@ test("every long-lived SSE surface closes when its current workspace authority i
   const readers = responses.map((response) => response.body!.getReader());
   await Promise.all(
     readers.map(async (reader) => {
-      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+      await expect(reader.read()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      });
     }),
   );
 });
@@ -653,7 +710,11 @@ test("workspace-control SSE uses the same one-frame stall bound", async () => {
   durableControlEvents = [controlEvent(1), controlEvent(2)];
   durableControlReads.length = 0;
   let released = 0;
-  const observations: Array<{ reason: string; queuedFrames: number; queuedBytes: number }> = [];
+  const observations: Array<{
+    reason: string;
+    queuedFrames: number;
+    queuedBytes: number;
+  }> = [];
   const bus = {
     subscribeWorkspaceControl: async () => () => {
       released += 1;

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -41,7 +41,9 @@ describe("web API auth helpers", () => {
     });
     let cleaned = 0;
     const response = managedActorTrackedResponse(
-      new Response(source, { headers: { "content-type": "text/event-stream" } }),
+      new Response(source, {
+        headers: { "content-type": "text/event-stream" },
+      }),
       new AbortController().signal,
       () => {
         cleaned += 1;
@@ -80,7 +82,9 @@ describe("web API auth helpers", () => {
         },
       });
       const response = managedActorTrackedResponse(
-        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        new Response(source, {
+          headers: { "content-type": "text/event-stream" },
+        }),
         new AbortController().signal,
         () => {
           cleaned += 1;
@@ -124,7 +128,9 @@ describe("web API auth helpers", () => {
       const actor = new AbortController();
       const source = new ReadableStream<Uint8Array>();
       const response = managedActorTrackedResponse(
-        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        new Response(source, {
+          headers: { "content-type": "text/event-stream" },
+        }),
         actor.signal,
         () => undefined,
         () => signalNativeAbort(),
@@ -373,7 +379,10 @@ describe("web API auth helpers", () => {
       await Promise.resolve();
       expect(observed.signal?.aborted).toBe(false);
       bodyController.enqueue(new Uint8Array([1]));
-      await expect(read).resolves.toEqual({ done: false, value: new Uint8Array([1]) });
+      await expect(read).resolves.toEqual({
+        done: false,
+        value: new Uint8Array([1]),
+      });
       await reader.cancel();
     } finally {
       configureManagedActorEpoch(null);
@@ -423,6 +432,71 @@ describe("web API auth helpers", () => {
     }
   });
 
+  test("drains a known-length HTTP/1 SSE batch before exposing it", async () => {
+    const originalFetch = globalThis.fetch;
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+    let source!: ReadableStream<Uint8Array>;
+    globalThis.fetch = (async () => {
+      source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+        },
+      });
+      return new Response(source, {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "content-length": "14",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("finite-sse");
+      let exposed = false;
+      const pending = managedActorFetch("https://api.example.test/v1/sessions/live").then(
+        (response) => {
+          exposed = true;
+          return response;
+        },
+      );
+      await Promise.resolve();
+      bodyController.enqueue(new TextEncoder().encode(": connected\n\n"));
+      await Promise.resolve();
+      expect(exposed).toBe(false);
+      bodyController.close();
+      const response = await pending;
+      expect(source.locked).toBe(false);
+      await expect(response.text()).resolves.toBe(": connected\n\n");
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not buffer an SSE response whose claimed length exceeds the batch bound", async () => {
+    const originalFetch = globalThis.fetch;
+    let source!: ReadableStream<Uint8Array>;
+    globalThis.fetch = (async () => {
+      source = new ReadableStream<Uint8Array>();
+      return new Response(source, {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "content-length": String(512 * 1024 + 1),
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("oversized-sse");
+      const response = await managedActorFetch("https://api.example.test/v1/sessions/live");
+      await response.body!.cancel();
+      expect(source.locked).toBe(false);
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("aborts a finite JSON drain when the accepted actor changes", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { signal?: AbortSignal | null } = {};
@@ -437,7 +511,9 @@ describe("web API auth helpers", () => {
           controller.enqueue(new TextEncoder().encode('{"partial":'));
         },
       });
-      return new Response(source, { headers: { "content-type": "application/json" } });
+      return new Response(source, {
+        headers: { "content-type": "application/json" },
+      });
     }) as unknown as typeof fetch;
 
     try {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -24,6 +24,7 @@ const deploymentReloadStoragePrefix = "opengeni.reloadForRevision:";
 const contractReloadStoragePrefix = "opengeni.reloadForApiContract:";
 const boundedHttp1SseTransport = "http1-bounded";
 const HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS = 2_000;
+const HTTP1_BROWSER_SSE_BATCH_MAX_BYTES = 512 * 1024;
 // The API normally closes bounded HTTP/1 streams after five seconds. Keep a
 // browser-owned backstop as well: a server/runtime adapter can acknowledge a
 // Web Stream close without retiring Chromium's native request, and one such
@@ -242,8 +243,8 @@ export async function managedActorFetch(
     // EOF. Draining here also guarantees the native body already has a
     // rejection consumer before any post-header actor abort.
     let actorResponse = response;
-    const finiteJsonResponse = isFiniteJsonResponse(response);
-    if (finiteJsonResponse) {
+    const detachedResponse = isFiniteJsonResponse(response) || isFiniteSseBatchResponse(response);
+    if (detachedResponse) {
       const bytes = await readFiniteResponseBytes(response);
       if (responseIsStale()) {
         throw new DOMException(
@@ -257,7 +258,7 @@ export async function managedActorFetch(
         headers: response.headers,
       });
     }
-    // Before headers—and through a finite JSON drain—actor rotation aborts the
+    // Before headers—and through a finite response drain—actor rotation aborts the
     // native fetch. A detached finite body no longer owns a network resource,
     // so only its wrapper remains actor-bound. A live body must also abort its
     // native fetch after admission: cancelling only the source reader can leave
@@ -267,10 +268,10 @@ export async function managedActorFetch(
     // transport is released. The native reader rejection is still delivered in
     // a later microtask, after the wrapper records its fail-closed AbortError.
     const actorBodyController = new AbortController();
-    const abortNativeTransport = finiteJsonResponse
+    const abortNativeTransport = detachedResponse
       ? undefined
       : (reason: unknown) => controller.abort(reason);
-    abortTarget = finiteJsonResponse
+    abortTarget = detachedResponse
       ? (reason) => actorBodyController.abort(reason)
       : (reason) => {
           // Abort the native fetch before publishing the wrapper abort. The
@@ -286,8 +287,8 @@ export async function managedActorFetch(
       actorBodyController.signal,
       cleanup,
       abortNativeTransport,
-      finiteJsonResponse ? 0 : cleanCloseDelayMs,
-      finiteJsonResponse ? 0 : nativeLifetimeMs,
+      isFiniteSseBatchResponse(actorResponse) ? cleanCloseDelayMs : 0,
+      detachedResponse ? 0 : nativeLifetimeMs,
     );
   } finally {
     if (!responseOwnsCleanup) cleanup();
@@ -345,6 +346,19 @@ function observedApiProtocol(): string | null {
 function isFiniteJsonResponse(response: Response): boolean {
   const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
   return contentType === "application/json" || contentType?.endsWith("+json") === true;
+}
+
+function isFiniteSseBatchResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  const contentLength = response.headers.get("content-length");
+  const parsedContentLength = contentLength === null ? Number.NaN : Number(contentLength);
+  return (
+    contentType === "text/event-stream" &&
+    contentLength !== null &&
+    /^\d+$/.test(contentLength) &&
+    Number.isSafeInteger(parsedContentLength) &&
+    parsedContentLength <= HTTP1_BROWSER_SSE_BATCH_MAX_BYTES
+  );
 }
 
 async function readFiniteResponseBytes(response: Response): Promise<ArrayBuffer> {

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -340,7 +340,8 @@ function sessionSetAuthorityHash(cookieHeader: string | null): string | null {
 }
 
 function requestFailureProblem(input: BrowserRequestFailureInput): string | null {
-  const pathname = new URL(input.url).pathname;
+  const requestUrl = new URL(input.url);
+  const pathname = requestUrl.pathname;
   const isConnectionReset = /NET_RESET|CONNECTION_RESET/iu.test(input.failure);
   const isCancellation =
     /ERR_ABORTED|NS_(?:BINDING_ABORTED|ERROR_ABORT)|NET_RESET|CONNECTION_RESET|cancelled|canceled/iu.test(
@@ -380,6 +381,27 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
         transition.acceptedAt >= startedAt &&
         transition.acceptedAt <= failedAt,
     ) === true;
+  const isExpectedLogoutAllBoundedStreamCancellation =
+    isCancellation &&
+    !isConnectionReset &&
+    input.method === "GET" &&
+    input.actorEpoch !== null &&
+    input.dispatchPhase === "late-old-epoch-primary-settled-before-old-release" &&
+    input.responsePhase === "logout-all-response-loss-replay" &&
+    requestUrl.searchParams.get("transport") === "http1-bounded" &&
+    /^\/v1\/workspaces\/[0-9a-f-]+\/live-events\/stream$/u.test(pathname) &&
+    typeof startedAt === "number" &&
+    Number.isFinite(startedAt) &&
+    typeof failedAt === "number" &&
+    Number.isFinite(failedAt) &&
+    input.acceptedActorTransitions?.some(
+      (transition) =>
+        transition.path === "/v1/auth/session-set/logout-all" &&
+        transition.actorEpoch !== null &&
+        transition.actorEpoch !== input.actorEpoch &&
+        transition.acceptedAt >= startedAt &&
+        transition.acceptedAt <= failedAt,
+    ) === true;
   const isExpectedEvidenceCatalogCancellation =
     isCancellation &&
     !isConnectionReset &&
@@ -400,6 +422,7 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
   if (
     isExpectedScopedActorReadCancellation ||
     isAcceptedActorTransitionCancellation ||
+    isExpectedLogoutAllBoundedStreamCancellation ||
     isExpectedEvidenceCatalogCancellation ||
     isExpectedDocumentBootstrapCancellation
   ) {
@@ -2302,6 +2325,43 @@ describe("provider-neutral browser account acceptance", () => {
         ],
       }),
     ).toContain("/live-events/stream");
+    const signedOutOldActorBoundedStream = {
+      ...longLivedOldActorStream,
+      acceptedActorTransitions: [
+        {
+          acceptedAt: 200,
+          actorEpoch: "signed-out-actor-epoch",
+          path: "/v1/auth/session-set/logout-all",
+          sessionSetAuthorityHash: "b".repeat(64),
+        },
+      ],
+      url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/live-events/stream?after=12&transport=http1-bounded`,
+    } satisfies BrowserRequestFailureInput;
+    expect(requestFailureProblem(signedOutOldActorBoundedStream)).toBeNull();
+    expect(
+      requestFailureProblem({
+        ...signedOutOldActorBoundedStream,
+        acceptedActorTransitions: [],
+      }),
+    ).toContain("/live-events/stream");
+    expect(
+      requestFailureProblem({
+        ...signedOutOldActorBoundedStream,
+        failure: "NS_ERROR_NET_RESET",
+      }),
+    ).toContain("/live-events/stream");
+    expect(
+      requestFailureProblem({
+        ...signedOutOldActorBoundedStream,
+        url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/live-events/stream?transport=sse`,
+      }),
+    ).toContain("/live-events/stream");
+    expect(
+      requestFailureProblem({
+        ...signedOutOldActorBoundedStream,
+        url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/sessions?transport=http1-bounded`,
+      }),
+    ).toContain("/sessions");
     expect(
       requestFailureProblem({
         ...longLivedOldActorStream,

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1409,7 +1409,11 @@ function accountMenuSurface(page: Page): Locator {
     .last();
 }
 
-async function openAccountMenu(page: Page, displayName: string): Promise<Locator> {
+async function openAccountMenu(
+  page: Page,
+  displayName: string,
+  prepareTrigger?: () => Promise<void>,
+): Promise<Locator> {
   const trigger = accountMenuTrigger(page, displayName);
   const menu = accountMenuSurface(page);
   let lastError: unknown;
@@ -1424,10 +1428,23 @@ async function openAccountMenu(page: Page, displayName: string): Promise<Locator
         await page.waitForTimeout(100);
       }
     }
-    if ((await trigger.getAttribute("aria-expanded")) === "true") {
-      await page.keyboard.press("Escape");
+    try {
+      await prepareTrigger?.();
+      await trigger.waitFor({ state: "visible", timeout: 3_000 });
+      if ((await trigger.getAttribute("aria-expanded", { timeout: 1_000 })) === "true") {
+        await page.keyboard.press("Escape");
+      }
+      await trigger.click({ timeout: 3_000 });
+    } catch (error) {
+      // Responsive navigation can finish a route transition after its account
+      // trigger first becomes visible, remounting or closing the drawer between
+      // two locator operations. Retry that bounded UI transition instead of
+      // spending Playwright's full default timeout on the vanished element.
+      lastError = error;
+      await page.keyboard.press("Escape").catch(() => undefined);
+      await page.waitForTimeout(100);
+      continue;
     }
-    await trigger.click();
     try {
       await menu.waitFor({ timeout: 3_000 });
       await waitForStableAccountMenu(page, menu);
@@ -1469,15 +1486,20 @@ async function openResponsiveAccountMenu(
     await waitForStableAccountMenu(page, menu);
     return menu;
   }
-  if (width < 1_024) {
-    const trigger = accountMenuTrigger(page, displayName);
-    if (!(await trigger.isVisible())) {
-      await page.getByRole("button", { name: "Open navigation" }).click();
-      await page.getByRole("tab", { name: "Workspace" }).click();
-      await trigger.waitFor();
-    }
-  }
-  const opened = await openAccountMenu(page, displayName);
+  const prepareTrigger =
+    width < 1_024
+      ? async () => {
+          const trigger = accountMenuTrigger(page, displayName);
+          if (await trigger.isVisible()) return;
+          const workspaceTab = page.getByRole("tab", { name: "Workspace" });
+          if (!(await workspaceTab.isVisible())) {
+            await page.getByRole("button", { name: "Open navigation" }).click({ timeout: 3_000 });
+          }
+          await workspaceTab.click({ timeout: 3_000 });
+          await trigger.waitFor({ state: "visible", timeout: 3_000 });
+        }
+      : undefined;
+  const opened = await openAccountMenu(page, displayName, prepareTrigger);
   return opened;
 }
 

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1481,11 +1481,6 @@ async function openResponsiveAccountMenu(
   displayName: string,
   width: number,
 ): Promise<Locator> {
-  const menu = accountMenuSurface(page);
-  if (await menu.isVisible()) {
-    await waitForStableAccountMenu(page, menu);
-    return menu;
-  }
   const prepareTrigger =
     width < 1_024
       ? async () => {


### PR DESCRIPTION
## Summary

- return every browser HTTP/1 event stream as a capped, known-length five-second batch
- fully drain that batch before exposing it to the SDK, then preserve the existing reconnect grace
- keep HTTP/2 and HTTP/3 streams live and unchanged
- keep the responsive account menu retry bounded across transient drawer remounts
- keep the account-transition ledger strict while admitting only the exact old-account bounded stream cancellation after an accepted sign-out-all rotation

## Why

The previous browser-owned lifetime still left Chromium with active HTTP/1 requests after a server stream seam. On the prior exact head, Chromium had four finite reads pending behind four active bounded streams in the primary page while another tab owned two more streams. The JavaScript lifetime timer could also be throttled in a background page.

The new HTTP/1 fallback is an actual finite response with Content-Length, not a chunked response that merely intends to close. The browser can therefore retire the request deterministically before the SDK reconnects.

## Correctness and bounds

- batches are limited to 512 KiB on both the API and web boundaries
- the collector stops only between complete SSE frames
- session and workspace cursors reconnect through existing durable replay, preserving ordering and gap repair
- only the outer multiplexed workspace stream is batched; its internal sources remain live
- actor rotation remains fail-closed during both the native drain and detached response consumption
- HTTP/2 and HTTP/3 behavior is unchanged
- the older native-lifetime fallback remains for rollout compatibility with an older API response
- the sign-out-all cancellation matcher requires the exact bounded live-event URL, old actor, accepted new actor, timing window, response phase, dispatch phase, and non-reset browser cancellation class

## Evidence

- repository formatting and lint pass
- all 31 TypeScript projects pass
- 47 focused API and web transport tests pass
- the strict browser-ledger unit test passes 87 assertions, including reset, wrong-transport, wrong-path, and missing-acceptance negative cases
- the independently rerun desktop lane passes 17 tests with one intentional live-service skip
- complete real-PostgreSQL account journeys pass locally in Chromium, Firefox, and WebKit on exact head `171ee3fa2b56ded52a7c4992e052580a46a27521`
- those journeys cover the strict request ledger, multi-tab switches, re-authentication, deep links, revocation, lost-response replay, responsive layouts, and finite-read quiescence
