### PR TITLE
fix(streams): preserve HTTP/1 pool headroom

### DIFF
--- a/.changeset/reusable-http1-sse-polling.md
+++ b/.changeset/reusable-http1-sse-polling.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep finite browser HTTP/1 event batches on reusable connections and shorten their bounded cycle so ordinary API reads retain connection-pool headroom across tabs and account changes.

--- a/apps/api/src/http/sse.ts
+++ b/apps/api/src/http/sse.ts
@@ -26,7 +26,7 @@ const WORKSPACE_CONTROL_REPLAY_PAGE_SIZE = 100;
 export const SSE_QUEUED_FRAME_MAX_COUNT = 1;
 export const SSE_WRITE_STALL_TIMEOUT_MS = 30_000;
 export const SSE_HEARTBEAT_INTERVAL_MS = 15_000;
-export const HTTP1_BROWSER_SSE_LIFETIME_MS = 5_000;
+export const HTTP1_BROWSER_SSE_LIFETIME_MS = 1_000;
 export const HTTP1_BROWSER_SSE_BATCH_MAX_BYTES = 512 * 1024;
 type SseStreamKind = "session" | "workspace_control" | "workspace_interaction";
 const activeSseStreams: Record<SseStreamKind, number> = {
@@ -982,14 +982,14 @@ async function sseHttpResponse(
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
-      // A clean authorization close must also retire the HTTP/1 transport.
-      // Reusing that socket can leave Chromium accounting the ended SSE as an
-      // active per-origin connection while a replacement document is already
-      // dispatching finite reads. HTTP/2 front doors strip this hop-by-hop
-      // header; direct Bun/self-hosted HTTP/1 clients receive an unambiguous
-      // connection end after the stream's terminal chunk.
-      Connection: "close",
-      ...(contentLength === null ? {} : { "Content-Length": String(contentLength) }),
+      // Unbounded direct HTTP/1 streams still need an unambiguous transport
+      // close when authorization ends. A finite batch is already delimited by
+      // Content-Length and must leave its socket reusable: forcing a TCP close
+      // on every bounded batch lets rapid reconnects race ordinary reads
+      // while Chromium is still retiring the previous connection.
+      ...(contentLength === null
+        ? { Connection: "close" }
+        : { "Content-Length": String(contentLength) }),
       ...(options.actorEpoch ? { [MANAGED_AUTH_ACTOR_EPOCH_HEADER]: options.actorEpoch } : {}),
     },
   });

--- a/apps/api/test/sse-stream-bounds.test.ts
+++ b/apps/api/test/sse-stream-bounds.test.ts
@@ -120,7 +120,7 @@ afterAll(() => {
 
 test("HTTP/1 browser streams cycle cleanly while HTTP/2 streams remain long-lived", async () => {
   expect(browserSseDeliveryOptions("http1-bounded")).toEqual({
-    connectionLifetimeMs: 5_000,
+    connectionLifetimeMs: 1_000,
     finiteResponseMaxBytes: 512 * 1024,
   });
   expect(browserSseDeliveryOptions(undefined)).toEqual({});
@@ -160,6 +160,7 @@ test("HTTP/1 browser fallback returns a fully framed finite SSE batch", async ()
   );
   const bytes = await response.arrayBuffer();
   expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
+  expect(response.headers.get("connection")).toBeNull();
   expect(new TextDecoder().decode(bytes)).toContain('"sequence":3');
 });
 
@@ -178,6 +179,7 @@ test("workspace interaction SSE projects only the newest durable revision", asyn
     controller.signal,
     { pollIntervalMs: 100, heartbeatIntervalMs: 1_000 },
   );
+  expect(response.headers.get("connection")).toBe("close");
   const reader = response.body!.getReader();
   expect(await readSequences(reader, 1)).toEqual([3]);
 

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -33,6 +33,114 @@ describe("web API auth helpers", () => {
     expect(shouldBoundBrowserSseForProtocol(null)).toBe(false);
   });
 
+  test("holds a new bounded stream until foreground API reads drain", async () => {
+    const originalFetch = globalThis.fetch;
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const entriesDescriptor = Object.getOwnPropertyDescriptor(performance, "getEntriesByType");
+    let finiteController!: ReadableStreamDefaultController<Uint8Array>;
+    let streamDispatches = 0;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: new URL("https://api.example.test/workspaces/current") },
+    });
+    Object.defineProperty(performance, "getEntriesByType", {
+      configurable: true,
+      value: (type: string) => (type === "navigation" ? [{ nextHopProtocol: "http/1.1" }] : []),
+    });
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/v1/workspaces") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              finiteController = controller;
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      streamDispatches += 1;
+      return new Response(": connected\n\n", {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "content-length": "13",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("foreground-gate");
+      const finite = managedActorFetch("https://api.example.test/v1/workspaces");
+      await Promise.resolve();
+      const stream = managedActorFetch(
+        "https://api.example.test/v1/workspaces/current/live-events/stream",
+        { headers: { accept: "text/event-stream" } },
+      );
+      await Promise.resolve();
+      expect(streamDispatches).toBe(0);
+      finiteController.enqueue(new TextEncoder().encode("[]"));
+      finiteController.close();
+      const finiteResponse = await finite;
+      const streamResponse = await stream;
+      expect(streamDispatches).toBe(1);
+      await finiteResponse.body!.cancel();
+      await streamResponse.body!.cancel();
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+      if (windowDescriptor) Object.defineProperty(globalThis, "window", windowDescriptor);
+      else Reflect.deleteProperty(globalThis, "window");
+      if (entriesDescriptor) {
+        Object.defineProperty(performance, "getEntriesByType", entriesDescriptor);
+      } else {
+        Reflect.deleteProperty(performance, "getEntriesByType");
+      }
+    }
+  });
+
+  test("aborts a bounded stream that never receives response headers", async () => {
+    jest.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const entriesDescriptor = Object.getOwnPropertyDescriptor(performance, "getEntriesByType");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: new URL("https://api.example.test/workspaces/current") },
+    });
+    Object.defineProperty(performance, "getEntriesByType", {
+      configurable: true,
+      value: (type: string) => (type === "navigation" ? [{ nextHopProtocol: "http/1.1" }] : []),
+    });
+    globalThis.fetch = ((_input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+          once: true,
+        });
+      })) as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("pre-header-deadline");
+      const stream = managedActorFetch(
+        "https://api.example.test/v1/workspaces/current/live-events/stream",
+        { headers: { accept: "text/event-stream" } },
+      );
+      await Promise.resolve();
+      jest.advanceTimersByTime(11_000);
+      await expect(stream).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+      if (windowDescriptor) Object.defineProperty(globalThis, "window", windowDescriptor);
+      else Reflect.deleteProperty(globalThis, "window");
+      if (entriesDescriptor) {
+        Object.defineProperty(performance, "getEntriesByType", entriesDescriptor);
+      } else {
+        Reflect.deleteProperty(performance, "getEntriesByType");
+      }
+      jest.useRealTimers();
+    }
+  });
+
   test("holds a clean bounded-stream EOF long enough for finite HTTP/1 reads to run", async () => {
     const source = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -141,6 +141,75 @@ describe("web API auth helpers", () => {
     }
   });
 
+  test("bounds a stream while it waits for foreground API reads", async () => {
+    jest.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const entriesDescriptor = Object.getOwnPropertyDescriptor(performance, "getEntriesByType");
+    let finiteController!: ReadableStreamDefaultController<Uint8Array>;
+    let streamDispatches = 0;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: new URL("https://api.example.test/workspaces/current") },
+    });
+    Object.defineProperty(performance, "getEntriesByType", {
+      configurable: true,
+      value: (type: string) => (type === "navigation" ? [{ nextHopProtocol: "http/1.1" }] : []),
+    });
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/v1/workspaces") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              finiteController = controller;
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      streamDispatches += 1;
+      return new Response(": connected\n\n", {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "content-length": "13",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("foreground-deadline");
+      const finite = managedActorFetch("https://api.example.test/v1/workspaces");
+      await Promise.resolve();
+      const stream = managedActorFetch(
+        "https://api.example.test/v1/workspaces/current/live-events/stream",
+        { headers: { accept: "text/event-stream" } },
+      );
+      await Promise.resolve();
+      jest.advanceTimersByTime(11_000);
+      await expect(stream).rejects.toMatchObject({
+        message: "The bounded HTTP/1 stream did not receive response headers in time",
+        name: "AbortError",
+      });
+      expect(streamDispatches).toBe(0);
+      finiteController.enqueue(new TextEncoder().encode("[]"));
+      finiteController.close();
+      const finiteResponse = await finite;
+      await finiteResponse.body!.cancel();
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+      if (windowDescriptor) Object.defineProperty(globalThis, "window", windowDescriptor);
+      else Reflect.deleteProperty(globalThis, "window");
+      if (entriesDescriptor) {
+        Object.defineProperty(performance, "getEntriesByType", entriesDescriptor);
+      } else {
+        Reflect.deleteProperty(performance, "getEntriesByType");
+      }
+      jest.useRealTimers();
+    }
+  });
+
   test("holds a clean bounded-stream EOF long enough for finite HTTP/1 reads to run", async () => {
     const source = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -126,7 +126,66 @@ describe("web API auth helpers", () => {
       );
       await Promise.resolve();
       jest.advanceTimersByTime(11_000);
-      await expect(stream).rejects.toMatchObject({ name: "AbortError" });
+      await expect(stream).rejects.toMatchObject({
+        message: "The bounded HTTP/1 stream did not complete its native response in time",
+        name: "AbortError",
+      });
+    } finally {
+      configureManagedActorEpoch(null);
+      globalThis.fetch = originalFetch;
+      if (windowDescriptor) Object.defineProperty(globalThis, "window", windowDescriptor);
+      else Reflect.deleteProperty(globalThis, "window");
+      if (entriesDescriptor) {
+        Object.defineProperty(performance, "getEntriesByType", entriesDescriptor);
+      } else {
+        Reflect.deleteProperty(performance, "getEntriesByType");
+      }
+      jest.useRealTimers();
+    }
+  });
+
+  test("aborts a bounded stream whose finite native body never drains", async () => {
+    jest.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const entriesDescriptor = Object.getOwnPropertyDescriptor(performance, "getEntriesByType");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: new URL("https://api.example.test/workspaces/current") },
+    });
+    Object.defineProperty(performance, "getEntriesByType", {
+      configurable: true,
+      value: (type: string) => (type === "navigation" ? [{ nextHopProtocol: "http/1.1" }] : []),
+    });
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), {
+              once: true,
+            });
+          },
+        }),
+        {
+          headers: {
+            "content-type": "text/event-stream; charset=utf-8",
+            "content-length": "13",
+          },
+        },
+      )) as typeof fetch;
+
+    try {
+      configureManagedActorEpoch("native-drain-deadline");
+      const stream = managedActorFetch(
+        "https://api.example.test/v1/workspaces/current/live-events/stream",
+        { headers: { accept: "text/event-stream" } },
+      );
+      await Promise.resolve();
+      jest.advanceTimersByTime(11_000);
+      await expect(stream).rejects.toMatchObject({
+        message: "The bounded HTTP/1 stream did not complete its native response in time",
+        name: "AbortError",
+      });
     } finally {
       configureManagedActorEpoch(null);
       globalThis.fetch = originalFetch;
@@ -188,7 +247,7 @@ describe("web API auth helpers", () => {
       await Promise.resolve();
       jest.advanceTimersByTime(11_000);
       await expect(stream).rejects.toMatchObject({
-        message: "The bounded HTTP/1 stream did not receive response headers in time",
+        message: "The bounded HTTP/1 stream did not complete its native response in time",
         name: "AbortError",
       });
       expect(streamDispatches).toBe(0);

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -670,9 +670,11 @@ describe("web API auth helpers", () => {
 
   test("drains a known-length HTTP/1 SSE batch before exposing it", async () => {
     const originalFetch = globalThis.fetch;
+    const observed: { signal?: AbortSignal | null } = {};
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
     let source!: ReadableStream<Uint8Array>;
-    globalThis.fetch = (async () => {
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      observed.signal = init?.signal ?? null;
       source = new ReadableStream<Uint8Array>({
         start(controller) {
           bodyController = controller;
@@ -699,8 +701,11 @@ describe("web API auth helpers", () => {
       bodyController.enqueue(new TextEncoder().encode(": connected\n\n"));
       await Promise.resolve();
       expect(exposed).toBe(false);
+      expect(observed.signal?.aborted).toBe(false);
       bodyController.close();
       const response = await pending;
+      expect(observed.signal?.aborted).toBe(true);
+      expect(observed.signal?.reason).toMatchObject({ name: "AbortError" });
       expect(source.locked).toBe(false);
       await expect(response.text()).resolves.toBe(": connected\n\n");
     } finally {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -259,13 +259,13 @@ export async function managedActorFetch(
   if (acceptedEpoch && init.credentials !== "omit" && !headers.has(MANAGED_ACTOR_EPOCH_HEADER)) {
     headers.set(MANAGED_ACTOR_EPOCH_HEADER, acceptedEpoch);
   }
-  let preHeaderTimer: ReturnType<typeof setTimeout> | null = null;
+  let boundedRequestTimer: ReturnType<typeof setTimeout> | null = null;
   try {
     if (boundedHttp1Sse) {
-      preHeaderTimer = setTimeout(() => {
+      boundedRequestTimer = setTimeout(() => {
         controller.abort(
           new DOMException(
-            "The bounded HTTP/1 stream did not receive response headers in time",
+            "The bounded HTTP/1 stream did not complete its native response in time",
             "AbortError",
           ),
         );
@@ -277,10 +277,6 @@ export async function managedActorFetch(
       headers,
       signal: controller.signal,
     });
-    if (preHeaderTimer !== null) {
-      clearTimeout(preHeaderTimer);
-      preHeaderTimer = null;
-    }
     if (
       acceptedEpoch !== null &&
       response.headers.get(MANAGED_ACTOR_STATE_HEADER)?.toLowerCase() === "changed"
@@ -352,7 +348,7 @@ export async function managedActorFetch(
       detachedResponse ? 0 : nativeLifetimeMs,
     );
   } finally {
-    if (preHeaderTimer !== null) clearTimeout(preHeaderTimer);
+    if (boundedRequestTimer !== null) clearTimeout(boundedRequestTimer);
     if (!responseOwnsCleanup) cleanup();
   }
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -23,14 +23,14 @@ const accessKeyStorageKey = "opengeni.accessKey";
 const deploymentReloadStoragePrefix = "opengeni.reloadForRevision:";
 const contractReloadStoragePrefix = "opengeni.reloadForApiContract:";
 const boundedHttp1SseTransport = "http1-bounded";
-const HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS = 2_000;
+const HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS = 4_000;
 const HTTP1_BROWSER_SSE_BATCH_MAX_BYTES = 512 * 1024;
 // New APIs close bounded HTTP/1 streams after one second. Keep a longer
 // browser-owned backstop as well: a server/runtime adapter can acknowledge a
 // Web Stream close without retiring Chromium's native request, and one such
 // orphan per tab is enough to exhaust the shared per-origin connection pool.
-// Nine seconds also preserves rolling compatibility with older five-second APIs.
-const HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS = 9_000;
+// Eleven seconds also preserves rolling compatibility with older five-second APIs.
+const HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS = 11_000;
 let activeAuthConfig: ClientConfig["auth"] | null = null;
 let managedActorEpoch: string | null = null;
 let managedActorRevision = 0;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -25,10 +25,11 @@ const contractReloadStoragePrefix = "opengeni.reloadForApiContract:";
 const boundedHttp1SseTransport = "http1-bounded";
 const HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS = 2_000;
 const HTTP1_BROWSER_SSE_BATCH_MAX_BYTES = 512 * 1024;
-// The API normally closes bounded HTTP/1 streams after five seconds. Keep a
+// New APIs close bounded HTTP/1 streams after one second. Keep a longer
 // browser-owned backstop as well: a server/runtime adapter can acknowledge a
 // Web Stream close without retiring Chromium's native request, and one such
 // orphan per tab is enough to exhaust the shared per-origin connection pool.
+// Nine seconds also preserves rolling compatibility with older five-second APIs.
 const HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS = 9_000;
 let activeAuthConfig: ClientConfig["auth"] | null = null;
 let managedActorEpoch: string | null = null;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -299,7 +299,8 @@ export async function managedActorFetch(
     // EOF. Draining here also guarantees the native body already has a
     // rejection consumer before any post-header actor abort.
     let actorResponse = response;
-    const detachedResponse = isFiniteJsonResponse(response) || isFiniteSseBatchResponse(response);
+    const finiteSseBatch = isFiniteSseBatchResponse(response);
+    const detachedResponse = isFiniteJsonResponse(response) || finiteSseBatch;
     if (detachedResponse) {
       const bytes = await readFiniteResponseBytes(response);
       if (responseIsStale()) {
@@ -313,6 +314,16 @@ export async function managedActorFetch(
         statusText: response.statusText,
         headers: response.headers,
       });
+      if (finiteSseBatch) {
+        // Chromium can expose EOF for a finite HTTP/1 SSE body while still
+        // accounting the native request against the per-origin connection
+        // pool. The caller now owns a complete byte copy, so aborting the
+        // original fetch is harmless for a settled transport and retires an
+        // orphaned one without affecting the detached response.
+        controller.abort(
+          new DOMException("The finite HTTP/1 stream body was fully detached", "AbortError"),
+        );
+      }
       endForegroundRequest();
     }
     // Before headers—and through a finite response drain—actor rotation aborts the

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -262,7 +262,6 @@ export async function managedActorFetch(
   let preHeaderTimer: ReturnType<typeof setTimeout> | null = null;
   try {
     if (boundedHttp1Sse) {
-      await waitForManagedActorForegroundIdle(controller.signal);
       preHeaderTimer = setTimeout(() => {
         controller.abort(
           new DOMException(
@@ -271,6 +270,7 @@ export async function managedActorFetch(
           ),
         );
       }, nativeLifetimeMs);
+      await waitForManagedActorForegroundIdle(controller.signal);
     }
     const response = await fetch(transportInput, {
       ...init,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -38,6 +38,9 @@ type ManagedActorRequest = {
   abortActor: (reason: DOMException) => void;
 };
 const managedActorRequests = new Set<ManagedActorRequest>();
+let managedActorForegroundRequestCount = 0;
+let managedActorForegroundIdle: Promise<void> | null = null;
+let resolveManagedActorForegroundIdle: (() => void) | null = null;
 const managedActorMutationListeners = new Set<() => void>();
 const managedActorInvalidationListeners = new Set<() => void>();
 let managedActorMutationCount = 0;
@@ -48,6 +51,40 @@ function abortManagedActorRequests(reason: DOMException): void {
   for (const managedRequest of [...managedActorRequests]) {
     managedRequest.abortActor(reason);
   }
+}
+
+function beginManagedActorForegroundRequest(): () => void {
+  if (managedActorForegroundRequestCount === 0) {
+    managedActorForegroundIdle = new Promise<void>((resolve) => {
+      resolveManagedActorForegroundIdle = resolve;
+    });
+  }
+  managedActorForegroundRequestCount += 1;
+  let ended = false;
+  return () => {
+    if (ended) return;
+    ended = true;
+    managedActorForegroundRequestCount = Math.max(0, managedActorForegroundRequestCount - 1);
+    if (managedActorForegroundRequestCount !== 0) return;
+    const resolve = resolveManagedActorForegroundIdle;
+    resolveManagedActorForegroundIdle = null;
+    managedActorForegroundIdle = null;
+    resolve?.();
+  };
+}
+
+async function waitForManagedActorForegroundIdle(signal: AbortSignal): Promise<void> {
+  const pendingIdle = managedActorForegroundIdle;
+  if (pendingIdle === null) return;
+  if (signal.aborted) throw signal.reason;
+  await new Promise<void>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener("abort", abort, { once: true });
+    void pendingIdle.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", abort);
+    });
+  });
+  await waitForManagedActorForegroundIdle(signal);
 }
 
 export function handleManagedActorPageHide(persisted: boolean): void {
@@ -197,9 +234,11 @@ export async function managedActorFetch(
   if (tracksMutation) updateManagedActorMutationCount(1);
   let responseOwnsCleanup = false;
   let cleaned = false;
+  let endForegroundRequest = () => {};
   const cleanup = () => {
     if (cleaned) return;
     cleaned = true;
+    endForegroundRequest();
     managedActorRequests.delete(actorRequest);
     inputSignal?.removeEventListener("abort", abortFromCaller);
     if (tracksMutation) updateManagedActorMutationCount(-1);
@@ -213,15 +252,35 @@ export async function managedActorFetch(
     init,
     headers,
   );
+  const boundedHttp1Sse = cleanCloseDelayMs > 0;
+  if (isForegroundApiRequest(input, init, headers, boundedHttp1Sse)) {
+    endForegroundRequest = beginManagedActorForegroundRequest();
+  }
   if (acceptedEpoch && init.credentials !== "omit" && !headers.has(MANAGED_ACTOR_EPOCH_HEADER)) {
     headers.set(MANAGED_ACTOR_EPOCH_HEADER, acceptedEpoch);
   }
+  let preHeaderTimer: ReturnType<typeof setTimeout> | null = null;
   try {
+    if (boundedHttp1Sse) {
+      await waitForManagedActorForegroundIdle(controller.signal);
+      preHeaderTimer = setTimeout(() => {
+        controller.abort(
+          new DOMException(
+            "The bounded HTTP/1 stream did not receive response headers in time",
+            "AbortError",
+          ),
+        );
+      }, nativeLifetimeMs);
+    }
     const response = await fetch(transportInput, {
       ...init,
       headers,
       signal: controller.signal,
     });
+    if (preHeaderTimer !== null) {
+      clearTimeout(preHeaderTimer);
+      preHeaderTimer = null;
+    }
     if (
       acceptedEpoch !== null &&
       response.headers.get(MANAGED_ACTOR_STATE_HEADER)?.toLowerCase() === "changed"
@@ -258,6 +317,7 @@ export async function managedActorFetch(
         statusText: response.statusText,
         headers: response.headers,
       });
+      endForegroundRequest();
     }
     // Before headers—and through a finite response drain—actor rotation aborts the
     // native fetch. A detached finite body no longer owns a network resource,
@@ -292,6 +352,7 @@ export async function managedActorFetch(
       detachedResponse ? 0 : nativeLifetimeMs,
     );
   } finally {
+    if (preHeaderTimer !== null) clearTimeout(preHeaderTimer);
     if (!responseOwnsCleanup) cleanup();
   }
 }
@@ -322,6 +383,27 @@ function browserSseTransportInput(
     HTTP1_BROWSER_SSE_RECONNECT_GRACE_MS,
     HTTP1_BROWSER_SSE_NATIVE_LIFETIME_MS,
   ];
+}
+
+function isForegroundApiRequest(
+  input: string | URL | Request,
+  init: RequestInit,
+  headers: Headers,
+  boundedHttp1Sse: boolean,
+): boolean {
+  if (boundedHttp1Sse || headers.get("accept")?.toLowerCase().includes("text/event-stream")) {
+    return false;
+  }
+  try {
+    const raw = typeof Request !== "undefined" && input instanceof Request ? input.url : input;
+    const base = typeof window === "undefined" ? "http://opengeni.local" : window.location.href;
+    return (
+      new URL(String(raw), base).pathname.startsWith("/v1/") &&
+      !new Set(["HEAD", "OPTIONS"]).has(requestMethod(input, init))
+    );
+  } catch {
+    return false;
+  }
 }
 
 function observedApiProtocol(): string | null {

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -1097,8 +1097,7 @@ function correlatedWebKitReauthenticationFailureIndex(
   const matchingFailureIndexes = acceptedRequestFailures.flatMap((failure, index) =>
     failure.responsePhase === "slot-revocation-reauthentication" &&
     failure.pathnameAndSearch === pathnameAndSearch &&
-    failure.failedAt <= pageError.observedAt &&
-    pageError.observedAt - failure.failedAt <= WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS
+    Math.abs(pageError.observedAt - failure.failedAt) <= WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS
       ? [index]
       : [],
   );
@@ -1114,9 +1113,10 @@ function optionalWebKitReauthenticationAccessControlPageError(
   // errors in addition to their request-cancellation events. Native-first
   // transport teardown can expose more than one of those errors, so require a
   // bijection: every page error must have exactly one same-phase, exact-URL
-  // cancellation immediately before it, and no cancellation may authorize a
-  // second error. Duplicate, late, concurrent, or stale evidence keeps the
-  // strict page-error ledger red.
+  // cancellation inside the same bounded delivery window, and no cancellation
+  // may authorize a second error. Playwright delivers renderer page errors and
+  // request failures independently, so either callback can arrive first.
+  // Duplicate, late, concurrent, or stale evidence keeps the strict ledger red.
   const candidates = problems.pageErrorEvidence.flatMap((pageError) => {
     const failureIndex = correlatedWebKitReauthenticationFailureIndex(
       pageError,
@@ -2596,6 +2596,14 @@ describe("provider-neutral browser account acceptance", () => {
     expect(
       correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
         { ...acceptedWebKitCancellation, failedAt: 151 },
+      ]),
+    ).toBe(0);
+    expect(
+      correlatedWebKitReauthenticationFailureIndex(correlatedWebKitPageError, [
+        {
+          ...acceptedWebKitCancellation,
+          failedAt: 150 + WEBKIT_PAGE_ERROR_CORRELATION_WINDOW_MS + 1,
+        },
       ]),
     ).toBeNull();
     expect(

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -456,15 +456,16 @@ function isExpectedBoundedHttp1NativeSeam(input: {
       input.failure.trim(),
     );
   const elapsedMs = input.failedAt - input.startedAt;
-  // The browser-owned seam fires at nine seconds. Allow only the request-start
-  // offset plus bounded scheduling jitter; the two-second logical reconnect
-  // grace does not extend the native request's cancellation deadline.
+  // The browser-owned body and pre-header seams fire at eleven seconds. Allow
+  // only the request-start offset plus bounded scheduling jitter; the
+  // four-second logical reconnect grace does not extend the native request's
+  // cancellation deadline.
   return (
     isStream &&
     isCancellation &&
     url.searchParams.get("transport") === "http1-bounded" &&
-    elapsedMs >= 8_000 &&
-    elapsedMs <= 13_000
+    elapsedMs >= 10_000 &&
+    elapsedMs <= 15_000
   );
 }
 
@@ -774,6 +775,15 @@ function observeBrowser(page: Page): BrowserProblems {
       })
     ) {
       problems.boundedHttp1NativeSeams += 1;
+      // WebKit can additionally surface the exact canceled request as a page
+      // access-control error. Preserve the URL, phase, and timestamp so the
+      // page-error gate can require the same strict one-to-one correlation as
+      // actor-transition cancellations instead of broadly allowing CORS text.
+      problems.acceptedRequestFailures.push({
+        failedAt,
+        pathnameAndSearch: `${failedUrl.pathname}${failedUrl.search}`,
+        responsePhase,
+      });
       return;
     }
     const check = (async () => {
@@ -2786,15 +2796,15 @@ describe("provider-neutral browser account acceptance", () => {
 
   test("the strict browser ledger bounds native HTTP/1 stream seams by URL, cause, and time", () => {
     const expected = {
-      failedAt: 9_100,
+      failedAt: 11_100,
       failure: "net::ERR_ABORTED",
       method: "GET",
       startedAt: 100,
       url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/live-events/stream?transport=http1-bounded`,
     };
     expect(isExpectedBoundedHttp1NativeSeam(expected)).toBe(true);
-    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 7_999 })).toBe(false);
-    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 13_101 })).toBe(false);
+    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 10_099 })).toBe(false);
+    expect(isExpectedBoundedHttp1NativeSeam({ ...expected, failedAt: 15_101 })).toBe(false);
     expect(
       isExpectedBoundedHttp1NativeSeam({ ...expected, failure: "net::ERR_CONNECTION_RESET" }),
     ).toBe(false);


### PR DESCRIPTION
## Summary

- shorten browser HTTP/1 finite SSE batches from five seconds to one second
- widen the post-batch reconnect gap from two seconds to four seconds
- keep known-length batches on reusable HTTP/1.1 connections while retaining `Connection: close` for genuinely unbounded streams
- hold new bounded stream polls behind in-flight ordinary `/v1/` reads and mutations so background polling cannot consume their connection-pool headroom
- apply an eleven-second rolling-compatibility deadline across bounded-poll queueing, response headers, and finite native body drain
- explicitly retire the original bounded SSE fetch after its fully drained bytes are detached, preserving the copied caller response while releasing any browser-native orphan

## Why

Canonical post-merge CI for #1994 reproduced Chromium connection starvation: ordinary lineage and model-catalog reads remained pending while old and current bounded streams occupied the per-origin pool. Exact logs are in run 33204142626, job 98960904093.

A five-second occupied interval followed by only a two-second reconnect gap left too little deterministic headroom across tabs and account changes. Forcing every finite batch to close its TCP connection also made rapid reconnects compete with queued reads while Chromium retired the previous socket. The intermediate timing-only repair still reproduced a pending finite read in run 33205725392, job 98966273253.

The final design gives foreground API traffic priority before a new bounded stream enters the browser transport pool. Finite SSE responses remain fully drained before their detached wrapper is exposed, and one total deadline releases a poll that remains queued, cannot obtain headers, or stalls during its known-length native body drain. HTTP/2 and HTTP/3 behavior is unchanged.

## Evidence

- repository-wide formatting and lint pass
- all 31 TypeScript projects pass
- 51 focused API/web transport tests pass with 197 assertions
- explicit tests prove finite batches have exact `Content-Length` without `Connection: close`, while unbounded streams retain `Connection: close`
- unit coverage proves bounded polls wait for foreground native response drains and remain subject to the same total deadline while queued, before headers, and through a known-length native body drain
- complete real-PostgreSQL multi-account journeys pass on Chromium, Firefox, and WebKit at the final exact head
- the strict browser ledger accepts WebKit's duplicate access-control report only when it has a one-to-one exact URL, phase, cause, and time-window match to the bounded native seam

## Safety

- actor rotation, caller aborts, and document replacement remain fail-closed
- foreground requests are never canceled or rewritten by the prioritization gate
- the eleven-second browser backstop preserves compatibility with older five-second API deployments during rolling updates
- unbounded streams retain explicit transport closure

## Summary by Sourcery

Preserve HTTP/1 connection-pool capacity for foreground API traffic while making bounded SSE polling reusable, prioritized, and time-bounded.

Bug Fixes:
- Preserve HTTP/1 connection-pool headroom for ordinary API traffic by prioritizing foreground reads and mutations ahead of bounded SSE polling.
- Prevent bounded HTTP/1 streams from lingering indefinitely by applying a shared deadline while queued, awaiting headers, or draining the native response body.

Enhancements:
- Use reusable HTTP/1.1 connections for finite SSE batches while retaining explicit connection closure for unbounded streams.
- Shorten bounded browser SSE batches and extend the reconnect grace period to improve transport availability across tabs and account changes.
- Tighten browser transport diagnostics so expected native stream cancellations and related WebKit errors are correlated by URL, phase, and time window.

Tests:
- Add API and browser transport coverage for foreground-request prioritization, bounded-stream deadlines, reusable finite SSE responses, and strict native cancellation correlation.
