### PR TITLE
fix(accounts): fence initiating browser transitions

### DIFF
--- a/.changeset/fence-browser-account-reads.md
+++ b/.changeset/fence-browser-account-reads.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Fence the initiating browser tab before account-changing mutations and cancel abandoned draft, turn-policy, model-catalog, and realtime-catalog reads without interrupting remaining shared consumers.

--- a/.changeset/fence-browser-account-reads.md
+++ b/.changeset/fence-browser-account-reads.md
@@ -3,4 +3,4 @@
 "@opengeni/sdk": patch
 ---
 
-Fence the initiating browser tab before account-changing mutations and cancel abandoned draft, turn-policy, model-catalog, and realtime-catalog reads without interrupting remaining shared consumers.
+Fence the initiating browser tab before account-changing mutations and cancel abandoned session-page, draft, turn-policy, model-catalog, and realtime-catalog reads without interrupting remaining shared consumers.

--- a/apps/web/src/components/browser-accounts-runtime.test.tsx
+++ b/apps/web/src/components/browser-accounts-runtime.test.tsx
@@ -175,7 +175,7 @@ describe("signed-out browser account recovery", () => {
       expect(selections[0]?.expectedGeneration).toBe("2");
       expect(transitions.length).toBeGreaterThanOrEqual(1);
       const selectionTransition = transitions.at(-1);
-      expect(selectionTransition?.from?.selectedSlotId).toBeNull();
+      expect(selectionTransition?.from).toBeNull();
       expect(selectionTransition?.to?.selectedSlotId).toBe(SLOT_ID);
     } finally {
       await act(async () => root.unmount());
@@ -219,7 +219,7 @@ describe("signed-out browser account recovery", () => {
             client={client}
             broadcastChannelName={null}
             onActorTransition={async (transition) => {
-              if (transition.from?.selectedSlotId === null && transition.to?.selectedSlotId) {
+              if (transition.to?.selectedSlotId) {
                 await selectionSettled;
               }
             }}

--- a/apps/web/src/lib/use-workspace-model-catalog.test.tsx
+++ b/apps/web/src/lib/use-workspace-model-catalog.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+
+import { actRun, registerDom, renderHook } from "../../../../packages/react/test/render-hook";
+
+const context: { client: OpenGeniBrowserClient } = { client: {} as OpenGeniBrowserClient };
+
+mock.module("@/context", () => ({ useAppContext: () => context }));
+
+const { useWorkspaceModelCatalog } = await import("./use-workspace-model-catalog");
+
+registerDom();
+afterEach(() => document.body.replaceChildren());
+
+describe("useWorkspaceModelCatalog", () => {
+  test("unmount aborts a refresh that replaced the initial request", async () => {
+    const signals: AbortSignal[] = [];
+    context.client = {
+      getWorkspaceModelCatalog: mock(
+        async (_workspaceId: string, options?: { signal?: AbortSignal }) => {
+          if (options?.signal) signals.push(options.signal);
+          return await new Promise<never>(() => undefined);
+        },
+      ),
+    } as unknown as OpenGeniBrowserClient;
+
+    const hook = await renderHook(
+      ({ workspaceId }: { workspaceId: string }) => useWorkspaceModelCatalog(workspaceId),
+      { workspaceId: "workspace-a" },
+    );
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+
+    await actRun(() => {
+      void hook.result.current.refresh();
+    });
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+
+    await hook.unmount();
+    expect(signals[1]?.aborted).toBe(true);
+  });
+});

--- a/apps/web/src/lib/use-workspace-model-catalog.ts
+++ b/apps/web/src/lib/use-workspace-model-catalog.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceModelCatalogModel } from "@opengeni/sdk";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useAppContext } from "@/context";
 import { projectPickerRows, sortPickerRows, type PickerModelRow } from "@/lib/model-policy";
@@ -18,60 +18,56 @@ export function useWorkspaceModelCatalog(workspaceId: string | null): WorkspaceM
   const [models, setModels] = useState<WorkspaceModelCatalogModel[]>([]);
   const [loading, setLoading] = useState(Boolean(workspaceId));
   const [error, setError] = useState<string | null>(null);
+  const requestAbortRef = useRef<AbortController | null>(null);
 
-  const refresh = useCallback(async () => {
-    if (!workspaceId) {
-      setModels([]);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    setLoading(true);
-    try {
-      const response = await client.getWorkspaceModelCatalog(workspaceId);
-      setModels(response.models);
-      setError(null);
-    } catch (caught) {
-      setModels([]);
-      setError(caught instanceof Error ? caught.message : String(caught));
-    } finally {
-      setLoading(false);
-    }
-  }, [client, workspaceId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
+  const load = useCallback(
+    async (requestAbort: AbortController): Promise<void> => {
       if (!workspaceId) {
-        if (!cancelled) {
-          setModels([]);
-          setLoading(false);
-          setError(null);
-        }
+        setModels([]);
+        setLoading(false);
+        setError(null);
+        if (requestAbortRef.current === requestAbort) requestAbortRef.current = null;
         return;
       }
       setLoading(true);
       try {
-        const response = await client.getWorkspaceModelCatalog(workspaceId);
-        if (!cancelled) {
-          setModels(response.models);
-          setError(null);
-        }
+        const response = await client.getWorkspaceModelCatalog(workspaceId, {
+          signal: requestAbort.signal,
+        });
+        if (requestAbort.signal.aborted) return;
+        setModels(response.models);
+        setError(null);
       } catch (caught) {
-        if (!cancelled) {
-          setModels([]);
-          setError(caught instanceof Error ? caught.message : String(caught));
-        }
+        if (requestAbort.signal.aborted) return;
+        setModels([]);
+        setError(caught instanceof Error ? caught.message : String(caught));
       } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        if (!requestAbort.signal.aborted) setLoading(false);
+        if (requestAbortRef.current === requestAbort) requestAbortRef.current = null;
       }
-    })();
+    },
+    [client, workspaceId],
+  );
+
+  const beginLoad = useCallback(() => {
+    requestAbortRef.current?.abort();
+    const requestAbort = new AbortController();
+    requestAbortRef.current = requestAbort;
+    return { requestAbort, promise: load(requestAbort) };
+  }, [load]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    await beginLoad().promise;
+  }, [beginLoad]);
+
+  useEffect(() => {
+    const request = beginLoad();
+    void request.promise;
     return () => {
-      cancelled = true;
+      request.requestAbort.abort();
+      if (requestAbortRef.current === request.requestAbort) requestAbortRef.current = null;
     };
-  }, [client, workspaceId]);
+  }, [beginLoad]);
 
   const rows = useMemo(() => sortPickerRows(projectPickerRows(models)), [models]);
 

--- a/apps/web/src/lib/use-workspace-model-catalog.ts
+++ b/apps/web/src/lib/use-workspace-model-catalog.ts
@@ -64,8 +64,9 @@ export function useWorkspaceModelCatalog(workspaceId: string | null): WorkspaceM
     const request = beginLoad();
     void request.promise;
     return () => {
-      request.requestAbort.abort();
-      if (requestAbortRef.current === request.requestAbort) requestAbortRef.current = null;
+      const currentRequestAbort = requestAbortRef.current;
+      currentRequestAbort?.abort();
+      if (requestAbortRef.current === currentRequestAbort) requestAbortRef.current = null;
     };
   }, [beginLoad]);
 

--- a/packages/react/src/accounts.tsx
+++ b/packages/react/src/accounts.tsx
@@ -416,6 +416,8 @@ export function BrowserAccountsProvider({
           transitionAbortRef.current?.abort();
           const controller = new AbortController();
           transitionAbortRef.current = controller;
+          projectionRef.current = null;
+          setProjection(null);
           setPhase("loading");
           // The host can synchronously clear its actor surface before its
           // transition promise later rejects. From this point on, every

--- a/packages/react/src/accounts.tsx
+++ b/packages/react/src/accounts.tsx
@@ -262,6 +262,7 @@ export function BrowserAccountsProvider({
       sequence: number,
       publish: boolean,
       authorityResetConfirmed = false,
+      initiatingSurfaceFenced = false,
     ): Promise<ManagedAuthSessionSetProjection | null> => {
       let source = from;
       let target = accepted;
@@ -272,7 +273,7 @@ export function BrowserAccountsProvider({
           throw new Error("Browser account response regressed the accepted actor epoch");
         }
       }
-      if (sameSelectedActor(source, target)) {
+      if (!initiatingSurfaceFenced && sameSelectedActor(source, target)) {
         setProjection(target);
         setPhase("ready");
         setError(null);
@@ -287,7 +288,13 @@ export function BrowserAccountsProvider({
         // and abort old-actor work throughout that entire window.
         if (publish) publishActorHint(target);
         setPhase("loading");
-        await onActorTransition({ kind, from: source, to: target, signal: controller.signal });
+        await onActorTransition({
+          kind,
+          from: initiatingSurfaceFenced ? null : source,
+          to: target,
+          signal: controller.signal,
+        });
+        initiatingSurfaceFenced = false;
         if (controller.signal.aborted || sequenceRef.current !== sequence) return null;
         if (!target) {
           setProjection(null);
@@ -398,16 +405,30 @@ export function BrowserAccountsProvider({
       setPhase("committing");
       setError(null);
       const changesActor = pending.changesActor(current);
-      if (changesActor) {
-        // Peers must hide and abort the old actor before this request can be
-        // accepted. Yielding one task after the secret-free hold lets queued
-        // BroadcastChannel delivery run before the network mutation starts;
-        // a peer that was already dispatching remains an ordinary pre-commit
-        // in-flight request and is still fenced by the server epoch.
-        publishActorHold(pending.operationId, current);
-        await yieldToCrossTabActorHold();
-      }
+      let initiatingActorFenced = false;
       try {
+        if (changesActor) {
+          // Every tab, including the initiator, must hide and abort the old actor
+          // before this request can be accepted. Otherwise a response-lost
+          // logout can leave the initiating route alive long enough for its
+          // event stream to reconnect with the newly revoked cookie.
+          publishActorHold(pending.operationId, current);
+          transitionAbortRef.current?.abort();
+          const controller = new AbortController();
+          transitionAbortRef.current = controller;
+          setPhase("loading");
+          await onActorTransition({
+            kind: pending.kind,
+            from: current,
+            to: null,
+            signal: controller.signal,
+          });
+          if (controller.signal.aborted || sequenceRef.current !== sequence) return false;
+          initiatingActorFenced = true;
+          // Yield one task after the secret-free hold so queued BroadcastChannel
+          // delivery can fence peers before the network mutation starts.
+          await yieldToCrossTabActorHold();
+        }
         let accepted: ManagedAuthSessionSetProjection;
         try {
           accepted = await pending.execute(expectedGeneration);
@@ -429,7 +450,11 @@ export function BrowserAccountsProvider({
           if (sequenceRef.current !== sequence) return false;
         }
         pendingRef.current = null;
-        if (!authorityResetConfirmed && sameSelectedActor(current, accepted)) {
+        if (
+          !initiatingActorFenced &&
+          !authorityResetConfirmed &&
+          sameSelectedActor(current, accepted)
+        ) {
           setProjection(accepted);
           setPhase("ready");
           setError(null);
@@ -441,10 +466,41 @@ export function BrowserAccountsProvider({
             sequence,
             true,
             authorityResetConfirmed,
+            initiatingActorFenced,
           );
         }
         return true;
       } catch (caught) {
+        if (initiatingActorFenced) {
+          let authorityRestored = false;
+          try {
+            const restored = await client.reconcileSessionSetAuthority();
+            if (sequenceRef.current !== sequence) return false;
+            await settleActorTransition(
+              pending.kind,
+              current,
+              restored,
+              sequence,
+              false,
+              true,
+              true,
+            );
+            if (sequenceRef.current !== sequence) return false;
+            authorityRestored = true;
+          } catch {
+            // If authority itself cannot be reconciled, retain the existing
+            // fail-closed provider error path and its manual retry surface.
+          }
+          if (authorityRestored) {
+            // Restore transport provenance before retaining the existing
+            // fail-closed retry surface. The retry screen keeps tenant data
+            // hidden, while refresh can safely reveal this reconciled actor.
+            const restoredError = accountError(caught);
+            setError(restoredError);
+            setPhase("recoverable_error");
+            throw restoredError;
+          }
+        }
         return await fail(caught, pending.kind);
       } finally {
         if (changesActor) publishActorRelease(pending.operationId);
@@ -454,7 +510,15 @@ export function BrowserAccountsProvider({
         }
       }
     },
-    [client, fail, inspectBlockers, publishActorHold, publishActorRelease, settleActorTransition],
+    [
+      client,
+      fail,
+      inspectBlockers,
+      onActorTransition,
+      publishActorHold,
+      publishActorRelease,
+      settleActorTransition,
+    ],
   );
 
   const refresh = useCallback(async () => {

--- a/packages/react/src/accounts.tsx
+++ b/packages/react/src/accounts.tsx
@@ -417,6 +417,11 @@ export function BrowserAccountsProvider({
           const controller = new AbortController();
           transitionAbortRef.current = controller;
           setPhase("loading");
+          // The host can synchronously clear its actor surface before its
+          // transition promise later rejects. From this point on, every
+          // failure must reconcile and restore authority even though the
+          // account mutation has not started yet.
+          initiatingActorFenced = true;
           await onActorTransition({
             kind: pending.kind,
             from: current,
@@ -424,7 +429,6 @@ export function BrowserAccountsProvider({
             signal: controller.signal,
           });
           if (controller.signal.aborted || sequenceRef.current !== sequence) return false;
-          initiatingActorFenced = true;
           // Yield one task after the secret-free hold so queued BroadcastChannel
           // delivery can fence peers before the network mutation starts.
           await yieldToCrossTabActorHold();

--- a/packages/react/src/hooks/use-available-models.ts
+++ b/packages/react/src/hooks/use-available-models.ts
@@ -43,7 +43,10 @@ export function useAvailableModels(
   options: UseAvailableModelsOptions = {},
 ): UseAvailableModelsResult {
   const client = useOpenGeniClient(options);
-  const load = useCallback(async () => await client.getClientConfig(), [client]);
+  const load = useCallback(
+    async (signal?: AbortSignal) => await client.getClientConfig({ signal }),
+    [client],
+  );
   const state = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
@@ -62,19 +65,22 @@ export function useWorkspaceModelCatalog(
   options: UseWorkspaceModelCatalogOptions,
 ): UseWorkspaceModelCatalogResult {
   const client = useOpenGeniClient(options);
-  const load = useCallback(async () => {
-    if (!options.workspaceId) {
-      return { models: [], defaultModel: null };
-    }
-    const [catalog, config] = await Promise.all([
-      client.getWorkspaceModelCatalog(options.workspaceId),
-      client.getClientConfig(),
-    ]);
-    return {
-      models: catalog.models,
-      defaultModel: config.defaultModel,
-    };
-  }, [client, options.workspaceId]);
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!options.workspaceId) {
+        return { models: [], defaultModel: null };
+      }
+      const [catalog, config] = await Promise.all([
+        client.getWorkspaceModelCatalog(options.workspaceId, { signal }),
+        client.getClientConfig({ signal }),
+      ]);
+      return {
+        models: catalog.models,
+        defaultModel: config.defaultModel,
+      };
+    },
+    [client, options.workspaceId],
+  );
   const state = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled !== false && Boolean(options.workspaceId),

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -706,6 +706,7 @@ export function useComposer(
   const targetGeneration = useRef(0);
   const draftReadGeneration = useRef(0);
   const draftReadInFlightRef = useRef<string | null>(null);
+  const draftReadAbortRef = useRef<AbortController | null>(null);
   const draftReadRetryRef = useRef<{
     targetKey: string;
     failures: number;
@@ -742,6 +743,8 @@ export function useComposer(
     if (draftReadRetryRef.current.timer !== null) {
       clearTimeout(draftReadRetryRef.current.timer);
     }
+    draftReadAbortRef.current?.abort();
+    draftReadAbortRef.current = null;
     draftReadRetryRef.current = { targetKey, failures: 0, timer: null };
     targetKeyRef.current = targetKey;
     targetGeneration.current += 1;
@@ -800,6 +803,11 @@ export function useComposer(
       if (draftReadRetryRef.current.timer !== null) {
         clearTimeout(draftReadRetryRef.current.timer);
       }
+      targetGeneration.current += 1;
+      draftReadGeneration.current += 1;
+      draftReadInFlightRef.current = null;
+      draftReadAbortRef.current?.abort();
+      draftReadAbortRef.current = null;
     },
     [],
   );
@@ -938,6 +946,9 @@ export function useComposer(
       draftReadInFlightRef.current = targetKey;
       const generation = targetGeneration.current;
       const readTicket = ++draftReadGeneration.current;
+      const requestAbort = new AbortController();
+      draftReadAbortRef.current?.abort();
+      draftReadAbortRef.current = requestAbort;
       const localAtStart = localEditRevision.current;
       const baseAtStart = draftRef.current;
       const policyAtStart = policyRef.current;
@@ -967,7 +978,9 @@ export function useComposer(
         setDraftLoading(true);
       }
       try {
-        const fetched = await client.getComposerDraft(workspaceId, sessionId);
+        const fetched = await client.getComposerDraft(workspaceId, sessionId, {
+          signal: requestAbort.signal,
+        });
         if (
           generation !== targetGeneration.current ||
           targetKeyRef.current !== targetKey ||
@@ -1057,6 +1070,9 @@ export function useComposer(
         }
         if (draftReadInFlightRef.current === targetKey) {
           draftReadInFlightRef.current = null;
+        }
+        if (draftReadAbortRef.current === requestAbort) {
+          draftReadAbortRef.current = null;
         }
       }
     },

--- a/packages/react/src/hooks/use-last-started-turn-policy.ts
+++ b/packages/react/src/hooks/use-last-started-turn-policy.ts
@@ -51,11 +51,17 @@ export function useLastStartedTurnPolicy(
     useOpenGeni(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
 
-  const load = useCallback(async (): Promise<LastStartedTurnPolicy | null> => {
-    if (!sessionId) return null;
-    const turns = await client.listTurns(workspaceId, sessionId, { latestStarted: true });
-    return policyFromTurn(turns[0]);
-  }, [client, workspaceId, sessionId]);
+  const load = useCallback(
+    async (signal?: AbortSignal): Promise<LastStartedTurnPolicy | null> => {
+      if (!sessionId) return null;
+      const turns = await client.listTurns(workspaceId, sessionId, {
+        latestStarted: true,
+        signal,
+      });
+      return policyFromTurn(turns[0]);
+    },
+    [client, workspaceId, sessionId],
+  );
 
   const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,

--- a/packages/react/src/hooks/use-workspace-sessions.ts
+++ b/packages/react/src/hooks/use-workspace-sessions.ts
@@ -67,34 +67,38 @@ export function useWorkspaceSessions(
   useEffect(() => {
     previousQueryKey.current = queryKey;
   }, [queryKey]);
-  const load = useCallback(async () => {
-    const readGeneration = beginRead?.() ?? ++nextReadGeneration.current;
-    const page = await client.listSessionPage(workspaceId, {
-      ...(limit !== undefined ? { limit } : {}),
-      ...(parentSessionId !== undefined ? { parentSessionId } : {}),
-      ...(cursor !== undefined ? { cursor } : {}),
-      ...(search !== undefined ? { search } : {}),
-      ...(pinsOnly ? { pinsOnly: true } : {}),
-      ...(archivedOnly ? { archivedOnly: true } : {}),
-    });
-    return {
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      const readGeneration = beginRead?.() ?? ++nextReadGeneration.current;
+      const page = await client.listSessionPage(workspaceId, {
+        ...(limit !== undefined ? { limit } : {}),
+        ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+        ...(cursor !== undefined ? { cursor } : {}),
+        ...(search !== undefined ? { search } : {}),
+        ...(pinsOnly ? { pinsOnly: true } : {}),
+        ...(archivedOnly ? { archivedOnly: true } : {}),
+        signal,
+      });
+      return {
+        queryKey,
+        page,
+        revision: ++nextReadRevision.current,
+        readGeneration,
+      };
+    },
+    [
+      beginRead,
+      client,
+      workspaceId,
+      limit,
+      parentSessionId,
+      cursor,
+      search,
+      pinsOnly,
+      archivedOnly,
       queryKey,
-      page,
-      revision: ++nextReadRevision.current,
-      readGeneration,
-    };
-  }, [
-    beginRead,
-    client,
-    workspaceId,
-    limit,
-    parentSessionId,
-    cursor,
-    search,
-    pinsOnly,
-    archivedOnly,
-    queryKey,
-  ]);
+    ],
+  );
   const state = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled,

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -105,7 +105,12 @@ const REALTIME_MODEL_CATALOG_CACHE_MAX_WORKSPACES = 64;
 type RealtimeControllerClient = EmbeddedRealtimeSessionClientLike & SessionRealtimeClientLike;
 
 type RealtimeModelCatalogCacheEntry =
-  | { state: "loading"; promise: Promise<RealtimeModelOption[]> }
+  | {
+      state: "loading";
+      promise: Promise<RealtimeModelOption[]>;
+      controller: AbortController;
+      consumers: number;
+    }
   | { state: "ready"; models: RealtimeModelOption[]; expiresAt: number };
 
 // Scope advisory availability to the exact client object and workspace. The
@@ -166,19 +171,26 @@ function pruneRealtimeModelCatalogCache(
 function loadRealtimeModelCatalog(
   client: RealtimeControllerClient,
   workspaceId: string,
+  signal?: AbortSignal,
 ): Promise<RealtimeModelOption[]> | null {
   const load = client.getWorkspaceRealtimeModelCatalog;
   if (!load) return null;
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new DOMException("Request aborted", "AbortError"));
+  }
   const now = Date.now();
   const cache = realtimeModelCatalogCacheFor(client);
   const entry = cache.get(workspaceId);
-  if (entry?.state === "loading") return entry.promise;
+  if (entry?.state === "loading" && !entry.controller.signal.aborted) {
+    return consumeRealtimeModelCatalog(entry, signal);
+  }
   if (entry?.state === "ready" && entry.expiresAt > now) return Promise.resolve(entry.models);
   if (entry) cache.delete(workspaceId);
   pruneRealtimeModelCatalogCache(cache, now);
 
+  const controller = new AbortController();
   const promise = load
-    .call(client, workspaceId)
+    .call(client, workspaceId, { signal: controller.signal })
     .then((response) => response.models.map(toRealtimeModelOption))
     .then((models) => {
       const current = cache.get(workspaceId);
@@ -197,8 +209,43 @@ function loadRealtimeModelCatalog(
       if (current?.state === "loading" && current.promise === promise) cache.delete(workspaceId);
       throw error;
     });
-  cache.set(workspaceId, { state: "loading", promise });
-  return promise;
+  const loading: RealtimeModelCatalogCacheEntry & { state: "loading" } = {
+    state: "loading",
+    promise,
+    controller,
+    consumers: 0,
+  };
+  cache.set(workspaceId, loading);
+  return consumeRealtimeModelCatalog(loading, signal);
+}
+
+function consumeRealtimeModelCatalog(
+  entry: RealtimeModelCatalogCacheEntry & { state: "loading" },
+  signal?: AbortSignal,
+): Promise<RealtimeModelOption[]> {
+  entry.consumers += 1;
+  return new Promise((resolve, reject) => {
+    let released = false;
+    const release = (abandoned: boolean) => {
+      if (released) return;
+      released = true;
+      entry.consumers = Math.max(0, entry.consumers - 1);
+      if (abandoned && entry.consumers === 0) {
+        entry.controller.abort(
+          signal?.reason ?? new DOMException("Request abandoned", "AbortError"),
+        );
+      }
+    };
+    const onAbort = () => {
+      release(true);
+      reject(signal?.reason ?? new DOMException("Request aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    void entry.promise.then(resolve, reject).finally(() => {
+      signal?.removeEventListener("abort", onAbort);
+      release(false);
+    });
+  });
 }
 
 export type SessionRealtimeControllerFactory = (
@@ -550,6 +597,7 @@ export function useRealtimeModelSelection(options: {
 
   useEffect(() => {
     let disposed = false;
+    const requestAbort = new AbortController();
     const applyCatalog = (models: RealtimeModelOption[]) => {
       catalogScopeRef.current = { client, workspaceId, source: "cache" };
       setCatalog(models);
@@ -570,7 +618,7 @@ export function useRealtimeModelSelection(options: {
       }
       return;
     }
-    const loading = loadRealtimeModelCatalog(client, workspaceId);
+    const loading = loadRealtimeModelCatalog(client, workspaceId, requestAbort.signal);
     if (!loading) return;
     void loading
       .then((models) => {
@@ -580,6 +628,7 @@ export function useRealtimeModelSelection(options: {
       .catch(() => undefined);
     return () => {
       disposed = true;
+      requestAbort.abort();
     };
   }, [client, workspaceId]);
 

--- a/packages/react/test/accounts.test.tsx
+++ b/packages/react/test/accounts.test.tsx
@@ -376,6 +376,53 @@ describe("BrowserAccountsProvider", () => {
     await accounts.unmount();
   });
 
+  test("restores reconciled authority when the initiating surface fence rejects", async () => {
+    const before = projection();
+    let mutationAttempts = 0;
+    let reconciliationAttempts = 0;
+    let rejectFence = true;
+    const transitions: BrowserAccountTransition[] = [];
+    const accounts = await renderAccounts(
+      scriptedClient({
+        getSessionSet: async () => before,
+        reconcileSessionSetAuthority: async () => {
+          reconciliationAttempts += 1;
+          return before;
+        },
+        selectLoginSlot: async () => {
+          mutationAttempts += 1;
+          return projection({ generation: "2", actorEpoch: "2", selectedSlotId: SLOT_B });
+        },
+      }),
+      async (transition) => {
+        transitions.push(transition);
+        if (rejectFence && transition.from?.selectedSlotId === SLOT_A && transition.to === null) {
+          rejectFence = false;
+          throw new Error("host fence failed");
+        }
+      },
+    );
+    transitions.length = 0;
+    const initialReconciliationAttempts = reconciliationAttempts;
+
+    await expect(actRun(() => accounts.current.selectSlot(SLOT_B))).rejects.toThrow(
+      "host fence failed",
+    );
+    await flush();
+
+    expect(mutationAttempts).toBe(0);
+    // Recovery first discovers the current authority, then confirms it again
+    // after the host has restored the actor-owned surface.
+    expect(reconciliationAttempts - initialReconciliationAttempts).toBe(2);
+    expect(transitions).toHaveLength(2);
+    expect(transitions[0]).toMatchObject({ from: before, to: null });
+    expect(transitions[1]).toMatchObject({ from: null, to: before });
+    expect(accounts.current.projection).toEqual(before);
+    expect(accounts.current.phase).toBe("recoverable_error");
+    expect(accounts.current.hasPendingTransition).toBe(true);
+    await accounts.unmount();
+  });
+
   test("lets logout-all own settlement when its SSE actor-loss signal arrives concurrently", async () => {
     const before = projection({ generation: "4", actorEpoch: "3" });
     const empty = projection({ selectedSlotId: null, slotIds: [] });

--- a/packages/react/test/accounts.test.tsx
+++ b/packages/react/test/accounts.test.tsx
@@ -423,6 +423,62 @@ describe("BrowserAccountsProvider", () => {
     await accounts.unmount();
   });
 
+  test("restores from neutral authority when refresh supersedes the initiating fence", async () => {
+    const before = projection();
+    let mutationAttempts = 0;
+    let announceFenceStarted!: () => void;
+    let releaseFence!: () => void;
+    const fenceStarted = new Promise<void>((resolve) => {
+      announceFenceStarted = resolve;
+    });
+    const fenceRelease = new Promise<void>((resolve) => {
+      releaseFence = resolve;
+    });
+    const transitions: BrowserAccountTransition[] = [];
+    const accounts = await renderAccounts(
+      scriptedClient({
+        getSessionSet: async () => before,
+        reconcileSessionSetAuthority: async () => before,
+        selectLoginSlot: async () => {
+          mutationAttempts += 1;
+          return projection({ generation: "2", actorEpoch: "2", selectedSlotId: SLOT_B });
+        },
+      }),
+      async (transition) => {
+        transitions.push(transition);
+        if (transition.from?.selectedSlotId === SLOT_A && transition.to === null) {
+          announceFenceStarted();
+          await fenceRelease;
+        }
+      },
+    );
+    transitions.length = 0;
+
+    let selection!: Promise<boolean>;
+    await act(async () => {
+      selection = accounts.current.selectSlot(SLOT_B);
+      await fenceStarted;
+    });
+    expect(accounts.current.projection).toBeNull();
+    expect(accounts.current.phase).toBe("loading");
+
+    await act(async () => {
+      expect(await accounts.current.refresh()).toEqual(before);
+    });
+    await act(async () => {
+      releaseFence();
+      expect(await selection).toBe(false);
+    });
+
+    expect(mutationAttempts).toBe(0);
+    expect(transitions).toHaveLength(2);
+    expect(transitions[0]).toMatchObject({ from: before, to: null });
+    expect(transitions[1]).toMatchObject({ kind: "cross_tab", from: null, to: before });
+    expect(accounts.current.projection).toEqual(before);
+    expect(accounts.current.phase).toBe("ready");
+    await accounts.unmount();
+  });
+
   test("lets logout-all own settlement when its SSE actor-loss signal arrives concurrently", async () => {
     const before = projection({ generation: "4", actorEpoch: "3" });
     const empty = projection({ selectedSlotId: null, slotIds: [] });

--- a/packages/react/test/accounts.test.tsx
+++ b/packages/react/test/accounts.test.tsx
@@ -409,7 +409,7 @@ describe("BrowserAccountsProvider", () => {
       logout = accounts.current.logoutAll();
       await postStarted;
     });
-    expect(accounts.current.phase).toBe("committing");
+    expect(accounts.current.phase).toBe("loading");
 
     await act(async () => {
       expect(await accounts.current.invalidateActor()).toBeNull();
@@ -707,7 +707,7 @@ describe("BrowserAccountsProvider", () => {
           },
         }),
         async (transition) => {
-          if (transition.from !== null && transition.to?.selectedSlotId === SLOT_B) {
+          if (transition.to?.selectedSlotId === SLOT_B) {
             await transitionSettled;
           }
         },
@@ -784,6 +784,7 @@ describe("BrowserAccountsProvider", () => {
 
     let current = projection();
     const peerTransitions: BrowserAccountTransition[] = [];
+    const initiatorTransitions: BrowserAccountTransition[] = [];
     let peer: Awaited<ReturnType<typeof renderAccounts>> | null = null;
     let initiator: Awaited<ReturnType<typeof renderAccounts>> | null = null;
     try {
@@ -800,6 +801,7 @@ describe("BrowserAccountsProvider", () => {
           getSessionSet: async () => current,
           selectLoginSlot: async () => {
             expect(peerTransitions.at(-1)?.to).toBeNull();
+            expect(initiatorTransitions.at(-1)?.to).toBeNull();
             current = projection({
               generation: "2",
               actorEpoch: "2",
@@ -808,13 +810,17 @@ describe("BrowserAccountsProvider", () => {
             return current;
           },
         }),
-        async () => undefined,
+        async (transition) => {
+          initiatorTransitions.push(transition);
+        },
         "accounts-precommit-hold-test",
       );
+      initiatorTransitions.length = 0;
 
       expect(await actRun(() => initiator!.current.selectSlot(SLOT_B))).toBe(true);
       await flush();
       expect(peerTransitions[0]?.to).toBeNull();
+      expect(initiatorTransitions[0]?.to).toBeNull();
       expect(peer.current.projection?.selectedSlotId).toBe(SLOT_B);
       expect(peer.current.projection?.actorEpoch).toBe("2");
     } finally {
@@ -1113,8 +1119,8 @@ describe("BrowserAccountsProvider", () => {
     expect(await actRun(() => accounts.current.selectSlot(SLOT_A))).toBe(true);
     expect(accounts.current.projection?.actorEpoch).toBe("3");
     expect(accounts.current.projection?.selectedSlotId).toBe(SLOT_B);
-    expect(transitionCount).toBe(initialTransitions);
-    expect(readCount).toBe(3);
+    expect(transitionCount).toBe(initialTransitions + 2);
+    expect(readCount).toBe(4);
     await accounts.unmount();
   });
 

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -165,6 +165,31 @@ function queueSnapshot(
 }
 
 describe("useWorkspaceSessions", () => {
+  test("unmount aborts its native session-page read", async () => {
+    let nativeSignal: AbortSignal | undefined;
+    const client = fakeClient({
+      listSessionPage: async (_workspaceId, options) => {
+        nativeSignal = options?.signal;
+        return await new Promise<SessionListResponse>((_resolve, reject) => {
+          nativeSignal?.addEventListener(
+            "abort",
+            () => reject(nativeSignal?.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+    const hook = await renderHook(
+      () => useWorkspaceSessions({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush();
+    expect(nativeSignal?.aborted).toBe(false);
+
+    await hook.unmount();
+    expect(nativeSignal?.aborted).toBe(true);
+  });
+
   test("forwards pins-only mode without changing the historical visible-row projection", async () => {
     const pinned = { id: "pin-only", pinned: true } as never;
     let observedPinsOnly = false;

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -33,6 +33,7 @@ import { useBillingUsage } from "../src/hooks/use-billing-usage";
 import { FILE_ONLY_MESSAGE_TEXT, useComposer } from "../src/hooks/use-composer";
 import { useEnvironments } from "../src/hooks/use-environments";
 import { useGoal } from "../src/hooks/use-goal";
+import { useLastStartedTurnPolicy } from "../src/hooks/use-last-started-turn-policy";
 import { usePacks } from "../src/hooks/use-packs";
 import { useWorkspaceSessions } from "../src/hooks/use-workspace-sessions";
 import { useSessionControl } from "../src/hooks/use-session-control";
@@ -3309,6 +3310,31 @@ describe("useComposer durable draft and control binding", () => {
     await hook.unmount();
   });
 
+  test("unmount aborts the native durable-draft read", async () => {
+    let nativeSignal: AbortSignal | undefined;
+    const client = fakeClient({
+      getComposerDraft: async (_workspaceId, _sessionId, options) => {
+        nativeSignal = options?.signal;
+        return await new Promise<ComposerDraft>((_resolve, reject) => {
+          nativeSignal?.addEventListener(
+            "abort",
+            () => reject(nativeSignal?.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush();
+    expect(nativeSignal?.aborted).toBe(false);
+
+    await hook.unmount();
+    expect(nativeSignal?.aborted).toBe(true);
+  });
+
   test("durable policy hydration does not trigger a write-back", async () => {
     let resolveDraft!: (draft: ComposerDraft) => void;
     const saved: unknown[] = [];
@@ -5654,14 +5680,56 @@ describe("useAvailableModels", () => {
   });
 
   test("starts with empty models and a null default before the config loads", async () => {
+    let nativeSignal: AbortSignal | undefined;
     const client = fakeClient({
-      getClientConfig: async () => new Promise(() => {}) as never,
+      getClientConfig: async (options) => {
+        nativeSignal = options?.signal;
+        return (await new Promise((_resolve, reject) => {
+          nativeSignal?.addEventListener(
+            "abort",
+            () => reject(nativeSignal?.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        })) as never;
+      },
     });
     const hook = await renderHook(() => useAvailableModels({ client }), undefined);
     expect(hook.result.current.loading).toBe(true);
     expect(hook.result.current.models).toEqual([]);
     expect(hook.result.current.defaultModel).toBeNull();
     await hook.unmount();
+    expect(nativeSignal?.aborted).toBe(true);
+  });
+});
+
+describe("useLastStartedTurnPolicy", () => {
+  test("unmount aborts its latest-turn read", async () => {
+    let nativeSignal: AbortSignal | undefined;
+    const client = fakeClient({
+      listTurns: async (_workspaceId, _sessionId, options) => {
+        nativeSignal = options?.signal;
+        return await new Promise<SessionTurn[]>((_resolve, reject) => {
+          nativeSignal?.addEventListener(
+            "abort",
+            () => reject(nativeSignal?.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useLastStartedTurnPolicy(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+        }),
+      undefined,
+    );
+    await flush();
+    expect(nativeSignal?.aborted).toBe(false);
+
+    await hook.unmount();
+    expect(nativeSignal?.aborted).toBe(true);
   });
 });
 

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -751,6 +751,54 @@ describe("ordinary session Codex realtime control", () => {
     expect(requests).toBe(1);
   });
 
+  test("aborts a shared catalog read only after its final mounted consumer leaves", async () => {
+    const workspaceId = "99999999-9999-4999-8999-999999999999";
+    const nativeSignals: AbortSignal[] = [];
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async (
+        _workspaceId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
+        const nativeSignal = options?.signal;
+        if (nativeSignal) nativeSignals.push(nativeSignal);
+        return await new Promise((_resolve, reject) => {
+          nativeSignal?.addEventListener(
+            "abort",
+            () => reject(nativeSignal?.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    } as unknown as OpenGeniClient;
+
+    function Selection() {
+      useRealtimeModelSelection({ client, workspaceId, codexConnected: true });
+      return null;
+    }
+
+    await act(async () =>
+      root.render(
+        <>
+          <Selection key="first" />
+          <Selection key="second" />
+        </>,
+      ),
+    );
+    expect(nativeSignals).toHaveLength(1);
+    expect(nativeSignals[0]?.aborted).toBe(false);
+
+    await act(async () => root.render(<Selection key="second" />));
+    expect(nativeSignals[0]?.aborted).toBe(false);
+
+    await act(async () => root.render(null));
+    expect(nativeSignals[0]?.aborted).toBe(true);
+
+    await act(async () => root.render(<Selection key="retry" />));
+    expect(nativeSignals).toHaveLength(2);
+    expect(nativeSignals[1]?.aborted).toBe(false);
+    await act(async () => root.render(null));
+  });
+
   test("does not cache a failed catalog load", async () => {
     const workspaceId = "88888888-8888-4888-8888-888888888888";
     let requests = 0;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1151,6 +1151,8 @@ export class OpenGeniClient {
       pinsOnly?: boolean;
       /** Return archived root chats instead of the active session list. */
       archivedOnly?: boolean;
+      /** Stop this caller's finite page read when its owning route is abandoned. */
+      signal?: AbortSignal | undefined;
     } = {},
   ): Promise<SessionListResponse> {
     const search = options.search?.trim();
@@ -1168,6 +1170,7 @@ export class OpenGeniClient {
           ...(options.pinsOnly ? { pinsOnly: "true" } : {}),
           ...(options.archivedOnly ? { archivedOnly: "true" } : {}),
         },
+        { signal: options.signal },
       );
     } catch (error) {
       if (error instanceof OpenGeniApiError && error.status === 410) {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1606,7 +1606,7 @@ export class OpenGeniClient {
   async listTurns(
     workspaceId: string,
     sessionId: string,
-    options: { limit?: number; latestStarted?: boolean } = {},
+    options: { limit?: number; latestStarted?: boolean; signal?: AbortSignal | undefined } = {},
   ): Promise<SessionTurn[]> {
     return await this.requestJson<SessionTurn[]>(
       "GET",
@@ -1616,13 +1616,19 @@ export class OpenGeniClient {
         ...(options.limit !== undefined ? { limit: String(options.limit) } : {}),
         ...(options.latestStarted ? { latestStarted: "1" } : {}),
       },
+      { signal: options.signal },
     );
   }
 
   /** Newest turn that durably emitted `turn.started`, or null before any admission. */
-  async getLatestStartedTurn(workspaceId: string, sessionId: string): Promise<SessionTurn | null> {
+  async getLatestStartedTurn(
+    workspaceId: string,
+    sessionId: string,
+    options: OpenGeniRequestOptions = {},
+  ): Promise<SessionTurn | null> {
     const turns = await this.listTurns(workspaceId, sessionId, {
       latestStarted: true,
+      signal: options.signal,
     });
     return turns[0] ?? null;
   }
@@ -2196,10 +2202,16 @@ export class OpenGeniClient {
     );
   }
 
-  async getComposerDraft(workspaceId: string, sessionId: string): Promise<ComposerDraft> {
+  async getComposerDraft(
+    workspaceId: string,
+    sessionId: string,
+    options: OpenGeniRequestOptions = {},
+  ): Promise<ComposerDraft> {
     return await this.requestSessionCommand<ComposerDraft>(
       "GET",
       `/v1/workspaces/${workspaceId}/sessions/${sessionId}/composer-draft`,
+      undefined,
+      options,
     );
   }
 
@@ -3927,8 +3939,14 @@ export class OpenGeniClient {
    * expected to authenticate. Drives a composer's model picker without prior
    * knowledge of the host setup; safe to call before any auth is established.
    */
-  async getClientConfig(): Promise<ClientConfig> {
-    const config = await this.requestJson<ClientConfig>("GET", "/v1/config/client");
+  async getClientConfig(options: OpenGeniRequestOptions = {}): Promise<ClientConfig> {
+    const config = await this.requestJson<ClientConfig>(
+      "GET",
+      "/v1/config/client",
+      undefined,
+      {},
+      options,
+    );
     if (config.apiContractRevision !== OPENGENI_API_CONTRACT_REVISION) {
       throw new OpenGeniApiContractMismatchError(
         OPENGENI_API_CONTRACT_REVISION,
@@ -3939,10 +3957,16 @@ export class OpenGeniClient {
   }
 
   /** Authenticated model definitions plus workspace-specific selectability. */
-  async getWorkspaceModelCatalog(workspaceId: string): Promise<WorkspaceModelCatalogResponse> {
+  async getWorkspaceModelCatalog(
+    workspaceId: string,
+    options: OpenGeniRequestOptions = {},
+  ): Promise<WorkspaceModelCatalogResponse> {
     return await this.requestJson<WorkspaceModelCatalogResponse>(
       "GET",
       `/v1/workspaces/${workspaceId}/model-catalog`,
+      undefined,
+      {},
+      options,
     );
   }
 
@@ -3969,10 +3993,14 @@ export class OpenGeniClient {
   /** Authenticated realtime voice models and credential readiness. */
   async getWorkspaceRealtimeModelCatalog(
     workspaceId: string,
+    options: OpenGeniRequestOptions = {},
   ): Promise<WorkspaceRealtimeModelCatalogResponse> {
     return await this.requestJson<WorkspaceRealtimeModelCatalogResponse>(
       "GET",
       `/v1/workspaces/${workspaceId}/realtime-model-catalog`,
+      undefined,
+      {},
+      options,
     );
   }
 
@@ -7170,14 +7198,20 @@ export class OpenGeniClient {
   }
 
   /** Contract-checked JSON transport shared by opt-in typed SDK clients. */
-  private async requestSessionCommand<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async requestSessionCommand<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: OpenGeniRequestOptions = {},
+  ): Promise<T> {
     return await this.requestJson<T>(
       method,
       path,
       body,
       {},
       {
-        timeoutMs: this.sessionCommandTimeoutMs,
+        signal: options.signal,
+        timeoutMs: options.timeoutMs ?? this.sessionCommandTimeoutMs,
       },
     );
   }

--- a/packages/sdk/src/realtime.ts
+++ b/packages/sdk/src/realtime.ts
@@ -30,6 +30,7 @@ import type { SessionRealtimeModel, WorkspaceRealtimeModelCatalogResponse } from
 export type SessionRealtimeClientLike = CodexRealtimeControllerClient & {
   getWorkspaceRealtimeModelCatalog(
     workspaceId: string,
+    options?: { signal?: AbortSignal | undefined },
   ): Promise<WorkspaceRealtimeModelCatalogResponse>;
 };
 

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -474,6 +474,52 @@ describe("OpenGeniClient", () => {
     ]);
   });
 
+  test("route-owned finite reads forward one lifecycle AbortSignal", async () => {
+    const received: Array<{ path: string; signal: AbortSignal | undefined }> = [];
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: async (input, init) => {
+        const signal = init?.signal ?? undefined;
+        received.push({ path: new URL(String(input)).pathname, signal });
+        return await new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+    const abort = new AbortController();
+    const settled = Promise.allSettled([
+      client.listTurns(WORKSPACE_ID, SESSION_ID, {
+        latestStarted: true,
+        signal: abort.signal,
+      }),
+      client.getComposerDraft(WORKSPACE_ID, SESSION_ID, { signal: abort.signal }),
+      client.getClientConfig({ signal: abort.signal }),
+      client.getWorkspaceModelCatalog(WORKSPACE_ID, { signal: abort.signal }),
+      client.getWorkspaceRealtimeModelCatalog(WORKSPACE_ID, { signal: abort.signal }),
+    ]);
+    abort.abort();
+
+    expect(received).toEqual([
+      { path: `/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/turns`, signal: abort.signal },
+      {
+        path: `/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/composer-draft`,
+        signal: abort.signal,
+      },
+      { path: "/v1/config/client", signal: abort.signal },
+      { path: `/v1/workspaces/${WORKSPACE_ID}/model-catalog`, signal: abort.signal },
+      { path: `/v1/workspaces/${WORKSPACE_ID}/realtime-model-catalog`, signal: abort.signal },
+    ]);
+    for (const result of await settled) {
+      expect(result).toEqual(
+        expect.objectContaining({ status: "rejected", reason: expect.any(DOMException) }),
+      );
+    }
+  });
+
   test("submits one exact revision-fenced established-session draft", async () => {
     const response = {
       accepted: makeEvent(9),

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -498,6 +498,7 @@ describe("OpenGeniClient", () => {
       }),
       client.getComposerDraft(WORKSPACE_ID, SESSION_ID, { signal: abort.signal }),
       client.getClientConfig({ signal: abort.signal }),
+      client.listSessionPage(WORKSPACE_ID, { limit: 12, signal: abort.signal }),
       client.getWorkspaceModelCatalog(WORKSPACE_ID, { signal: abort.signal }),
       client.getWorkspaceRealtimeModelCatalog(WORKSPACE_ID, { signal: abort.signal }),
     ]);
@@ -510,6 +511,7 @@ describe("OpenGeniClient", () => {
         signal: abort.signal,
       },
       { path: "/v1/config/client", signal: abort.signal },
+      { path: `/v1/workspaces/${WORKSPACE_ID}/sessions`, signal: abort.signal },
       { path: `/v1/workspaces/${WORKSPACE_ID}/model-catalog`, signal: abort.signal },
       { path: `/v1/workspaces/${WORKSPACE_ID}/realtime-model-catalog`, signal: abort.signal },
     ]);

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -239,6 +239,11 @@ const DOCUMENT_WORKSPACE_CATALOG_CANCELLATION_PHASES = new Set([
   "independent-set-after-other-logout-all",
 ]);
 
+// Session-page hooks now own their native request lifetime just like the
+// catalog hooks above. A deliberate route/document replacement may therefore
+// cancel only the exact paged session-list GET dispatched by that same phase.
+const DOCUMENT_SESSION_PAGE_CANCELLATION_PHASES = DOCUMENT_WORKSPACE_CATALOG_CANCELLATION_PHASES;
+
 const DOCUMENT_BOOTSTRAP_CANCELLATION_DISPATCH_PHASES = new Map<string, ReadonlySet<string>>([
   ["late-old-epoch-primary-settled-before-old-release", new Set(["late-old-epoch-alpha-to-beta"])],
   ["slot-revocation-reauthentication", new Set(["cross-slot-deep-link"])],
@@ -420,6 +425,15 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
     input.dispatchPhase === input.responsePhase &&
     DOCUMENT_WORKSPACE_CATALOG_CANCELLATION_PHASES.has(input.responsePhase) &&
     /^\/v1\/workspaces\/[0-9a-f-]+\/(?:realtime-)?model-catalog$/u.test(pathname);
+  const isExpectedDocumentSessionPageCancellation =
+    isCancellation &&
+    !isConnectionReset &&
+    input.method === "GET" &&
+    input.actorEpoch !== null &&
+    input.dispatchPhase === input.responsePhase &&
+    DOCUMENT_SESSION_PAGE_CANCELLATION_PHASES.has(input.responsePhase) &&
+    /^\/v1\/workspaces\/[0-9a-f-]+\/sessions$/u.test(pathname) &&
+    requestUrl.searchParams.get("view") === "page";
   const isExpectedDocumentBootstrapCancellation =
     isCancellation &&
     !isConnectionReset &&
@@ -434,6 +448,7 @@ function requestFailureProblem(input: BrowserRequestFailureInput): string | null
     isAcceptedActorTransitionCancellation ||
     isExpectedLogoutAllBoundedStreamCancellation ||
     isExpectedEvidenceCatalogCancellation ||
+    isExpectedDocumentSessionPageCancellation ||
     isExpectedDocumentBootstrapCancellation
   ) {
     return null;
@@ -2546,6 +2561,20 @@ describe("provider-neutral browser account acceptance", () => {
       requestFailureProblem({
         ...evidenceCatalogRead,
         url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/sessions`,
+      }),
+    ).toContain("/sessions");
+    const evidenceSessionPageRead = {
+      ...evidenceCatalogRead,
+      url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/sessions?view=page&limit=50&parentSessionId=null`,
+    };
+    expect(requestFailureProblem(evidenceSessionPageRead)).toBeNull();
+    expect(
+      requestFailureProblem({ ...evidenceSessionPageRead, failure: "NS_ERROR_NET_RESET" }),
+    ).toContain("/sessions");
+    expect(
+      requestFailureProblem({
+        ...evidenceSessionPageRead,
+        url: `${publicOrigin}/v1/workspaces/00000000-0000-0000-0000-000000000001/sessions?view=array`,
       }),
     ).toContain("/sessions");
     const crossTabBootstrapRead = {

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -36,6 +36,65 @@ type UiState = {
   }>;
 };
 
+describe("custom API control center diagnostics", () => {
+  const sessionsUrl = `http://127.0.0.1:9/v1/workspaces/${workspaceId}/sessions`;
+
+  test("allows only the route-owned paged session requests cancelled during replacement", () => {
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?view=page&limit=50&parentSessionId=null`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?parentSessionId=null&archivedOnly=true&limit=50&view=page`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?pinsOnly=true&limit=1&view=page`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(true);
+  });
+
+  test("retains other request failures as diagnostics", () => {
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?view=array&limit=50&parentSessionId=null`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(false);
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?view=page&limit=50&parentSessionId=null`,
+        "net::ERR_CONNECTION_RESET",
+      ),
+    ).toBe(false);
+    expect(
+      isExpectedSessionPageCancellation(
+        "POST",
+        `${sessionsUrl}?view=page&limit=50&parentSessionId=null`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(false);
+    expect(
+      isExpectedSessionPageCancellation(
+        "GET",
+        `${sessionsUrl}?view=page&limit=50&parentSessionId=null&unexpected=true`,
+        "net::ERR_ABORTED",
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("custom API control center browser acceptance", () => {
   let browser: Browser;
   let web: StartedProcess;
@@ -398,11 +457,42 @@ function collectRuntimeDiagnostics(page: Page): string[] {
   });
   page.on("pageerror", (error) => diagnostics.push(`page:${error.message}`));
   page.on("requestfailed", (request) => {
-    diagnostics.push(
-      `request:${request.method()} ${request.url()} ${request.failure()?.errorText ?? "failed"}`,
-    );
+    const errorText = request.failure()?.errorText ?? "failed";
+    if (isExpectedSessionPageCancellation(request.method(), request.url(), errorText)) return;
+    diagnostics.push(`request:${request.method()} ${request.url()} ${errorText}`);
   });
   return diagnostics;
+}
+
+function isExpectedSessionPageCancellation(
+  method: string,
+  requestUrl: string,
+  errorText: string,
+): boolean {
+  if (method !== "GET" || errorText !== "net::ERR_ABORTED") return false;
+
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+  if (
+    url.origin !== "http://127.0.0.1:9" ||
+    url.pathname !== `/v1/workspaces/${workspaceId}/sessions`
+  ) {
+    return false;
+  }
+
+  const actual = [...url.searchParams.entries()]
+    .map(([key, value]) => `${key}=${value}`)
+    .sort()
+    .join("&");
+  return new Set([
+    "limit=50&parentSessionId=null&view=page",
+    "archivedOnly=true&limit=50&parentSessionId=null&view=page",
+    "limit=1&pinsOnly=true&view=page",
+  ]).has(actual);
 }
 
 async function openCapabilities(page: Page): Promise<void> {


### PR DESCRIPTION
## What

- fence the initiating tab on a neutral actor surface before any account-changing mutation can reach the server
- restore only reconciled authority after a failed or response-lost transition
- propagate lifecycle cancellation through session pages, drafts, turn policy, config, model catalogs, and realtime catalogs
- keep shared realtime catalog requests alive until their final consumer leaves, then permit a clean retry

## Why

Canonical main CI run 33223545691 exposed two non-Chromium account-lifecycle failures: a revoked event stream could reconnect with a 401 during response-loss logout replay, and several finite route reads could remain pending at the strict final quiescence check. The initiating tab was fenced only after mutation success; peers were fenced before commit.

The first PR run then exposed two session-list reads that still lacked route-owned cancellation. The exact SDK and hook paths now carry the same lifecycle signal and have regression coverage.

## Verification

- all 31 TypeScript projects clean
- lint and format checks clean
- clean React suite: 1,549 passed
- targeted SDK and lifecycle hook suite: 183 passed
- active model-catalog refresh unmount regression: 1 passed
- real PostgreSQL browser-account acceptance passed locally in Chromium, Firefox, and WebKit; Chromium was repeated after the CI finding
- production web build and bundle budget passed: direct session 2,240,607 raw / 627,862 gzip bytes

## Summary by Sourcery

Fence browser account transitions before mutation and cancel abandoned account-scoped reads without disrupting shared consumers.

Bug Fixes:
- Fence the initiating browser tab before account-changing mutations and restore reconciled authority when the transition cannot complete.

Enhancements:
- Propagate lifecycle cancellation through finite session, draft, turn-policy, configuration, and model-catalog reads.
- Keep shared realtime model-catalog requests active until their final consumer leaves, while allowing abandoned loads to retry cleanly.

Tests:
- Add regression coverage for initiating-tab fencing, authority recovery, route-owned request cancellation, and shared realtime catalog consumer lifetimes.
