### PR TITLE
fix(accounts): reconcile precommit invalidations

### DIFF
--- a/.changeset/restore-precommit-account-invalidation.md
+++ b/.changeset/restore-precommit-account-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Reconcile browser account authority when an invalidation supersedes the initiating fence before its server mutation starts.

--- a/packages/react/src/accounts.tsx
+++ b/packages/react/src/accounts.tsx
@@ -197,6 +197,7 @@ export function BrowserAccountsProvider({
     expectedGeneration: string;
   } | null>(null);
   const pendingCommitSequenceRef = useRef<number | null>(null);
+  const pendingServerMutationSequenceRef = useRef<number | null>(null);
   const invalidatedDuringPendingCommitRef = useRef(false);
   const sequenceRef = useRef(0);
   const transitionAbortRef = useRef<AbortController | null>(null);
@@ -400,6 +401,7 @@ export function BrowserAccountsProvider({
       pending.expectedGeneration = expectedGeneration;
       const sequence = ++sequenceRef.current;
       pendingCommitSequenceRef.current = sequence;
+      pendingServerMutationSequenceRef.current = null;
       invalidatedDuringPendingCommitRef.current = false;
       pendingRef.current = pending;
       setPhase("committing");
@@ -434,7 +436,9 @@ export function BrowserAccountsProvider({
           // Yield one task after the secret-free hold so queued BroadcastChannel
           // delivery can fence peers before the network mutation starts.
           await yieldToCrossTabActorHold();
+          if (controller.signal.aborted || sequenceRef.current !== sequence) return false;
         }
+        pendingServerMutationSequenceRef.current = sequence;
         let accepted: ManagedAuthSessionSetProjection;
         try {
           accepted = await pending.execute(expectedGeneration);
@@ -510,6 +514,9 @@ export function BrowserAccountsProvider({
         return await fail(caught, pending.kind);
       } finally {
         if (changesActor) publishActorRelease(pending.operationId);
+        if (pendingServerMutationSequenceRef.current === sequence) {
+          pendingServerMutationSequenceRef.current = null;
+        }
         if (pendingCommitSequenceRef.current === sequence) {
           pendingCommitSequenceRef.current = null;
           invalidatedDuringPendingCommitRef.current = false;
@@ -563,10 +570,23 @@ export function BrowserAccountsProvider({
   );
 
   const invalidateActor = useCallback(async () => {
-    if (pendingCommitSequenceRef.current !== null) {
+    const pendingCommitSequence = pendingCommitSequenceRef.current;
+    if (
+      pendingCommitSequence !== null &&
+      pendingServerMutationSequenceRef.current === pendingCommitSequence
+    ) {
       invalidatedDuringPendingCommitRef.current = true;
       await beginNeutralActorInvalidation(projectionRef.current);
       return null;
+    }
+    // An authority hint that arrives while the initiating host fence is still
+    // pending supersedes the not-yet-dispatched mutation. Reconcile it here;
+    // otherwise aborting that fence makes executePending return early while no
+    // operation remains to restore the neutral actor surface.
+    if (pendingCommitSequence !== null) {
+      pendingCommitSequenceRef.current = null;
+      pendingServerMutationSequenceRef.current = null;
+      invalidatedDuringPendingCommitRef.current = false;
     }
     const sequence = ++sequenceRef.current;
     const before = projectionRef.current;

--- a/packages/react/test/accounts.test.tsx
+++ b/packages/react/test/accounts.test.tsx
@@ -479,6 +479,107 @@ describe("BrowserAccountsProvider", () => {
     await accounts.unmount();
   });
 
+  test("reconciles authority when invalidation supersedes a pre-mutation fence", async () => {
+    const before = projection();
+    const replacement = projection({
+      generation: "2",
+      actorEpoch: "2",
+      selectedSlotId: SLOT_B,
+    });
+    let current = before;
+    let mutationAttempts = 0;
+    let announceFenceStarted!: () => void;
+    const fenceStarted = new Promise<void>((resolve) => {
+      announceFenceStarted = resolve;
+    });
+    const transitions: BrowserAccountTransition[] = [];
+    const accounts = await renderAccounts(
+      scriptedClient({
+        getSessionSet: async () => current,
+        reconcileSessionSetAuthority: async () => current,
+        selectLoginSlot: async () => {
+          mutationAttempts += 1;
+          return replacement;
+        },
+      }),
+      async (transition) => {
+        transitions.push(transition);
+        if (transition.from === before && transition.to === null) {
+          announceFenceStarted();
+          if (!transition.signal.aborted) {
+            await new Promise<void>((resolve) =>
+              transition.signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+          }
+        }
+      },
+    );
+    transitions.length = 0;
+
+    let selection!: Promise<boolean>;
+    await act(async () => {
+      selection = accounts.current.selectSlot(SLOT_B);
+      await fenceStarted;
+    });
+    expect(accounts.current.projection).toBeNull();
+
+    current = replacement;
+    expect(await actRun(() => accounts.current.invalidateActor())).toEqual(replacement);
+    expect(await actRun(async () => await selection)).toBe(false);
+
+    expect(mutationAttempts).toBe(0);
+    expect(accounts.current.projection).toEqual(replacement);
+    expect(accounts.current.phase).toBe("ready");
+    expect(transitions.at(-1)).toMatchObject({
+      kind: "cross_tab",
+      from: null,
+      to: replacement,
+    });
+    await accounts.unmount();
+  });
+
+  test("does not dispatch a mutation superseded during the peer-hold yield", async () => {
+    const before = projection();
+    const replacement = projection({
+      generation: "2",
+      actorEpoch: "2",
+      selectedSlotId: SLOT_B,
+    });
+    let current = before;
+    let mutationAttempts = 0;
+    let settleInvalidation!: (value: ManagedAuthSessionSetProjection | null) => void;
+    const invalidationSettled = new Promise<ManagedAuthSessionSetProjection | null>((resolve) => {
+      settleInvalidation = resolve;
+    });
+    let accounts!: Awaited<ReturnType<typeof renderAccounts>>;
+    accounts = await renderAccounts(
+      scriptedClient({
+        getSessionSet: async () => current,
+        reconcileSessionSetAuthority: async () => current,
+        selectLoginSlot: async () => {
+          mutationAttempts += 1;
+          return replacement;
+        },
+      }),
+      async (transition) => {
+        if (transition.from === before && transition.to === null) {
+          current = replacement;
+          setTimeout(() => {
+            void accounts.current.invalidateActor().then(settleInvalidation);
+          }, 0);
+        }
+      },
+    );
+
+    expect(await actRun(() => accounts.current.selectSlot(SLOT_B))).toBe(false);
+    expect(await actRun(async () => await invalidationSettled)).toEqual(replacement);
+
+    expect(mutationAttempts).toBe(0);
+    expect(accounts.current.projection).toEqual(replacement);
+    expect(accounts.current.phase).toBe("ready");
+    await accounts.unmount();
+  });
+
   test("lets logout-all own settlement when its SSE actor-loss signal arrives concurrently", async () => {
     const before = projection({ generation: "4", actorEpoch: "3" });
     const empty = projection({ selectedSlotId: null, slotIds: [] });


### PR DESCRIPTION
## What

- distinguish a browser-account transition that is still inside its initiating host fence from one whose server mutation has started
- let a server/cross-tab invalidation supersede and reconcile the pre-request transition instead of leaving the provider neutral
- re-check cancellation after the deliberate peer-hold task yield so a superseded mutation cannot reach the server
- add focused regressions for invalidation during both the host fence and the peer-hold yield

## Why

Follow-up security review of #1998 found a remaining precommit race. `invalidateActor()` treated every pending commit as though its server mutation already owned settlement. If an authority hint aborted the initiating fence before `pending.execute()` began, `executePending()` returned early and no path restored the reconciled actor. An invalidation during the peer-hold yield could also reconcile the new actor and then still dispatch the stale mutation because there was no post-yield sequence check.

The regression reproduced the first case on merged main: `invalidateActor()` returned `null`, the mutation did not start, and the provider remained on a neutral loading surface.

## Verification

- `bun test ./packages/react/test/accounts.test.tsx` — 31 passed
- `cd packages/react && bun run typecheck`
- targeted oxlint — clean
- targeted oxfmt check — clean
- `git diff --check` — clean

## Scheduled session provenance

This follow-up was found and implemented by the scheduled PR review session on August 29, 2026. No Linear issue was linked from #1998.

## Summary by Sourcery

Ensure superseding account invalidations restore the reconciled actor and prevent stale mutations from reaching the server.

Bug Fixes:
- Reconcile browser account authority when invalidation supersedes a pending transition before its server mutation begins.
- Prevent stale account mutations from being dispatched after invalidation during the peer-hold window.

Tests:
- Add regression coverage for invalidation during the pre-mutation host fence and peer-hold yield.