### PR TITLE
fix(accounts): complete invalidation ownership handoff

### DIFF
--- a/.changeset/restore-precommit-account-invalidation.md
+++ b/.changeset/restore-precommit-account-invalidation.md
@@ -2,4 +2,4 @@
 "@opengeni/react": patch
 ---
 
-Reconcile browser account authority when an invalidation supersedes the initiating fence before its server mutation starts.
+Reconcile browser account authority when an invalidation supersedes the initiating fence or post-mutation host settlement, prevent stale dispatch after the peer-hold yield, and discard superseded retry commands.

--- a/packages/react/src/accounts.tsx
+++ b/packages/react/src/accounts.tsx
@@ -460,6 +460,17 @@ export function BrowserAccountsProvider({
           if (sequenceRef.current !== sequence) return false;
         }
         pendingRef.current = null;
+        // The server response and any invalidation reconciliation are now
+        // authoritative. Release commit ownership before host settlement so a
+        // later invalidation starts its own reconciliation instead of relying
+        // on the already-consumed check above.
+        if (pendingServerMutationSequenceRef.current === sequence) {
+          pendingServerMutationSequenceRef.current = null;
+        }
+        if (pendingCommitSequenceRef.current === sequence) {
+          pendingCommitSequenceRef.current = null;
+          invalidatedDuringPendingCommitRef.current = false;
+        }
         if (
           !initiatingActorFenced &&
           !authorityResetConfirmed &&
@@ -587,6 +598,7 @@ export function BrowserAccountsProvider({
       pendingCommitSequenceRef.current = null;
       pendingServerMutationSequenceRef.current = null;
       invalidatedDuringPendingCommitRef.current = false;
+      pendingRef.current = null;
     }
     const sequence = ++sequenceRef.current;
     const before = projectionRef.current;

--- a/packages/react/test/accounts.test.tsx
+++ b/packages/react/test/accounts.test.tsx
@@ -530,6 +530,7 @@ describe("BrowserAccountsProvider", () => {
     expect(mutationAttempts).toBe(0);
     expect(accounts.current.projection).toEqual(replacement);
     expect(accounts.current.phase).toBe("ready");
+    expect(accounts.current.hasPendingTransition).toBe(false);
     expect(transitions.at(-1)).toMatchObject({
       kind: "cross_tab",
       from: null,
@@ -577,6 +578,71 @@ describe("BrowserAccountsProvider", () => {
     expect(mutationAttempts).toBe(0);
     expect(accounts.current.projection).toEqual(replacement);
     expect(accounts.current.phase).toBe("ready");
+    await accounts.unmount();
+  });
+
+  test("reconciles an invalidation that supersedes post-mutation host settlement", async () => {
+    const before = projection();
+    const replacement = projection({
+      generation: "2",
+      actorEpoch: "2",
+      selectedSlotId: SLOT_B,
+    });
+    let current = before;
+    let mutationAttempts = 0;
+    let announceSettlementStarted!: () => void;
+    const settlementStarted = new Promise<void>((resolve) => {
+      announceSettlementStarted = resolve;
+    });
+    const transitions: BrowserAccountTransition[] = [];
+    const accounts = await renderAccounts(
+      scriptedClient({
+        getSessionSet: async () => current,
+        reconcileSessionSetAuthority: async () => current,
+        selectLoginSlot: async () => {
+          mutationAttempts += 1;
+          current = replacement;
+          return replacement;
+        },
+      }),
+      async (transition) => {
+        transitions.push(transition);
+        if (
+          transition.kind === "select" &&
+          transition.from === null &&
+          transition.to === replacement
+        ) {
+          announceSettlementStarted();
+          if (!transition.signal.aborted) {
+            await new Promise<void>((resolve) =>
+              transition.signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+          }
+        }
+      },
+    );
+    transitions.length = 0;
+
+    let selection!: Promise<boolean>;
+    await act(async () => {
+      selection = accounts.current.selectSlot(SLOT_B);
+      await settlementStarted;
+    });
+    expect(accounts.current.projection).toBeNull();
+    expect(accounts.current.phase).toBe("loading");
+
+    expect(await actRun(() => accounts.current.invalidateActor())).toEqual(replacement);
+    expect(await actRun(async () => await selection)).toBe(true);
+
+    expect(mutationAttempts).toBe(1);
+    expect(accounts.current.projection).toEqual(replacement);
+    expect(accounts.current.phase).toBe("ready");
+    expect(accounts.current.hasPendingTransition).toBe(false);
+    expect(transitions.at(-1)).toMatchObject({
+      kind: "cross_tab",
+      from: null,
+      to: replacement,
+    });
     await accounts.unmount();
   });
 


### PR DESCRIPTION
## What

- release pending-commit ownership once the server response and any response-time invalidation reconciliation are authoritative
- let invalidation during post-mutation host settlement start a fresh authority reconciliation
- discard a precommit command when an actor invalidation supersedes it instead of retaining a stale generation for retry
- add focused regressions for both ownership boundaries and update the existing release note

## Why

Follow-up human review of #1999 reproduced two remaining races before release. An invalidation during host settlement could abort the only restoring transition after the earlier invalidation check had already been consumed, leaving the provider neutral/loading. A pre-mutation invalidation also retained the superseded command with its frozen old generation.

## Verification

- BrowserAccountsProvider suite: 32 passed
- browser-account web runtime: 3 passed
- all 31 TypeScript projects clean
- targeted lint and format checks clean
- git diff check clean

## Tracking

Follow-up under OPE-365. Release/version promotion remains paused until this exact head passes review and CI, merges, and canonical main is green.

## Summary by Sourcery

Complete browser account invalidation ownership handoff so concurrent invalidations trigger fresh reconciliation without leaving stale authority state.

Bug Fixes:
- Fix browser account authority reconciliation when invalidations race with post-mutation host settlement or supersede a precommit command.
- Prevent stale pending transitions and precommit generations from being retained after invalidation or authoritative server reconciliation.

Documentation:
- Update the release note for browser account invalidation reconciliation.

Tests:
- Add regression coverage for invalidation during host settlement and assert that completed reconciliation leaves no pending transition.