### PR TITLE
test(timeline): serve browser harness from production build

### DIFF
--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -50,12 +50,20 @@ export default defineConfig({
     // that limit and production additionally gates every asset by gzip size.
     chunkSizeWarningLimit: 800,
     rollupOptions: {
-      // Pages: the full component harness (index.html), the timeline tool-call
-      // renderer harness (timeline.html), the queue presentation browser
-      // regression (queue.html), and the Machines / enrollment UI screenshot
-      // harness (machines.html — M9 / V12), all static.
+      // The timeline-scroll browser lane repeatedly navigates among these
+      // harnesses. Build every page into one production graph so the lane tests
+      // shipped chunks without accumulating a fresh dev-module graph on each
+      // navigation. The ordinary demo build continues to use the full input set.
       input: timelineScrollTestBuild
-        ? { timelineScrollTest: resolve(__dirname, "timeline-scroll-test.html") }
+        ? {
+            timelineScrollTest: resolve(__dirname, "timeline-scroll-test.html"),
+            timelineScrollMergeTest: resolve(__dirname, "timeline-scroll-merge-test.html"),
+            timelineCollapsedHistoryTest: resolve(
+              __dirname,
+              "timeline-collapsed-history-test.html",
+            ),
+            timelineHeldTurnTest: resolve(__dirname, "timeline-held-turn-test.html"),
+          }
         : demoInputs,
     },
   },

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { freePort } from "@opengeni/testing";
 import { chromium, type Browser, type Page } from "playwright";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
@@ -41,29 +41,15 @@ function observeBrowserErrors(page: Page, browserErrors: string[]): void {
 }
 
 describe("timeline scroll ownership browser regression", () => {
-  let web: StartedProcess;
   let productionServer: ReturnType<typeof Bun.serve> | undefined;
   let browser: Browser;
   let page: Page;
   let baseUrl: string;
-  let productionBaseUrl: string;
   let productionBuildDir: string | undefined;
   let networkRequests = 0;
   const browserErrors: string[] = [];
 
   beforeAll(async () => {
-    const port = await freePort();
-    baseUrl = `http://127.0.0.1:${port}`;
-    web = await startProcess(
-      ["bun", "run", "vite", ".", "--port", String(port), "--strictPort", "--host", "127.0.0.1"],
-      {
-        cwd: demoRoot,
-        ready: async () =>
-          (await fetch(baseUrl, { signal: AbortSignal.timeout(2_000) }).catch(() => null))?.ok ===
-          true,
-        timeoutMs: 45_000,
-      },
-    );
     productionBuildDir = await mkdtemp(join(tmpdir(), "opengeni-timeline-scroll-"));
     const productionEnvironment = {
       OPENGENI_REACT_DEMO_OUT_DIR: productionBuildDir,
@@ -85,7 +71,7 @@ describe("timeline scroll ownership browser regression", () => {
       );
     }
     const productionPort = await freePort();
-    productionBaseUrl = `http://127.0.0.1:${productionPort}`;
+    baseUrl = `http://127.0.0.1:${productionPort}`;
     productionServer = Bun.serve({
       hostname: "127.0.0.1",
       port: productionPort,
@@ -124,7 +110,7 @@ describe("timeline scroll ownership browser regression", () => {
     try {
       expect(browserErrors).toEqual([]);
     } finally {
-      await Promise.allSettled([browser?.close(), web?.stop(), productionServer?.stop(true)]);
+      await Promise.allSettled([browser?.close(), productionServer?.stop(true)]);
       if (productionBuildDir) {
         await rm(productionBuildDir, { recursive: true, force: true });
       }
@@ -258,7 +244,7 @@ describe("timeline scroll ownership browser regression", () => {
     const performancePage = await browser.newPage({ viewport: { width: 1280, height: 900 } });
     observeBrowserErrors(performancePage, browserErrors);
     try {
-      await performancePage.goto(`${productionBaseUrl}/timeline-scroll-test.html`);
+      await performancePage.goto(`${baseUrl}/timeline-scroll-test.html`);
       await performancePage.waitForFunction(() => window.timelineScrollHarness !== undefined);
       await performancePage.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
       await performancePage.locator('[data-timeline-row="row-1040"]').evaluate((node) => {


### PR DESCRIPTION
## Summary
- build every timeline-scroll acceptance page into one production asset graph
- serve all 33 timeline-scroll journeys from that immutable build
- remove the repeated Vite dev-module reloads that exhaust Chromium resources late in the protected lane

## Verification
- exact failing full timeline-scroll file: 33/33 pass twice
- timeline tip-follow: 13/13 pass
- remaining interaction browser groups: all pass locally on the exact merged tree
- all 31 TypeScript projects clean
- repository lint, format, and diff checks clean

Follow-up required by the protected-main delivery gate for OPE-365. No product runtime behavior or package release changes.

## Summary by Sourcery

Serve the complete timeline-scroll browser regression suite from a single production build to improve test stability.

Bug Fixes:
- Prevent timeline-scroll browser tests from exhausting Chromium resources by running all journeys against a single production asset graph instead of a Vite development server.

Enhancements:
- Expand the timeline-scroll production build to include all four acceptance-test pages and serve the browser regression suite entirely from that immutable build.

Build:
- Configure the React demo production build to bundle all timeline-scroll harness pages as one asset graph.

Tests:
- Update the timeline-scroll browser regression setup to build and serve production assets directly, removing the development-server dependency.