### PR TITLE
test(accounts): retire deep-link reads after logout-all

### DIFF
--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -194,6 +194,14 @@ const SCOPED_ACTOR_READ_CANCELLATION_DISPATCH_PHASES = new Map<string, ReadonlyS
   ],
 ]);
 
+const LOGOUT_ALL_FINITE_READ_RETIREMENT_DISPATCH_PHASES = new Set([
+  "cross-slot-deep-link",
+  "slot-revocation-reauthentication",
+  "logout-one",
+  "csrf-fail-closed",
+  "logout-all-response-loss-replay",
+]);
+
 const DOCUMENT_BOOTSTRAP_CANCELLATION_PATHS = new Map<string, ReadonlySet<string>>([
   // These phases intentionally create or reload a whole document. React can
   // cancel only its configuration/session bootstrap reads while replacing
@@ -632,16 +640,13 @@ function finiteReadMayRetireAfterLogoutAllAuthorityReset(
   // only a pre-acceptance read whose old HttpOnly authority is bound to the
   // exact accepted reset and differs from the confirmed replacement set.
   const exactOldWorkspacePrefix = `/v1/workspaces/${encodeURIComponent(input.oldWorkspaceId)}/`;
-  const allowedDispatchPhases = SCOPED_ACTOR_READ_CANCELLATION_DISPATCH_PHASES.get(
-    "logout-all-response-loss-replay",
-  );
   return (
     new Set(["GET", "HEAD"]).has(input.method) &&
     input.actorEpoch !== null &&
     input.actorEpoch !== input.confirmedActorEpoch &&
     !input.responseSeen &&
     input.pathname.startsWith(exactOldWorkspacePrefix) &&
-    allowedDispatchPhases?.has(input.dispatchPhase) === true &&
+    LOGOUT_ALL_FINITE_READ_RETIREMENT_DISPATCH_PHASES.has(input.dispatchPhase) &&
     input.currentSessionSetAuthorityHash !== null &&
     input.requestSessionSetAuthorityHash !== null &&
     input.requestSessionSetAuthorityHash !== input.currentSessionSetAuthorityHash &&
@@ -3354,12 +3359,21 @@ describe("provider-neutral browser account acceptance", () => {
       startedAt: 100,
     } satisfies LogoutAllFiniteReadRetirementInput;
     expect(finiteReadMayRetireAfterLogoutAllAuthorityReset(logoutAllRetirement)).toBe(true);
+    expect(
+      finiteReadMayRetireAfterLogoutAllAuthorityReset({
+        ...logoutAllRetirement,
+        dispatchPhase: "cross-slot-deep-link",
+      }),
+    ).toBe(true);
     for (const invalid of [
       { ...logoutAllRetirement, method: "POST" },
       { ...logoutAllRetirement, actorEpoch: null },
       { ...logoutAllRetirement, actorEpoch: "new-neutral-epoch" },
       { ...logoutAllRetirement, responseSeen: true },
-      { ...logoutAllRetirement, dispatchPhase: "cross-slot-deep-link" },
+      {
+        ...logoutAllRetirement,
+        dispatchPhase: "late-old-epoch-primary-settled-before-old-release",
+      },
       {
         ...logoutAllRetirement,
         pathname: "/v1/workspaces/another-workspace/sessions",


### PR DESCRIPTION
## Summary

- include exact cross-slot deep-link reads in the evidence-bound logout-all finite-read retirement matrix
- keep later phases explicit instead of deriving retirement authority from the broader cancellation map
- preserve negative coverage for method, actor, response, dispatch phase, workspace path, authority, timing, and accepted transition identity

## Release-gate finding

Versioned production-promotion CI run 33236969960 observed four old-workspace reads that began under `cross-slot-deep-link`, carried the old HttpOnly authority, preceded the accepted logout-all, and received no Playwright terminal event after Chromium aborted the old actor. The prior exact retirement list began one phase too late.

## Verification

- focused strict-ledger test: 2/2, 169 assertions
- full real-PostgreSQL Chromium account journey twice: 3/3, 292 assertions each
- all 31 TypeScript projects
- lint, format, and diff checks

Linear: OPE-365

## Summary by Sourcery

Retire stale cross-slot deep-link reads as part of the evidence-bound logout-all finite-read transition.

Bug Fixes:
- Allow exact cross-slot deep-link workspace reads to be retired after an accepted logout-all when they use stale authority and have no terminal response.

Enhancements:
- Make the logout-all finite-read retirement matrix explicit and preserve negative coverage for out-of-scope dispatch phases and retirement conditions.

Tests:
- Extend strict-ledger coverage to verify cross-slot deep-link retirement and reject unrelated late-phase reads.