### PR TITLE
fix(worker): isolate detached MCP lifecycle rejections

### DIFF
--- a/.changeset/worker-mcp-rejection-boundary.md
+++ b/.changeset/worker-mcp-rejection-boundary.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Keep detached duplicates of already-handled MCP lifecycle failures from restarting turn workers.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -87,6 +87,7 @@ import {
   type TurnWorkerMemoryPressureGuard,
 } from "./memory-pressure-guard";
 import { assertSandboxReaperActivityTimeout } from "./sandbox-reaper-timeout";
+import { installWorkerUnhandledRejectionBoundary } from "./unhandled-rejection-boundary";
 import {
   SANDBOX_REAPER_V2_WORKFLOW_ID,
   sandboxLifecycleTaskQueue,
@@ -1034,6 +1035,10 @@ export async function startWorker() {
   }
   const settings = getSettings();
   const observability = createObservability(settings, { component: `worker-${role}` });
+  // The Agents SDK also listens for unhandled rejections and exits the process.
+  // Keep its detached duplicate of an already-handled MCP lifecycle failure from
+  // restarting the whole turn-worker pod; every unknown rejection remains fatal.
+  const disposeUnhandledRejectionBoundary = installWorkerUnhandledRejectionBoundary();
   const retryOptions = startupRetryOptions(settings);
   const onRetry = (event: Parameters<typeof logStartupDependencyRetry>[1]) =>
     logStartupDependencyRetry(observability, event);
@@ -1092,6 +1097,7 @@ export async function startWorker() {
     });
   } finally {
     await Promise.allSettled([bus?.close(), readinessDbClient.close(), dbClient.close()]);
+    disposeUnhandledRejectionBoundary();
   }
 }
 

--- a/apps/worker/src/unhandled-rejection-boundary.ts
+++ b/apps/worker/src/unhandled-rejection-boundary.ts
@@ -1,0 +1,50 @@
+export type WorkerUnhandledRejectionProcess = {
+  on: (event: "unhandledRejection", listener: (reason: unknown) => void) => void;
+  off: (event: "unhandledRejection", listener: (reason: unknown) => void) => void;
+  exit: (code: number) => never | void;
+};
+
+type RuntimeMcpLifecycleError = {
+  name: "McpLifecycleError";
+  code: "mcp_connect_failed" | "mcp_close_failed";
+  origin: "runtime";
+  serverId: string;
+};
+
+/**
+ * The Agents SDK owns MCP connect promises and also installs a process-global
+ * unhandled-rejection listener. A best-effort lifecycle rejection can surface
+ * twice under concurrent teardown: once through the awaited MCP result and once
+ * through the SDK's detached worker promise. The first path already records and
+ * degrades the server; the second must not terminate the whole turn-worker pod.
+ */
+export function isDetachedRuntimeMcpLifecycleRejection(
+  reason: unknown,
+): reason is RuntimeMcpLifecycleError {
+  try {
+    if (!reason || typeof reason !== "object") return false;
+    const candidate = reason as Partial<RuntimeMcpLifecycleError>;
+    return (
+      candidate.name === "McpLifecycleError" &&
+      (candidate.code === "mcp_connect_failed" || candidate.code === "mcp_close_failed") &&
+      candidate.origin === "runtime" &&
+      typeof candidate.serverId === "string" &&
+      candidate.serverId.length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Keep known duplicate MCP lifecycle rejections non-fatal; preserve fail-fast
+ * behavior for every unknown process-level rejection. */
+export function installWorkerUnhandledRejectionBoundary(
+  runtimeProcess: WorkerUnhandledRejectionProcess = process,
+): () => void {
+  const onUnhandledRejection = (reason: unknown): void => {
+    if (isDetachedRuntimeMcpLifecycleRejection(reason)) return;
+    runtimeProcess.exit(1);
+  };
+  runtimeProcess.on("unhandledRejection", onUnhandledRejection);
+  return () => runtimeProcess.off("unhandledRejection", onUnhandledRejection);
+}

--- a/apps/worker/test/unhandled-rejection-boundary.test.ts
+++ b/apps/worker/test/unhandled-rejection-boundary.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  installWorkerUnhandledRejectionBoundary,
+  isDetachedRuntimeMcpLifecycleRejection,
+  type WorkerUnhandledRejectionProcess,
+} from "../src/unhandled-rejection-boundary";
+
+function fakeProcess() {
+  let listener: ((reason: unknown) => void) | undefined;
+  const exits: number[] = [];
+  const runtimeProcess: WorkerUnhandledRejectionProcess = {
+    on: (_event, next) => {
+      listener = next;
+    },
+    off: (_event, current) => {
+      if (listener === current) listener = undefined;
+    },
+    exit: (code) => {
+      exits.push(code);
+    },
+  };
+  return {
+    runtimeProcess,
+    emit: (reason: unknown) => listener?.(reason),
+    exits,
+    hasListener: () => listener !== undefined,
+  };
+}
+
+describe("worker unhandled rejection boundary", () => {
+  test("keeps detached structural MCP lifecycle duplicates non-fatal", () => {
+    const runtime = fakeProcess();
+    const dispose = installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess);
+
+    runtime.emit(
+      Object.assign(new Error("MCP lifecycle connect failed"), {
+        name: "McpLifecycleError",
+        code: "mcp_connect_failed",
+        origin: "runtime",
+        serverId: "optional-slack",
+      }),
+    );
+
+    expect(runtime.exits).toEqual([]);
+    dispose();
+    expect(runtime.hasListener()).toBe(false);
+  });
+
+  test("keeps unknown and malformed rejections fatal", () => {
+    const runtime = fakeProcess();
+    installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess);
+
+    runtime.emit(new Error("unknown"));
+    runtime.emit({ name: "McpLifecycleError", code: "mcp_connect_failed" });
+
+    expect(runtime.exits).toEqual([1, 1]);
+  });
+
+  test("fails closed for hostile rejection objects", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("hostile getter");
+        },
+      },
+    );
+    expect(isDetachedRuntimeMcpLifecycleRejection(hostile)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Incident
Optional Slack MCP connect failures were correctly degraded, but an Agents SDK detached duplicate reached its global `unhandledRejection` listener, which exited the turn-worker process and caused lease-loss retries across staging sessions.

## Fix
- keep only structural runtime MCP lifecycle duplicates non-fatal
- preserve fail-fast exit for unknown or malformed unhandled rejections
- add fail-closed boundary tests

## Verification
- `bun test apps/worker/test/unhandled-rejection-boundary.test.ts`
- targeted runtime MCP/deferred tests
- worker typecheck
- oxfmt + oxlint

## Summary by Sourcery

Isolate already-handled runtime MCP lifecycle rejection duplicates without weakening fail-fast handling for unexpected worker failures.

Bug Fixes:
- Prevent detached duplicate runtime MCP lifecycle rejections from restarting turn workers after the original failure has already been handled.
- Preserve fail-fast worker termination for unknown or malformed unhandled rejections.

Enhancements:
- Add a scoped worker-level unhandled-rejection boundary with cleanup during shutdown.

Tests:
- Add boundary tests covering recognized MCP lifecycle rejections, unknown and malformed rejections, listener cleanup, and hostile rejection objects.