### PR TITLE
fix(runtime): own Agents trace processors

### DIFF
--- a/.changeset/runtime-own-agents-tracing.md
+++ b/.changeset/runtime-own-agents-tracing.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Replace the Agents SDK default batch trace exporter with OpenGeni's in-process preparation processor.

--- a/packages/runtime/src/model-preparation-diagnostics.ts
+++ b/packages/runtime/src/model-preparation-diagnostics.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { addTraceProcessor, type Span, type Trace, type TracingProcessor } from "@openai/agents";
+import { setTraceProcessors, type Span, type Trace, type TracingProcessor } from "@openai/agents";
 
 export type ModelPreparationPhase =
   | "sandbox_agent_preparation"
@@ -84,7 +84,12 @@ class ModelPreparationTraceProcessor implements TracingProcessor {
   async forceFlush(): Promise<void> {}
 }
 
-addTraceProcessor(new ModelPreparationTraceProcessor());
+// OpenGeni exports observability through its own OTLP pipeline. Replace the
+// Agents SDK default batch exporter instead of adding to it: the default has no
+// OpenAI tracing key on Azure/Codex deployments and its async timer can leak a
+// rejected export promise into the SDK's process-global unhandled-rejection
+// listener. Keep only the in-process preparation processor we actually consume.
+setTraceProcessors([new ModelPreparationTraceProcessor()]);
 
 export function withModelPreparationObserver<T>(
   observer: ModelPreparationObserver | undefined,


### PR DESCRIPTION
## Incident follow-up
Fresh staging turn workers reproduced the process exit without an MCP log. The common source was the Agents SDK default batch trace exporter: OpenGeni enabled SDK tracing for OTLP deployments but never configured the SDK OpenAI exporter, which ran an async timer and fed rejected work into the SDK global `unhandledRejection` listener.

## Fix
Replace the SDK default processor with OpenGeni's existing in-process model-preparation processor. OpenGeni observability remains on its own OTLP pipeline.

## Verification
- runtime typecheck
- model-preparation diagnostics tests
- MCP lifecycle regression test
- oxfmt + oxlint

## Summary by Sourcery

Prevent Agents tracing from destabilizing runtime workers by making OpenGeni own the SDK trace processor configuration.

Bug Fixes:
- Replace the Agents SDK default batch trace exporter to prevent rejected asynchronous exports from causing runtime process exits.

Enhancements:
- Use OpenGeni’s in-process model-preparation trace processor as the sole Agents SDK trace processor while keeping observability on OpenGeni’s OTLP pipeline.