### PR TITLE
fix(github): expose bot identity config drift

### DIFF
--- a/.changeset/github-identity-health-warning.md
+++ b/.changeset/github-identity-health-warning.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/github": patch
+---
+
+Expose a non-secret health warning when workspace GitHub App settings cannot provide a stable Git commit identity.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -44,6 +44,7 @@ import {
   withSessionRlsActorContext,
 } from "@opengeni/db";
 import { requireSessionEventDurableFanoutCapability } from "@opengeni/events";
+import { githubAppBotIdentityWarnings } from "@opengeni/github";
 import { createObservability } from "@opengeni/observability";
 import { createObjectStorage } from "@opengeni/storage";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -734,15 +735,17 @@ export function createAppComposition(deps: AppDependencies): {
     });
   }
 
-  app.get("/healthz", (c) =>
-    c.json({
+  app.get("/healthz", (c) => {
+    const warnings = githubAppBotIdentityWarnings(deps.settings);
+    return c.json({
       service: deps.settings.serviceName,
       environment: deps.settings.environment,
       deploymentRevision: deps.settings.deploymentRevision,
       ...(deps.settings.serverVersion ? { serverVersion: deps.settings.serverVersion } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
       ok: true,
-    }),
-  );
+    });
+  });
 
   app.get("/readyz", async (c) => {
     const result = await runReadinessChecks(readinessChecks(deps), 2_000);

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -826,6 +826,50 @@ describe("API helpers", () => {
     expect(JSON.stringify(body)).not.toContain("PRIVATE-DATABASE-CREDENTIAL");
   });
 
+  test("health omits configuration warnings when GitHub App bot identity is available", async () => {
+    const app = createApp({
+      settings: testSettings({ githubAppId: "12345", githubAppSlug: "opengeni-test-app" }),
+      db: {} as never,
+      bus: {} as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+    });
+
+    const response = await app.request("http://localhost/healthz");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      service: "opengeni",
+      environment: "test",
+      deploymentRevision: "dev",
+      ok: true,
+    });
+  });
+
+  test("health exposes incomplete GitHub App bot identity without failing liveness", async () => {
+    const settings = {
+      ...testSettings(),
+      gitAuthorName: undefined,
+      gitAuthorEmail: undefined,
+      githubAppId: undefined,
+      githubAppSlug: undefined,
+      githubClientId: "configured-client",
+    };
+    const app = createApp({
+      settings,
+      db: {} as never,
+      bus: {} as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+    });
+
+    const response = await app.request("http://localhost/healthz");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      warnings: ["github_app_bot_identity_unavailable"],
+    });
+  });
+
   test("readyz reports a failing dependency", async () => {
     const sentinel = "READYZ_PUBLIC_SENTINEL_9e3468";
     const app = createApp({

--- a/apps/worker/src/http.ts
+++ b/apps/worker/src/http.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeDatabasePostureOptions,
 } from "@opengeni/db";
 import { requireSessionEventDurableFanoutCapability, type EventBus } from "@opengeni/events";
+import { githubAppBotIdentityWarnings } from "@opengeni/github";
 import type { Observability } from "@opengeni/observability";
 
 export type ReadinessCheckName = "db" | "nats" | "temporal";
@@ -45,12 +46,14 @@ export function createWorkerHttpHandler(
     if (url.pathname === "/healthz") {
       const state = lifecycle?.state();
       const ok = state !== "failed" && state !== "stopped";
+      const warnings = githubAppBotIdentityWarnings(settings);
       return Response.json(
         {
           service: settings.serviceName,
           environment: settings.environment,
           deploymentRevision: settings.deploymentRevision,
           ...(lifecycle ? { role: lifecycle.role, state } : {}),
+          ...(warnings.length > 0 ? { warnings } : {}),
           ok,
         },
         { status: ok ? 200 : 503 },

--- a/apps/worker/test/embedded-lifecycle.test.ts
+++ b/apps/worker/test/embedded-lifecycle.test.ts
@@ -757,7 +757,10 @@ describe("embedded worker lifecycle contract", () => {
 
     const startingHealth = await fetch(new Request("http://worker.test/healthz"));
     expect(startingHealth.status).toBe(200);
-    expect(await startingHealth.json()).toMatchObject({
+    expect(await startingHealth.json()).toEqual({
+      service: "opengeni",
+      environment: "test",
+      deploymentRevision: "dev",
       ok: true,
       role: "control",
       state: "starting",
@@ -783,6 +786,30 @@ describe("embedded worker lifecycle contract", () => {
     const metrics = await fetch(new Request("http://worker.test/metrics"));
     expect(metrics.status).toBe(200);
     expect(metrics.headers.get("content-type")).toContain("text/plain");
+  });
+
+  test("health exposes incomplete GitHub App bot identity without failing liveness", async () => {
+    const settings = {
+      ...testSettings(),
+      gitAuthorName: undefined,
+      gitAuthorEmail: undefined,
+      githubAppId: undefined,
+      githubAppSlug: undefined,
+      githubClientId: "configured-client",
+    };
+    const fetch = createWorkerHttpHandler({
+      settings,
+      observability: createObservability(settings, { component: "worker-test" }),
+      checks: { db: () => undefined, nats: () => undefined, temporal: () => undefined },
+      lifecycle: { role: "turn", state: () => "ready" },
+    });
+
+    const response = await fetch(new Request("http://worker.test/healthz"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      warnings: ["github_app_bot_identity_unavailable"],
+    });
   });
 
   test("a failed dependency keeps a ready-state worker out of service", async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2207,6 +2207,14 @@ Service endpoints:
 - Worker: `GET /metrics`, `GET /healthz`, and `GET /readyz` on `OPENGENI_WORKER_HTTP_PORT` (default `8001`); readiness requires lifecycle state `ready` plus healthy Postgres, NATS, and Temporal checks. The standalone worker reserves a one-connection Postgres probe pool so ordinary activity-pool saturation cannot create false readiness failures. A draining worker stays live but becomes unready before polling stops.
 - Relay: `GET /metrics` and `GET /healthz` on the relay port when the relay is enabled.
 
+API and worker health responses include the non-fatal warning
+`github_app_bot_identity_unavailable` when that process has partial workspace
+GitHub App configuration, cannot derive the App bot identity, and has no
+complete `OPENGENI_GIT_AUTHOR_NAME`/`OPENGENI_GIT_AUTHOR_EMAIL` fallback. Compare
+the warning across API and worker processes: a difference means attach and turn
+startup would declare different stable Git identity environment keys. The
+warning never includes provider credentials and does not change liveness.
+
 Useful settings:
 
 - `OPENGENI_OBSERVABILITY_STRUCTURED_LOGS=true` for JSON logs.

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -944,6 +944,42 @@ export function githubAppBotIdentity(settings: Settings): { name: string; email:
   };
 }
 
+export const GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING =
+  "github_app_bot_identity_unavailable" as const;
+
+/**
+ * Non-secret health posture for the stable sandbox Git identity. API-direct
+ * attach and worker-turn startup must add the same identity keys. A complete
+ * deployment-level author identity is sufficient because committer values
+ * default to it; otherwise a partially configured workspace GitHub App must
+ * surface that its bot identity cannot be derived.
+ */
+export function githubAppBotIdentityWarnings(
+  settings: Settings,
+): Array<typeof GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING> {
+  const workspaceAppConfigured = [
+    settings.githubAppId,
+    settings.githubClientId,
+    settings.githubClientSecret,
+    settings.githubAppSlug,
+    settings.githubWebhookSecret,
+    settings.githubAppPrivateKey,
+  ].some((value) => typeof value === "string" && value.trim().length > 0);
+  const explicitGitIdentityConfigured =
+    typeof settings.gitAuthorName === "string" &&
+    settings.gitAuthorName.trim().length > 0 &&
+    typeof settings.gitAuthorEmail === "string" &&
+    settings.gitAuthorEmail.trim().length > 0;
+  if (
+    !workspaceAppConfigured ||
+    explicitGitIdentityConfigured ||
+    githubAppBotIdentity(settings) !== null
+  ) {
+    return [];
+  }
+  return [GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING];
+}
+
 async function createGitHubAppJwt(settings: GitHubAppSigningSettings): Promise<string> {
   const privateKey = normalizeGitHubAppPrivateKey(settings.githubAppPrivateKey ?? "");
   const appId = settings.githubAppId?.trim();

--- a/packages/github/test/github.test.ts
+++ b/packages/github/test/github.test.ts
@@ -11,6 +11,8 @@ import {
   discoverGitHubInstallationBindingCandidates,
   envLinesFromGitHubManifestConversion,
   githubAppBotIdentity,
+  githubAppBotIdentityWarnings,
+  GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING,
   githubOAuthAuthorizeUrl,
   normalizeGitHubAppPrivateKey,
   openPersonalGitHubGitBrokerClaims,
@@ -187,6 +189,35 @@ describe("GitHub app manifest helpers", () => {
       name: "opengeni[bot]",
       email: "12345+opengeni[bot]@users.noreply.github.com",
     });
+  });
+
+  test("warns only when a configured workspace App cannot supply stable git identity", () => {
+    expect(githubAppBotIdentityWarnings({} as any)).toEqual([]);
+    expect(
+      githubAppBotIdentityWarnings({
+        githubClientId: "configured-client",
+      } as any),
+    ).toEqual([GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING]);
+    expect(
+      githubAppBotIdentityWarnings({
+        githubClientId: "configured-client",
+        githubAppId: "12345",
+        githubAppSlug: "opengeni",
+      } as any),
+    ).toEqual([]);
+    expect(
+      githubAppBotIdentityWarnings({
+        githubClientId: "configured-client",
+        gitAuthorName: "OpenGeni",
+        gitAuthorEmail: "bot@opengeni.dev",
+      } as any),
+    ).toEqual([]);
+    expect(
+      githubAppBotIdentityWarnings({
+        githubClientId: "configured-client",
+        gitAuthorName: "OpenGeni",
+      } as any),
+    ).toEqual([GITHUB_APP_BOT_IDENTITY_UNAVAILABLE_WARNING]);
   });
 
   test("proves exact personal-account ownership with a fresh GitHub user authorization", async () => {


### PR DESCRIPTION
## Summary

- expose a non-secret GitHub App bot-identity warning on API and worker health endpoints
- keep healthy response shape and liveness semantics unchanged
- document cross-process comparison and cover complete, absent, and incomplete settings

## Validation

- 121 focused tests pass
- full typecheck passes across 31 projects
- lint, formatting, docs references, changeset plan, and diff checks pass
- independent exact-head review found no actionable correctness defects

Linear: OPE-394

## Summary by Sourcery

Expose non-secret GitHub App bot-identity configuration drift through API and worker health checks without changing liveness semantics.

New Features:
- Expose a non-secret GitHub App bot-identity warning on API and worker health endpoints when stable identity configuration is unavailable.

Enhancements:
- Preserve existing health response shapes when no warning applies and keep warnings non-fatal to liveness.
- Centralize detection of incomplete GitHub App identity configuration and document comparing the warning across processes.

Documentation:
- Document the health warning conditions, cross-process comparison, credential-safety guarantees, and unchanged liveness behavior.

Tests:
- Cover complete, absent, and incomplete GitHub App and Git identity settings across GitHub helpers and API/worker health endpoints.