### PR TITLE
fix(runtime): avoid detached MCP lifecycle workers

### DIFF
--- a/.changeset/runtime-avoid-detached-mcp-workers.md
+++ b/.changeset/runtime-avoid-detached-mcp-workers.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Keep MCP lifecycle work on the awaited SDK path so optional server failures cannot leak from detached parallel workers.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3353,7 +3353,13 @@ export async function connectMcpServersInBatches(
             ...(options.connectTimeoutMs === undefined
               ? {}
               : { connectTimeoutMs: options.connectTimeoutMs }),
-            connectInParallel: true,
+            // OpenGeni already bounds lifecycle work in batches. The Agents SDK
+            // parallel path additionally starts a detached `void drain()` task;
+            // a best-effort server rejection can escape that task as a process-
+            // level unhandled rejection even though the session records and
+            // degrades the failed server. Keep lifecycle ownership on the
+            // awaited serial path inside each bounded batch.
+            connectInParallel: false,
             strict: options.strict,
           }),
         );


### PR DESCRIPTION
## What
- keep Agents SDK MCP lifecycle on awaited serial path inside OpenGeni bounded batches
- eliminate detached SDK drain rejection leak
- preserve best-effort optional MCP degradation

## Evidence
- exact-SHA staging worker still exited after optional Slack connect failure via SDK parallel worker
- targeted runtime tests pass
- runtime typecheck, oxfmt, oxlint pass

## Summary by Sourcery

Ensure MCP lifecycle workers remain awaited so optional server failures do not leak from detached SDK tasks.

Bug Fixes:
- Prevent optional MCP connection failures from surfacing as unhandled process-level rejections.

Enhancements:
- Keep MCP lifecycle work on the awaited path while preserving bounded batch processing and best-effort server degradation.