### PR TITLE
fix(worker): isolate detached promise rejections

### DIFF
--- a/.changeset/worker-isolate-detached-rejections.md
+++ b/.changeset/worker-isolate-detached-rejections.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Keep detached SDK and transport promise rejections from restarting shared worker pods and causing cross-session lease loss.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1036,8 +1036,9 @@ export async function startWorker() {
   const settings = getSettings();
   const observability = createObservability(settings, { component: `worker-${role}` });
   // The Agents SDK also listens for unhandled rejections and exits the process.
-  // Keep its detached duplicate of an already-handled MCP lifecycle failure from
-  // restarting the whole turn-worker pod; every unknown rejection remains fatal.
+  // Keep detached SDK/transport promises observational here: durable turn
+  // activity boundaries own failures, while process exit causes cross-session
+  // lease loss for every turn assigned to this shared worker pod.
   const disposeUnhandledRejectionBoundary = installWorkerUnhandledRejectionBoundary();
   const retryOptions = startupRetryOptions(settings);
   const onRetry = (event: Parameters<typeof logStartupDependencyRetry>[1]) =>

--- a/apps/worker/src/unhandled-rejection-boundary.ts
+++ b/apps/worker/src/unhandled-rejection-boundary.ts
@@ -1,8 +1,11 @@
 export type WorkerUnhandledRejectionProcess = {
   on: (event: "unhandledRejection", listener: (reason: unknown) => void) => void;
   off: (event: "unhandledRejection", listener: (reason: unknown) => void) => void;
-  exit: (code: number) => never | void;
 };
+
+export type WorkerUnhandledRejectionClassification =
+  | "detached_runtime_mcp_lifecycle"
+  | "detached_unknown";
 
 type RuntimeMcpLifecycleError = {
   name: "McpLifecycleError";
@@ -36,14 +39,34 @@ export function isDetachedRuntimeMcpLifecycleRejection(
   }
 }
 
-/** Keep known duplicate MCP lifecycle rejections non-fatal; preserve fail-fast
- * behavior for every unknown process-level rejection. */
+function reportIsolatedUnhandledRejection(
+  classification: WorkerUnhandledRejectionClassification,
+): void {
+  // Never render the rejection itself: provider and transport errors can carry
+  // request bodies or credentials. The durable activity path owns exact errors.
+  console.error("[worker] isolated detached unhandled rejection", { classification });
+}
+
+/**
+ * Keep process-global promise rejection handling observational. Turn activities
+ * have their own durable failure/lease boundary; killing the shared worker here
+ * converts one detached SDK/transport promise into unrelated lease losses across
+ * every session assigned to the pod. The Agents SDK also checks for a consumer
+ * listener before applying its own process.exit(1), so this boundary must never
+ * reintroduce that fail-fast behavior for an unknown rejection shape.
+ */
 export function installWorkerUnhandledRejectionBoundary(
   runtimeProcess: WorkerUnhandledRejectionProcess = process,
+  report: (
+    classification: WorkerUnhandledRejectionClassification,
+  ) => void = reportIsolatedUnhandledRejection,
 ): () => void {
   const onUnhandledRejection = (reason: unknown): void => {
-    if (isDetachedRuntimeMcpLifecycleRejection(reason)) return;
-    runtimeProcess.exit(1);
+    report(
+      isDetachedRuntimeMcpLifecycleRejection(reason)
+        ? "detached_runtime_mcp_lifecycle"
+        : "detached_unknown",
+    );
   };
   runtimeProcess.on("unhandledRejection", onUnhandledRejection);
   return () => runtimeProcess.off("unhandledRejection", onUnhandledRejection);

--- a/apps/worker/test/unhandled-rejection-boundary.test.ts
+++ b/apps/worker/test/unhandled-rejection-boundary.test.ts
@@ -7,7 +7,6 @@ import {
 
 function fakeProcess() {
   let listener: ((reason: unknown) => void) | undefined;
-  const exits: number[] = [];
   const runtimeProcess: WorkerUnhandledRejectionProcess = {
     on: (_event, next) => {
       listener = next;
@@ -15,14 +14,10 @@ function fakeProcess() {
     off: (_event, current) => {
       if (listener === current) listener = undefined;
     },
-    exit: (code) => {
-      exits.push(code);
-    },
   };
   return {
     runtimeProcess,
     emit: (reason: unknown) => listener?.(reason),
-    exits,
     hasListener: () => listener !== undefined,
   };
 }
@@ -30,7 +25,10 @@ function fakeProcess() {
 describe("worker unhandled rejection boundary", () => {
   test("keeps detached structural MCP lifecycle duplicates non-fatal", () => {
     const runtime = fakeProcess();
-    const dispose = installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess);
+    const reports: string[] = [];
+    const dispose = installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess, (event) =>
+      reports.push(event),
+    );
 
     runtime.emit(
       Object.assign(new Error("MCP lifecycle connect failed"), {
@@ -41,19 +39,20 @@ describe("worker unhandled rejection boundary", () => {
       }),
     );
 
-    expect(runtime.exits).toEqual([]);
+    expect(reports).toEqual(["detached_runtime_mcp_lifecycle"]);
     dispose();
     expect(runtime.hasListener()).toBe(false);
   });
 
-  test("keeps unknown and malformed rejections fatal", () => {
+  test("keeps unknown and malformed detached rejections non-fatal", () => {
     const runtime = fakeProcess();
-    installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess);
+    const reports: string[] = [];
+    installWorkerUnhandledRejectionBoundary(runtime.runtimeProcess, (event) => reports.push(event));
 
     runtime.emit(new Error("unknown"));
     runtime.emit({ name: "McpLifecycleError", code: "mcp_connect_failed" });
 
-    expect(runtime.exits).toEqual([1, 1]);
+    expect(reports).toEqual(["detached_unknown", "detached_unknown"]);
   });
 
   test("fails closed for hostile rejection objects", () => {


### PR DESCRIPTION
## What
- make worker process-level unhandled rejections observational, never process-fatal
- preserve structural classification without logging rejection contents
- let durable turn/activity boundaries own exact failures and recovery

## Staging evidence
- poison session d5291f66 kills any assigned pod at turn start with an unhandled object
- failure reproduces without optional Slack and after detached MCP worker removal
- process exit causes cross-session lease loss

## Verification
- worker boundary tests pass
- worker typecheck, oxfmt, oxlint pass

## Summary by Sourcery

Isolate detached worker promise rejections so they remain observational without compromising durable activity failure handling.

Bug Fixes:
- Prevent detached SDK and transport promise rejections from terminating shared worker processes and causing cross-session lease loss.

Enhancements:
- Preserve structural classification of detached rejections while reporting only safe classification labels instead of rejection contents.
- Keep durable turn and activity boundaries responsible for exact failure handling and recovery.

Tests:
- Update worker boundary tests to verify non-fatal handling and classification of unknown, malformed, and MCP lifecycle rejections.