### PR TITLE
fix(core): return learning receipts before notifications

### DIFF
--- a/.changeset/core-learning-receipt-before-notification.md
+++ b/.changeset/core-learning-receipt-before-notification.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/core": patch
+---
+
+Return governed-learning activation receipts before optional Slack publication settles, so exact retries recover durable outcomes even when notification dispatch stalls.

--- a/docs/company-brain-write-routing.md
+++ b/docs/company-brain-write-routing.md
@@ -137,6 +137,13 @@ operation id, so exact retries converge on the same receipts. The public
 receipt exposes only the effective source-specific decision and snapshot
 identity/hash, not the snapshot's other source overrides.
 
+Optional post-activation Slack publication starts only after the activation
+receipt is durable and is never awaited by the proposal or `remember` router. A
+stalled notification sink therefore cannot withhold the activated receipt.
+Exact retries return the same durable activation outcome and may dispatch the
+publication again; the publication outbox deduplicates on the activation
+receipt identity.
+
 The first-party proposal surface is intentionally explicit:
 `knowledge_propose`, `knowledge_correct`, `task_note_promote_knowledge`,
 `task_note_promote_instruction_policy`, `task_note_promote_preference`,

--- a/packages/core/src/domain/company-brain-governed-writes.ts
+++ b/packages/core/src/domain/company-brain-governed-writes.ts
@@ -67,6 +67,26 @@ export const DEFAULT_AUTOMATIC_LEARNING_DESTINATIONS: ReadonlyArray<GovernedLear
   ["preference"];
 
 /**
+ * Start a non-authoritative post-activation notification without making the
+ * durable activation receipt wait for its settlement. The callback is invoked
+ * synchronously so immediate enqueue work begins before the router returns;
+ * both synchronous throws and later promise rejections are contained.
+ *
+ * Exact retries intentionally dispatch again: the publication sink owns an
+ * activation-receipt idempotency key, while the activation receipt remains the
+ * caller-facing source of truth even if notification delivery stalls forever.
+ */
+export function dispatchBestEffortGovernedLearningNotification(
+  notify: () => Promise<unknown>,
+): void {
+  try {
+    void notify().catch(() => undefined);
+  } catch {
+    // Notification is best-effort; the durable activation receipt already exists.
+  }
+}
+
+/**
  * Transport-neutral facade for explicit governed Company Brain proposals.
  * It intentionally exposes no generic remember call, selector, activation,
  * rollback token, or personal/organization destination.
@@ -297,16 +317,14 @@ export function createCompanyBrainLearningPolicyRouter(
           learningFailure: classifyLearningFailure("activation", error),
         });
       }
-      try {
-        await notifyActivation({
+      dispatchBestEffortGovernedLearningNotification(() =>
+        notifyActivation({
           db: options.db,
           receipt: activation,
           sessionId: attempt.sessionId,
           attemptId: attempt.attemptId,
-        });
-      } catch {
-        // Notification is best-effort; the durable receipts already exist.
-      }
+        }),
+      );
       return CompanyBrainLearningPolicyRouteReceipt.parse({
         operationId: request.operationId,
         workspaceId: attempt.workspaceId,

--- a/packages/core/src/domain/remember.ts
+++ b/packages/core/src/domain/remember.ts
@@ -35,6 +35,7 @@ import { createHash } from "node:crypto";
 import {
   createCompanyBrainLearningPolicyRouter,
   derivedGovernedLearningOperationId,
+  dispatchBestEffortGovernedLearningNotification,
 } from "./company-brain-governed-writes";
 import { publishGovernedLearningEventToSlack } from "./governed-learning-slack-publication";
 
@@ -548,16 +549,14 @@ export function createRememberRouter(options: RememberRouterOptions): {
         }
       }
       if (!activation) throw asRememberFailure(lastFailure);
-      try {
-        await notifyActivation({
+      dispatchBestEffortGovernedLearningNotification(() =>
+        notifyActivation({
           db: options.db,
           receipt: activation,
           sessionId: attempt.sessionId,
           attemptId: attempt.attemptId,
-        });
-      } catch {
-        // Notification is best-effort; the durable receipts already exist.
-      }
+        }),
+      );
       return RememberConfirmReceipt.parse({
         status: "activated",
         operationId: request.operationId,

--- a/packages/core/test/company-brain-governed-writes.test.ts
+++ b/packages/core/test/company-brain-governed-writes.test.ts
@@ -602,6 +602,54 @@ describe("Company Brain learning-policy router: evaluator and activation wiring"
     });
   });
 
+  test("automatic returns and replays the durable receipt without waiting for notification", async () => {
+    const notifications: string[] = [];
+    const neverSettles = new Promise<never>(() => undefined);
+    const router = createCompanyBrainLearningPolicyRouter({
+      db: {} as Database,
+      async learningPolicySnapshot() {
+        return policySnapshot("automatic");
+      },
+      async authority() {
+        return receiptFor(preferenceRequest);
+      },
+      async evaluate() {
+        return decisionReceipt({ outcome: "automatic", automaticEligible: true });
+      },
+      async activate() {
+        return activationReceipt();
+      },
+      async notifyActivation(input) {
+        notifications.push(input.receipt.id);
+        return await neverSettles;
+      },
+    });
+
+    const settlesWithin = async <T>(promise: Promise<T>): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("durable receipt waited for notification settlement")),
+              500,
+            );
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+
+    const first = await settlesWithin(router.write({ attempt, request: preferenceRequest }));
+    const replay = await settlesWithin(router.write({ attempt, request: preferenceRequest }));
+
+    expect(first.decision).toBe("activated");
+    expect(replay).toEqual(first);
+    expect(notifications).toEqual([ACTIVATION_ID, ACTIVATION_ID]);
+  });
+
   test("automatic without eligibility keeps the proposal for human review", async () => {
     let activations = 0;
     const router = createCompanyBrainLearningPolicyRouter({


### PR DESCRIPTION
## Summary

- return durable governed-learning activation receipts before optional Slack publication settles
- apply the same non-blocking notification boundary to automatic and human-confirmed activation paths
- preserve exact-retry publication attempts through the existing activation-receipt idempotency key
- document the post-activation receipt boundary and add a regression test with a notification promise that never settles

## Verification

- `bun test packages/core/test/company-brain-governed-writes.test.ts`
- `bun test packages/core/test/governed-learning-slack-publication.test.ts packages/core/test/company-brain-governed-writes.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run lint`
- `bun run check:docs-refs`
- `bun run check:public-hygiene`
- targeted `oxfmt --check`

## Summary by Sourcery

Return governed-learning activation receipts before optional notification publication completes.

Bug Fixes:
- Return durable governed-learning activation receipts without waiting for optional Slack notifications to settle, including automatic and human-confirmed activation flows.

Enhancements:
- Preserve exact-retry activation outcomes while allowing publication attempts to be retried through existing receipt-based deduplication.

Documentation:
- Document that post-activation Slack publication is non-blocking and that durable activation receipts are the source of truth.

Tests:
- Add regression coverage for durable receipt returns and exact retries when notification delivery never settles.