### PR TITLE
fix(api): bound preference proposal conflicts

### DIFF
--- a/.changeset/preference-proposal-conflict-projection.md
+++ b/.changeset/preference-proposal-conflict-projection.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+---
+
+Return bounded stable-key conflict outcomes for governed preference proposals instead of exposing persistence query details.

--- a/apps/api/src/mcp/company-brain-governed-writes.ts
+++ b/apps/api/src/mcp/company-brain-governed-writes.ts
@@ -11,7 +11,7 @@ import {
   type CompanyBrainGovernedWriteAttempt,
 } from "@opengeni/contracts";
 import { createCompanyBrainLearningPolicyRouter } from "@opengeni/core";
-import type { Database } from "@opengeni/db";
+import { PreferenceRegistryStableKeyConflictError, type Database } from "@opengeni/db";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 
@@ -66,6 +66,20 @@ export function registerCompanyBrainGovernedWriteTools(
   input: RegisterCompanyBrainGovernedWriteToolsInput,
 ): void {
   const router = input.router ?? createCompanyBrainLearningPolicyRouter({ db: input.db });
+  const writeResult = async (write: () => ReturnType<typeof router.write>) => {
+    try {
+      return input.json(await write());
+    } catch (error) {
+      if (error instanceof PreferenceRegistryStableKeyConflictError) {
+        return input.json({
+          status: "not_proposed",
+          code: "preference_stable_key_conflict",
+          message: error.message,
+        });
+      }
+      throw error;
+    }
+  };
   input.server.registerTool(
     "knowledge_propose",
     {
@@ -75,8 +89,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "propose_knowledge", ...request },
         }),
@@ -93,8 +107,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "correct_knowledge", ...request },
         }),
@@ -111,8 +125,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "promote_task_note_knowledge", ...request },
         }),
@@ -136,8 +150,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "promote_task_note_instruction_policy", ...request },
         }),
@@ -172,8 +186,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "promote_task_note_preference", ...request },
         }),
@@ -206,8 +220,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "propose_instruction_policy", ...request },
         }),
@@ -251,8 +265,8 @@ export function registerCompanyBrainGovernedWriteTools(
     },
     async (request) => {
       await input.authorize();
-      return input.json(
-        await router.write({
+      return writeResult(() =>
+        router.write({
           attempt: input.attempt,
           request: { kind: "propose_preference", ...request },
         }),

--- a/apps/api/src/mcp/remember.ts
+++ b/apps/api/src/mcp/remember.ts
@@ -11,7 +11,7 @@ import {
   type RememberLane,
 } from "@opengeni/contracts";
 import { RememberError, createRememberRouter } from "@opengeni/core";
-import type { Database } from "@opengeni/db";
+import { PreferenceRegistryStableKeyConflictError, type Database } from "@opengeni/db";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 
@@ -120,9 +120,20 @@ export function registerRememberTools(input: RegisterRememberToolsInput): void {
           : lane === "instruction_policy"
             ? { ...base, lane, target: request.target }
             : { ...base, lane, subject: request.subject ?? content.slice(0, 80) };
-      return input.json(
-        await router.remember({ attempt: input.attempt, request: rememberRequest }),
-      );
+      try {
+        return input.json(
+          await router.remember({ attempt: input.attempt, request: rememberRequest }),
+        );
+      } catch (error) {
+        if (error instanceof PreferenceRegistryStableKeyConflictError) {
+          return input.json({
+            status: "not_remembered",
+            code: "preference_stable_key_conflict",
+            message: error.message,
+          });
+        }
+        throw error;
+      }
     },
   );
 

--- a/apps/api/test/company-brain-governed-write-tools.test.ts
+++ b/apps/api/test/company-brain-governed-write-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CompanyBrainLearningPolicyRouteReceipt } from "@opengeni/contracts";
-import type { Database } from "@opengeni/db";
+import { PreferenceRegistryStableKeyConflictError, type Database } from "@opengeni/db";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerCompanyBrainGovernedWriteTools } from "../src/mcp/company-brain-governed-writes";
 
@@ -168,5 +168,47 @@ describe("Company Brain governed write tools", () => {
       }),
     ).rejects.toThrow("denied");
     expect(writes).toBe(0);
+  });
+
+  test("returns a bounded stable-key conflict instead of throwing persistence details", async () => {
+    const handlers = new Map<string, Handler>();
+    registerCompanyBrainGovernedWriteTools({
+      server: {
+        registerTool(name: string, _config: unknown, handler: Handler) {
+          handlers.set(name, handler);
+        },
+      } as unknown as McpServer,
+      db: {} as Database,
+      attempt: ATTEMPT,
+      async authorize() {},
+      json: (value) => ({ content: [{ type: "text", text: JSON.stringify(value) }] }),
+      router: {
+        async write() {
+          throw new PreferenceRegistryStableKeyConflictError(
+            "A preference with this stable key already exists for the workspace",
+          );
+        },
+      },
+    });
+
+    const result = await handlers.get("preference_propose")!({
+      operationId: "00000000-0000-4000-8000-000000000114",
+      claimId: CLAIM_ID,
+      evidenceId: EVIDENCE_ID,
+      stableKey: "support.tone",
+      title: "Support tone",
+      description: "Suggested tone for support replies.",
+      content: "Use a concise, direct tone for support replies.",
+      precedenceRank: 0,
+      conflictStrategy: "override",
+      conflictsWith: [],
+      expiresAt: null,
+      reason: "Propose an evidence-backed working method.",
+    });
+    expect(JSON.parse((result as { content: Array<{ text: string }> }).content[0]!.text)).toEqual({
+      status: "not_proposed",
+      code: "preference_stable_key_conflict",
+      message: "A preference with this stable key already exists for the workspace",
+    });
   });
 });

--- a/apps/api/test/remember-tools.test.ts
+++ b/apps/api/test/remember-tools.test.ts
@@ -5,7 +5,7 @@ import {
   agentAuthoredDurableTextTooLongMessage,
 } from "@opengeni/contracts";
 import { RememberError } from "@opengeni/core";
-import type { Database } from "@opengeni/db";
+import { PreferenceRegistryStableKeyConflictError, type Database } from "@opengeni/db";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerRememberTools } from "../src/mcp/remember";
 
@@ -26,7 +26,7 @@ type Handler = (input: Record<string, unknown>) => Promise<{
   content: { type: "text"; text: string }[];
 }>;
 
-function harness() {
+function harness(options: { rememberError?: Error } = {}) {
   const handlers = new Map<string, Handler>();
   const configs = new Map<string, { description?: string }>();
   const remembers: unknown[] = [];
@@ -49,6 +49,7 @@ function harness() {
     router: {
       async remember(input) {
         remembers.push(input);
+        if (options.rememberError) throw options.rememberError;
         return {
           status: "blocked",
           operationId: OPERATION_ID,
@@ -208,6 +209,28 @@ describe("remember MCP tools", () => {
       subject: "Acme",
     });
     expect(h.remembers).toHaveLength(1);
+  });
+
+  test("remember returns a bounded stable-key conflict instead of throwing persistence details", async () => {
+    const h = harness({
+      rememberError: new PreferenceRegistryStableKeyConflictError(
+        "A preference with this stable key already exists for the workspace",
+      ),
+    });
+    const result = await h.handlers.get("remember")!({
+      lane: "preference",
+      operationId: OPERATION_ID,
+      content: "Use a concise, direct tone for support replies.",
+      stableKey: "support.tone",
+      title: "Support tone",
+      description: "Suggested tone for support replies.",
+      reason: "The user asked to remember it.",
+    });
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      status: "not_remembered",
+      code: "preference_stable_key_conflict",
+      message: "A preference with this stable key already exists for the workspace",
+    });
   });
 
   test("remember_confirm returns a bounded not_confirmed result instead of throwing on remember errors", async () => {

--- a/docs/company-brain-write-routing.md
+++ b/docs/company-brain-write-routing.md
@@ -83,6 +83,12 @@ is a write-destination receipt only; it does not select context, freeze a
 logical-turn snapshot, or overlap the permission-first selector's context
 receipt ownership.
 
+A new operation that selects a workspace preference stable key already owned by
+another proposal returns the bounded `preference_stable_key_conflict` tool
+outcome. The database adapter maps the collision to the preference registry's
+domain error before the MCP surface renders it, so SQL text and parameters are
+never part of the public failure.
+
 Migration `0255_company_brain_governed_write_proposals.sql` broadens the
 historically named onboarding-proposal validator without changing its table. A
 Knowledge-backed instruction draft is admitted only when its provenance source

--- a/packages/db/src/company-brain-governed-writes.ts
+++ b/packages/db/src/company-brain-governed-writes.ts
@@ -15,7 +15,11 @@ import {
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "./database";
 import { rawRows, setSubjectRlsContext, withRlsContext } from "./database";
-import { sanitizePreferenceDescriptorText } from "./preference-registry";
+import {
+  PreferenceRegistryStableKeyConflictError,
+  sanitizePreferenceDescriptorText,
+} from "./preference-registry";
+import { nestedPostgresSqlState, safeDatabaseErrorFacts } from "./persistence-errors";
 import {
   appendKnowledgeClaim,
   appendKnowledgeClaimReview,
@@ -847,6 +851,26 @@ function isInstructionPolicyProposal(
   );
 }
 
+function isPreferenceProposal(
+  request: CompanyBrainGovernedWriteRequestType,
+): request is PreferenceProposalRequest {
+  return request.kind === "propose_preference" || request.kind === "promote_task_note_preference";
+}
+
+const PREFERENCE_PROPOSAL_STABLE_KEY_CONFLICT_DIAGNOSTIC =
+  "workspace preference key is bound to another proposal";
+
+function isPreferenceProposalStableKeyConflict(error: unknown): boolean {
+  if (nestedPostgresSqlState(error) !== "23505") return false;
+  const constraint = safeDatabaseErrorFacts(error).constraint ?? "";
+  if (constraint.startsWith("preference_registry_preferences_")) return true;
+  for (let current = error, depth = 0; current instanceof Error && depth < 8; depth += 1) {
+    if (current.message.includes(PREFERENCE_PROPOSAL_STABLE_KEY_CONFLICT_DIAGNOSTIC)) return true;
+    current = current.cause;
+  }
+  return false;
+}
+
 async function materializeWaysOfWorkingProposal(
   db: Database,
   input: {
@@ -1007,6 +1031,11 @@ export async function writeCompanyBrainGovernedProposal(
       error instanceof CompanyBrainGovernedWriteInvalidOperationError
     ) {
       throw error;
+    }
+    if (isPreferenceProposal(request) && isPreferenceProposalStableKeyConflict(error)) {
+      throw new PreferenceRegistryStableKeyConflictError(
+        "A preference with this stable key already exists for the workspace",
+      );
     }
     if (error instanceof ScopedKnowledgeAuthorityError) {
       throw new CompanyBrainGovernedWriteAuthorityError(error.message);

--- a/packages/db/test/task-notes-postgres.test.ts
+++ b/packages/db/test/task-notes-postgres.test.ts
@@ -16,6 +16,7 @@ import {
   listTaskNotes,
   listCompanyBrainKnowledgeProposals,
   nestedPostgresSqlState,
+  PreferenceRegistryStableKeyConflictError,
   replaceTaskNote,
   transitionSessionVisibility,
   updateOrganizationPrivateSessionSettings,
@@ -652,6 +653,26 @@ describe("task-tree notes PostgreSQL authority", () => {
     } finally {
       await app.end();
     }
+
+    const conflictingPreferenceNote = await createTaskNote(client.db, {
+      ...claims(attempt),
+      operationId: crypto.randomUUID(),
+      kind: "decision",
+      text: "Use the existing implementation tracking preference.",
+      expiresInDays: 7,
+    });
+    await expect(
+      writeCompanyBrainGovernedProposal(client.db, {
+        ...preferenceInput,
+        request: {
+          ...preferenceInput.request,
+          operationId: crypto.randomUUID(),
+          noteId: conflictingPreferenceNote.note.id,
+          normalizedKey: "implementation-linear-conflict",
+          stableKey: preferenceInput.request.stableKey,
+        },
+      }),
+    ).rejects.toBeInstanceOf(PreferenceRegistryStableKeyConflictError);
 
     const instructionText = "Never place secret values in public logs.";
     const instructionNote = await createTaskNote(client.db, {


### PR DESCRIPTION
## Summary

- map governed preference stable-key collisions to the existing preference registry domain conflict
- return bounded `preference_stable_key_conflict` results from `remember` and direct governed-write MCP tools
- keep SQL text and parameters out of caller-facing failures
- cover the database mapping with real PostgreSQL and both MCP projections with unit tests

## Verification

- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 180000 packages/db/test/task-notes-postgres.test.ts -t "atomically promotes exact Task-note bytes into inactive Ways proposals with archival replay"`
- `bun test apps/api/test/company-brain-governed-write-tools.test.ts apps/api/test/remember-tools.test.ts`
- `bun run --cwd apps/api typecheck`
- `bun run --cwd packages/db typecheck`
- `bun run lint`
- `bun run check:docs-refs`
- `bun run check:public-hygiene`
- targeted `oxfmt --check`

## Summary by Sourcery

Bound preference proposal stable-key conflicts into safe, consistent API outcomes.

Bug Fixes:
- Map governed preference stable-key collisions to a bounded preference conflict outcome instead of exposing persistence errors.
- Return consistent `preference_stable_key_conflict` results from the remember and governed-write MCP tools.

Enhancements:
- Prevent SQL statements and query parameters from appearing in caller-facing conflict messages.

Documentation:
- Document the bounded stable-key conflict behavior for governed preference writes.

Tests:
- Add MCP unit coverage and PostgreSQL integration coverage for stable-key conflict projection.