### PR TITLE
fix(worker): own Agents SDK async lifecycle

### DIFF
--- a/.changeset/agents-sdk-owned-async-boundary.md
+++ b/.changeset/agents-sdk-owned-async-boundary.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/worker-bundle": patch
+"@opengeni/runtime": patch
+---
+
+Keep Agents SDK MCP lifecycle failures inside owned promises and reserve shared-worker process termination policy for OpenGeni.

--- a/apps/worker/test/agents-sdk-async-ownership.test.ts
+++ b/apps/worker/test/agents-sdk-async-ownership.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { MCPServers, TraceProvider, type MCPServer } from "@openai/agents-core";
+
+const observedUnhandledRejections: unknown[] = [];
+const observeUnhandledRejection = (reason: unknown): void => {
+  observedUnhandledRejections.push(reason);
+};
+
+afterEach(() => {
+  process.off("unhandledRejection", observeUnhandledRejection);
+  observedUnhandledRejections.length = 0;
+});
+
+describe("Agents SDK async ownership", () => {
+  test("settles a hostile parallel MCP rejection without a process-global rejection", async () => {
+    process.on("unhandledRejection", observeUnhandledRejection);
+    const hostileReason = new Proxy(Object.create(null) as object, {
+      get() {
+        throw new Error("hostile rejection getter");
+      },
+    });
+    const server: MCPServer = {
+      name: "hostile-test-server",
+      connect: async () => {
+        throw hostileReason;
+      },
+      close: async () => undefined,
+      listTools: async () => [],
+      callTool: async () => "unused",
+    };
+
+    await expect(
+      MCPServers.open([server], {
+        connectInParallel: true,
+        connectTimeoutMs: 100,
+        closeTimeoutMs: 100,
+        strict: true,
+      }),
+    ).rejects.toThrow("Unknown MCP lifecycle failure");
+    await Promise.resolve();
+
+    expect(observedUnhandledRejections).toEqual([]);
+  });
+
+  test("does not let the tracing provider register host-process rejection policy", () => {
+    const before = process.listenerCount("unhandledRejection");
+
+    const provider = new TraceProvider();
+
+    expect(provider).toBeInstanceOf(TraceProvider);
+    expect(process.listenerCount("unhandledRejection")).toBe(before);
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -809,6 +809,13 @@ dependencies. `@opengeni/runtime` owns provider-neutral agent construction,
 model input/output handling, tool execution, progressive disclosure, and the
 sandbox interface.
 
+The embedding process—not the Agents SDK—owns process-global rejection and
+termination policy. SDK background lifecycle work must settle an owned promise;
+it may not detach a rejecting task or install an `unhandledRejection` handler
+that exits the shared worker. The worker's global rejection listener is a
+last-resort observational boundary, while deliberate restart remains an
+OpenGeni drain-and-checkpoint decision.
+
 The worker supplies frozen authority and durable sinks. Runtime must not invent
 tenancy or persistence authority from its in-memory agent context.
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1298,6 +1298,14 @@ explicit checkpoint/resume, not an automatic Temporal retry. A newer control
 revision, terminal state, or successor attempt wins instead of being
 overwritten.
 
+The shared worker process owns its own fatality policy. The pinned Agents SDK
+is patched so its MCP lifecycle queue settles every submitted command even when
+an internal error value is hostile, and its tracing provider does not register
+process-global `unhandledRejection` termination behavior. No SDK background
+promise may escape into the process boundary. The worker listener remains an
+observational last resort; a genuinely unhealthy worker stops polling and uses
+the normal drain path rather than letting a dependency call `process.exit(1)`.
+
 An active-route filesystem-root change uses the same durable same-logical-turn
 boundary. A machine-primary attempt never pre-leases home. Clearing its pointer
 to managed home emits `home_unavailable_this_turn`; swapping to a route whose

--- a/patches/@openai%2Fagents-core@0.14.3.patch
+++ b/patches/@openai%2Fagents-core@0.14.3.patch
@@ -1,13 +1,16 @@
-diff --git a/node_modules/.bun/@openai+agents-core@0.14.3+933c5e7db4cd33c2/node_modules/@openai/agents-core/.bun-tag-1a92431e4f62cd51 b/.bun-tag-1a92431e4f62cd51
+diff --git a/node_modules/@openai/agents-core/.bun-tag-1a92431e4f62cd51 b/.bun-tag-1a92431e4f62cd51
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/.bun/@openai+agents-core@0.14.3+933c5e7db4cd33c2/node_modules/@openai/agents-core/.bun-tag-2da6ec976600e880 b/.bun-tag-2da6ec976600e880
+diff --git a/node_modules/@openai/agents-core/.bun-tag-2b0b2155efcca04e b/.bun-tag-2b0b2155efcca04e
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/.bun/@openai+agents-core@0.14.3+933c5e7db4cd33c2/node_modules/@openai/agents-core/.bun-tag-7c21d377cb19cf3e b/.bun-tag-7c21d377cb19cf3e
+diff --git a/node_modules/@openai/agents-core/.bun-tag-2da6ec976600e880 b/.bun-tag-2da6ec976600e880
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/.bun/@openai+agents-core@0.14.3+933c5e7db4cd33c2/node_modules/@openai/agents-core/.bun-tag-ac46de758592501 b/.bun-tag-ac46de758592501
+diff --git a/node_modules/@openai/agents-core/.bun-tag-7c21d377cb19cf3e b/.bun-tag-7c21d377cb19cf3e
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@openai/agents-core/.bun-tag-ac46de758592501 b/.bun-tag-ac46de758592501
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/index.d.ts b/dist/index.d.ts
@@ -27,6 +30,294 @@ index 21b58188472152339a1747df5cfe8dd256356cd1..1ecb7bff25d73312059991d05d44978f
  export type { TracingConfig } from './tracing';
  export { HostedTool, attachClientToolSearchExecutor, ComputerTool, computerTool, ShellTool, shellTool, ApplyPatchTool, applyPatchTool, HostedMCPTool, hostedMcpTool, FunctionTool, FunctionToolResult, FunctionToolTimeoutBehavior, ToolTimeoutErrorFunction, Tool, tool, toolNamespace, invokeFunctionTool, getClientToolSearchExecutor, getToolSearchRuntimeToolKey, ToolExecuteArgument, ToolEnabledFunction, ToolOptionsWithGuardrails, ToolAllowedCaller, ToolAllowedCallers, } from './tool';
  export type { ClientToolSearchExecutor, ClientToolSearchExecutorArgs, ClientToolSearchExecutorResult, ComputerOnSafetyCheckFunction, ComputerSafetyCheck, ComputerSafetyCheckResult, ShellToolEnvironment, ShellToolLocalEnvironment, ShellToolLocalSkill, ShellToolHostedEnvironment, ShellToolContainerAutoEnvironment, ShellToolContainerReferenceEnvironment, ShellToolContainerSkill, ShellToolSkillReference, ShellToolInlineSkill, ShellToolInlineSkillSource, ShellToolContainerNetworkPolicy, ShellToolContainerNetworkPolicyAllowlist, ShellToolContainerNetworkPolicyDisabled, ShellToolContainerNetworkPolicyDomainSecret, ToolInputParameters, ToolOutputSchema, ToolOptions, ToolNamespaceOptions, ToolOutputCustomData, FunctionToolCustomDataContext, FunctionToolCustomDataExtractor, ComputerToolCustomDataContext, ComputerToolCustomDataExtractor, ApplyPatchToolCustomDataContext, ApplyPatchToolCustomDataExtractor, } from './tool';
+diff --git a/dist/mcpServers.js b/dist/mcpServers.js
+index af947813fbe90ec3c275f6a1fd5e0793fb2ed720..60e27cc668b0b83b350619002ca3aed5d8f5cf1b 100644
+--- a/dist/mcpServers.js
++++ b/dist/mcpServers.js
+@@ -62,6 +62,9 @@ class ServerWorker {
+             this.closeResult = promise;
+         }
+         this.queue.push(command);
++        // `submit()` is intentionally synchronous, but the drain it starts still
++        // belongs to this worker. Never detach a rejecting promise onto the host
++        // process: every lifecycle failure must settle the submitted command.
+         void this.drain();
+         return promise;
+     }
+@@ -70,51 +73,72 @@ class ServerWorker {
+             return;
+         }
+         this.draining = true;
+-        while (this.queue.length > 0) {
+-            const command = this.queue.shift();
+-            if (!command) {
+-                continue;
+-            }
+-            const shouldExit = command.action === 'close';
+-            let closeError = null;
+-            try {
+-                if (command.action === 'connect') {
+-                    await runWithTimeout(() => this.server.connect(), command.timeoutMs, createTimeoutError('connect', this.server, command.timeoutMs));
+-                }
+-                else {
+-                    const closeTask = this.server.close();
+-                    this.closing = closeTask
+-                        .then(() => undefined, () => undefined)
+-                        .finally(() => {
+-                        this.closing = null;
+-                    });
+-                    await runWithTimeoutTask(closeTask, command.timeoutMs, createTimeoutError('close', this.server, command.timeoutMs));
++        let activeCommand = null;
++        try {
++            while (this.queue.length > 0) {
++                const command = this.queue.shift();
++                if (!command) {
++                    continue;
+                 }
+-                command.resolve();
+-            }
+-            catch (error) {
+-                const err = toError(error);
+-                command.reject(err);
+-                if (shouldExit) {
+-                    closeError = err;
++                activeCommand = command;
++                const shouldExit = command.action === 'close';
++                let closeError = null;
++                try {
++                    if (command.action === 'connect') {
++                        await runWithTimeout(() => this.server.connect(), command.timeoutMs, createTimeoutError('connect', this.server, command.timeoutMs));
++                    }
++                    else {
++                        const closeTask = this.server.close();
++                        this.closing = closeTask
++                            .then(() => undefined, () => undefined)
++                            .finally(() => {
++                            this.closing = null;
++                        });
++                        await runWithTimeoutTask(closeTask, command.timeoutMs, createTimeoutError('close', this.server, command.timeoutMs));
++                    }
++                    command.resolve();
+                 }
+-            }
+-            if (shouldExit) {
+-                const pendingError = closeError ?? createClosedError(this.server);
+-                while (this.queue.length > 0) {
+-                    const pending = this.queue.shift();
+-                    if (pending) {
+-                        pending.reject(pendingError);
++                catch (error) {
++                    const err = toError(error);
++                    command.reject(err);
++                    if (shouldExit) {
++                        closeError = err;
+                     }
+                 }
+-                this.closeResult = null;
+-                if (!closeError) {
+-                    this.done = true;
++                activeCommand = null;
++                if (shouldExit) {
++                    const pendingError = closeError ?? createClosedError(this.server);
++                    while (this.queue.length > 0) {
++                        const pending = this.queue.shift();
++                        if (pending) {
++                            pending.reject(pendingError);
++                        }
++                    }
++                    this.closeResult = null;
++                    if (!closeError) {
++                        this.done = true;
++                    }
++                    break;
+                 }
+-                break;
+             }
+         }
+-        this.draining = false;
++        catch (error) {
++            // A programming failure in the queue machinery must still settle
++            // every promise it owns. Converting it into a command failure keeps
++            // it inside the caller's awaited lifecycle boundary instead of
++            // producing process-global `unhandledRejection`.
++            const err = toError(error);
++            activeCommand?.reject(err);
++            while (this.queue.length > 0) {
++                this.queue.shift()?.reject(err);
++            }
++            this.closeResult = null;
++            this.closing = null;
++            this.done = true;
++        }
++        finally {
++            this.draining = false;
++        }
+     }
+ }
+ /**
+@@ -505,10 +529,15 @@ async function runWithTimeoutTask(task, timeoutMs, timeoutError) {
+     }
+ }
+ function toError(error) {
+-    if (error instanceof Error) {
+-        return error;
++    try {
++        if (error instanceof Error) {
++            return error;
++        }
++        return new Error(String(error));
++    }
++    catch {
++        return new Error('Unknown MCP lifecycle failure.');
+     }
+-    return new Error(String(error));
+ }
+ function isAbortError(error) {
+     const code = error.code;
+diff --git a/dist/mcpServers.mjs b/dist/mcpServers.mjs
+index b3a030614725c7d9500483e4778d1d0e0a6085c9..78c69a6fc05adb6fc6d44994d9907c3b7573afbe 100644
+--- a/dist/mcpServers.mjs
++++ b/dist/mcpServers.mjs
+@@ -58,6 +58,9 @@ class ServerWorker {
+             this.closeResult = promise;
+         }
+         this.queue.push(command);
++        // `submit()` is intentionally synchronous, but the drain it starts still
++        // belongs to this worker. Never detach a rejecting promise onto the host
++        // process: every lifecycle failure must settle the submitted command.
+         void this.drain();
+         return promise;
+     }
+@@ -66,51 +69,72 @@ class ServerWorker {
+             return;
+         }
+         this.draining = true;
+-        while (this.queue.length > 0) {
+-            const command = this.queue.shift();
+-            if (!command) {
+-                continue;
+-            }
+-            const shouldExit = command.action === 'close';
+-            let closeError = null;
+-            try {
+-                if (command.action === 'connect') {
+-                    await runWithTimeout(() => this.server.connect(), command.timeoutMs, createTimeoutError('connect', this.server, command.timeoutMs));
+-                }
+-                else {
+-                    const closeTask = this.server.close();
+-                    this.closing = closeTask
+-                        .then(() => undefined, () => undefined)
+-                        .finally(() => {
+-                        this.closing = null;
+-                    });
+-                    await runWithTimeoutTask(closeTask, command.timeoutMs, createTimeoutError('close', this.server, command.timeoutMs));
++        let activeCommand = null;
++        try {
++            while (this.queue.length > 0) {
++                const command = this.queue.shift();
++                if (!command) {
++                    continue;
+                 }
+-                command.resolve();
+-            }
+-            catch (error) {
+-                const err = toError(error);
+-                command.reject(err);
+-                if (shouldExit) {
+-                    closeError = err;
++                activeCommand = command;
++                const shouldExit = command.action === 'close';
++                let closeError = null;
++                try {
++                    if (command.action === 'connect') {
++                        await runWithTimeout(() => this.server.connect(), command.timeoutMs, createTimeoutError('connect', this.server, command.timeoutMs));
++                    }
++                    else {
++                        const closeTask = this.server.close();
++                        this.closing = closeTask
++                            .then(() => undefined, () => undefined)
++                            .finally(() => {
++                            this.closing = null;
++                        });
++                        await runWithTimeoutTask(closeTask, command.timeoutMs, createTimeoutError('close', this.server, command.timeoutMs));
++                    }
++                    command.resolve();
+                 }
+-            }
+-            if (shouldExit) {
+-                const pendingError = closeError ?? createClosedError(this.server);
+-                while (this.queue.length > 0) {
+-                    const pending = this.queue.shift();
+-                    if (pending) {
+-                        pending.reject(pendingError);
++                catch (error) {
++                    const err = toError(error);
++                    command.reject(err);
++                    if (shouldExit) {
++                        closeError = err;
+                     }
+                 }
+-                this.closeResult = null;
+-                if (!closeError) {
+-                    this.done = true;
++                activeCommand = null;
++                if (shouldExit) {
++                    const pendingError = closeError ?? createClosedError(this.server);
++                    while (this.queue.length > 0) {
++                        const pending = this.queue.shift();
++                        if (pending) {
++                            pending.reject(pendingError);
++                        }
++                    }
++                    this.closeResult = null;
++                    if (!closeError) {
++                        this.done = true;
++                    }
++                    break;
+                 }
+-                break;
+             }
+         }
+-        this.draining = false;
++        catch (error) {
++            // A programming failure in the queue machinery must still settle
++            // every promise it owns. Converting it into a command failure keeps
++            // it inside the caller's awaited lifecycle boundary instead of
++            // producing process-global `unhandledRejection`.
++            const err = toError(error);
++            activeCommand?.reject(err);
++            while (this.queue.length > 0) {
++                this.queue.shift()?.reject(err);
++            }
++            this.closeResult = null;
++            this.closing = null;
++            this.done = true;
++        }
++        finally {
++            this.draining = false;
++        }
+     }
+ }
+ /**
+@@ -500,10 +524,15 @@ async function runWithTimeoutTask(task, timeoutMs, timeoutError) {
+     }
+ }
+ function toError(error) {
+-    if (error instanceof Error) {
+-        return error;
++    try {
++        if (error instanceof Error) {
++            return error;
++        }
++        return new Error(String(error));
++    }
++    catch {
++        return new Error('Unknown MCP lifecycle failure.');
+     }
+-    return new Error(String(error));
+ }
+ function isAbortError(error) {
+     const code = error.code;
 diff --git a/dist/run.d.ts b/dist/run.d.ts
 index 7863d754f4d6a5e1bfb99b8cde39417796533741..abe4b6f6c6e9ac8824a0b5d0ae1b909715db5c1a 100644
 --- a/dist/run.d.ts
@@ -1830,3 +2121,67 @@ index fc2aa3141933c96cc080d65b05f7cffb13ee18d7..c4324d271c7bc90128dad0285198f687
 +}
  //# sourceMappingURL=workspacePaths.mjs.map
 \ No newline at end of file
+diff --git a/dist/tracing/provider.js b/dist/tracing/provider.js
+index cbb32c71706cde4fae21cb80eca21c4d6194ba98..3fca31233c74369bd285a33b148972524628657c 100644
+--- a/dist/tracing/provider.js
++++ b/dist/tracing/provider.js
+@@ -356,14 +356,9 @@ class TraceProvider {
+                     process.exit(0);
+                 }
+             });
+-            process.on('unhandledRejection', async (reason, promise) => {
+-                (0, logger_1.logModelAndToolActionError)(logger_1.default, 'Unhandled rejection', reason, promise);
+-                await cleanup();
+-                if (!hasOtherListenersForEvents('unhandledRejection')) {
+-                    // Only when there are no other listeners, exit the process on this SDK side
+-                    process.exit(1);
+-                }
+-            });
++            // The embedding host owns process-global promise rejection policy.
++            // A tracing provider must never convert an unrelated dependency or
++            // application rejection into process termination.
+         }
+     }
+     async forceFlush() {
+@@ -375,9 +370,6 @@ let moduleTraceProvider;
+ function hasOtherListenersForSignals(event) {
+     return process.listeners(event).length > 1;
+ }
+-function hasOtherListenersForEvents(event) {
+-    return process.listeners(event).length > 1;
+-}
+ function getGlobalTraceProvider() {
+     const symbol = Symbol.for('openai.agents.core.traceProvider');
+     try {
+diff --git a/dist/tracing/provider.mjs b/dist/tracing/provider.mjs
+index 99b8962bc8a73330e8c6b7080a75fff64b39ae2f..7dac6b2fbf0a7914af6e750e54685254de1f3bd8 100644
+--- a/dist/tracing/provider.mjs
++++ b/dist/tracing/provider.mjs
+@@ -319,14 +319,9 @@ export class TraceProvider {
+                     process.exit(0);
+                 }
+             });
+-            process.on('unhandledRejection', async (reason, promise) => {
+-                logModelAndToolActionError(logger, 'Unhandled rejection', reason, promise);
+-                await cleanup();
+-                if (!hasOtherListenersForEvents('unhandledRejection')) {
+-                    // Only when there are no other listeners, exit the process on this SDK side
+-                    process.exit(1);
+-                }
+-            });
++            // The embedding host owns process-global promise rejection policy.
++            // A tracing provider must never convert an unrelated dependency or
++            // application rejection into process termination.
+         }
+     }
+     async forceFlush() {
+@@ -337,9 +332,6 @@ let moduleTraceProvider;
+ function hasOtherListenersForSignals(event) {
+     return process.listeners(event).length > 1;
+ }
+-function hasOtherListenersForEvents(event) {
+-    return process.listeners(event).length > 1;
+-}
+ export function getGlobalTraceProvider() {
+     const symbol = Symbol.for('openai.agents.core.traceProvider');
+     try {


### PR DESCRIPTION
## Summary
- patch Agents SDK MCP queue so every lifecycle failure settles an owned command promise
- remove Agents SDK process-global unhandled-rejection exit authority
- add hostile-rejection and listener-ownership regression tests

## Verification
- bun install --frozen-lockfile
- bun test apps/worker/test/agents-sdk-async-ownership.test.ts apps/worker/test/unhandled-rejection-boundary.test.ts
- bun run lint
- bun run typecheck

## Summary by Sourcery

Contain Agents SDK asynchronous lifecycle failures within OpenGeni-owned boundaries and preserve the worker’s control over process termination.

Bug Fixes:
- Keep Agents SDK MCP lifecycle failures contained within owned promises so hostile asynchronous rejections do not become process-global unhandled rejections.
- Prevent the Agents SDK tracing provider from taking control of shared-worker process termination policy.

Enhancements:
- Document the worker’s ownership of global rejection handling and deliberate drain-based shutdown decisions.

Documentation:
- Document the Agents SDK async ownership boundary and shared-worker fatality policy in the architecture and run-lifecycle guides.

Tests:
- Add regression coverage for hostile parallel MCP failures and tracing-provider listener ownership.