### PR TITLE
chore(release): prepare product 0.23.13

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.12
-appVersion: "0.23.12"
+version: 0.23.13
+appVersion: "0.23.13"


### PR DESCRIPTION
## Summary

- advance the immutable Helm product version from 0.23.12 to 0.23.13
- keep chart and app versions identical
- avoid collision with the already-published 0.23.12 candidate before the personal GitHub rollout

Tracks OPE-295.

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts`
- 24 focused tests passed