### PR TITLE
chore(release): admit the 0.23.13 version projection

### DIFF
--- a/.changeset/fresh-product-chart-identity.md
+++ b/.changeset/fresh-product-chart-identity.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Prepare the OpenGeni 0.23.13 product chart with a fresh immutable release identity.


### PR DESCRIPTION
## Summary
- record the 0.23.13 product-chart cut as a publishable config release
- allow trusted Changesets automation to create the final exact-head-admitted Version PR

## Validation
- `bunx changeset status --output ...` projects `@opengeni/config` 0.22.3 and its fixed dependency group
- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts scripts/package-release-chart.test.ts` (26 pass)

Linear: OPE-295

## Summary by Sourcery

Enhancements:
- Record the OpenGeni 0.23.13 product chart as a publishable patch release with a fresh immutable release identity.