### PR TITLE
fix(worker): guarantee quiescence recovery convergence

### DIFF
--- a/apps/worker/src/activities/agent-turn/finalization.ts
+++ b/apps/worker/src/activities/agent-turn/finalization.ts
@@ -38,6 +38,7 @@ import { safeErrorDiagnostic, safeErrorForTelemetry } from "./errors";
 import {
   assertPhysicalToolQuiescenceForCancellation,
   assertSessionAttemptQuiescenceRecoveryDurable,
+  armTurnQuiescenceWatchdog,
   clearAttemptCredentialsWithSettledFence,
   drainAttemptOwnedSandboxWriters,
   persistOrSignalSessionAttemptQuiescence,
@@ -136,6 +137,17 @@ export async function finalizeTurnAttempt(deps: TurnFinalizationDeps): Promise<v
   let finalizationError: unknown;
   let physicalToolQuiescenceConfirmed = !control.acknowledgeQuiescence;
   let quiescenceReceiptOrProofDurable = !control.acknowledgeQuiescence;
+  const disarmQuiescenceWatchdog = armTurnQuiescenceWatchdog({
+    enabled: control.acknowledgeQuiescence,
+    onTimeout: () => {
+      observability.error("turn quiescence drain exceeded hard containment deadline", {
+        "opengeni.session_id": input.sessionId,
+        "opengeni.turn_id": attempt.turnId ?? "",
+        "opengeni.attempt_id": input.attemptId,
+      });
+    },
+    terminateWorker: () => process.exit(1),
+  });
   const finalizerSignal = turnFinalizerCancellationSignal(
     cancellationSignal,
     control.activityStatus,
@@ -302,6 +314,7 @@ export async function finalizeTurnAttempt(deps: TurnFinalizationDeps): Promise<v
         },
       });
       quiescenceReceiptOrProofDurable = true;
+      disarmQuiescenceWatchdog();
       if (recoveryMode === "signal") {
         observability.info("agent turn quiescence proof handed to workflow recovery", {
           "opengeni.session_id": input.sessionId,

--- a/apps/worker/src/activities/agent-turn/quiescence.ts
+++ b/apps/worker/src/activities/agent-turn/quiescence.ts
@@ -79,6 +79,32 @@ export function assertSessionAttemptQuiescenceRecoveryDurable(input: {
 
 export const QUIESCENCE_PROOF_SIGNAL_INITIAL_RETRY_MS = 250;
 export const QUIESCENCE_PROOF_SIGNAL_MAX_RETRY_MS = 5_000;
+export const TURN_QUIESCENCE_WATCHDOG_MS = 5 * 60_000;
+
+/** A fenced activity must never heartbeat forever while its physical writer
+ * drain is stuck. The last-resort worker exit stops every in-process writer;
+ * Kubernetes replaces the pod and the workflow's heartbeat-lease reconciler
+ * then commits the exact quiescence receipt. */
+export function armTurnQuiescenceWatchdog(input: {
+  enabled: boolean;
+  timeoutMs?: number;
+  onTimeout?: () => void;
+  terminateWorker: () => void;
+}): () => void {
+  if (!input.enabled) return () => undefined;
+  let armed = true;
+  const timer = setTimeout(() => {
+    if (!armed) return;
+    input.onTimeout?.();
+    input.terminateWorker();
+  }, input.timeoutMs ?? TURN_QUIESCENCE_WATCHDOG_MS);
+  timer.unref?.();
+  return () => {
+    if (!armed) return;
+    armed = false;
+    clearTimeout(timer);
+  };
+}
 
 /** Persist the authoritative receipt or durably hand the exact physical proof
  * to Temporal. This retries signal delivery, not DB eligibility or workflow

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -583,19 +583,20 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         if (reconciliation.action === "quiesced") continue;
       }
       // Logical settlement is complete, but the exact predecessor activity has
-      // not yet durably proved sandbox/tool quiescence. Wait only briefly for
-      // its transactional queueChanged wake. If provider/tool cancellation is
-      // genuinely slow, close this workflow run rather than consuming a turn
-      // slot or churning control activities; the outbox uses signalWithStart to
-      // restart this exact workflow after the receipt commits.
+      // not yet durably proved sandbox/tool quiescence. Prefer its transactional
+      // queueChanged wake. Also retain one low-frequency deterministic timer:
+      // Pause may acknowledge its control wake before quiescence, leaving no
+      // pending outbox row to restart this workflow after the activity heartbeat
+      // lease expires. The timer guarantees convergence without admission or a
+      // hot control-activity loop.
       const seenSignalVersion = signalVersion;
-      const woke = await condition(() => signalVersion !== seenSignalVersion, "5s");
+      const woke = await condition(() => signalVersion !== seenSignalVersion, "2 minutes");
       if (woke) continue;
       // Close only against the same signal snapshot. A proof signal accepted
       // at the timer/completion boundary must loop through the DB-only receipt
       // activity rather than disappearing with this workflow run.
       if (signalVersion !== seenSignalVersion || pendingQuiescenceProofs.size > 0) continue;
-      return;
+      continue;
     }
     if (peek.kind === "capacity-wait") {
       await waitForProviderCapacity(peek.ref);

--- a/apps/worker/test/turn-quiescence-watchdog.test.ts
+++ b/apps/worker/test/turn-quiescence-watchdog.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { armTurnQuiescenceWatchdog } from "../src/activities/agent-turn/quiescence";
+
+describe("turn quiescence watchdog", () => {
+  test("terminates a worker whose fenced writer drain never settles", async () => {
+    let terminated = false;
+    armTurnQuiescenceWatchdog({
+      enabled: true,
+      timeoutMs: 1,
+      terminateWorker: () => {
+        terminated = true;
+      },
+    });
+    await Bun.sleep(10);
+    expect(terminated).toBe(true);
+  });
+
+  test("disarms after the durable receipt is established", async () => {
+    let terminated = false;
+    const disarm = armTurnQuiescenceWatchdog({
+      enabled: true,
+      timeoutMs: 1,
+      terminateWorker: () => {
+        terminated = true;
+      },
+    });
+    disarm();
+    await Bun.sleep(10);
+    expect(terminated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep cancellation-wait workflows alive on a low-frequency deterministic reconciliation timer
- restart a turn worker if a fenced physical writer drain heartbeats forever
- allow heartbeat-lease reconciliation to persist the exact receipt after restart

## Verification
- `bun test apps/worker/test/attempt-activity-lease.test.ts apps/worker/test/session-state-cancel.test.ts apps/worker/test/turn-quiescence-watchdog.test.ts`
- `bun run --filter @opengeni/worker-bundle typecheck`
- `bun run --filter @opengeni/worker-bundle build`

## Summary by Sourcery

Guarantee convergence of turn quiescence recovery when cancellation or physical writer draining stalls.

Bug Fixes:
- Guarantee recovery from stalled turn quiescence by restarting workers whose fenced writer drain exceeds the containment deadline.
- Ensure session workflows continue reconciling until quiescence receipts are durably established, including after heartbeat-lease expiry.

Enhancements:
- Add watchdog coverage for worker termination and successful watchdog disarming after durable quiescence receipt establishment.

Tests:
- Add tests covering quiescence watchdog timeout and disarm behavior.