### PR TITLE
test(worker): assert persistent quiescence reconciliation

### DIFF
--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1069,7 +1069,7 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "Temporal activity failure never manufactures quiescence or pins workflow completion",
+    "Temporal activity failure never manufactures quiescence and keeps reconciliation live",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
@@ -1122,12 +1122,14 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await handle.result();
+        await waitFor(() => controls.length === 1);
 
         expect(runs).toBe(1);
         expect(controls).toEqual([
           { ...scope, sessionId, attemptId: expect.any(String), workflowId },
         ]);
+        expect((await handle.describe()).status.name).toBe("RUNNING");
+        await handle.terminate("test verified persistent reconciliation");
       } finally {
         terminateFirst = true;
         worker.shutdown();


### PR DESCRIPTION
## Summary
- update Temporal integration proof for persistent cancellation-wait reconciliation
- assert failed activity never manufactures quiescence or admits replacement work
- assert workflow remains live for exact receipt convergence

## Verification
- `bun test ./test/integration/temporal-workflow.integration.ts -t "Temporal activity failure never manufactures quiescence and keeps reconciliation live"` (1 pass)

## Summary by Sourcery

Verify that failed activity reconciliation stays live without manufacturing quiescence or admitting replacement work.

Enhancements:
- Strengthen the Temporal integration proof that failed activities do not create false quiescence or allow replacement work while persistent reconciliation remains active.

Tests:
- Update the activity-failure integration test to verify exact control receipt convergence and that the workflow remains running until explicitly terminated.