### PR TITLE
OPE-411: prove persistent Temporal cancellation reconciliation

### DIFF
--- a/test/integration/steer-cancellation-deadlock.fixture.test.ts
+++ b/test/integration/steer-cancellation-deadlock.fixture.test.ts
@@ -370,23 +370,22 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         });
         expect(rows.wake?.deliveredRevision).toBeLessThan(rows.wake?.wakeRevision ?? 0);
 
-        // Current v2 closes after its bounded cancellation wait without
-        // waiting for the cancellation-ignoring activity to terminalize. The
-        // exact activity must remain visible in Temporal and physically keep
-        // heartbeating while the predecessor fence remains closed.
-        await handle.result();
-        const completedDescription = await handle.describe();
-        expect(completedDescription.status.name).toBe("COMPLETED");
-        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
+        // Persistent reconciliation must keep the workflow open past the old
+        // five-second close boundary. The exact activity remains visible in
+        // Temporal and physically heartbeats while the predecessor fence is
+        // closed, so no replacement work can be admitted.
+        const beatsBeforeReconciliationWindow = heartbeats;
+        await Bun.sleep(6_000);
+        const reconcilingDescription = await handle.describe();
+        expect(reconcilingDescription.status.name).toBe("RUNNING");
+        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
-        expect(pendingAfterWorkflowClose?.state).toBe(
+        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
+        expect(pendingDuringReconciliation?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
-
-        const beatsAtWorkflowClose = heartbeats;
-        await waitFor(() => heartbeats >= beatsAtWorkflowClose + 3);
+        expect(heartbeats).toBeGreaterThan(beatsBeforeReconciliationWindow);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -394,7 +393,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         try {
           await handle.terminate("cancellation-settlement lane fixture final cleanup");
         } catch {
-          // The workflow already completed naturally after exact-activity cleanup.
+          // The workflow may have completed naturally after exact-activity cleanup.
         }
         worker.shutdown();
         await workerRun;
@@ -404,7 +403,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
   );
 
   test(
-    "a bounded cancellation close leaves the receipt fence closed while the activity remains pending",
+    "missing heartbeats keep persistent reconciliation and the receipt fence live",
     async () => {
       const suffix = crypto.randomUUID();
       const access = await bootstrapWorkspace(dbClient.db, {
@@ -614,28 +613,26 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         expect(pendingActivityId).toBeTruthy();
 
         // Stop acknowledging the server heartbeat contract without allowing
-        // the local function to settle. The receipt-gated workflow closes its
-        // run after the bounded cancellation wait; it must not infer a
-        // physical stop or admit replacement work from that closure.
+        // the local function to settle. Persistent reconciliation must not
+        // infer a physical stop, close the workflow, or admit replacement work.
         stopHeartbeats = true;
         const beatsAtStop = heartbeats;
-        await handle.result();
+        const ticksAtStop = hungTicks;
+        await Bun.sleep(6_000);
         expect(heartbeats).toBe(beatsAtStop);
-        const completedDescription = await handle.describe();
-        expect(completedDescription.status.name).toBe("COMPLETED");
-        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
+        expect(hungTicks).toBeGreaterThan(ticksAtStop);
+        const reconcilingDescription = await handle.describe();
+        expect(reconcilingDescription.status.name).toBe("RUNNING");
+        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
-        expect(pendingAfterWorkflowClose?.state).toBe(
+        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
+        expect(pendingDuringReconciliation?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
 
-        // The bounded workflow close is not a heartbeat timeout or physical
-        // quiescence proof. The disposable loop remains live until exact
-        // cleanup releases its gate.
-        const ticksAtWorkflowClose = hungTicks;
-        await waitFor(() => hungTicks >= ticksAtWorkflowClose + 3);
+        // Missing heartbeats are not themselves a physical quiescence proof.
+        // The disposable loop remains live until exact cleanup releases it.
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -645,7 +642,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
             "cancellation-settlement lane failed-workflow fixture final cleanup",
           );
         } catch {
-          // The workflow already closed after its bounded cancellation wait.
+          // The workflow may have completed naturally after exact-activity cleanup.
         }
         worker.shutdown();
         await workerRun;

--- a/test/integration/steer-cancellation-deadlock.fixture.test.ts
+++ b/test/integration/steer-cancellation-deadlock.fixture.test.ts
@@ -385,7 +385,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         expect(pendingDuringReconciliation?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
-        expect(heartbeats).toBeGreaterThan(beatsBeforeReconciliationWindow);
+        expect(heartbeats).toBeGreaterThanOrEqual(beatsBeforeReconciliationWindow + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -620,7 +620,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         const ticksAtStop = hungTicks;
         await Bun.sleep(6_000);
         expect(heartbeats).toBe(beatsAtStop);
-        expect(hungTicks).toBeGreaterThan(ticksAtStop);
+        expect(hungTicks).toBeGreaterThanOrEqual(ticksAtStop + 3);
         const reconcilingDescription = await handle.describe();
         expect(reconcilingDescription.status.name).toBe("RUNNING");
         const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1080,6 +1080,7 @@ describe("Temporal workflow integration", () => {
       const queuedTurns = [first];
       const controls: unknown[] = [];
       let runs = 0;
+      let reconciliationAttempts = 0;
       let cancellationWaitAttemptId: string | null = null;
       let terminateFirst = false;
       const admission = createTurnAdmission(queuedTurns, async () => {
@@ -1108,7 +1109,10 @@ describe("Temporal workflow integration", () => {
           terminateFirst = true;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () => ({ action: "pending" as const }),
+        reconcileSessionAttemptQuiescence: async () => {
+          reconciliationAttempts += 1;
+          return { action: "pending" as const };
+        },
       });
       const run = worker.run();
       try {
@@ -1122,7 +1126,14 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await waitFor(() => controls.length === 1);
+        await waitFor(() => reconciliationAttempts >= 1);
+
+        // A later wake must drive another exact reconciliation pass without
+        // admitting the queued replacement or closing the workflow. This
+        // distinguishes persistent receipt convergence from a single RUNNING
+        // snapshot taken just before an erroneous workflow completion.
+        await handle.signal("queueChanged");
+        await waitFor(() => reconciliationAttempts >= 2);
 
         expect(runs).toBe(1);
         expect(controls).toEqual([


### PR DESCRIPTION
## Summary
- align the two production cancellation fixtures with persistent receipt reconciliation
- prove workflows remain live past the retired five-second close boundary while the exact activity is still pending
- require a second reconciliation pass after a later wake, so a transient RUNNING snapshot cannot mask premature completion
- keep replacement work fail-closed until exact quiescence

## Verification
- focused Temporal workflow integration test: passed
- cancellation-settlement production fixture: 2 passed
- formatting check: passed
- all 31 TypeScript projects: passed

Linear: https://linear.app/cloudgeni/issue/OPE-411/restore-temporal-cancellation-settlement-convergence-after-quiescence

## Summary by Sourcery

Prove persistent cancellation reconciliation keeps workflows and receipt fences live until exact activity quiescence is established.

Bug Fixes:
- Keep cancellation workflows running while the exact cancelled activity remains pending, preventing premature completion and replacement-work admission.
- Require a later wake to trigger an additional quiescence reconciliation pass before cancellation settlement.

Enhancements:
- Update production cancellation fixtures to verify persistent reconciliation, continued heartbeating, and fail-closed receipt fences beyond the former close boundary.

Tests:
- Strengthen Temporal integration coverage for repeated reconciliation after a later workflow wake.
- Adjust cancellation-settlement fixture expectations to validate live workflows and pending CANCEL_REQUESTED activities during reconciliation.