### PR TITLE
fix(worker): restore bounded cancellation-wait closure

### DIFF
--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -583,20 +583,19 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         if (reconciliation.action === "quiesced") continue;
       }
       // Logical settlement is complete, but the exact predecessor activity has
-      // not yet durably proved sandbox/tool quiescence. Prefer its transactional
-      // queueChanged wake. Also retain one low-frequency deterministic timer:
-      // Pause may acknowledge its control wake before quiescence, leaving no
-      // pending outbox row to restart this workflow after the activity heartbeat
-      // lease expires. The timer guarantees convergence without admission or a
-      // hot control-activity loop.
+      // not yet durably proved sandbox/tool quiescence. Wait only briefly for
+      // its transactional queueChanged wake. If provider/tool cancellation is
+      // genuinely slow, close this workflow run rather than consuming a turn
+      // slot or churning control activities; the outbox uses signalWithStart to
+      // restart this exact workflow after the receipt commits.
       const seenSignalVersion = signalVersion;
-      const woke = await condition(() => signalVersion !== seenSignalVersion, "2 minutes");
+      const woke = await condition(() => signalVersion !== seenSignalVersion, "5s");
       if (woke) continue;
       // Close only against the same signal snapshot. A proof signal accepted
       // at the timer/completion boundary must loop through the DB-only receipt
       // activity rather than disappearing with this workflow run.
       if (signalVersion !== seenSignalVersion || pendingQuiescenceProofs.size > 0) continue;
-      continue;
+      return;
     }
     if (peek.kind === "capacity-wait") {
       await waitForProviderCapacity(peek.ref);

--- a/test/integration/steer-cancellation-deadlock.fixture.test.ts
+++ b/test/integration/steer-cancellation-deadlock.fixture.test.ts
@@ -370,22 +370,23 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         });
         expect(rows.wake?.deliveredRevision).toBeLessThan(rows.wake?.wakeRevision ?? 0);
 
-        // Persistent reconciliation must keep the workflow open past the old
-        // five-second close boundary. The exact activity remains visible in
-        // Temporal and physically heartbeats while the predecessor fence is
-        // closed, so no replacement work can be admitted.
-        const beatsBeforeReconciliationWindow = heartbeats;
-        await Bun.sleep(6_000);
-        const reconcilingDescription = await handle.describe();
-        expect(reconcilingDescription.status.name).toBe("RUNNING");
-        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
+        // Current v2 closes after its bounded cancellation wait without
+        // waiting for the cancellation-ignoring activity to terminalize. The
+        // exact activity must remain visible in Temporal and physically keep
+        // heartbeating while the predecessor fence remains closed.
+        await handle.result();
+        const completedDescription = await handle.describe();
+        expect(completedDescription.status.name).toBe("COMPLETED");
+        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
-        expect(pendingDuringReconciliation?.state).toBe(
+        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
+        expect(pendingAfterWorkflowClose?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
-        expect(heartbeats).toBeGreaterThanOrEqual(beatsBeforeReconciliationWindow + 3);
+
+        const beatsAtWorkflowClose = heartbeats;
+        await waitFor(() => heartbeats >= beatsAtWorkflowClose + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -393,7 +394,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         try {
           await handle.terminate("cancellation-settlement lane fixture final cleanup");
         } catch {
-          // The workflow may have completed naturally after exact-activity cleanup.
+          // The workflow already completed naturally after exact-activity cleanup.
         }
         worker.shutdown();
         await workerRun;
@@ -403,7 +404,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
   );
 
   test(
-    "missing heartbeats keep persistent reconciliation and the receipt fence live",
+    "a bounded cancellation close leaves the receipt fence closed while the activity remains pending",
     async () => {
       const suffix = crypto.randomUUID();
       const access = await bootstrapWorkspace(dbClient.db, {
@@ -613,26 +614,28 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         expect(pendingActivityId).toBeTruthy();
 
         // Stop acknowledging the server heartbeat contract without allowing
-        // the local function to settle. Persistent reconciliation must not
-        // infer a physical stop, close the workflow, or admit replacement work.
+        // the local function to settle. The receipt-gated workflow closes its
+        // run after the bounded cancellation wait; it must not infer a
+        // physical stop or admit replacement work from that closure.
         stopHeartbeats = true;
         const beatsAtStop = heartbeats;
-        const ticksAtStop = hungTicks;
-        await Bun.sleep(6_000);
+        await handle.result();
         expect(heartbeats).toBe(beatsAtStop);
-        expect(hungTicks).toBeGreaterThanOrEqual(ticksAtStop + 3);
-        const reconcilingDescription = await handle.describe();
-        expect(reconcilingDescription.status.name).toBe("RUNNING");
-        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
+        const completedDescription = await handle.describe();
+        expect(completedDescription.status.name).toBe("COMPLETED");
+        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
-        expect(pendingDuringReconciliation?.state).toBe(
+        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
+        expect(pendingAfterWorkflowClose?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
 
-        // Missing heartbeats are not themselves a physical quiescence proof.
-        // The disposable loop remains live until exact cleanup releases it.
+        // The bounded workflow close is not a heartbeat timeout or physical
+        // quiescence proof. The disposable loop remains live until exact
+        // cleanup releases its gate.
+        const ticksAtWorkflowClose = hungTicks;
+        await waitFor(() => hungTicks >= ticksAtWorkflowClose + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -642,7 +645,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
             "cancellation-settlement lane failed-workflow fixture final cleanup",
           );
         } catch {
-          // The workflow may have completed naturally after exact-activity cleanup.
+          // The workflow already closed after its bounded cancellation wait.
         }
         worker.shutdown();
         await workerRun;

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1069,7 +1069,7 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "Temporal activity failure never manufactures quiescence and keeps reconciliation live",
+    "Temporal activity failure never manufactures quiescence or pins workflow completion",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
@@ -1080,7 +1080,6 @@ describe("Temporal workflow integration", () => {
       const queuedTurns = [first];
       const controls: unknown[] = [];
       let runs = 0;
-      let reconciliationAttempts = 0;
       let cancellationWaitAttemptId: string | null = null;
       let terminateFirst = false;
       const admission = createTurnAdmission(queuedTurns, async () => {
@@ -1109,10 +1108,7 @@ describe("Temporal workflow integration", () => {
           terminateFirst = true;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () => {
-          reconciliationAttempts += 1;
-          return { action: "pending" as const };
-        },
+        reconcileSessionAttemptQuiescence: async () => ({ action: "pending" as const }),
       });
       const run = worker.run();
       try {
@@ -1126,21 +1122,12 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await waitFor(() => reconciliationAttempts >= 1);
-
-        // A later wake must drive another exact reconciliation pass without
-        // admitting the queued replacement or closing the workflow. This
-        // distinguishes persistent receipt convergence from a single RUNNING
-        // snapshot taken just before an erroneous workflow completion.
-        await handle.signal("queueChanged");
-        await waitFor(() => reconciliationAttempts >= 2);
+        await handle.result();
 
         expect(runs).toBe(1);
         expect(controls).toEqual([
           { ...scope, sessionId, attemptId: expect.any(String), workflowId },
         ]);
-        expect((await handle.describe()).status.name).toBe("RUNNING");
-        await handle.terminate("test verified persistent reconciliation");
       } finally {
         terminateFirst = true;
         worker.shutdown();


### PR DESCRIPTION
## Summary
- restore bounded workflow completion after the exact cancellation-wait signal fence
- rely on the retained durable wake revision and `signalWithStart` to resume receipt reconciliation
- retain the hard worker quiescence watchdog
- restore all three integration assertions that cancellation recovery closes the workflow without manufacturing quiescence or opening the replacement fence

## Why
The low-frequency timer loop keeps a control workflow resident indefinitely while physical quiescence remains pending. That conflicts with the durable workflow-wake handoff: unresolved exact quiescence leaves the wake revision unacknowledged, and receipt settlement advances that revision so `signalWithStart` can restart the stable workflow id without polling inside Temporal.

Two independent exact-SHA CI runs exposed the resulting Temporal integration and cancellation-deadlock fixture timeouts. Later test-only changes rewrote those fixtures around persistent workflow residency, but did not alter the runtime or the documented durable-outbox ownership model.

## Verification
- `bun test ./apps/worker/test/session-state-cancel.test.ts ./apps/worker/test/turn-quiescence-watchdog.test.ts --timeout 120000` (11 pass)
- `bun run --filter @opengeni/worker-bundle typecheck`
- `bunx oxfmt --check apps/worker/src/workflows/session.ts test/integration/temporal-workflow.integration.ts test/integration/steer-cancellation-deadlock.fixture.test.ts`
- `git diff --check`
- the service-backed Temporal and cancellation-deadlock fixtures are delegated to PR CI because Docker is unavailable in the local environment

## Summary by Sourcery

Restore bounded cancellation-wait closure so workflows complete safely while durable wake handling resumes reconciliation after exact quiescence is established.

Bug Fixes:
- Restore bounded workflow completion when cancellation quiescence cannot be confirmed promptly, allowing durable receipt settlement to restart reconciliation without polling.
- Prevent cancellation recovery from manufacturing quiescence or admitting replacement work while the exact cancellation activity remains pending.

Enhancements:
- Retain the hard worker quiescence watchdog while shortening the cancellation wait to a bounded interval.
- Update Temporal integration and cancellation-deadlock assertions to verify completed workflow runs, preserved cancellation fences, and continued activity heartbeats or cleanup progress.

Tests:
- Restore integration coverage for bounded cancellation closure and protection against replacement dispatch during unresolved quiescence.