### PR TITLE
fix(worker): preserve forward sandbox recovery convergence

### DIFF
--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -3,6 +3,7 @@ import {
   ApprovalRunStateLimitExceededError,
   isRetryableDatabaseTransportFailure,
   isSessionEventPersistenceError,
+  SandboxLeaseTransitionError,
 } from "@opengeni/db";
 import {
   ActiveBackendUnresolvableError,
@@ -365,6 +366,66 @@ export function postClaimDatabaseRecoveryFailure(input: {
  */
 export function isWorkerShutdownCancellation(error: unknown): boolean {
   return error instanceof CancelledFailure && error.message === "WORKER_SHUTDOWN";
+}
+
+export type SandboxLifecycleTransitionDiagnostic = {
+  sandboxGroupId: string;
+  leaseEpoch: number;
+  reason: "capture_in_progress" | "rotation_in_progress" | "provider_recovery_in_progress";
+};
+
+/**
+ * Recover a typed sandbox lifecycle transition through the structural wrappers
+ * used by parallel Agents SDK function-tool execution. Never infer transition
+ * truth from message text: only the original class or an exact, fully-shaped
+ * cross-package error object is accepted.
+ */
+export function sandboxLifecycleTransitionDiagnostic(
+  error: unknown,
+): SandboxLifecycleTransitionDiagnostic | null {
+  const pending: unknown[] = [error];
+  const seen = new WeakSet<object>();
+  let inspected = 0;
+
+  while (pending.length > 0 && inspected < 64) {
+    const current = pending.shift();
+    inspected += 1;
+    if (!current || typeof current !== "object" || seen.has(current)) continue;
+    seen.add(current);
+
+    try {
+      const record = current as Record<string, unknown>;
+      const reason = record.reason;
+      if (
+        (current instanceof SandboxLeaseTransitionError ||
+          record.name === "SandboxLeaseTransitionError") &&
+        typeof record.sandboxGroupId === "string" &&
+        record.sandboxGroupId.length > 0 &&
+        typeof record.leaseEpoch === "number" &&
+        Number.isSafeInteger(record.leaseEpoch) &&
+        record.leaseEpoch >= 0 &&
+        (reason === "capture_in_progress" ||
+          reason === "rotation_in_progress" ||
+          reason === "provider_recovery_in_progress")
+      ) {
+        return {
+          sandboxGroupId: record.sandboxGroupId,
+          leaseEpoch: record.leaseEpoch,
+          reason,
+        };
+      }
+
+      for (const key of ["cause", "error"] as const) {
+        const nested = record[key];
+        if (nested && typeof nested === "object") pending.push(nested);
+      }
+      if (Array.isArray(record.errors)) pending.push(...record.errors.slice(0, 32));
+    } catch {
+      // A hostile proxy or getter is not durable lifecycle evidence.
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/apps/worker/src/activities/agent-turn/failure-settlement.ts
+++ b/apps/worker/src/activities/agent-turn/failure-settlement.ts
@@ -18,7 +18,6 @@ import {
   settleCodexCredentialFailover,
   readLease,
   SandboxLeaseSupersededError,
-  SandboxLeaseTransitionError,
   isSessionEventPersistenceError,
 } from "@opengeni/db";
 import { publishDurableSessionEvents } from "@opengeni/events";
@@ -61,6 +60,7 @@ import {
   escapedMcpTimeoutRecoveryFailure,
   preClaimAdmissionFailure,
   isWorkerShutdownCancellation,
+  sandboxLifecycleTransitionDiagnostic,
   sandboxRouteTransitionCode,
   safeErrorDiagnostic,
   classifyXaiCredentialFailure,
@@ -159,20 +159,20 @@ export async function settleTurnFailure(deps: TurnFailureDeps): Promise<RunAgent
   // recoverable control-plane states, never session failures. The latter is
   // paced briefly; the next acquire waits on the durable claim and resumes
   // immediately when it clears.
-  if (
-    (error instanceof SandboxLeaseSupersededError ||
-      error instanceof SandboxLeaseTransitionError) &&
-    recoveryTurnId
-  ) {
+  const lifecycleTransition = sandboxLifecycleTransitionDiagnostic(error);
+  const leaseControlError =
+    error instanceof SandboxLeaseSupersededError ? error : lifecycleTransition;
+  if (leaseControlError && recoveryTurnId) {
     try {
-      const fencedLease = await readLease(db, input.workspaceId, error.sandboxGroupId).catch(
-        () => null,
-      );
-      const lifecycleTransition = error instanceof SandboxLeaseTransitionError;
+      const fencedLease = await readLease(
+        db,
+        input.workspaceId,
+        leaseControlError.sandboxGroupId,
+      ).catch(() => null);
       const rotationPending =
         fencedLease?.rotationRequestedAt != null ||
-        (lifecycleTransition && error.reason === "rotation_in_progress");
-      const transitionPending = lifecycleTransition || rotationPending;
+        lifecycleTransition?.reason === "rotation_in_progress";
+      const transitionPending = lifecycleTransition !== null || rotationPending;
       const deadlineRotationPending =
         rotationPending && fencedLease?.rotationReason === "provider_deadline";
       const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
@@ -182,20 +182,20 @@ export async function settleTurnFailure(deps: TurnFailureDeps): Promise<RunAgent
         attemptId: input.attemptId,
         reason: deadlineRotationPending
           ? "sandbox_deadline_rotation"
-          : lifecycleTransition
+          : lifecycleTransition !== null
             ? "sandbox_lifecycle_transition"
             : "sandbox_lease_superseded",
         ...(transitionPending
           ? {
               detail: {
-                sandboxGroupId: error.sandboxGroupId,
-                leaseEpoch: error.leaseEpoch,
+                sandboxGroupId: leaseControlError.sandboxGroupId,
+                leaseEpoch: leaseControlError.leaseEpoch,
                 ...(rotationPending
                   ? {
                       rotationReason: fencedLease?.rotationReason ?? "operator",
                     }
                   : {}),
-                ...(lifecycleTransition ? { transitionReason: error.reason } : {}),
+                ...(lifecycleTransition ? { transitionReason: lifecycleTransition.reason } : {}),
               },
             }
           : {}),

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -583,19 +583,21 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         if (reconciliation.action === "quiesced") continue;
       }
       // Logical settlement is complete, but the exact predecessor activity has
-      // not yet durably proved sandbox/tool quiescence. Wait only briefly for
-      // its transactional queueChanged wake. If provider/tool cancellation is
-      // genuinely slow, close this workflow run rather than consuming a turn
-      // slot or churning control activities; the outbox uses signalWithStart to
-      // restart this exact workflow after the receipt commits.
+      // not yet durably proved sandbox/tool quiescence. Prefer its transactional
+      // queueChanged wake. Also retain one low-frequency deterministic timer:
+      // the recovery wake can already be delivered while the physical activity
+      // still owns its heartbeat lease, leaving no future transaction that can
+      // signalWithStart after the lease expires. Keeping this workflow available
+      // guarantees passive receipt convergence without admitting replacement
+      // work or creating a hot control-activity loop.
       const seenSignalVersion = signalVersion;
-      const woke = await condition(() => signalVersion !== seenSignalVersion, "5s");
+      const woke = await condition(() => signalVersion !== seenSignalVersion, "2 minutes");
       if (woke) continue;
       // Close only against the same signal snapshot. A proof signal accepted
       // at the timer/completion boundary must loop through the DB-only receipt
       // activity rather than disappearing with this workflow run.
       if (signalVersion !== seenSignalVersion || pendingQuiescenceProofs.size > 0) continue;
-      return;
+      continue;
     }
     if (peek.kind === "capacity-wait") {
       await waitForProviderCapacity(peek.ref);

--- a/apps/worker/test/home-sandbox-turn-transition.test.ts
+++ b/apps/worker/test/home-sandbox-turn-transition.test.ts
@@ -6,11 +6,139 @@ import {
 } from "@opengeni/runtime";
 import {
   isHomeSandboxTurnTransitionError,
+  sandboxLifecycleTransitionDiagnostic,
   sandboxRouteTransitionCode,
 } from "../src/activities/agent-turn/errors";
 import { settleTurnFailure } from "../src/activities/agent-turn/failure-settlement";
 
 describe("Connected Machine to managed-home turn transition", () => {
+  test("recognizes sandbox lifecycle transitions through SDK aggregate wrappers only", () => {
+    const transition = new opengeniDb.SandboxLeaseTransitionError(
+      "group-1",
+      5,
+      "capture_in_progress",
+      "modal",
+      "sb-1",
+      "draining",
+    );
+
+    expect(
+      sandboxLifecycleTransitionDiagnostic(
+        new Error("Failed to run function tools", {
+          cause: new AggregateError([new Error("peer failed"), transition], "tool failures"),
+        }),
+      ),
+    ).toEqual({
+      sandboxGroupId: "group-1",
+      leaseEpoch: 5,
+      reason: "capture_in_progress",
+    });
+    expect(
+      sandboxLifecycleTransitionDiagnostic(
+        new Error("SandboxLeaseTransitionError: capture_in_progress"),
+      ),
+    ).toBeNull();
+  });
+
+  test("recovers a lifecycle transition wrapped by function-tool execution", async () => {
+    const transition = new opengeniDb.SandboxLeaseTransitionError(
+      "group-1",
+      5,
+      "capture_in_progress",
+      "modal",
+      "sb-1",
+      "draining",
+    );
+    const error = new AggregateError([transition], "Failed to run function tools");
+    const requestRecovery = spyOn(opengeniDb, "requestSessionTurnRecovery").mockResolvedValue({
+      action: "recovering",
+      events: [],
+    });
+    const readLease = spyOn(opengeniDb, "readLease").mockResolvedValue({
+      rotationRequestedAt: new Date(),
+      rotationReason: "operator",
+    } as never);
+    const acknowledgeRecoveryQuiescence = mock(() => undefined);
+    const control = {
+      cancellationRequestedAt: null,
+      activityStatus: "unknown",
+      turnMetricOutcome: null,
+      activityError: null,
+      acknowledgeQuiescence: false,
+    };
+
+    try {
+      const result = await settleTurnFailure({
+        error,
+        input: {
+          accountId: "account-1",
+          workspaceId: "workspace-1",
+          sessionId: "session-1",
+          attemptId: "attempt-1",
+        },
+        settings: { sandboxLeaseReaperPeriodMs: 10_000 },
+        db: {},
+        bus: {},
+        observability: {},
+        wakeSessionWorkflow: async () => undefined,
+        signalCodexCapacityWorkflow: async () => undefined,
+        cancellationSignal: undefined,
+        sandboxRotationController: new AbortController(),
+        noteCancellationRequested: () => undefined,
+        codexWorkspaceKey: "workspace-key",
+        control,
+        attempt: {
+          turnId: "turn-1",
+          triggerEventId: "trigger-1",
+          executionGeneration: 1,
+          providerRecoveryCount: 0,
+          modelRequestStarted: true,
+          redispatchesAtDispatch: 0,
+          triggerType: "user",
+        },
+        billingState: {},
+        eventing: { publish: async () => [], turnStartedPublished: true },
+        providerTurn: {},
+        leases: {},
+        historySink: { reconcileConversationTruth: async () => undefined },
+        claimedResult: (value: Record<string, unknown>) => ({
+          ...value,
+          turnId: "turn-1",
+          attemptId: "attempt-1",
+        }),
+        flushRuntimeBatcher: async () => undefined,
+        acknowledgeLostAttemptOwnership: () => undefined,
+        acknowledgeRecoveryQuiescence,
+      } as never);
+
+      expect(result).toEqual({
+        status: "recovering",
+        continueDelayMs: 5_000,
+        turnId: "turn-1",
+        attemptId: "attempt-1",
+      });
+      expect(requestRecovery).toHaveBeenCalledWith({}, "workspace-1", {
+        sessionId: "session-1",
+        turnId: "turn-1",
+        triggerEventId: "trigger-1",
+        attemptId: "attempt-1",
+        reason: "sandbox_lifecycle_transition",
+        detail: {
+          sandboxGroupId: "group-1",
+          leaseEpoch: 5,
+          rotationReason: "operator",
+          transitionReason: "capture_in_progress",
+        },
+      });
+      expect(acknowledgeRecoveryQuiescence).toHaveBeenCalledTimes(1);
+      expect(control.activityStatus).toBe("recovering");
+      expect(control.turnMetricOutcome).toBe("recovering");
+    } finally {
+      requestRecovery.mockRestore();
+      readLease.mockRestore();
+    }
+  });
+
   test("recognizes the typed routing signal through SDK aggregate wrappers only", () => {
     const transition = new ActiveBackendUnresolvableError(
       "home_unavailable_this_turn",

--- a/test/integration/steer-cancellation-deadlock.fixture.test.ts
+++ b/test/integration/steer-cancellation-deadlock.fixture.test.ts
@@ -370,23 +370,22 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         });
         expect(rows.wake?.deliveredRevision).toBeLessThan(rows.wake?.wakeRevision ?? 0);
 
-        // Current v2 closes after its bounded cancellation wait without
-        // waiting for the cancellation-ignoring activity to terminalize. The
-        // exact activity must remain visible in Temporal and physically keep
-        // heartbeating while the predecessor fence remains closed.
-        await handle.result();
-        const completedDescription = await handle.describe();
-        expect(completedDescription.status.name).toBe("COMPLETED");
-        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
+        // Persistent reconciliation must keep the workflow open past the old
+        // five-second close boundary. The exact activity remains visible in
+        // Temporal and physically heartbeats while the predecessor fence is
+        // closed, so no replacement work can be admitted.
+        const beatsBeforeReconciliationWindow = heartbeats;
+        await Bun.sleep(6_000);
+        const reconcilingDescription = await handle.describe();
+        expect(reconcilingDescription.status.name).toBe("RUNNING");
+        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
-        expect(pendingAfterWorkflowClose?.state).toBe(
+        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
+        expect(pendingDuringReconciliation?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
-
-        const beatsAtWorkflowClose = heartbeats;
-        await waitFor(() => heartbeats >= beatsAtWorkflowClose + 3);
+        expect(heartbeats).toBeGreaterThanOrEqual(beatsBeforeReconciliationWindow + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -394,7 +393,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         try {
           await handle.terminate("cancellation-settlement lane fixture final cleanup");
         } catch {
-          // The workflow already completed naturally after exact-activity cleanup.
+          // The workflow may have completed naturally after exact-activity cleanup.
         }
         worker.shutdown();
         await workerRun;
@@ -404,7 +403,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
   );
 
   test(
-    "a bounded cancellation close leaves the receipt fence closed while the activity remains pending",
+    "missing heartbeats keep persistent reconciliation and the receipt fence live",
     async () => {
       const suffix = crypto.randomUUID();
       const access = await bootstrapWorkspace(dbClient.db, {
@@ -614,28 +613,26 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         expect(pendingActivityId).toBeTruthy();
 
         // Stop acknowledging the server heartbeat contract without allowing
-        // the local function to settle. The receipt-gated workflow closes its
-        // run after the bounded cancellation wait; it must not infer a
-        // physical stop or admit replacement work from that closure.
+        // the local function to settle. Persistent reconciliation must not
+        // infer a physical stop, close the workflow, or admit replacement work.
         stopHeartbeats = true;
         const beatsAtStop = heartbeats;
-        await handle.result();
+        const ticksAtStop = hungTicks;
+        await Bun.sleep(6_000);
         expect(heartbeats).toBe(beatsAtStop);
-        const completedDescription = await handle.describe();
-        expect(completedDescription.status.name).toBe("COMPLETED");
-        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
+        expect(hungTicks).toBeGreaterThanOrEqual(ticksAtStop + 3);
+        const reconcilingDescription = await handle.describe();
+        expect(reconcilingDescription.status.name).toBe("RUNNING");
+        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
-        expect(pendingAfterWorkflowClose?.state).toBe(
+        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
+        expect(pendingDuringReconciliation?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
 
-        // The bounded workflow close is not a heartbeat timeout or physical
-        // quiescence proof. The disposable loop remains live until exact
-        // cleanup releases its gate.
-        const ticksAtWorkflowClose = hungTicks;
-        await waitFor(() => hungTicks >= ticksAtWorkflowClose + 3);
+        // Missing heartbeats are not themselves a physical quiescence proof.
+        // The disposable loop remains live until exact cleanup releases it.
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -645,7 +642,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
             "cancellation-settlement lane failed-workflow fixture final cleanup",
           );
         } catch {
-          // The workflow already closed after its bounded cancellation wait.
+          // The workflow may have completed naturally after exact-activity cleanup.
         }
         worker.shutdown();
         await workerRun;

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1069,7 +1069,7 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "Temporal activity failure never manufactures quiescence or pins workflow completion",
+    "Temporal activity failure never manufactures quiescence and keeps reconciliation live",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
@@ -1080,6 +1080,7 @@ describe("Temporal workflow integration", () => {
       const queuedTurns = [first];
       const controls: unknown[] = [];
       let runs = 0;
+      let reconciliationAttempts = 0;
       let cancellationWaitAttemptId: string | null = null;
       let terminateFirst = false;
       const admission = createTurnAdmission(queuedTurns, async () => {
@@ -1108,7 +1109,10 @@ describe("Temporal workflow integration", () => {
           terminateFirst = true;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () => ({ action: "pending" as const }),
+        reconcileSessionAttemptQuiescence: async () => {
+          reconciliationAttempts += 1;
+          return { action: "pending" as const };
+        },
       });
       const run = worker.run();
       try {
@@ -1122,12 +1126,21 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await handle.result();
+        await waitFor(() => reconciliationAttempts >= 1);
+
+        // A later wake must drive another exact reconciliation pass without
+        // admitting the queued replacement or closing the workflow. This
+        // distinguishes persistent receipt convergence from a single RUNNING
+        // snapshot taken just before an erroneous workflow completion.
+        await handle.signal("queueChanged");
+        await waitFor(() => reconciliationAttempts >= 2);
 
         expect(runs).toBe(1);
         expect(controls).toEqual([
           { ...scope, sessionId, attemptId: expect.any(String), workflowId },
         ]);
+        expect((await handle.describe()).status.name).toBe("RUNNING");
+        await handle.terminate("test verified persistent reconciliation");
       } finally {
         terminateFirst = true;
         worker.shutdown();


### PR DESCRIPTION
## Summary

- keep cancellation-wait workflows available for low-frequency exact quiescence reconciliation instead of closing after an already-delivered wake
- recover typed sandbox lifecycle transitions through Agents SDK aggregate/cause wrappers
- preserve fail-closed classification: never infer lifecycle truth from message strings
- add real Temporal/deadlock proofs for persistent fencing and no replacement admission

## Generic problem statement

- a recovery wake can be delivered while the physical activity still owns its heartbeat lease, so a later lease transition may require another exact reconciliation pass
- typed, retryable sandbox lifecycle transitions can be wrapped by parallel function-tool execution and must retain structured recovery semantics

## Verification

- worker unit cluster: 14 pass
- wrapped lifecycle settlement proof: 4 pass
- worker typecheck: pass
- real Temporal persistent reconciliation proof: pass
- formatting and diff checks: pass