### PR TITLE
fix(worker): restore event-driven quiescence closure

### DIFF
--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -583,21 +583,19 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         if (reconciliation.action === "quiesced") continue;
       }
       // Logical settlement is complete, but the exact predecessor activity has
-      // not yet durably proved sandbox/tool quiescence. Prefer its transactional
-      // queueChanged wake. Also retain one low-frequency deterministic timer:
-      // the recovery wake can already be delivered while the physical activity
-      // still owns its heartbeat lease, leaving no future transaction that can
-      // signalWithStart after the lease expires. Keeping this workflow available
-      // guarantees passive receipt convergence without admitting replacement
-      // work or creating a hot control-activity loop.
+      // not yet durably proved sandbox/tool quiescence. Wait only briefly for
+      // its transactional queueChanged wake. If provider/tool cancellation is
+      // genuinely slow, close this workflow run rather than consuming a turn
+      // slot or churning control activities; the outbox uses signalWithStart to
+      // restart this exact workflow after the receipt commits.
       const seenSignalVersion = signalVersion;
-      const woke = await condition(() => signalVersion !== seenSignalVersion, "2 minutes");
+      const woke = await condition(() => signalVersion !== seenSignalVersion, "5s");
       if (woke) continue;
       // Close only against the same signal snapshot. A proof signal accepted
       // at the timer/completion boundary must loop through the DB-only receipt
       // activity rather than disappearing with this workflow run.
       if (signalVersion !== seenSignalVersion || pendingQuiescenceProofs.size > 0) continue;
-      continue;
+      return;
     }
     if (peek.kind === "capacity-wait") {
       await waitForProviderCapacity(peek.ref);

--- a/test/integration/steer-cancellation-deadlock.fixture.test.ts
+++ b/test/integration/steer-cancellation-deadlock.fixture.test.ts
@@ -370,22 +370,23 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         });
         expect(rows.wake?.deliveredRevision).toBeLessThan(rows.wake?.wakeRevision ?? 0);
 
-        // Persistent reconciliation must keep the workflow open past the old
-        // five-second close boundary. The exact activity remains visible in
-        // Temporal and physically heartbeats while the predecessor fence is
-        // closed, so no replacement work can be admitted.
-        const beatsBeforeReconciliationWindow = heartbeats;
-        await Bun.sleep(6_000);
-        const reconcilingDescription = await handle.describe();
-        expect(reconcilingDescription.status.name).toBe("RUNNING");
-        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
+        // Current v2 closes after its bounded cancellation wait without
+        // waiting for the cancellation-ignoring activity to terminalize. The
+        // exact activity must remain visible in Temporal and physically keep
+        // heartbeating while the predecessor fence remains closed.
+        await handle.result();
+        const completedDescription = await handle.describe();
+        expect(completedDescription.status.name).toBe("COMPLETED");
+        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
-        expect(pendingDuringReconciliation?.state).toBe(
+        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
+        expect(pendingAfterWorkflowClose?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
-        expect(heartbeats).toBeGreaterThanOrEqual(beatsBeforeReconciliationWindow + 3);
+
+        const beatsAtWorkflowClose = heartbeats;
+        await waitFor(() => heartbeats >= beatsAtWorkflowClose + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -393,7 +394,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         try {
           await handle.terminate("cancellation-settlement lane fixture final cleanup");
         } catch {
-          // The workflow may have completed naturally after exact-activity cleanup.
+          // The workflow already closed after its bounded cancellation wait.
         }
         worker.shutdown();
         await workerRun;
@@ -403,7 +404,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
   );
 
   test(
-    "missing heartbeats keep persistent reconciliation and the receipt fence live",
+    "a bounded cancellation close leaves the receipt fence closed while the activity remains pending",
     async () => {
       const suffix = crypto.randomUUID();
       const access = await bootstrapWorkspace(dbClient.db, {
@@ -613,26 +614,28 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
         expect(pendingActivityId).toBeTruthy();
 
         // Stop acknowledging the server heartbeat contract without allowing
-        // the local function to settle. Persistent reconciliation must not
-        // infer a physical stop, close the workflow, or admit replacement work.
+        // the local function to settle. The receipt-gated workflow closes its
+        // run after the bounded cancellation wait; it must not infer a
+        // physical stop or admit replacement work from that closure.
         stopHeartbeats = true;
         const beatsAtStop = heartbeats;
-        const ticksAtStop = hungTicks;
-        await Bun.sleep(6_000);
+        await handle.result();
         expect(heartbeats).toBe(beatsAtStop);
-        expect(hungTicks).toBeGreaterThanOrEqual(ticksAtStop + 3);
-        const reconcilingDescription = await handle.describe();
-        expect(reconcilingDescription.status.name).toBe("RUNNING");
-        const pendingDuringReconciliation = reconcilingDescription.raw.pendingActivities?.find(
+        const completedDescription = await handle.describe();
+        expect(completedDescription.status.name).toBe("COMPLETED");
+        const pendingAfterWorkflowClose = completedDescription.raw.pendingActivities?.find(
           (activity) => activity.activityId === pendingActivityId,
         );
-        expect(pendingDuringReconciliation?.activityId).toBe(pendingActivityId);
-        expect(pendingDuringReconciliation?.state).toBe(
+        expect(pendingAfterWorkflowClose?.activityId).toBe(pendingActivityId);
+        expect(pendingAfterWorkflowClose?.state).toBe(
           encodePendingActivityState("CANCEL_REQUESTED"),
         );
 
-        // Missing heartbeats are not themselves a physical quiescence proof.
-        // The disposable loop remains live until exact cleanup releases it.
+        // The bounded workflow close is not a heartbeat timeout or physical
+        // quiescence proof. The disposable loop remains live until exact
+        // cleanup releases its gate.
+        const ticksAtWorkflowClose = hungTicks;
+        await waitFor(() => hungTicks >= ticksAtWorkflowClose + 3);
         expect(replacementDispatches).toBe(0);
         expect(model.calls).toBe(0);
       } finally {
@@ -642,7 +645,7 @@ describe("cancellation-settlement lane Agent Steer cancellation deadlock product
             "cancellation-settlement lane failed-workflow fixture final cleanup",
           );
         } catch {
-          // The workflow may have completed naturally after exact-activity cleanup.
+          // The workflow already closed after its bounded cancellation wait.
         }
         worker.shutdown();
         await workerRun;

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1069,7 +1069,7 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "Temporal activity failure never manufactures quiescence or pins workflow completion",
+    "Temporal activity failure closes boundedly and a later wake retries exact quiescence",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
@@ -1080,6 +1080,7 @@ describe("Temporal workflow integration", () => {
       const queuedTurns = [first];
       const controls: unknown[] = [];
       let runs = 0;
+      let reconciliationAttempts = 0;
       let cancellationWaitAttemptId: string | null = null;
       let terminateFirst = false;
       const admission = createTurnAdmission(queuedTurns, async () => {
@@ -1108,7 +1109,10 @@ describe("Temporal workflow integration", () => {
           terminateFirst = true;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () => ({ action: "pending" as const }),
+        reconcileSessionAttemptQuiescence: async () => {
+          reconciliationAttempts += 1;
+          return { action: "pending" as const };
+        },
       });
       const run = worker.run();
       try {
@@ -1123,8 +1127,29 @@ describe("Temporal workflow integration", () => {
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
         await handle.result();
+        const attemptsAfterFirstClose = reconciliationAttempts;
+        expect(attemptsAfterFirstClose).toBeGreaterThanOrEqual(1);
+
+        // Model the still-undelivered wake-outbox revision after the bounded
+        // close. signalWithStart must create a fresh run under the same durable
+        // workflow identity and retry exact receipt reconciliation without
+        // manufacturing quiescence or admitting the fenced replacement.
+        const restarted = await client.workflow.signalWithStart("sessionWorkflow", {
+          taskQueue,
+          workflowId,
+          workflowIdReusePolicy: "ALLOW_DUPLICATE",
+          args: [{ ...scope, sessionId }],
+          signal: "queueChanged",
+          signalArgs: [],
+        });
+        await waitFor(() => reconciliationAttempts > attemptsAfterFirstClose, {
+          timeoutMs: temporalWorkflowTestTimeoutMs,
+          describe: () => "outbox restart did not retry exact quiescence reconciliation",
+        });
+        await restarted.result();
 
         expect(runs).toBe(1);
+        expect(restarted.firstExecutionRunId).not.toBe(handle.firstExecutionRunId);
         expect(controls).toEqual([
           { ...scope, sessionId, attemptId: expect.any(String), workflowId },
         ]);

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1069,7 +1069,7 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "Temporal activity failure never manufactures quiescence and keeps reconciliation live",
+    "Temporal activity failure never manufactures quiescence or pins workflow completion",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
@@ -1080,7 +1080,6 @@ describe("Temporal workflow integration", () => {
       const queuedTurns = [first];
       const controls: unknown[] = [];
       let runs = 0;
-      let reconciliationAttempts = 0;
       let cancellationWaitAttemptId: string | null = null;
       let terminateFirst = false;
       const admission = createTurnAdmission(queuedTurns, async () => {
@@ -1109,10 +1108,7 @@ describe("Temporal workflow integration", () => {
           terminateFirst = true;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () => {
-          reconciliationAttempts += 1;
-          return { action: "pending" as const };
-        },
+        reconcileSessionAttemptQuiescence: async () => ({ action: "pending" as const }),
       });
       const run = worker.run();
       try {
@@ -1126,21 +1122,12 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await waitFor(() => reconciliationAttempts >= 1);
-
-        // A later wake must drive another exact reconciliation pass without
-        // admitting the queued replacement or closing the workflow. This
-        // distinguishes persistent receipt convergence from a single RUNNING
-        // snapshot taken just before an erroneous workflow completion.
-        await handle.signal("queueChanged");
-        await waitFor(() => reconciliationAttempts >= 2);
+        await handle.result();
 
         expect(runs).toBe(1);
         expect(controls).toEqual([
           { ...scope, sessionId, attemptId: expect.any(String), workflowId },
         ]);
-        expect((await handle.describe()).status.name).toBe("RUNNING");
-        await handle.terminate("test verified persistent reconciliation");
       } finally {
         terminateFirst = true;
         worker.shutdown();


### PR DESCRIPTION
## Summary

- restore the bounded five-second workflow close while an exact predecessor still lacks durable quiescence proof
- rely on the durable wake outbox and `signalWithStart` to restart the exact workflow after the proof commits
- restore state-based Temporal fixture assertions and remove fixed-duration reconciliation sleeps
- preserve wrapped sandbox lifecycle-transition recovery unchanged

## Testing

- `bun test ./apps/worker/test/session-state-cancel.test.ts ./apps/worker/test/turn-quiescence-watchdog.test.ts ./apps/worker/test/home-sandbox-turn-transition.test.ts --timeout 120000`
- `bun run --filter @opengeni/worker-bundle typecheck`
- `bunx oxfmt --check apps/worker/src/workflows/session.ts test/integration/temporal-workflow.integration.ts test/integration/steer-cancellation-deadlock.fixture.test.ts`
- `git diff --check`

Service-backed Temporal and PostgreSQL suites are delegated to the public CI runners.

## Summary by Sourcery

Restore event-driven quiescence closure by bounding workflow waits and relying on durable wake signals to resume exact reconciliation.

Bug Fixes:
- Restore bounded five-second workflow closure when exact predecessor quiescence is not durably proven, allowing durable wake processing to restart the workflow for a later reconciliation attempt.

Enhancements:
- Update Temporal integration and cancellation-settlement fixtures to assert completed workflow state while preserving receipt fences and preventing replacement work until exact quiescence is proven.

Tests:
- Replace fixed-duration reconciliation sleeps with state-based workflow and activity assertions, including validation of restarted workflow runs after durable wake delivery.