### PR TITLE
fix(web): make session attention monotonic

### DIFF
--- a/.changeset/smooth-session-attention.md
+++ b/.changeset/smooth-session-attention.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/sdk": patch
+---
+
+Make session attention monotonic across rapid navigation and nested trees. Failed sessions now remain red only until the viewer or their parent agent acknowledges the latest event, while historical failure lifecycle state remains intact.

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -125,9 +125,10 @@ import {
   subscribeToSessionPinChanges,
 } from "@/lib/session-pins";
 import {
-  applySessionAttentionProjection,
+  applySessionAttentionProjections,
   localSessionDeliveryAttentionCounts,
   latestSessionAttentionProjection,
+  notifySessionAttentionChanged,
   subscribeToLocalSessionDeliveryAttention,
   subscribeToSessionAttentionChanges,
   type SessionAttentionProjection,
@@ -259,6 +260,28 @@ export function SessionList() {
   const sessionClient = context.client;
   const setContextSession = context.setSession;
   const navigate = useNavigate();
+  const activeSessionId = useRouterState({
+    select: (state): string | null => {
+      const match = /\/sessions\/([^/]+)/.exec(state.location.pathname);
+      return match?.[1] ?? null;
+    },
+  });
+  const [documentForeground, setDocumentForeground] = useState(() =>
+    Boolean(document.visibilityState === "visible" && document.hasFocus()),
+  );
+  useEffect(() => {
+    const reconcileDocumentForeground = () => {
+      setDocumentForeground(document.visibilityState === "visible" && document.hasFocus());
+    };
+    window.addEventListener("focus", reconcileDocumentForeground);
+    window.addEventListener("blur", reconcileDocumentForeground);
+    document.addEventListener("visibilitychange", reconcileDocumentForeground);
+    return () => {
+      window.removeEventListener("focus", reconcileDocumentForeground);
+      window.removeEventListener("blur", reconcileDocumentForeground);
+      document.removeEventListener("visibilitychange", reconcileDocumentForeground);
+    };
+  }, []);
   // Poll so running sessions surface and move to the top without a manual
   // refresh; the previous index relied on a one-shot load.
   const [searchDraft, setSearchDraft] = useState("");
@@ -715,16 +738,35 @@ export function SessionList() {
           : override.session,
       );
     }
-    for (const [id, override] of attentionOverrides) {
-      const current = source.get(id);
-      if (current) source.set(id, applySessionAttentionProjection(current, override));
-    }
     for (const [id, override] of channelMoveOverrides) {
       const current = source.get(id);
       if (current) source.set(id, applySessionChannelMove(current, override));
     }
-    return [...source.values()];
-  }, [attentionOverrides, channelMoveOverrides, pinOverrides, serverSessions]);
+    const projectedAttention = new Map(attentionOverrides);
+    const active = activeSessionId ? source.get(activeSessionId) : null;
+    if (documentForeground && active?.unread && active.workspaceId === rail.workspaceId) {
+      const foregroundProjection: SessionAttentionProjection = {
+        id: active.id,
+        workspaceId: active.workspaceId,
+        unread: false,
+        attentionVersion: active.attentionVersion,
+        lastSequence: active.lastSequence,
+      };
+      projectedAttention.set(
+        active.id,
+        latestSessionAttentionProjection(projectedAttention.get(active.id), foregroundProjection),
+      );
+    }
+    return applySessionAttentionProjections([...source.values()], projectedAttention);
+  }, [
+    activeSessionId,
+    attentionOverrides,
+    channelMoveOverrides,
+    documentForeground,
+    pinOverrides,
+    rail.workspaceId,
+    serverSessions,
+  ]);
 
   const verifySessionChannelMove = useCallback(
     (sessionId: string, operation: number): Promise<void> => {
@@ -1035,12 +1077,6 @@ export function SessionList() {
     setContextSession,
   ]);
 
-  const activeSessionId = useRouterState({
-    select: (state): string | null => {
-      const match = /\/sessions\/([^/]+)/.exec(state.location.pathname);
-      return match?.[1] ?? null;
-    },
-  });
   // Only a route transition or keyboard navigation may reveal a row. Polls and
   // pagination replace `flat` too, so a derived focus index is not itself
   // permission to move this scroll container.
@@ -2822,6 +2858,7 @@ function SessionRow(props: {
   onRequestDelete: RequestDeleteFn;
 }) {
   const rail = useRail();
+  const context = useAppContext();
   const title = sessionDisplayTitle(props.session);
   const rename = useInlineRename(props.session, props.onRename);
   const contextPinSelection = useRef(false);
@@ -2937,6 +2974,58 @@ function SessionRow(props: {
             onFocus={props.onFocus}
             onClick={(event) => {
               if (isModifiedNavigationClick(event)) return;
+              if (
+                props.session.unread &&
+                !props.session.archived &&
+                document.visibilityState === "visible" &&
+                document.hasFocus()
+              ) {
+                const projection: SessionAttentionProjection = {
+                  id: props.session.id,
+                  workspaceId: props.session.workspaceId,
+                  unread: false,
+                  attentionVersion: props.session.attentionVersion,
+                  lastSequence: props.session.lastSequence,
+                };
+                // A rail click is already a foreground view. Commit its exact
+                // known frontier before route data loads so a fast second
+                // navigation cannot cancel the read.
+                notifySessionAttentionChanged(projection);
+                const acceptedTransition = context.captureWorkspaceInvocation(
+                  props.session.workspaceId,
+                );
+                if (acceptedTransition) {
+                  const acknowledge = (retry: boolean): void => {
+                    void context.client
+                      .updateSessionAttention(props.session.workspaceId, props.session.id, {
+                        unread: false,
+                        acknowledgedThroughSequence: props.session.lastSequence,
+                      })
+                      .then((updated) => {
+                        if (
+                          context.ownsWorkspaceInvocation(
+                            props.session.workspaceId,
+                            acceptedTransition,
+                          )
+                        ) {
+                          notifySessionAttentionChanged(updated);
+                        }
+                      })
+                      .catch(() => {
+                        if (
+                          retry &&
+                          context.ownsWorkspaceInvocation(
+                            props.session.workspaceId,
+                            acceptedTransition,
+                          )
+                        ) {
+                          acknowledge(false);
+                        }
+                      });
+                  };
+                  acknowledge(true);
+                }
+              }
               if (!rail.isMobile) {
                 requestSessionComposerFocus(rail.workspaceId, props.session.id);
               }

--- a/apps/web/src/lib/session-attention.test.ts
+++ b/apps/web/src/lib/session-attention.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, test } from "bun:test";
 import type { Session } from "@/types";
 import {
   applySessionAttentionProjection,
+  applySessionAttentionProjections,
   localSessionDeliveryAttentionCounts,
   latestSessionAttentionProjection,
   notifySessionAttentionChanged,
-  restoreUnreadSessionAttentionProjection,
   sessionReadProjectionKey,
   shouldAcknowledgeActiveSession,
   shouldProjectActiveSessionRead,
@@ -49,6 +49,77 @@ describe("session attention reconciliation", () => {
 
     expect(latestSessionAttentionProjection(newest, delayed)).toBe(newest);
     expect(latestSessionAttentionProjection(delayed, newest)).toBe(newest);
+  });
+
+  test("does not let an equal-coordinate unread projection resurrect a viewed chat", () => {
+    const read = { ...session, unread: false } as Session;
+    const staleUnread = { ...session, unread: true };
+
+    expect(applySessionAttentionProjection(read, staleUnread)).toBe(read);
+    expect(latestSessionAttentionProjection(read, staleUnread)).toBe(read);
+    expect(
+      applySessionAttentionProjection(read, {
+        ...staleUnread,
+        attentionVersion: (session.attentionVersion ?? 0) + 1,
+      }).unread,
+    ).toBe(true);
+  });
+
+  test("projects a viewed failed child through every loaded ancestor", () => {
+    const root = {
+      ...session,
+      id: "root",
+      unread: false,
+      treeStats: {
+        directChildren: 1,
+        totalDescendants: 2,
+        runningDescendants: 0,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 1,
+        unreadFailedDescendants: 1,
+        unreadDescendants: 2,
+        activelyWorkingDescendants: 0,
+        truncated: false,
+      },
+    } as Session;
+    const parent = {
+      ...root,
+      id: "parent",
+      parentSessionId: root.id,
+      unread: true,
+      treeStats: {
+        ...root.treeStats!,
+        directChildren: 1,
+        totalDescendants: 1,
+        unreadDescendants: 1,
+      },
+    } as Session;
+    const child = {
+      ...session,
+      id: "child",
+      parentSessionId: parent.id,
+      status: "failed",
+    } as Session;
+
+    const projected = applySessionAttentionProjections(
+      [root, parent, child],
+      new Map([
+        [child.id, { ...child, unread: false }],
+        [parent.id, { ...parent, unread: false }],
+      ]),
+    );
+
+    expect(projected.find((candidate) => candidate.id === child.id)?.unread).toBe(false);
+    expect(projected.find((candidate) => candidate.id === parent.id)?.unread).toBe(false);
+    for (const ancestorId of [root.id, parent.id]) {
+      expect(projected.find((candidate) => candidate.id === ancestorId)?.treeStats).toMatchObject({
+        failedDescendants: 1,
+        unreadFailedDescendants: 0,
+        unreadDescendants: 0,
+      });
+    }
   });
 
   test("notifies and unsubscribes same-tab listeners", () => {
@@ -100,17 +171,7 @@ describe("active session read acknowledgement", () => {
     expect(sessionReadProjectionKey(session.id, 21)).not.toBe(acknowledged);
   });
 
-  test("restores the exact unread frontier when acknowledgement cannot start", () => {
-    expect(restoreUnreadSessionAttentionProjection(session, 23)).toEqual({
-      id: session.id,
-      workspaceId: session.workspaceId,
-      unread: true,
-      attentionVersion: session.attentionVersion,
-      lastSequence: 23,
-    });
-  });
-
-  test("acknowledges the exact unread chat only at the foreground live tip", () => {
+  test("acknowledges the exact unread chat as soon as it is foregrounded", () => {
     expect(
       shouldAcknowledgeActiveSession({
         activeSessionId: session.id,
@@ -118,12 +179,11 @@ describe("active session read acknowledgement", () => {
         session,
         documentVisible: true,
         windowFocused: true,
-        liveTipLoaded: true,
       }),
     ).toBe(true);
   });
 
-  test("clears the foreground route optimistically before its live tip finishes loading", () => {
+  test("clears and acknowledges the foreground route before its live tip finishes loading", () => {
     expect(
       shouldProjectActiveSessionRead({
         activeSessionId: session.id,
@@ -140,16 +200,14 @@ describe("active session read acknowledgement", () => {
         session,
         documentVisible: true,
         windowFocused: true,
-        liveTipLoaded: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  test("does not consume unread state in the background or from a historical window", () => {
+  test("does not consume unread state in the background", () => {
     for (const candidate of [
-      { documentVisible: false, windowFocused: true, liveTipLoaded: true },
-      { documentVisible: true, windowFocused: false, liveTipLoaded: true },
-      { documentVisible: true, windowFocused: true, liveTipLoaded: false },
+      { documentVisible: false, windowFocused: true },
+      { documentVisible: true, windowFocused: false },
     ]) {
       expect(
         shouldAcknowledgeActiveSession({
@@ -184,7 +242,6 @@ describe("active session read acknowledgement", () => {
           ...candidate,
           documentVisible: true,
           windowFocused: true,
-          liveTipLoaded: true,
         }),
       ).toBe(false);
     }

--- a/apps/web/src/lib/session-attention.ts
+++ b/apps/web/src/lib/session-attention.ts
@@ -62,31 +62,22 @@ export function subscribeToLocalSessionDeliveryAttention(onChange: () => void): 
 }
 
 function isOlder(
-  current: Pick<SessionAttentionProjection, "attentionVersion" | "lastSequence">,
+  current: Pick<SessionAttentionProjection, "unread" | "attentionVersion" | "lastSequence">,
   projected: SessionAttentionProjection,
 ): boolean {
   return (
     projected.attentionVersion! < current.attentionVersion! ||
-    projected.lastSequence < current.lastSequence
+    projected.lastSequence < current.lastSequence ||
+    (projected.attentionVersion === current.attentionVersion &&
+      projected.lastSequence === current.lastSequence &&
+      !current.unread &&
+      Boolean(projected.unread))
   );
 }
 
 /** One foreground-view receipt per exact session event frontier. */
 export function sessionReadProjectionKey(sessionId: string, latestEventSequence: number): string {
   return `${sessionId}:${latestEventSequence}`;
-}
-
-export function restoreUnreadSessionAttentionProjection(
-  session: Pick<Session, "id" | "workspaceId" | "attentionVersion">,
-  lastSequence: number,
-): SessionAttentionProjection {
-  return {
-    id: session.id,
-    workspaceId: session.workspaceId,
-    unread: true,
-    attentionVersion: session.attentionVersion,
-    lastSequence,
-  };
 }
 
 type ActiveSessionReadEligibility = {
@@ -98,9 +89,9 @@ type ActiveSessionReadEligibility = {
 };
 
 /**
- * An unread chat can clear optimistically as soon as its exact route is the
- * foreground destination. Durable acknowledgement still waits for the live
- * timeline tip, but loading that timeline must not keep the rail stale.
+ * An unread chat clears as soon as its exact route is the foreground
+ * destination. The durable writer receives the exact known frontier and can
+ * advance again when later events render.
  */
 export function shouldProjectActiveSessionRead(input: ActiveSessionReadEligibility): boolean {
   const { session } = input;
@@ -120,10 +111,8 @@ export function shouldProjectActiveSessionRead(input: ActiveSessionReadEligibili
  * Merely leaving a session route mounted in a background tab/window must not
  * consume its unread signal.
  */
-export function shouldAcknowledgeActiveSession(
-  input: ActiveSessionReadEligibility & { liveTipLoaded: boolean },
-): boolean {
-  return input.liveTipLoaded && shouldProjectActiveSessionRead(input);
+export function shouldAcknowledgeActiveSession(input: ActiveSessionReadEligibility): boolean {
+  return shouldProjectActiveSessionRead(input);
 }
 
 /**
@@ -131,8 +120,11 @@ export function shouldAcknowledgeActiveSession(
  * resurrect a read marker. Attention revisions order explicit mutations,
  * while lastSequence orders new durable activity; either older coordinate is
  * stale. Equal coordinates let the latest mutation response replace the page
- * projection immediately. The rail calls this only after an id-keyed lookup,
- * so both arguments represent the same session.
+ * projection immediately. At an equal coordinate, read wins over unread: a
+ * cleanup or stale render cannot resurrect a dot after the user viewed it.
+ * Explicit mark-unread actions still win because they increment
+ * `attentionVersion`. The rail calls this only after an id-keyed lookup, so
+ * both arguments represent the same session.
  */
 export function applySessionAttentionProjection(
   current: Session,
@@ -154,6 +146,61 @@ export function latestSessionAttentionProjection(
   projected: SessionAttentionProjection,
 ): SessionAttentionProjection {
   return current && isOlder(current, projected) ? current : projected;
+}
+
+/**
+ * Apply personal attention projections to rows and their loaded ancestor
+ * aggregates in one pass. Server `treeStats` count every descendant, so a
+ * foreground child read must adjust each loaded ancestor immediately instead
+ * of leaving a stale blue or red parent marker until the next list poll.
+ */
+export function applySessionAttentionProjections(
+  sessions: readonly Session[],
+  projections: ReadonlyMap<string, SessionAttentionProjection>,
+): Session[] {
+  const sourceById = new Map(sessions.map((session) => [session.id, session]));
+  const projectedById = new Map(sourceById);
+
+  for (const [sessionId, projection] of projections) {
+    const source = sourceById.get(sessionId);
+    if (!source) continue;
+    // A descendant projection may already have adjusted this session's
+    // treeStats. Apply its own attention state to that accumulated row so map
+    // iteration order cannot wipe an earlier descendant delta.
+    const projected = applySessionAttentionProjection(projectedById.get(sessionId)!, projection);
+    projectedById.set(sessionId, projected);
+
+    const unreadDelta = Number(projected.unread) - Number(source.unread);
+    if (unreadDelta === 0) continue;
+    const failedDelta = source.status === "failed" ? unreadDelta : 0;
+    const visited = new Set<string>([sessionId]);
+    let parentSessionId = source.parentSessionId;
+    while (parentSessionId && !visited.has(parentSessionId)) {
+      visited.add(parentSessionId);
+      const ancestorSource = sourceById.get(parentSessionId);
+      const ancestor = projectedById.get(parentSessionId);
+      if (!ancestorSource || !ancestor) break;
+      const stats = ancestor.treeStats;
+      if (stats) {
+        const unreadDescendants = Math.max(0, (stats.unreadDescendants ?? 0) + unreadDelta);
+        const unreadFailedDescendants = Math.max(
+          0,
+          (stats.unreadFailedDescendants ?? stats.failedDescendants) + failedDelta,
+        );
+        projectedById.set(parentSessionId, {
+          ...ancestor,
+          treeStats: {
+            ...stats,
+            unreadDescendants,
+            unreadFailedDescendants,
+          },
+        });
+      }
+      parentSessionId = ancestorSource.parentSessionId;
+    }
+  }
+
+  return sessions.map((session) => projectedById.get(session.id) ?? session);
 }
 
 export function notifySessionAttentionChanged(projection: SessionAttentionProjection): void {

--- a/apps/web/src/lib/session-branch-cache.ts
+++ b/apps/web/src/lib/session-branch-cache.ts
@@ -39,6 +39,7 @@ export function sessionBranchSummaryKey(session: Session): string {
     stats.attentionDescendants,
     stats.pausedDescendants,
     stats.failedDescendants,
+    stats.unreadFailedDescendants ?? stats.failedDescendants,
     stats.unreadDescendants ?? 0,
     stats.activelyWorkingDescendants ?? 0,
     stats.attentionSince ?? "",

--- a/apps/web/src/lib/session-pins.test.ts
+++ b/apps/web/src/lib/session-pins.test.ts
@@ -980,6 +980,33 @@ describe("session pin reconciliation", () => {
     expect(applySessionRailProjection(current, refreshed)).toBe(current);
   });
 
+  test("adopts personal descendant attention changes from a fresh list summary", () => {
+    const treeStats = {
+      directChildren: 1,
+      totalDescendants: 1,
+      runningDescendants: 0,
+      queuedDescendants: 0,
+      attentionDescendants: 0,
+      pausedDescendants: 0,
+      failedDescendants: 1,
+      unreadFailedDescendants: 1,
+      unreadDescendants: 1,
+      activelyWorkingDescendants: 0,
+      truncated: false,
+    };
+    const current = { ...session, treeStats } as Session;
+    const refreshed = {
+      ...current,
+      treeStats: { ...treeStats, unreadFailedDescendants: 0, unreadDescendants: 0 },
+    } as Session;
+
+    expect(applySessionRailProjection(current, refreshed).treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 0,
+      unreadDescendants: 0,
+    });
+  });
+
   test("keeps a newer context pin while adopting detail content", () => {
     const current = {
       ...session,

--- a/apps/web/src/lib/session-pins.ts
+++ b/apps/web/src/lib/session-pins.ts
@@ -510,6 +510,10 @@ function sameTreeStats(a: SessionTreeStats | undefined, b: SessionTreeStats | un
     a.attentionDescendants === b.attentionDescendants &&
     a.pausedDescendants === b.pausedDescendants &&
     a.failedDescendants === b.failedDescendants &&
+    (a.unreadFailedDescendants ?? a.failedDescendants) ===
+      (b.unreadFailedDescendants ?? b.failedDescendants) &&
+    (a.unreadDescendants ?? 0) === (b.unreadDescendants ?? 0) &&
+    (a.activelyWorkingDescendants ?? 0) === (b.activelyWorkingDescendants ?? 0) &&
     (a.attentionSince ?? null) === (b.attentionSince ?? null) &&
     a.truncated === b.truncated
   );

--- a/apps/web/src/lib/sessions-group-channels.test.ts
+++ b/apps/web/src/lib/sessions-group-channels.test.ts
@@ -247,6 +247,55 @@ describe("summarizeRailNodes", () => {
     });
   });
 
+  test("shows a failed task in red only until that viewer has acknowledged it", () => {
+    const unreadFailure = buildRailForest([
+      session({ id: "failed-unread", status: "failed", unread: true }),
+    ]);
+    expect(summarizeRailNodes(unreadFailure.grouped[0]!.sessions)).toEqual({
+      kind: "failed",
+      count: 1,
+      total: 1,
+      label: "1 failed",
+    });
+
+    const reviewedFailure = buildRailForest([
+      session({ id: "failed-reviewed", status: "failed", unread: false }),
+    ]);
+    expect(summarizeRailNodes(reviewedFailure.grouped[0]!.sessions)).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 1,
+      label: "Read",
+    });
+  });
+
+  test("does not keep a parent red for an acknowledged failed descendant", () => {
+    const forest = buildRailForest([
+      session({
+        id: "root-with-reviewed-failure",
+        treeStats: {
+          directChildren: 1,
+          totalDescendants: 1,
+          runningDescendants: 0,
+          queuedDescendants: 0,
+          attentionDescendants: 0,
+          pausedDescendants: 0,
+          failedDescendants: 1,
+          unreadFailedDescendants: 0,
+          unreadDescendants: 0,
+          activelyWorkingDescendants: 0,
+          truncated: false,
+        },
+      }),
+    ]);
+    expect(summarizeRailNodes(forest.grouped[0]!.sessions)).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 2,
+      label: "Read",
+    });
+  });
+
   test("solid unread wins over the actively-working follow-up label", () => {
     const forest = buildRailForest([
       session({ id: "one", unread: true, activelyWorking: true }),

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -219,7 +219,10 @@ function ownRailStatusCounts(
     attention: session.status === "requires_action" ? 1 : 0,
     attentionSince:
       session.status === "requires_action" ? (session.requiresActionSince ?? null) : null,
-    failed: session.status === "failed" ? 1 : 0,
+    // Failed is a review signal in the rail, not a permanent copy of the
+    // lifecycle badge. Opening the session (or a parent agent consuming its
+    // result) acknowledges the failure together with the unread frontier.
+    failed: session.status === "failed" && session.unread ? 1 : 0,
     active:
       session.backgroundCommandActivity ||
       (hasActiveEffectiveControl(session) &&
@@ -255,7 +258,7 @@ function railStatusCounts(
     counts.total += stats.totalDescendants;
     counts.attention += stats.attentionDescendants;
     counts.attentionSince = earliestIso(counts.attentionSince, stats.attentionSince);
-    counts.failed += stats.failedDescendants;
+    counts.failed += stats.unreadFailedDescendants ?? stats.failedDescendants;
     counts.active += stats.runningDescendants + stats.queuedDescendants;
     counts.unread += stats.unreadDescendants ?? 0;
     counts.activeWork += stats.activelyWorkingDescendants ?? 0;
@@ -759,10 +762,23 @@ type RemovedCounts = {
   attention: number;
   paused: number;
   failed: number;
+  unreadFailed: number;
+  unread: number;
+  activeWork: number;
 };
 
 function emptyRemovedCounts(): RemovedCounts {
-  return { total: 0, running: 0, queued: 0, attention: 0, paused: 0, failed: 0 };
+  return {
+    total: 0,
+    running: 0,
+    queued: 0,
+    attention: 0,
+    paused: 0,
+    failed: 0,
+    unreadFailed: 0,
+    unread: 0,
+    activeWork: 0,
+  };
 }
 
 function addRemovedCounts(target: RemovedCounts, source: RemovedCounts): void {
@@ -772,6 +788,9 @@ function addRemovedCounts(target: RemovedCounts, source: RemovedCounts): void {
   target.attention += source.attention;
   target.paused += source.paused;
   target.failed += source.failed;
+  target.unreadFailed += source.unreadFailed;
+  target.unread += source.unread;
+  target.activeWork += source.activeWork;
 }
 
 function subtreeCounts(node: SessionTreeNode): RemovedCounts {
@@ -784,6 +803,9 @@ function subtreeCounts(node: SessionTreeNode): RemovedCounts {
     attention: status === "requires_action" ? 1 : 0,
     paused: node.session.effectiveControl?.state === "paused" ? 1 : 0,
     failed: status === "failed" ? 1 : 0,
+    unreadFailed: status === "failed" && node.session.unread ? 1 : 0,
+    unread: node.session.unread ? 1 : 0,
+    activeWork: node.session.activelyWorking ? 1 : 0,
   };
   const stats = node.session.treeStats;
   if (stats) {
@@ -793,6 +815,9 @@ function subtreeCounts(node: SessionTreeNode): RemovedCounts {
     counts.attention += stats.attentionDescendants;
     counts.paused += stats.pausedDescendants;
     counts.failed += stats.failedDescendants;
+    counts.unreadFailed += stats.unreadFailedDescendants ?? stats.failedDescendants;
+    counts.unread += stats.unreadDescendants ?? 0;
+    counts.activeWork += stats.activelyWorkingDescendants ?? 0;
   } else {
     for (const child of node.children) addRemovedCounts(counts, subtreeCounts(child));
   }
@@ -829,6 +854,25 @@ function prunePinnedSubtreesWithCounts(
           attentionDescendants: Math.max(0, stats.attentionDescendants - removed.attention),
           pausedDescendants: Math.max(0, stats.pausedDescendants - removed.paused),
           failedDescendants: Math.max(0, stats.failedDescendants - removed.failed),
+          ...(stats.unreadFailedDescendants !== undefined
+            ? {
+                unreadFailedDescendants: Math.max(
+                  0,
+                  stats.unreadFailedDescendants - removed.unreadFailed,
+                ),
+              }
+            : {}),
+          ...(stats.unreadDescendants !== undefined
+            ? { unreadDescendants: Math.max(0, stats.unreadDescendants - removed.unread) }
+            : {}),
+          ...(stats.activelyWorkingDescendants !== undefined
+            ? {
+                activelyWorkingDescendants: Math.max(
+                  0,
+                  stats.activelyWorkingDescendants - removed.activeWork,
+                ),
+              }
+            : {}),
           // The pruned subtree may have held the oldest waiter; keep the server
           // timestamp only while some counted attention descendant remains.
           ...(stats.attentionSince !== undefined

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -38,6 +38,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -113,7 +114,6 @@ import {
   updateLocalSessionDeliveryAttention,
   notifySessionAttentionChanged,
   sessionReadProjectionKey,
-  restoreUnreadSessionAttentionProjection,
   shouldAcknowledgeActiveSession,
   shouldProjectActiveSessionRead,
 } from "@/lib/session-attention";
@@ -206,7 +206,6 @@ export function SessionRoute({
     loadNewer,
     loadingOldest,
     loadOldest,
-    loadingLatest,
     lastSequence: renderedThroughSequence,
     jumpToLatest,
     error: streamError,
@@ -333,7 +332,6 @@ export function SessionRoute({
   } = context;
   const acknowledgedProjectionRef = useRef<string | null>(null);
   const confirmedProjectionRef = useRef<string | null>(null);
-  const failedProjectionRef = useRef<string | null>(null);
   const retriedProjectionRef = useRef<string | null>(null);
   const [foreground, setForeground] = useState(() => ({
     documentVisible: document.visibilityState === "visible",
@@ -424,11 +422,10 @@ export function SessionRoute({
         : null,
     [readThroughSequence, session],
   );
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!session || !activeReadProjectionKey) return;
     if (
       confirmedProjectionRef.current === activeReadProjectionKey ||
-      failedProjectionRef.current === activeReadProjectionKey ||
       !shouldProjectActiveSessionRead({
         activeSessionId: sessionId,
         workspaceId,
@@ -447,15 +444,6 @@ export function SessionRoute({
       lastSequence: readThroughSequence,
     };
     projectSessionAttention(optimisticProjection);
-    return () => {
-      if (
-        confirmedProjectionRef.current === activeReadProjectionKey ||
-        failedProjectionRef.current === activeReadProjectionKey
-      ) {
-        return;
-      }
-      projectSessionAttention({ ...optimisticProjection, unread: true });
-    };
   }, [
     activeReadProjectionKey,
     foreground,
@@ -468,8 +456,6 @@ export function SessionRoute({
   ]);
   useEffect(() => {
     const projectionKey = activeReadProjectionKey;
-    const liveTipLoaded =
-      !initialLoading && !hasNewer && !loadingNewer && !loadingOldest && !loadingLatest;
     if (
       !session ||
       !projectionKey ||
@@ -478,67 +464,53 @@ export function SessionRoute({
         activeSessionId: sessionId,
         workspaceId,
         session: routeUnreadProjection,
-        liveTipLoaded,
         ...foreground,
       })
     ) {
       return;
     }
-    const targetSession = session;
     let active = true;
-    const timer = window.setTimeout(() => {
-      if (document.visibilityState !== "visible" || !document.hasFocus()) return;
-      const acceptedTransition = captureWorkspaceInvocation(workspaceId);
-      if (!acceptedTransition) {
-        failedProjectionRef.current = projectionKey;
-        projectSessionAttention(
-          restoreUnreadSessionAttentionProjection(targetSession, readThroughSequence),
-        );
-        return;
-      }
-      acknowledgedProjectionRef.current = projectionKey;
-      void client
-        .updateSessionAttention(workspaceId, targetSession.id, {
-          unread: false,
-          acknowledgedThroughSequence: readThroughSequence,
-        })
-        .then((updated) => {
-          if (!ownsWorkspaceInvocation(workspaceId, acceptedTransition)) return;
-          confirmedProjectionRef.current = projectionKey;
-          if (failedProjectionRef.current === projectionKey) {
-            failedProjectionRef.current = null;
-          }
-          // The rail owns separately polled page objects. Keep this exact
-          // frontier result there so a stale list poll cannot resurrect or
-          // prematurely clear the unread dot.
-          projectSessionAttention(updated);
-        })
-        .catch(() => {
-          // Retry one transient failure for this exact frontier. Keeping the
-          // receipt after the second failure prevents a permanent 4xx/5xx from
-          // becoming an unbounded request and log loop.
-          if (
-            active &&
-            ownsWorkspaceInvocation(workspaceId, acceptedTransition) &&
-            acknowledgedProjectionRef.current === projectionKey &&
-            retriedProjectionRef.current !== projectionKey
-          ) {
-            retriedProjectionRef.current = projectionKey;
-            acknowledgedProjectionRef.current = null;
-            setAttentionRetryRevision((revision) => revision + 1);
-            return;
-          }
-          if (active && ownsWorkspaceInvocation(workspaceId, acceptedTransition)) {
-            failedProjectionRef.current = projectionKey;
-            projectSessionAttention(
-              restoreUnreadSessionAttentionProjection(targetSession, readThroughSequence),
-            );
-          }
-        });
-    }, 750);
+    const acceptedTransition = captureWorkspaceInvocation(workspaceId);
+    if (!acceptedTransition) return;
+    acknowledgedProjectionRef.current = projectionKey;
+    void client
+      .updateSessionAttention(workspaceId, session.id, {
+        unread: false,
+        acknowledgedThroughSequence: readThroughSequence,
+      })
+      .then((updated) => {
+        if (!ownsWorkspaceInvocation(workspaceId, acceptedTransition)) return;
+        confirmedProjectionRef.current = projectionKey;
+        // The rail owns separately polled page objects. Keep this exact
+        // frontier result there so a stale list poll cannot resurrect or
+        // prematurely clear the unread dot.
+        projectSessionAttention(updated);
+      })
+      .catch(() => {
+        // Retry one transient failure for this exact frontier. Keeping the
+        // receipt after the second failure prevents a permanent 4xx/5xx from
+        // becoming an unbounded request and log loop.
+        if (
+          active &&
+          ownsWorkspaceInvocation(workspaceId, acceptedTransition) &&
+          acknowledgedProjectionRef.current === projectionKey &&
+          retriedProjectionRef.current !== projectionKey
+        ) {
+          retriedProjectionRef.current = projectionKey;
+          acknowledgedProjectionRef.current = null;
+          setAttentionRetryRevision((revision) => revision + 1);
+          return;
+        }
+        // A transient failure must never resurrect a dot the user already
+        // cleared. Release the attempt receipt so a later focus/navigation
+        // can retry this exact frontier; a reload still reads durable truth
+        // if both attempts failed.
+        if (acknowledgedProjectionRef.current === projectionKey) {
+          acknowledgedProjectionRef.current = null;
+        }
+      });
     return () => {
       active = false;
-      window.clearTimeout(timer);
     };
   }, [
     attentionRetryRevision,
@@ -546,11 +518,6 @@ export function SessionRoute({
     captureWorkspaceInvocation,
     client,
     foreground,
-    hasNewer,
-    initialLoading,
-    loadingLatest,
-    loadingNewer,
-    loadingOldest,
     ownsWorkspaceInvocation,
     projectSessionAttention,
     readThroughSequence,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,8 @@ sequence authority. Semantic writers retain the session row because state and
 event truth commit together. Accepted raw exact-attempt batches hold only the
 session identity with `FOR KEY SHARE`, serialize on the compact cursor, retain
 the exact turn/attempt fence, and do not update the wide session row. Public
-`lastSequence`, unread, child acknowledgment, and tree projections read the
+`lastSequence`, unread, child acknowledgment, and viewer-specific tree
+attention projections (including unacknowledged failed descendants) read the
 cursor; `sessions.last_sequence` remains only a semantic/legacy compatibility
 projection. Legacy SQL writers are rebased at the database boundary, and late
 raw events roll back and retry through the semantic gate before becoming

--- a/docs/durable-agent-inputs.md
+++ b/docs/durable-agent-inputs.md
@@ -146,11 +146,15 @@ writes nothing.
 Read state is per viewer, so this only ever changes the rail for that one
 human; another member still sees the child unread. It only ever removes noise:
 `unread` is nothing but `sessions.last_sequence > acknowledged_sequence`, so a
-child that emits one more event goes unread again with no special handling, and
-the `failed` and `requires_action` rail indicators are derived from
-`sessions.status`, rank above unread, and are untouched. The fence is monotone:
-a human who has already read further, or a racing claim that observed a later
-sequence, is never regressed.
+child that emits one more event goes unread again with no special handling.
+`requires_action` remains a live lifecycle indicator until the input is
+resolved. A failed lifecycle remains visible inside the session, while the
+rail's red failure-attention marker is viewer-specific and appears only while
+that failed session's latest event is unread. Parent tree projections expose a
+separate `unreadFailedDescendants` count so an acknowledged historical failure
+does not color every ancestor forever. The fence is monotone: a human who has
+already read further, or a racing claim that observed a later sequence, is
+never regressed.
 
 Monotonicity has one consequence worth stating plainly: an explicit mark-unread
 is **not** sticky against a later consumption. Marking a child unread, then

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -11785,8 +11785,11 @@ export const Session = z.object({
       queuedDescendants: z.number().int().nonnegative(),
       attentionDescendants: z.number().int().nonnegative(),
       pausedDescendants: z.number().int().nonnegative(),
+      /** Historical failed lifecycle states, including already-reviewed failures. */
       failedDescendants: z.number().int().nonnegative(),
       unreadDescendants: z.number().int().nonnegative().optional(),
+      /** Failed descendants whose latest durable event this viewer has not acknowledged. */
+      unreadFailedDescendants: z.number().int().nonnegative().optional(),
       activelyWorkingDescendants: z.number().int().nonnegative().optional(),
       /**
        * Earliest moment one of the counted `attentionDescendants` entered

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30081,6 +30081,7 @@ type SessionTreeStatsRow = {
   attentionDescendants: number | string;
   pausedDescendants: number | string;
   failedDescendants: number | string;
+  unreadFailedDescendants: number | string;
   unreadDescendants: number | string;
   activelyWorkingDescendants: number | string;
   attentionSince: Date | string | null;
@@ -30100,6 +30101,7 @@ const EMPTY_SESSION_TREE_STATS: SessionTreeStats = {
   attentionDescendants: 0,
   pausedDescendants: 0,
   failedDescendants: 0,
+  unreadFailedDescendants: 0,
   unreadDescendants: 0,
   activelyWorkingDescendants: 0,
   attentionSince: null,
@@ -30215,6 +30217,7 @@ export async function sessionTreeStatsForSessions(
         stats."attentionDescendants",
         stats."pausedDescendants",
         stats."failedDescendants",
+        stats."unreadFailedDescendants",
         stats."unreadDescendants",
         stats."activelyWorkingDescendants",
         stats."attentionSince",
@@ -30347,6 +30350,19 @@ export async function sessionTreeStatsForSessions(
           count(*) filter (
             where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
               and depth > 0
+              and status = 'failed'
+              and ${subjectId ?? null}::text is not null
+              and last_sequence > coalesce((
+                select personal.acknowledged_sequence
+                from ${schema.sessionPins} personal
+                where personal.workspace_id = ${workspaceId}
+                  and personal.subject_id = ${subjectId ?? null}
+                  and personal.session_id = numbered.id
+              ), 0)
+          )::int as "unreadFailedDescendants",
+          count(*) filter (
+            where ordinal <= ${SESSION_TREE_STATS_MAX_DESCENDANTS + 1}
+              and depth > 0
               and ${subjectId ?? null}::text is not null
               and last_sequence > coalesce((
                 select personal.acknowledged_sequence
@@ -30423,6 +30439,7 @@ export async function sessionTreeStatsForSessions(
         attentionDescendants: Number(row.attentionDescendants),
         pausedDescendants: Number(row.pausedDescendants),
         failedDescendants: Number(row.failedDescendants),
+        unreadFailedDescendants: Number(row.unreadFailedDescendants),
         unreadDescendants: Number(row.unreadDescendants),
         activelyWorkingDescendants: Number(row.activelyWorkingDescendants),
         attentionSince: row.attentionSince ? new Date(row.attentionSince).toISOString() : null,

--- a/packages/db/test/child-read-acknowledgment.test.ts
+++ b/packages/db/test/child-read-acknowledgment.test.ts
@@ -14,6 +14,7 @@ import {
   getSessionForSubject,
   grantWorkspaceAccess,
   initializeSessionStartAtomically,
+  listSessionsForSubject,
   markSessionSystemUpdateOutboxDeliveredInTransaction,
   materializeGoalContinuation,
   mutateSessionControlInTransaction,
@@ -392,13 +393,24 @@ describe("child read acknowledgment on parent consumption", () => {
     expect(await pinRowCount(child.session.id)).toBe(0);
   });
 
-  test("acknowledging a failed child never touches its status-derived indicator", async () => {
+  test("a parent-consumed failure keeps lifecycle truth but clears failure attention", async () => {
     const grant = await workspace();
     const parent = await startSession(grant, { message: "orchestrate" });
     const child = await startSession(grant, { parent, message: "work" });
     await settleFailed(grant, child);
     expect(await deliverOutboxTo(parent.session.id)).toBe(1);
     await settleIdle(grant, parent);
+    const beforeClaim = await listSessionsForSubject(client.db, grant.workspaceId, {
+      subjectId: grant.subjectId,
+      parentSessionId: null,
+    });
+    expect(
+      beforeClaim.sessions.find((session) => session.id === parent.session.id)?.treeStats,
+    ).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 1,
+      unreadDescendants: 1,
+    });
     await enqueueHumanTurn(grant, parent.session.id);
     expect((await claim(grant, parent.session.id)).action).toBe("claimed");
 
@@ -409,9 +421,20 @@ describe("child read acknowledgment on parent consumption", () => {
       grant.subjectId,
     );
     expect(seen?.unread).toBe(false);
-    // Failed (red) and needs-attention (purple) come from `sessions.status` and
-    // outrank unread in the rail, so the acknowledgment removes noise only.
+    // Lifecycle truth is unchanged, while the viewer-specific rail attention
+    // on this child and its ancestors has been acknowledged.
     expect(seen?.status).toBe("failed");
+    const afterClaim = await listSessionsForSubject(client.db, grant.workspaceId, {
+      subjectId: grant.subjectId,
+      parentSessionId: null,
+    });
+    expect(
+      afterClaim.sessions.find((session) => session.id === parent.session.id)?.treeStats,
+    ).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 0,
+      unreadDescendants: 0,
+    });
   });
 
   test("an acknowledgment already ahead of the consumed child is never regressed", async () => {

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -258,6 +258,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 1,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: waitingSince.toISOString(),
@@ -280,6 +281,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 1,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: waitingSince.toISOString(),
@@ -294,6 +296,67 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     });
     expect(grandchildren.sessions[0]?.requiresActionSince).toBe(waitingSince.toISOString());
     expect(children.sessions[0]?.requiresActionSince).toBeNull();
+  });
+
+  test("counts only unacknowledged failed descendants as failure attention per viewer", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const viewer = "user:failure-viewer";
+    const otherViewer = "user:other-failure-viewer";
+    await grantMember(workspace, viewer);
+    await grantMember(workspace, otherViewer);
+    const root = await session({ ...workspace, message: "failure root" });
+    const child = await session({
+      ...workspace,
+      message: "failed child",
+      parentSessionId: root.id,
+    });
+    await executeSessionActivity(
+      workspace.workspaceId,
+      sql`update sessions set status = 'failed', updated_at = now() where id = ${child.id}`,
+    );
+    await appendSessionEvents(db, workspace.workspaceId, child.id, [
+      { type: "session.title_set", payload: { title: "Failed child" } },
+    ]);
+
+    const before = await listSessionsForSubject(db, workspace.workspaceId, {
+      subjectId: viewer,
+      parentSessionId: null,
+    });
+    expect(before.sessions.find((row) => row.id === root.id)?.treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 1,
+      unreadDescendants: 1,
+    });
+
+    const childForViewer = await getSessionForSubject(db, workspace.workspaceId, child.id, viewer);
+    await setSessionAttention(db, {
+      workspaceId: workspace.workspaceId,
+      subjectId: viewer,
+      sessionId: child.id,
+      unread: false,
+      acknowledgedThroughSequence: childForViewer!.lastSequence,
+      expectedVersion: childForViewer!.attentionVersion,
+    });
+
+    const after = await listSessionsForSubject(db, workspace.workspaceId, {
+      subjectId: viewer,
+      parentSessionId: null,
+    });
+    expect(after.sessions.find((row) => row.id === root.id)?.treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 0,
+      unreadDescendants: 0,
+    });
+    const other = await listSessionsForSubject(db, workspace.workspaceId, {
+      subjectId: otherViewer,
+      parentSessionId: null,
+    });
+    expect(other.sessions.find((row) => row.id === root.id)?.treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 1,
+      unreadDescendants: 1,
+    });
   });
 
   test("counts effective pauses and excludes paused descendants from active totals", async () => {
@@ -474,6 +537,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 0,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: null,
@@ -487,6 +551,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 0,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: null,
@@ -500,6 +565,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 0,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: null,
@@ -597,6 +663,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       attentionDescendants: 0,
       pausedDescendants: 0,
       failedDescendants: 0,
+      unreadFailedDescendants: 0,
       unreadDescendants: 0,
       activelyWorkingDescendants: 0,
       attentionSince: null,
@@ -1147,6 +1214,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
         attentionDescendants: 0,
         pausedDescendants: 0,
         failedDescendants: 0,
+        unreadFailedDescendants: 0,
         unreadDescendants: 0,
         activelyWorkingDescendants: 0,
         truncated: false,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1357,6 +1357,7 @@ export type Session = {
         pausedDescendants: number;
         failedDescendants: number;
         unreadDescendants?: number | undefined;
+        unreadFailedDescendants?: number | undefined;
         activelyWorkingDescendants?: number | undefined;
         /**
          * Earliest moment one of the counted `attentionDescendants` entered

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -3931,6 +3931,19 @@ describe("provider-neutral browser account acceptance", () => {
       await accountMenuTrigger(page, beta.displayName).waitFor({
         timeout: 30_000,
       });
+      const deepLinkSelectionSettledAt = performance.now();
+      const deepLinkSelectionAcceptance = actorMutationAcceptances
+        .filter(({ path }) => path === "/v1/auth/session-set/select")
+        .at(-1);
+      if (!deepLinkSelectionAcceptance?.actorEpoch) {
+        throw new Error("deep-link selection did not expose its accepted actor epoch");
+      }
+      await retirePendingReadsAfterConfirmedActorTransition(page, pageProblems, {
+        confirmedActorEpoch: deepLinkSelectionAcceptance.actorEpoch,
+        confirmedAt: deepLinkSelectionSettledAt,
+        oldWorkspaceId: alpha.workspaceId,
+      });
+      await waitForFiniteReadQuiescence(pageProblems);
       await expectAndConsumeConsoleErrors(
         page,
         pageProblems,

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -233,6 +233,22 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       // only be caused by the event appended below, not by a second initial
       // render of the same chat.
       await page.waitForTimeout(1_500);
+      await page.evaluate((sessionId) => {
+        const observedWindow = window as Window & { __activeSessionUnreadFlash?: boolean };
+        observedWindow.__activeSessionUnreadFlash = false;
+        const row = document.querySelector(`a[data-session-row="${sessionId}"]`);
+        if (!row) throw new Error("active session row is missing");
+        const observeLabel = () => {
+          if (row.getAttribute("aria-label")?.includes("unread")) {
+            observedWindow.__activeSessionUnreadFlash = true;
+          }
+        };
+        observeLabel();
+        new MutationObserver(observeLabel).observe(row, {
+          attributes: true,
+          attributeFilter: ["aria-label"],
+        });
+      }, target.id);
 
       const laterAcknowledgement = page.waitForResponse(
         (response) =>
@@ -272,8 +288,76 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         .locator(`a[data-session-row="${target.id}"]`)
         .waitFor({ state: "visible", timeout: 10_000 });
       expect(await targetRow.getAttribute("aria-label")).not.toContain("unread");
+      expect(
+        await page.evaluate(
+          () =>
+            (window as Window & { __activeSessionUnreadFlash?: boolean })
+              .__activeSessionUnreadFlash,
+        ),
+      ).toBe(false);
     } finally {
       releaseFirstAcknowledgement();
+      await context.close();
+    }
+  }, 60_000);
+
+  test("keeps a rapidly viewed chat read after switching to another chat", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const first = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Rapid read first chat",
+      );
+      const second = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Rapid read second chat",
+      );
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions`);
+      await page.locator(`a[data-session-row="${first.id}"]`).waitFor();
+      await page.locator(`a[data-session-row="${second.id}"]`).waitFor();
+
+      // Exercise the real rail links inside the old 750 ms acknowledgement
+      // window. Merely visiting the first chat must commit its read receipt;
+      // changing routes cannot cancel or roll back that receipt.
+      await page.evaluate(
+        ({ firstId, secondId }) => {
+          document.querySelector<HTMLElement>(`a[data-session-row="${firstId}"]`)?.click();
+          window.setTimeout(() => {
+            document.querySelector<HTMLElement>(`a[data-session-row="${secondId}"]`)?.click();
+          }, 50);
+        },
+        { firstId: first.id, secondId: second.id },
+      );
+      await page.waitForURL(`**/sessions/${second.id}`);
+      await page.waitForResponse(
+        (response) =>
+          response.ok() &&
+          response.request().method() === "PUT" &&
+          new URL(response.url()).pathname ===
+            `/v1/workspaces/${workspaceId}/sessions/${second.id}/attention`,
+        { timeout: 10_000 },
+      );
+
+      await page.reload();
+      const firstRow = page.locator(`a[data-session-row="${first.id}"]`);
+      await firstRow.waitFor();
+      const pageAfterSwitch = await listPageFromBrowser(page, apiBaseUrl, workspaceId, {
+        limit: 50,
+      });
+      expect(pageAfterSwitch.sessions.find((session) => session.id === first.id)?.unread).toBe(
+        false,
+      );
+    } finally {
       await context.close();
     }
   }, 60_000);


### PR DESCRIPTION
Linear: https://linear.app/cloudgeni/issue/OPE-412/make-session-read-and-failure-attention-race-free-across-nested-trees

Summary:
- acknowledge a viewed task immediately and keep equal-frontier read state monotonic
- treat failed red dots as per-viewer attention while preserving durable failure history
- propagate child attention changes through loaded ancestors and retain parent-consumed child acknowledgements
- cover rapid navigation and foreground output with production-build browser tests

Verification:
- formatting and lint
- contracts, database, SDK, and web type checks
- 70 targeted web tests plus 140 related app/session tests
- 47 database attention tests
- 11 production-build browser tests, including rapid task switching and no foreground unread flash

## Summary by Sourcery

Make session attention monotonic across foreground navigation and nested session trees while separating viewer-specific failure attention from durable lifecycle history.

New Features:
- Make failed-session attention viewer-specific so red failure indicators clear when the latest event is acknowledged while historical failure status remains visible.
- Propagate acknowledged child attention through loaded ancestor trees and expose unread failed-descendant counts across contracts, SDK, database, and UI models.

Bug Fixes:
- Prevent stale or equal-frontier unread projections from resurrecting read indicators during rapid navigation.
- Acknowledge foreground sessions immediately and avoid transient unread flashes or canceled read receipts when switching sessions.

Enhancements:
- Improve session rail reconciliation for personal attention state across fresh data, local projections, nested trees, and browser focus changes.

Documentation:
- Document viewer-specific failed-session attention and unacknowledged failed descendant projections.

Tests:
- Add unit, database, and production-browser coverage for monotonic attention, nested acknowledgment propagation, viewer-specific failures, rapid navigation, and foreground unread flashes.