### PR TITLE
fix(web): keep acknowledged failure attention monotonic

### DIFF
--- a/apps/web/src/lib/session-pins.test.ts
+++ b/apps/web/src/lib/session-pins.test.ts
@@ -1007,6 +1007,110 @@ describe("session pin reconciliation", () => {
     });
   });
 
+  test("does not resurrect locally acknowledged failed-descendant attention", () => {
+    const acknowledged = {
+      ...session,
+      treeStats: {
+        directChildren: 2,
+        totalDescendants: 2,
+        runningDescendants: 1,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 1,
+        unreadFailedDescendants: 0,
+        unreadDescendants: 0,
+        activelyWorkingDescendants: 0,
+        truncated: false,
+      },
+    } as Session;
+    const stale = {
+      ...acknowledged,
+      treeStats: {
+        ...acknowledged.treeStats!,
+        unreadFailedDescendants: 1,
+        unreadDescendants: 1,
+      },
+    } as Session;
+
+    expect(applySessionRailProjection(acknowledged, stale).treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 0,
+      unreadDescendants: 0,
+    });
+  });
+
+  test("removes only stale failed attention from a legacy summary", () => {
+    const acknowledged = {
+      ...session,
+      treeStats: {
+        directChildren: 3,
+        totalDescendants: 3,
+        runningDescendants: 2,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 1,
+        unreadFailedDescendants: 0,
+        unreadDescendants: 0,
+        activelyWorkingDescendants: 0,
+        truncated: false,
+      },
+    } as Session;
+    const staleLegacyWithNewUnread = {
+      ...acknowledged,
+      treeStats: {
+        ...acknowledged.treeStats!,
+        unreadFailedDescendants: undefined,
+        unreadDescendants: 2,
+      },
+    } as Session;
+
+    expect(
+      applySessionRailProjection(acknowledged, staleLegacyWithNewUnread).treeStats,
+    ).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 0,
+      // One legacy unread is the acknowledged failure; the other is new work.
+      unreadDescendants: 1,
+    });
+  });
+
+  test("adopts newly failed descendants instead of treating them as stale", () => {
+    const current = {
+      ...session,
+      treeStats: {
+        directChildren: 1,
+        totalDescendants: 1,
+        runningDescendants: 1,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 0,
+        unreadFailedDescendants: 0,
+        unreadDescendants: 0,
+        activelyWorkingDescendants: 0,
+        truncated: false,
+      },
+    } as Session;
+    const newlyFailed = {
+      ...current,
+      treeStats: {
+        ...current.treeStats!,
+        runningDescendants: 0,
+        failedDescendants: 1,
+        unreadFailedDescendants: 1,
+        unreadDescendants: 1,
+      },
+    } as Session;
+
+    expect(applySessionRailProjection(current, newlyFailed).treeStats).toMatchObject({
+      failedDescendants: 1,
+      unreadFailedDescendants: 1,
+      unreadDescendants: 1,
+    });
+  });
+
   test("keeps a newer context pin while adopting detail content", () => {
     const current = {
       ...session,

--- a/apps/web/src/lib/session-pins.ts
+++ b/apps/web/src/lib/session-pins.ts
@@ -520,6 +520,44 @@ function sameTreeStats(a: SessionTreeStats | undefined, b: SessionTreeStats | un
 }
 
 /**
+ * Merge a fresh hierarchy summary without letting an older personal failure
+ * projection resurrect attention the viewer already consumed locally.
+ *
+ * `failedDescendants` is durable lifecycle history, while
+ * `unreadFailedDescendants` is viewer-specific. When the lifecycle count is
+ * unchanged but an incoming page reports more unread failures, the excess may
+ * be a list read that started before the local acknowledgement committed. Keep
+ * the acknowledged failure count, and remove only that stale failure delta
+ * from the broader unread count so genuinely new unrelated unread work still
+ * surfaces.
+ */
+function mergeTreeStats(
+  current: SessionTreeStats | undefined,
+  projected: SessionTreeStats | undefined,
+): SessionTreeStats | undefined {
+  if (!projected || !current) return projected ?? current;
+
+  const currentUnreadFailed = current.unreadFailedDescendants ?? current.failedDescendants;
+  const projectedUnreadFailed = projected.unreadFailedDescendants ?? projected.failedDescendants;
+  if (
+    current.failedDescendants !== projected.failedDescendants ||
+    currentUnreadFailed >= projectedUnreadFailed
+  ) {
+    return projected;
+  }
+
+  const staleFailureDelta = projectedUnreadFailed - currentUnreadFailed;
+  return {
+    ...projected,
+    unreadFailedDescendants: currentUnreadFailed,
+    unreadDescendants: Math.max(
+      current.unreadDescendants ?? 0,
+      (projected.unreadDescendants ?? 0) - staleFailureDelta,
+    ),
+  };
+}
+
+/**
  * Merge only personal pin fields from a list/page projection into the open
  * route projection. Lifecycle and event-driven session fields remain owned by
  * the route/SSE reducer and cannot be regressed by a slower list poll.
@@ -624,7 +662,8 @@ export function applySessionRailProjection(
   if (sameTreeStats(merged.treeStats, projected.treeStats)) {
     return merged;
   }
-  return projected.treeStats ? { ...merged, treeStats: projected.treeStats } : merged;
+  const treeStats = mergeTreeStats(merged.treeStats, projected.treeStats);
+  return treeStats ? { ...merged, treeStats } : merged;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #2051.

Summary:
- preserve locally acknowledged failed-descendant attention when a stale or legacy rail summary arrives
- subtract only the stale failed-attention delta so unrelated new unread work still surfaces
- continue adopting genuinely new failures when the durable failed-descendant count changes

Verification:
- 97 focused web/session tests
- oxlint with warnings denied
- oxfmt check
- apps/web typecheck passed within the full workspace typecheck run

Tracking: This fix resulted from the `Bendik PR review and merge` scheduled task.

## Summary by Sourcery

Keep failed-descendant attention monotonic when reconciling session rail summaries.

Bug Fixes:
- Prevent stale or legacy session summaries from restoring failed-descendant attention that the user has already acknowledged locally.
- Continue surfacing genuinely new failed descendants while preserving unrelated unread work.

Tests:
- Add focused coverage for acknowledged failures, legacy unread summaries, and newly failed descendants.