### PR TITLE
fix(web): stop child session loading flicker

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -35,6 +35,7 @@ import {
   beginSessionBranchRequest,
   commitSessionBranchPage,
   failSessionBranchRequest,
+  sessionBranchNeedsHydration,
   sessionBranchSummaryKey,
   sessionBranchSummaryDecision,
   upsertSessionBranchChild,
@@ -451,6 +452,7 @@ describe("rail session grouping", () => {
           channelGenerations: new Map(),
           nextCursor: null,
           loading: false,
+          feedbackVisible: false,
           failed: false,
           stale: false,
           requestId: null,
@@ -654,6 +656,34 @@ describe("rail session grouping", () => {
       "newer-worker",
       "active-worker",
     ]);
+  });
+
+  test("fresh active branches skip hydration and background requests stay visually silent", () => {
+    const managerId = "manager-silent-hydration";
+    const active = railSession({ id: "active-worker", parentSessionId: managerId });
+    let pages = commitSessionBranchPage(new Map(), managerId, {
+      sessions: [active],
+      nextCursor: null,
+    });
+
+    expect(sessionBranchNeedsHydration(pages.get(managerId))).toBe(false);
+    expect(sessionBranchNeedsHydration(undefined)).toBe(true);
+    expect(sessionBranchNeedsHydration({ ...pages.get(managerId)!, stale: true })).toBe(true);
+    expect(sessionBranchNeedsHydration({ ...pages.get(managerId)!, failed: true })).toBe(true);
+
+    pages = beginSessionBranchRequest(pages, managerId, 12, undefined, {
+      feedbackVisible: false,
+    });
+    expect(pages.get(managerId)).toMatchObject({
+      loading: true,
+      feedbackVisible: false,
+    });
+    pages = failSessionBranchRequest(pages, managerId, 12);
+    expect(pages.get(managerId)).toMatchObject({
+      loading: false,
+      feedbackVisible: false,
+      failed: true,
+    });
   });
 
   test("visibleForestRows expands only where the set says so", () => {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -658,7 +658,7 @@ describe("rail session grouping", () => {
     ]);
   });
 
-  test("fresh active branches skip hydration and background requests stay visually silent", () => {
+  test("fresh active branches skip hydration and background failures expose retry", () => {
     const managerId = "manager-silent-hydration";
     const active = railSession({ id: "active-worker", parentSessionId: managerId });
     let pages = commitSessionBranchPage(new Map(), managerId, {
@@ -681,7 +681,7 @@ describe("rail session grouping", () => {
     pages = failSessionBranchRequest(pages, managerId, 12);
     expect(pages.get(managerId)).toMatchObject({
       loading: false,
-      feedbackVisible: false,
+      feedbackVisible: true,
       failed: true,
     });
   });

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -168,6 +168,7 @@ import {
   beginSessionBranchRequest,
   commitSessionBranchPage,
   failSessionBranchRequest,
+  sessionBranchNeedsHydration,
   sessionBranchSummaryKey,
   sessionBranchSummaryDecision,
   upsertSessionBranchChild,
@@ -448,6 +449,8 @@ export function SessionList() {
   const [childPages, setChildPages] = useState<ReadonlyMap<string, ChildPageState>>(
     () => new Map(),
   );
+  const childPagesRef = useRef(childPages);
+  childPagesRef.current = childPages;
   const childLoadEpoch = useRef(0);
   const childRequestSequence = useRef(0);
   const branchSummaryKeys = useRef(new Map<string, string>());
@@ -1438,7 +1441,10 @@ export function SessionList() {
     async (
       parentSessionId: string,
       cursor?: string,
-      preserve: readonly Session[] = [],
+      options: {
+        preserve?: readonly Session[] | undefined;
+        feedbackVisible?: boolean | undefined;
+      } = {},
     ): Promise<void> => {
       const epoch = childLoadEpoch.current;
       if (!branchSummaryKeys.current.has(parentSessionId)) {
@@ -1450,7 +1456,9 @@ export function SessionList() {
       childRequestSequence.current += 1;
       const requestId = childRequestSequence.current;
       setChildPages((current) =>
-        beginSessionBranchRequest(current, parentSessionId, requestId, cursor),
+        beginSessionBranchRequest(current, parentSessionId, requestId, cursor, {
+          feedbackVisible: options.feedbackVisible,
+        }),
       );
       try {
         const readGeneration = context.sessionChannelProjectionAuthority.beginRead();
@@ -1471,7 +1479,7 @@ export function SessionList() {
             },
             {
               append: cursor !== undefined,
-              preserve,
+              preserve: options.preserve,
               requestId,
               readGeneration,
             },
@@ -1494,11 +1502,16 @@ export function SessionList() {
       activeBranchHydration.current = null;
       return;
     }
+    const cachedPage = childPagesRef.current.get(active.parentSessionId);
     setChildPages((current) => upsertSessionBranchChild(current, active));
     const hydrationKey = `${active.parentSessionId}:${active.id}`;
     if (activeBranchHydration.current === hydrationKey) return;
     activeBranchHydration.current = hydrationKey;
-    void loadChildPage(active.parentSessionId, undefined, [active]);
+    if (!sessionBranchNeedsHydration(cachedPage)) return;
+    void loadChildPage(active.parentSessionId, undefined, {
+      preserve: [active],
+      feedbackVisible: false,
+    });
   }, [context.session, hierarchyMode, loadChildPage]);
 
   // Deep active routes auto-expand their ancestor path. Load every missing
@@ -1515,7 +1528,9 @@ export function SessionList() {
       const node = nodesById.get(parentId);
       const knownDirectChildren =
         node?.session.treeStats?.directChildren ?? node?.children.length ?? 0;
-      if (knownDirectChildren > 0) void loadChildPage(parentId);
+      if (knownDirectChildren > 0) {
+        void loadChildPage(parentId, undefined, { feedbackVisible: false });
+      }
     }
   }, [
     autoExpanded,
@@ -1551,8 +1566,9 @@ export function SessionList() {
         stale: page.stale,
       });
       if (decision.acknowledge) branchSummaryKeys.current.set(parentId, nextKey);
-      if (decision.refresh) void loadChildPage(parentId);
-      else if (decision.markStale) newlyStale.add(parentId);
+      if (decision.refresh) {
+        void loadChildPage(parentId, undefined, { feedbackVisible: false });
+      } else if (decision.markStale) newlyStale.add(parentId);
     }
     if (newlyStale.size > 0) {
       setChildPages((current) => {
@@ -2777,10 +2793,10 @@ function SessionTreeRow(props: {
                 />
               ))
             : null}
-          {isExpanded && childPage?.loading ? (
+          {isExpanded && childPage?.loading && childPage.feedbackVisible ? (
             <TreeLoadRow depth={props.depth + 1} text="Loading sessions…" />
           ) : null}
-          {isExpanded && childPage?.failed ? (
+          {isExpanded && childPage?.failed && childPage.feedbackVisible ? (
             <TreeLoadRow
               depth={props.depth + 1}
               text="Retry loading sessions"

--- a/apps/web/src/lib/session-branch-cache.ts
+++ b/apps/web/src/lib/session-branch-cache.ts
@@ -173,7 +173,7 @@ export function authoritativeSessionBranchChannels(
   return evidence;
 }
 
-/** Fail only the still-current request and retain its exact retry cursor. */
+/** Fail only the still-current request and expose its exact retry cursor. */
 export function failSessionBranchRequest(
   pages: ReadonlyMap<string, SessionBranchPage>,
   parentSessionId: string,
@@ -184,6 +184,10 @@ export function failSessionBranchRequest(
   return new Map(pages).set(parentSessionId, {
     ...previous,
     loading: false,
+    // Background hydration may suppress transient loading feedback, but a
+    // failure must become actionable instead of leaving the branch silently
+    // incomplete for the rest of the active route.
+    feedbackVisible: true,
     failed: true,
     stale: false,
     requestId: null,

--- a/apps/web/src/lib/session-branch-cache.ts
+++ b/apps/web/src/lib/session-branch-cache.ts
@@ -8,6 +8,8 @@ export type SessionBranchPage = {
   channelGenerations: ReadonlyMap<string, number>;
   nextCursor: string | null;
   loading: boolean;
+  /** Whether this load cycle may paint loading or retry feedback in the tree. */
+  feedbackVisible: boolean;
   failed: boolean;
   stale: boolean;
   requestId: number | null;
@@ -75,6 +77,7 @@ export function upsertSessionBranchChild(
     channelGenerations: page?.channelGenerations ?? new Map(),
     nextCursor: page?.nextCursor ?? null,
     loading: page?.loading ?? false,
+    feedbackVisible: page?.feedbackVisible ?? false,
     failed: page?.failed ?? false,
     stale: page?.stale ?? false,
     requestId: page?.requestId ?? null,
@@ -88,6 +91,7 @@ export function beginSessionBranchRequest(
   parentSessionId: string,
   requestId: number,
   cursor?: string,
+  options: { feedbackVisible?: boolean | undefined } = {},
 ): ReadonlyMap<string, SessionBranchPage> {
   const previous = pages.get(parentSessionId);
   return new Map(pages).set(parentSessionId, {
@@ -95,6 +99,7 @@ export function beginSessionBranchRequest(
     channelGenerations: previous?.channelGenerations ?? new Map(),
     nextCursor: previous?.nextCursor ?? null,
     loading: true,
+    feedbackVisible: options.feedbackVisible ?? true,
     failed: false,
     stale: false,
     requestId,
@@ -109,7 +114,7 @@ export function commitSessionBranchPage(
   input: { sessions: readonly Session[]; nextCursor: string | null },
   options: {
     append?: boolean;
-    preserve?: readonly Session[];
+    preserve?: readonly Session[] | undefined;
     requestId?: number;
     readGeneration?: number;
   } = {},
@@ -147,6 +152,7 @@ export function commitSessionBranchPage(
     channelGenerations,
     nextCursor: input.nextCursor,
     loading: false,
+    feedbackVisible: false,
     failed: false,
     stale: false,
     requestId: null,
@@ -182,6 +188,11 @@ export function failSessionBranchRequest(
     stale: false,
     requestId: null,
   });
+}
+
+/** A fresh cached page already owns the active child's parent branch. */
+export function sessionBranchNeedsHydration(page: SessionBranchPage | undefined): boolean {
+  return page === undefined || page.failed || page.stale;
 }
 
 /** Decide whether a changed parent summary can be acknowledged right now. */

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -27,6 +27,7 @@ import {
   type BrowserContextOptions,
   type Page,
   type Response as PlaywrightResponse,
+  type Route,
 } from "playwright";
 import postgres from "postgres";
 
@@ -919,6 +920,60 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         descendant,
         true,
       );
+
+      // A direct child route hydrates its parent branch in the background.
+      // Hold that request open so any transient tree feedback remains visible
+      // long enough to catch: route reconciliation must not append a loading
+      // row beneath the workstream.
+      const childPagePattern = `${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions?**`;
+      let releaseChildPage!: () => void;
+      let markChildPageStarted!: () => void;
+      let markChildPageFinished!: () => void;
+      let childPageRequestStarted = false;
+      const childPageGate = new Promise<void>((resolve) => {
+        releaseChildPage = resolve;
+      });
+      const childPageStarted = new Promise<void>((resolve) => {
+        markChildPageStarted = resolve;
+      });
+      const childPageFinished = new Promise<void>((resolve) => {
+        markChildPageFinished = resolve;
+      });
+      const holdChildPage = async (route: Route): Promise<void> => {
+        const url = new URL(route.request().url());
+        if (
+          url.searchParams.get("parentSessionId") !== manager.id ||
+          url.searchParams.has("cursor")
+        ) {
+          await route.continue();
+          return;
+        }
+        childPageRequestStarted = true;
+        markChildPageStarted();
+        await childPageGate;
+        await route.continue();
+        markChildPageFinished();
+      };
+      await page.route(childPagePattern, holdChildPage);
+      try {
+        await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${ordinaryChild.id}`);
+        await page
+          .getByTestId("session-timeline")
+          .getByText("Ordinary manager child", { exact: true })
+          .waitFor();
+        await childPageStarted;
+        expect(
+          await page
+            .locator("[data-sessionpin-session-list]")
+            .getByText("Loading sessions…", { exact: true })
+            .count(),
+        ).toBe(0);
+      } finally {
+        releaseChildPage();
+        if (childPageRequestStarted) await childPageFinished;
+        await page.unroute(childPagePattern, holdChildPage);
+      }
+
       await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${manager.id}`);
 
       const pinnedList = page.getByRole("list", { name: "Pinned sessions" });


### PR DESCRIPTION
## Summary
- skip redundant parent-branch hydration when a child session opens from an already fresh sidebar branch
- keep route-driven and polling reconciliation visually silent while preserving loading/retry feedback for explicit expand and pagination actions
- cover direct child navigation with a delayed real-API branch response

## Verification
- `bun test apps/web/src/App.test.ts`
- `bun run typecheck` (apps/web)
- `bun x oxfmt --check apps/web/src/App.test.ts apps/web/src/components/rail/session-list.tsx apps/web/src/lib/session-branch-cache.ts test/e2e/session-pins.browser.e2e.ts`
- `bun x oxlint --deny-warnings apps/web/src/App.test.ts apps/web/src/components/rail/session-list.tsx apps/web/src/lib/session-branch-cache.ts test/e2e/session-pins.browser.e2e.ts`
- `bun --no-env-file test --max-concurrency=1 ./test/e2e/session-pins.browser.e2e.ts -t "keeps lazy hierarchy, nested pins, keyboard order, and nested-list semantics truthful"`

## Summary by Sourcery

Prevent session-tree flicker during background child-branch reconciliation while retaining actionable feedback for failed and explicit loads.

Bug Fixes:
- Prevent child session routes from showing transient loading flicker when the parent branch is already fresh.
- Keep background reconciliation failures actionable by exposing retry feedback while suppressing transient loading indicators.

Enhancements:
- Distinguish silent background branch hydration from user-initiated loading and pagination feedback.
- Skip redundant hydration for fresh cached parent branches and preserve direct-child route handling.

Tests:
- Add unit coverage for fresh-branch hydration decisions and background failure feedback.
- Add end-to-end coverage for direct child navigation with a delayed API branch response.