### PR TITLE
fix(web): preserve session hierarchy in browse grouping

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -137,7 +137,7 @@ import {
   buildPinnedRailSections,
   channelRailSections,
   filterSessionsForBrowse,
-  groupSessionsForBrowse,
+  groupSessionForestForBrowse,
   projectRailSessions,
   groupSessionsForRail,
   mergeSessionForRail,
@@ -316,7 +316,10 @@ export function SessionList() {
   }, [searchDraft]);
   const browseControlsActive =
     browseGroupBy !== "activity" || browseDateRange !== "any" || browseCreator !== null;
-  const hierarchyMode = search.length === 0 && !browseControlsActive;
+  // Search is the one intentionally flat projection: it can surface a match
+  // from anywhere in a workstream. Sorting and filtering still operate on
+  // root workstreams and preserve their expandable descendant hierarchy.
+  const hierarchyMode = search.length === 0;
   const clearBrowseControls = useCallback(() => {
     setBrowseGroupBy("activity");
     setBrowseDateField("activity");
@@ -397,12 +400,12 @@ export function SessionList() {
   // polled hook owns page one; additional pages are appended and deduplicated.
   // A filter change starts a fresh cursor chain rather than mixing snapshots.
   // The continuation generation is keyed to workspace/search and whether the
-  // projection is a root hierarchy or flat browse. Polling page one rotates
+  // projection is a root hierarchy or flat search. Polling page one rotates
   // the server's short-lived snapshot, but must not discard older pages the
   // user already loaded from the prior snapshot.
   const paginationKey = sessionPageKey(
     rail.workspaceId,
-    `${search}\n${hierarchyMode ? "tree" : "browse"}`,
+    `${search}\n${hierarchyMode ? "tree" : "search"}`,
   );
   const paginationIdentity = useRef({ key: paginationKey, generation: 0 });
   paginationIdentity.current = advanceSessionPageIdentity(
@@ -896,7 +899,14 @@ export function SessionList() {
       });
     });
   }, [rail.workspaceId]);
-  const creatorLabels = useMemo(() => sessionCreatorLabelMap(allSessions), [allSessions]);
+  const creatorSessions = useMemo(() => {
+    if (!hierarchyMode) return allSessions;
+    const loadedIds = new Set(allSessions.map((session) => session.id));
+    return allSessions.filter(
+      (session) => !session.parentSessionId || !loadedIds.has(session.parentSessionId),
+    );
+  }, [allSessions, hierarchyMode]);
+  const creatorLabels = useMemo(() => sessionCreatorLabelMap(creatorSessions), [creatorSessions]);
   const creatorOptions = useMemo(() => {
     return [...creatorLabels].map(([value, label]) => ({ value, label }));
   }, [creatorLabels]);
@@ -913,9 +923,17 @@ export function SessionList() {
           creator: browseCreator,
           dateField: browseDateField,
           dateRange: browseDateRange,
+          hierarchical: hierarchyMode,
         },
       ),
-    [allSessions, archiveTransitions, browseCreator, browseDateField, browseDateRange],
+    [
+      allSessions,
+      archiveTransitions,
+      browseCreator,
+      browseDateField,
+      browseDateRange,
+      hierarchyMode,
+    ],
   );
 
   // A complete pins-only page makes presence authoritative, but absence does
@@ -1082,11 +1100,9 @@ export function SessionList() {
   // permission to move this scroll container.
   const rowRevealIntent = useRef<string | null>(activeSessionId);
 
-  // Search results and browse groupings are deliberately flat: a partial match
-  // set is not a tree, and a browse bucket is a list. Normal navigation instead
-  // carries only true roots, lazily loaded children, and the active lineage.
-  // Both flat consumers read the SAME normalized rows, so a session rendered as
-  // a top-level row never still claims a parent that is nowhere on screen.
+  // Search results are deliberately flat because a partial match set is not a
+  // tree. Normal and custom-grouped browsing carry true roots, lazily loaded
+  // children, and the active lineage.
   const projectedSessions = useMemo(
     () => projectRailSessions(browseSessions, hierarchyMode),
     [browseSessions, hierarchyMode],
@@ -1101,18 +1117,14 @@ export function SessionList() {
     () =>
       browseGroupBy === "activity"
         ? railSections.ordinary
-        : groupSessionsForBrowse(
-            projectedSessions.filter((session) => !session.pinned),
-            browseGroupBy,
-            { creatorLabels },
-          ),
-    [browseGroupBy, projectedSessions, creatorLabels, railSections.ordinary],
+        : groupSessionForestForBrowse(railSections.ordinary, browseGroupBy, { creatorLabels }),
+    [browseGroupBy, creatorLabels, railSections.ordinary],
   );
   const pinnedNodes = railSections.pinned;
   // The hierarchy rail always has the same shape: unfiled Recents first, then
   // workstreams. A workspace with no created workstreams should not fall back
   // to a completely different recency UI.
-  const channelMode = hierarchyMode;
+  const channelMode = hierarchyMode && !browseControlsActive;
   const channelSections = useMemo(
     () => (channelMode ? channelRailSections(forest, channels) : []),
     [channelMode, forest, channels],
@@ -2017,7 +2029,7 @@ export function SessionList() {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex min-w-0 items-center justify-between gap-2 pb-1 pl-[18px] pr-3 pt-1">
         <span className="text-sm font-normal text-fg-muted">
-          {hierarchyMode ? "Sessions" : search ? "Search results" : "Browse sessions"}
+          {search ? "Search results" : browseControlsActive ? "Browse sessions" : "Sessions"}
         </span>
       </div>
 
@@ -2044,7 +2056,7 @@ export function SessionList() {
             className="h-7 w-full min-w-0 rounded-md border border-border bg-bg/45 pl-7 pr-2 text-xs text-fg outline-none placeholder:text-fg-subtle hover:border-border-strong focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 pointer-coarse:h-11 pointer-coarse:text-base"
           />
         </label>
-        {hierarchyMode ? (
+        {channelMode ? (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -2173,7 +2185,7 @@ export function SessionList() {
       <div
         ref={listRef}
         role="region"
-        aria-label={hierarchyMode ? "Sessions" : search ? "Session search results" : "Sessions"}
+        aria-label={search ? "Session search results" : "Sessions"}
         data-sessionpin-session-list
         onKeyDown={onKeyDown}
         onPointerDown={() => {
@@ -2194,7 +2206,7 @@ export function SessionList() {
           {announcement}
         </p>
         {(loading && allSessions.length === 0) ||
-        (hierarchyMode && channelsQuery.loading && channels.length === 0) ? (
+        (channelMode && channelsQuery.loading && channels.length === 0) ? (
           // The second clause holds the skeleton until the initial channels
           // read resolves, so the rail paints Recents/workstreams directly
           // instead of flashing the old recency layout first.
@@ -2365,7 +2377,7 @@ export function SessionList() {
                 ))}
               </>
             )}
-            {hierarchyMode ? (
+            {channelMode ? (
               <SessionGroup
                 label="Archived"
                 sectionId="archived"

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -141,8 +141,10 @@ import {
   projectRailSessions,
   groupSessionsForRail,
   mergeSessionForRail,
+  normalizeSessionBrowseCreator,
   relativeTimeLabel,
   scheduledTaskIdOf,
+  sessionBrowseResultCount,
   selectedDescendantNode,
   sessionCreatorLabelMap,
   visibleForestRows,
@@ -298,6 +300,7 @@ export function SessionList() {
   const [browseDateField, setBrowseDateField] = useState<SessionBrowseDateField>("activity");
   const [browseDateRange, setBrowseDateRange] = useState<SessionBrowseDateRange>("any");
   const [browseCreator, setBrowseCreator] = useState<string | null>(null);
+  const browseCreatorOrigin = useRef<"search" | "hierarchy" | null>(null);
   useEffect(() => {
     if (previousBrowsePreferenceStorageId.current === browsePreferenceStorageId) return;
     previousBrowsePreferenceStorageId.current = browsePreferenceStorageId;
@@ -314,8 +317,6 @@ export function SessionList() {
     const timer = window.setTimeout(() => setSearch(searchDraft.trim()), 200);
     return () => window.clearTimeout(timer);
   }, [searchDraft]);
-  const browseControlsActive =
-    browseGroupBy !== "activity" || browseDateRange !== "any" || browseCreator !== null;
   // Search is the one intentionally flat projection: it can surface a match
   // from anywhere in a workstream. Sorting and filtering still operate on
   // root workstreams and preserve their expandable descendant hierarchy.
@@ -324,8 +325,22 @@ export function SessionList() {
     setBrowseGroupBy("activity");
     setBrowseDateField("activity");
     setBrowseDateRange("any");
+    browseCreatorOrigin.current = null;
     setBrowseCreator(null);
   }, [setBrowseGroupBy]);
+  const updateSearchDraft = useCallback((value: string) => {
+    setSearchDraft(value);
+    if (value.trim().length > 0 || browseCreatorOrigin.current !== "search") return;
+    browseCreatorOrigin.current = null;
+    setBrowseCreator(null);
+  }, []);
+  const updateBrowseCreator = useCallback(
+    (creator: string | null) => {
+      browseCreatorOrigin.current = creator ? (hierarchyMode ? "hierarchy" : "search") : null;
+      setBrowseCreator(creator);
+    },
+    [hierarchyMode],
+  );
 
   const rootPage = useWorkspaceSessions({
     limit: 50,
@@ -910,6 +925,13 @@ export function SessionList() {
   const creatorOptions = useMemo(() => {
     return [...creatorLabels].map(([value, label]) => ({ value, label }));
   }, [creatorLabels]);
+  const activeBrowseCreator = normalizeSessionBrowseCreator(
+    browseCreator,
+    creatorLabels,
+    hierarchyMode,
+  );
+  const browseControlsActive =
+    browseGroupBy !== "activity" || browseDateRange !== "any" || activeBrowseCreator !== null;
   const browseSessions = useMemo(
     () =>
       filterSessionsForBrowse(
@@ -920,7 +942,7 @@ export function SessionList() {
           return session.parentSessionId !== null || !session.archived;
         }),
         {
-          creator: browseCreator,
+          creator: activeBrowseCreator,
           dateField: browseDateField,
           dateRange: browseDateRange,
           hierarchical: hierarchyMode,
@@ -929,7 +951,7 @@ export function SessionList() {
     [
       allSessions,
       archiveTransitions,
-      browseCreator,
+      activeBrowseCreator,
       browseDateField,
       browseDateRange,
       hierarchyMode,
@@ -2021,9 +2043,9 @@ export function SessionList() {
 
   useEffect(() => {
     if (loading || (!search && !browseControlsActive)) return;
-    const count = browseSessions.length;
+    const count = sessionBrowseResultCount(browseSessions, hierarchyMode);
     setAnnouncement(`${count} matching session${count === 1 ? "" : "s"}.`);
-  }, [browseControlsActive, browseSessions.length, loading, search]);
+  }, [browseControlsActive, browseSessions, hierarchyMode, loading, search]);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -2043,11 +2065,11 @@ export function SessionList() {
           <input
             type="search"
             value={searchDraft}
-            onChange={(event) => setSearchDraft(event.target.value)}
+            onChange={(event) => updateSearchDraft(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Escape" && searchDraft) {
                 event.preventDefault();
-                setSearchDraft("");
+                updateSearchDraft("");
               }
             }}
             maxLength={200}
@@ -2148,16 +2170,15 @@ export function SessionList() {
               <DropdownMenuSubTrigger>
                 Creator
                 <span className="ml-auto mr-1 max-w-20 truncate text-2xs text-fg-subtle">
-                  {browseCreator
-                    ? (creatorOptions.find((option) => option.value === browseCreator)?.label ??
-                      "Selected")
+                  {activeBrowseCreator
+                    ? creatorOptions.find((option) => option.value === activeBrowseCreator)?.label
                     : "Anyone"}
                 </span>
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto">
                 <DropdownMenuRadioGroup
-                  value={browseCreator ?? "all"}
-                  onValueChange={(value) => setBrowseCreator(value === "all" ? null : value)}
+                  value={activeBrowseCreator ?? "all"}
+                  onValueChange={(value) => updateBrowseCreator(value === "all" ? null : value)}
                 >
                   <DropdownMenuRadioItem value="all">Anyone</DropdownMenuRadioItem>
                   {creatorOptions.map((option) => (
@@ -2239,7 +2260,7 @@ export function SessionList() {
               type="button"
               className="mt-2 min-h-8 rounded px-2 underline hover:text-fg pointer-coarse:min-h-11"
               onClick={() => {
-                setSearchDraft("");
+                updateSearchDraft("");
                 clearBrowseControls();
               }}
             >

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -6,7 +6,9 @@ import {
   buildPinnedRailSections,
   filterSessionsForBrowse,
   groupSessionsForBrowse,
+  normalizeSessionBrowseCreator,
   projectRailSessions,
+  sessionBrowseResultCount,
   sessionCreatorLabelMap,
   sessionCreatorLabel,
   sessionCreatorOptions,
@@ -138,15 +140,16 @@ describe("session browse projections", () => {
       createdBy: { kind: "subject", subjectId: "user:grace", label: "Grace Hopper" },
     });
 
-    expect(
-      filterSessionsForBrowse([manager, worker], {
-        creator: "subject:user:ada",
-        dateField: "activity",
-        dateRange: "any",
-        hierarchical: true,
-        now: NOW,
-      }).map((item) => item.id),
-    ).toEqual(["manager", "worker"]);
+    const matchingWorkstream = filterSessionsForBrowse([manager, worker], {
+      creator: "subject:user:ada",
+      dateField: "activity",
+      dateRange: "any",
+      hierarchical: true,
+      now: NOW,
+    });
+    expect(matchingWorkstream.map((item) => item.id)).toEqual(["manager", "worker"]);
+    expect(sessionBrowseResultCount(matchingWorkstream, true)).toBe(1);
+    expect(sessionBrowseResultCount(matchingWorkstream, false)).toBe(2);
     expect(
       filterSessionsForBrowse([manager, worker], {
         creator: "subject:user:grace",
@@ -156,6 +159,24 @@ describe("session browse projections", () => {
         now: NOW,
       }),
     ).toEqual([]);
+  });
+
+  test("normalizes child-only creator selections when returning to hierarchical browse", () => {
+    const manager = session({ id: "manager" });
+    const worker = session({
+      id: "worker",
+      parentSessionId: manager.id,
+      createdBy: { kind: "subject", subjectId: "user:grace", label: "Grace Hopper" },
+    });
+    const childCreator = "subject:user:grace";
+    const searchLabels = sessionCreatorLabelMap([manager, worker]);
+    const hierarchyLabels = sessionCreatorLabelMap([manager]);
+
+    expect(normalizeSessionBrowseCreator(childCreator, searchLabels, false)).toBe(childCreator);
+    expect(normalizeSessionBrowseCreator(childCreator, hierarchyLabels, true)).toBeNull();
+    expect(normalizeSessionBrowseCreator("subject:user:ada", hierarchyLabels, true)).toBe(
+      "subject:user:ada",
+    );
   });
 
   test("disambiguates duplicate frozen creator labels with opaque identities", () => {

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -77,7 +77,7 @@ describe("session browse projections", () => {
     expect(sessionCreatorLabel(scheduler)).toBe("Service · service:scheduler");
   });
 
-  test("groups flat browse results by creator or created-date buckets", () => {
+  test("groups root browse results by creator or created-date buckets", () => {
     const ada = session({ id: "ada" });
     const grace = session({
       id: "grace",
@@ -91,6 +91,71 @@ describe("session browse projections", () => {
     expect(
       groupSessionsForBrowse([grace, ada], "created", { now: NOW }).grouped.map((g) => g.label),
     ).toEqual(["Created today", "Created earlier"]);
+  });
+
+  test("groups workstream roots while preserving their descendant hierarchy", () => {
+    const manager = session({
+      id: "manager",
+      createdAt: "2026-08-01T12:00:00.000Z",
+      updatedAt: "2026-08-13T10:00:00.000Z",
+    });
+    const worker = session({
+      id: "worker",
+      parentSessionId: manager.id,
+      createdAt: "2026-08-14T09:00:00.000Z",
+      updatedAt: "2026-08-14T11:00:00.000Z",
+      createdBy: { kind: "subject", subjectId: "user:grace", label: "Grace Hopper" },
+    });
+
+    const byCreated = groupSessionsForBrowse([worker, manager], "created", { now: NOW });
+    expect(byCreated.grouped.map((group) => group.label)).toEqual(["Created earlier"]);
+    expect(byCreated.grouped[0]?.sessions.map((node) => node.session.id)).toEqual(["manager"]);
+    expect(byCreated.grouped[0]?.sessions[0]?.children.map((node) => node.session.id)).toEqual([
+      "worker",
+    ]);
+
+    const byCreator = groupSessionsForBrowse([worker, manager], "creator", { now: NOW });
+    expect(byCreator.grouped.map((group) => group.label)).toEqual(["Ada Lovelace"]);
+    expect(byCreator.grouped[0]?.sessions[0]?.children[0]?.session.id).toBe("worker");
+
+    const withActiveWorker = groupSessionsForBrowse(
+      [{ ...worker, status: "running" }, manager],
+      "created",
+      { now: NOW },
+    );
+    expect(withActiveWorker.running.map((node) => node.session.id)).toEqual(["manager"]);
+    expect(withActiveWorker.running[0]?.children.map((node) => node.session.id)).toEqual([
+      "worker",
+    ]);
+  });
+
+  test("hierarchical filters keep complete matching workstreams instead of orphaning children", () => {
+    const manager = session({ id: "manager" });
+    const worker = session({
+      id: "worker",
+      parentSessionId: manager.id,
+      createdAt: "2026-08-14T09:00:00.000Z",
+      createdBy: { kind: "subject", subjectId: "user:grace", label: "Grace Hopper" },
+    });
+
+    expect(
+      filterSessionsForBrowse([manager, worker], {
+        creator: "subject:user:ada",
+        dateField: "activity",
+        dateRange: "any",
+        hierarchical: true,
+        now: NOW,
+      }).map((item) => item.id),
+    ).toEqual(["manager", "worker"]);
+    expect(
+      filterSessionsForBrowse([manager, worker], {
+        creator: "subject:user:grace",
+        dateField: "activity",
+        dateRange: "any",
+        hierarchical: true,
+        now: NOW,
+      }),
+    ).toEqual([]);
   });
 
   test("disambiguates duplicate frozen creator labels with opaque identities", () => {
@@ -181,22 +246,20 @@ describe("flat rail projection", () => {
     expect(child.parentSessionId).toBe("manager");
   });
 
-  test("browse groupings and search sections agree on which rows are top-level", () => {
-    // Both flat consumers must read the same projection. Feeding one of them
-    // the raw rows leaves a chip-less child sitting beside chipped roots in a
-    // list where every row is top-level and no parent is on screen.
-    const projected = projectRailSessions([parent, child], false);
-    const grouped = groupSessionsForBrowse(projected, "created", { now: NOW });
-    const searched = buildPinnedRailSections(projected);
+  test("browse grouping preserves lineage while search results stay top-level", () => {
+    const grouped = groupSessionsForBrowse([parent, child], "created", { now: NOW });
+    const searched = buildPinnedRailSections(projectRailSessions([parent, child], false));
 
     const groupedRows = [
       ...grouped.running,
       ...grouped.grouped.flatMap((bucket) => bucket.sessions),
     ];
-    expect(groupedRows.map((node) => node.session.id).sort()).toEqual(["manager", "worker"]);
-    for (const node of groupedRows) {
-      expect(railRowCreator(node.session)).not.toBeNull();
-    }
+    expect(groupedRows.map((node) => node.session.id)).toEqual(["manager"]);
+    expect(groupedRows[0]?.children.map((node) => node.session.id)).toEqual(["worker"]);
+    expect(railRowCreator(groupedRows[0]!.children[0]!.session)).toBeNull();
+
+    const searchedRows = searched.ordinary.grouped.flatMap((bucket) => bucket.sessions);
+    expect(searchedRows.map((node) => node.session.id).sort()).toEqual(["manager", "worker"]);
     for (const node of searched.ordinary.grouped.flatMap((bucket) => bucket.sessions)) {
       expect(railRowCreator(node.session)).not.toBeNull();
     }

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -470,6 +470,28 @@ export function sessionCreatorOptions(sessions: Session[]): SessionCreatorOption
   return [...sessionCreatorLabelMap(sessions)].map(([value, label]) => ({ value, label }));
 }
 
+/** Drop a flat-search creator selection that is not valid for hierarchical browse roots. */
+export function normalizeSessionBrowseCreator(
+  creator: string | null,
+  creatorLabels: ReadonlyMap<string, string>,
+  hierarchical: boolean,
+): string | null {
+  if (!hierarchical || !creator || creatorLabels.has(creator)) return creator;
+  return null;
+}
+
+/** Count matching rows in flat search, or matching workstream roots in hierarchical browse. */
+export function sessionBrowseResultCount(
+  sessions: readonly Session[],
+  hierarchical: boolean,
+): number {
+  if (!hierarchical) return sessions.length;
+  const loadedIds = new Set(sessions.map((session) => session.id));
+  return sessions.filter(
+    (session) => !session.parentSessionId || !loadedIds.has(session.parentSessionId),
+  ).length;
+}
+
 function browseTimestamp(session: Session, field: SessionBrowseDateField): number {
   if (field === "activity") return sessionActivityTime(session);
   const created = Date.parse(session.createdAt);

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -482,6 +482,8 @@ export function filterSessionsForBrowse(
     creator: string | null;
     dateField: SessionBrowseDateField;
     dateRange: SessionBrowseDateRange;
+    /** Filter whole loaded workstreams by their root instead of orphaning descendants. */
+    hierarchical?: boolean;
     now?: Date;
   },
 ): Session[] {
@@ -495,16 +497,43 @@ export function filterSessionsForBrowse(
         : options.dateRange === "month"
           ? startOfToday - 29 * 24 * 60 * 60 * 1000
           : null;
-  return sessions.filter(
-    (session) =>
-      (!options.creator || sessionCreatorKey(session) === options.creator) &&
-      (threshold === null || browseTimestamp(session, options.dateField) >= threshold),
-  );
+  const matches = (session: Session): boolean =>
+    (!options.creator || sessionCreatorKey(session) === options.creator) &&
+    (threshold === null || browseTimestamp(session, options.dateField) >= threshold);
+  if (!options.hierarchical) return sessions.filter(matches);
+
+  const byId = new Map(sessions.map((session) => [session.id, session]));
+  const rootById = new Map<string, Session>();
+  const hierarchyRoot = (session: Session): Session => {
+    const cached = rootById.get(session.id);
+    if (cached) return cached;
+
+    const path: Session[] = [];
+    const seen = new Set<string>();
+    let current = session;
+    while (current.parentSessionId) {
+      if (seen.has(current.id)) {
+        // A pathological cycle has no meaningful root. Fall back to direct
+        // row filtering so every member stays independently reachable.
+        return session;
+      }
+      seen.add(current.id);
+      path.push(current);
+      const parent = byId.get(current.parentSessionId);
+      if (!parent) break;
+      current = parent;
+    }
+    rootById.set(current.id, current);
+    for (const member of path) rootById.set(member.id, current);
+    return current;
+  };
+
+  return sessions.filter((session) => matches(hierarchyRoot(session)));
 }
 
-/** Flat browse projection used only when the operator selects custom grouping. */
-export function groupSessionsForBrowse(
-  sessions: Session[],
+/** Regroup already-built workstream roots without flattening their descendants. */
+export function groupSessionForestForBrowse(
+  forest: SessionForest,
   groupBy: Exclude<SessionBrowseGroupBy, "activity">,
   options: {
     now?: Date;
@@ -512,17 +541,17 @@ export function groupSessionsForBrowse(
   } = {},
 ): SessionForest {
   const now = options.now ?? new Date();
-  const running = sessions
-    .filter(isEffectivelyRunning)
-    .sort(compareSessionActivity)
-    .map((session) => ({ session, children: [], hasActiveDescendant: false }));
-  const rest = sessions.filter((session) => !isEffectivelyRunning(session));
+  const roots = forestRoots(forest);
+  const running = roots
+    .filter(nodeIsActive)
+    .sort((left, right) => compareSessionActivity(left.session, right.session));
+  const rest = roots.filter((node) => !nodeIsActive(node));
   if (groupBy === "created") {
-    const buckets = new Map<SessionRecencyGroup, Session[]>();
-    for (const session of rest) {
-      const group = recencyGroupFor(browseTimestamp(session, "created"), now);
+    const buckets = new Map<SessionRecencyGroup, SessionTreeNode[]>();
+    for (const node of rest) {
+      const group = recencyGroupFor(browseTimestamp(node.session, "created"), now);
       const list = buckets.get(group) ?? [];
-      list.push(session);
+      list.push(node);
       buckets.set(group, list);
     }
     return {
@@ -542,27 +571,28 @@ export function groupSessionsForBrowse(
           {
             group: `created:${group}`,
             label,
-            sessions: list
-              .sort(
-                (left, right) =>
-                  browseTimestamp(right, "created") - browseTimestamp(left, "created"),
-              )
-              .map((session) => ({ session, children: [], hasActiveDescendant: false })),
+            sessions: list.sort(
+              (left, right) =>
+                browseTimestamp(right.session, "created") -
+                  browseTimestamp(left.session, "created") ||
+                right.session.id.localeCompare(left.session.id),
+            ),
           },
         ];
       }),
     };
   }
 
-  const creatorLabels = options.creatorLabels ?? sessionCreatorLabelMap(sessions);
-  const creators = new Map<string, { label: string; sessions: Session[] }>();
-  for (const session of rest) {
-    const key = sessionCreatorKey(session);
+  const creatorLabels =
+    options.creatorLabels ?? sessionCreatorLabelMap(roots.map((node) => node.session));
+  const creators = new Map<string, { label: string; sessions: SessionTreeNode[] }>();
+  for (const node of rest) {
+    const key = sessionCreatorKey(node.session);
     const bucket = creators.get(key) ?? {
-      label: creatorLabels.get(key) ?? sessionCreatorLabel(session),
+      label: creatorLabels.get(key) ?? sessionCreatorLabel(node.session),
       sessions: [],
     };
-    bucket.sessions.push(session);
+    bucket.sessions.push(node);
     creators.set(key, bucket);
   }
   return {
@@ -572,13 +602,23 @@ export function groupSessionsForBrowse(
       .map(([key, bucket]) => ({
         group: `creator:${key}`,
         label: bucket.label,
-        sessions: bucket.sessions.sort(compareSessionActivity).map((session) => ({
-          session,
-          children: [],
-          hasActiveDescendant: false,
-        })),
+        sessions: bucket.sessions.sort((left, right) =>
+          compareSessionActivity(left.session, right.session),
+        ),
       })),
   };
+}
+
+/** Build and regroup a loaded session set while preserving its lineage tree. */
+export function groupSessionsForBrowse(
+  sessions: Session[],
+  groupBy: Exclude<SessionBrowseGroupBy, "activity">,
+  options: {
+    now?: Date;
+    creatorLabels?: ReadonlyMap<string, string>;
+  } = {},
+): SessionForest {
+  return groupSessionForestForBrowse(buildRailForest(sessions, options.now), groupBy, options);
 }
 
 export type PinnedRailSections = {
@@ -915,11 +955,9 @@ function forestRoots(forest: SessionForest): SessionTreeNode[] {
  * Rows as the rail will actually render them.
  *
  * Hierarchy mode nests spawned sessions under their parent, so lineage stays.
- * Search results and browse groupings are deliberately flat - a partial match
- * set is not a tree, and a browse bucket is a list - so every row there IS
- * top-level and must say so. Both flat consumers (`buildPinnedRailSections`
- * and `groupSessionsForBrowse`) read this one projection; a row that renders at
- * the top level while still naming an absent parent is the bug this prevents.
+ * Search results are deliberately flat because a partial match set is not a
+ * tree, so every result there IS top-level and must say so. A row that renders
+ * at the top level while still naming an absent parent is the bug this prevents.
  */
 export function projectRailSessions(sessions: Session[], hierarchyMode: boolean): Session[] {
   return hierarchyMode

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -262,10 +262,16 @@ describe("session control surface architecture", () => {
     const list = await source("components/rail/session-list.tsx");
     expect(list).toContain("const creatorSessions = useMemo");
     expect(list).toContain("sessionCreatorLabelMap(creatorSessions)");
+    expect(list).toContain("const activeBrowseCreator = normalizeSessionBrowseCreator(");
+    expect(list).toContain("creator: activeBrowseCreator");
+    expect(list).toContain('browseCreatorOrigin.current !== "search"');
+    expect(list).toContain("updateSearchDraft(event.target.value)");
+    expect(list).not.toContain('"Selected"');
     expect(list).toContain("{ creatorLabels }");
     expect(list).toContain(
       'className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto"',
     );
+    expect(list).toContain("sessionBrowseResultCount(browseSessions, hierarchyMode)");
   });
 
   test("the retired client-side queue model is gone", async () => {

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -165,7 +165,7 @@ describe("session control surface architecture", () => {
     expect(list).toContain("const projected = serverSessions.find");
     const paginationKey = list.match(/const paginationKey = sessionPageKey\([\s\S]*?\n  \);/)?.[0];
     expect(paginationKey).toContain("rail.workspaceId");
-    expect(paginationKey).toContain('hierarchyMode ? "tree" : "browse"');
+    expect(paginationKey).toContain('hierarchyMode ? "tree" : "search"');
     expect(paginationKey).not.toContain("pinOverrides");
     expect(paginationKey).not.toContain("serverSessions");
   });
@@ -260,7 +260,8 @@ describe("session control surface architecture", () => {
 
   test("keeps the loaded creator picker identifiable and reachable", async () => {
     const list = await source("components/rail/session-list.tsx");
-    expect(list).toContain("sessionCreatorLabelMap(allSessions)");
+    expect(list).toContain("const creatorSessions = useMemo");
+    expect(list).toContain("sessionCreatorLabelMap(creatorSessions)");
     expect(list).toContain("{ creatorLabels }");
     expect(list).toContain(
       'className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto"',

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -171,6 +171,66 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     }
   }, 60_000);
 
+  test("keeps created-date browse results nested under their parent workstream", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const manager = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Created grouping manager",
+      );
+      const child = await createTitledSession(dbClient.db, {
+        accountId: manager.accountId,
+        workspaceId,
+        initialMessage: "Created grouping child",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sandboxBackend: "none",
+        parentSessionId: manager.id,
+      });
+
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions`);
+      const rail = page.locator("[data-sessionpin-session-list]");
+      const managerRow = rail.locator(`a[data-session-row="${manager.id}"]`);
+      await managerRow.waitFor();
+
+      await page.getByRole("button", { name: "Session filters" }).click();
+      await page.getByRole("menuitemradio", { name: "Created date" }).click();
+      await page.getByRole("button", { name: "Session filters, active" }).waitFor();
+
+      // Browse grouping keeps root-only pagination and lazy child loading. The
+      // child must not appear beside its manager as another top-level result.
+      expect(await rail.locator(`a[data-session-row="${child.id}"]`).count()).toBe(0);
+      const managerItem = managerRow.locator("xpath=../..");
+      await managerItem.getByRole("button", { name: "Expand spawned sessions" }).click();
+      const childRow = rail.locator(`a[data-session-row="${child.id}"]`);
+      await childRow.waitFor();
+      expect(
+        await childRow.evaluate((element) =>
+          element.closest('[role="list"]')?.getAttribute("aria-label"),
+        ),
+      ).toBe("Spawned sessions from Created grouping manager");
+      expect(await rail.locator(`a[data-session-row="${child.id}"]`).count()).toBe(1);
+      await expectNoAxeViolations(page, ["[data-sessionpin-session-list]"]);
+      await page.screenshot({
+        path: "/tmp/opengeni-session-created-group-hierarchy.png",
+        fullPage: true,
+      });
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+
   test("acknowledges later output without leaving and reopening the active chat", async () => {
     const context = await configuredContext(browser, {
       viewport: { width: 1280, height: 800 },

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -171,7 +171,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     }
   }, 60_000);
 
-  test("keeps created-date browse results nested under their parent workstream", async () => {
+  test("normalizes search-only creators and counts hierarchical browse roots", async () => {
     const context = await configuredContext(browser, {
       viewport: { width: 1280, height: 800 },
       extraHTTPHeaders: ownerHeaders,
@@ -180,6 +180,12 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     try {
       await page.goto(webBaseUrl);
       const workspaceId = await workspaceFromPage(page);
+      await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Created grouping unrelated root",
+      );
       const manager = await createSessionThroughApi(
         page,
         apiBaseUrl,
@@ -197,6 +203,11 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         latencyMode: "standard",
         sandboxBackend: "none",
         parentSessionId: manager.id,
+        createdBy: {
+          kind: "subject",
+          subjectId: "sessionpin-child-only-creator",
+          label: "Child-only creator",
+        },
       });
 
       await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions`);
@@ -204,9 +215,31 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       const managerRow = rail.locator(`a[data-session-row="${manager.id}"]`);
       await managerRow.waitFor();
 
+      const search = page.getByRole("searchbox", { name: "Search sessions" });
+      await search.fill("Created grouping child");
+      await page.getByText("1 matching session.").waitFor();
       await page.getByRole("button", { name: "Session filters" }).click();
+      await page.getByRole("menuitem", { name: /^Creator/ }).hover();
+      await page.getByRole("menuitemradio", { name: "Child-only creator" }).click();
+
+      // A creator offered only by flat child search is not a valid root filter.
+      // Leaving search clears that scoped choice instead of painting an empty
+      // hierarchy or leaving the submenu with a generic "Selected" value.
+      await search.fill("");
+      await managerRow.waitFor();
+      await page.getByRole("button", { name: "Session filters" }).click();
+      expect(await page.getByText("Selected", { exact: true }).count()).toBe(0);
       await page.getByRole("menuitemradio", { name: "Created date" }).click();
       await page.getByRole("button", { name: "Session filters, active" }).waitFor();
+      const liveRegion = rail.locator('[aria-live="polite"]');
+      await page.waitForFunction(() => {
+        const message = document.querySelector(
+          '[data-sessionpin-session-list] [aria-live="polite"]',
+        )?.textContent;
+        return Boolean(message && message !== "1 matching session.");
+      });
+      const rootCountAnnouncement = await liveRegion.textContent();
+      expect(rootCountAnnouncement).toMatch(/^\d+ matching sessions?\.$/);
 
       // Browse grouping keeps root-only pagination and lazy child loading. The
       // child must not appear beside its manager as another top-level result.
@@ -215,6 +248,8 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await managerItem.getByRole("button", { name: "Expand spawned sessions" }).click();
       const childRow = rail.locator(`a[data-session-row="${child.id}"]`);
       await childRow.waitFor();
+      await page.waitForTimeout(250);
+      expect(await liveRegion.textContent()).toBe(rootCountAnnouncement);
       expect(
         await childRow.evaluate((element) =>
           element.closest('[role="list"]')?.getAttribute("aria-label"),


### PR DESCRIPTION
## Summary
- keep created-date, creator, and filtered session browsing hierarchical by grouping parent workstreams instead of flattening sub-agents
- keep search intentionally flat so matches from any session remain directly discoverable
- preserve lazy child loading, pin pruning, scheduled-run folding, and active-descendant promotion under custom grouping
- add unit, static-contract, and real-browser coverage for nested created-date results

## Validation
- `bun test apps/web/src/lib/session-browse.test.ts apps/web/src/session-control-surface.test.ts apps/web/src/App.test.ts` (146 passed)
- `bun run --cwd apps/web typecheck`
- targeted `oxfmt` / `oxlint` / `git diff --check`
- `bun --no-env-file test --max-concurrency=1 ./test/e2e/session-pins.browser.e2e.ts -t "keeps created-date browse results nested under their parent workstream"` (passed against real API + PostgreSQL)
- inspected the 1280x800 browser screenshot produced by the test
- `bun test apps/web/src`: 1,173 passed; one unrelated workspace-member-picker timing test failed in the full run and passed on immediate isolated rerun

## Summary by Sourcery

Preserve session hierarchy for filtered and grouped browsing while keeping search results intentionally flat.

Bug Fixes:
- Preserve parent workstream hierarchy when grouping session browse results by created date or creator, preventing child sessions from appearing as orphaned top-level rows.

Enhancements:
- Keep session search flat while retaining hierarchical behavior for date, creator, and other browse filters, including lazy child loading, active-descendant promotion, pin handling, and scheduled-run folding.
- Normalize creator filters when switching between flat search and hierarchical browse, and report matching workstream roots accurately.

Tests:
- Add unit, architecture-contract, and real-browser coverage for hierarchical browse grouping, creator normalization, root counting, and nested created-date results.