### PR TITLE
Fix persistent broken sessions in For You

### DIFF
--- a/apps/web/src/components/rail/for-you-link.tsx
+++ b/apps/web/src/components/rail/for-you-link.tsx
@@ -5,20 +5,28 @@
 import { useWorkspaceSessions } from "@opengeni/react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { SendIcon } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
 import { rootNeedsYou } from "@/lib/needs-you";
 import { workspacePriorityPath } from "@/lib/routes";
+import { subscribeToSessionListChanges } from "@/lib/session-list-invalidation";
 import { cn } from "@/lib/utils";
 
 export function ForYouLink(props: { embedded?: boolean }) {
   const rail = useRail();
-  const { sessions } = useWorkspaceSessions({
+  const { sessions, refresh } = useWorkspaceSessions({
     limit: 50,
     parentSessionId: null,
     pollIntervalMs: 60_000,
   });
+  useEffect(
+    () =>
+      subscribeToSessionListChanges((invalidation) => {
+        if (invalidation.workspaceId === rail.workspaceId) void refresh();
+      }),
+    [rail.workspaceId, refresh],
+  );
   // rootNeedsYou is the same leaf predicate buildPriorityFeed classifies its
   // blocked+broken tiers with, so the badge and the page cannot drift. The
   // full feed lib stays un-imported here on purpose (bundle clustering).

--- a/apps/web/src/components/rail/for-you-link.tsx
+++ b/apps/web/src/components/rail/for-you-link.tsx
@@ -10,7 +10,7 @@ import { useEffect, useMemo } from "react";
 import { useRail } from "@/components/rail/rail-context";
 import { rootNeedsYou } from "@/lib/needs-you";
 import { workspacePriorityPath } from "@/lib/routes";
-import { subscribeToSessionListChanges } from "@/lib/session-list-invalidation";
+import { subscribeToWorkspaceSessionListChanges } from "@/lib/session-list-invalidation";
 import { cn } from "@/lib/utils";
 
 export function ForYouLink(props: { embedded?: boolean }) {
@@ -22,8 +22,8 @@ export function ForYouLink(props: { embedded?: boolean }) {
   });
   useEffect(
     () =>
-      subscribeToSessionListChanges((invalidation) => {
-        if (invalidation.workspaceId === rail.workspaceId) void refresh();
+      subscribeToWorkspaceSessionListChanges(rail.workspaceId, () => {
+        void refresh();
       }),
     [rail.workspaceId, refresh],
   );

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -163,6 +163,7 @@ import { railRowCreator } from "@/lib/creator-initials";
 import { formatWaitingSince } from "@/lib/format";
 import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
 import { requestCreateComposerFocus } from "@/lib/create-composer-focus";
+import { notifySessionListChanged } from "@/lib/session-list-invalidation";
 import {
   authoritativeSessionBranchChannels,
   beginSessionBranchRequest,
@@ -1345,6 +1346,11 @@ export function SessionList() {
               }
             : current,
         );
+        notifySessionListChanged({
+          workspaceId: rail.workspaceId,
+          sessionId: session.id,
+          archived: updated.archived,
+        });
         toast.success(archived ? "Chat archived" : "Chat restored");
         await refreshSessionPages();
       } catch (archiveError) {

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -163,7 +163,10 @@ import { railRowCreator } from "@/lib/creator-initials";
 import { formatWaitingSince } from "@/lib/format";
 import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
 import { requestCreateComposerFocus } from "@/lib/create-composer-focus";
-import { notifySessionListChanged } from "@/lib/session-list-invalidation";
+import {
+  notifySessionListChanged,
+  subscribeToWorkspaceSessionListChanges,
+} from "@/lib/session-list-invalidation";
 import {
   authoritativeSessionBranchChannels,
   beginSessionBranchRequest,
@@ -513,6 +516,17 @@ export function SessionList() {
     return subscribeToLocalSessionDeliveryAttention(refreshLocalDeliveryAttention);
   }, [rail.workspaceId]);
   const archiving = useRef(new Set<string>());
+  useEffect(
+    () =>
+      subscribeToWorkspaceSessionListChanges(rail.workspaceId, (invalidation) => {
+        // The archive callback below already awaits this refresh while holding
+        // its optimistic transition. Other mounted producers, including For
+        // You Dismiss/Stop, need the same prompt re-read immediately.
+        if (archiving.current.has(invalidation.sessionId)) return;
+        void refreshSessionPages();
+      }),
+    [rail.workspaceId, refreshSessionPages],
+  );
   const moveRequestOwner = useRef({});
   const pinOperation = useRef(0);
   const focusRestoreOperation = useRef(0);

--- a/apps/web/src/lib/session-list-invalidation.test.ts
+++ b/apps/web/src/lib/session-list-invalidation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  notifySessionListChanged,
+  subscribeToSessionListChanges,
+} from "./session-list-invalidation";
+
+describe("session list invalidation", () => {
+  test("notifies mounted consumers and stops after unsubscribe", () => {
+    const received: Array<{ workspaceId: string; sessionId: string; archived?: boolean }> = [];
+    const unsubscribe = subscribeToSessionListChanges((invalidation) => {
+      received.push(invalidation);
+    });
+
+    notifySessionListChanged({
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      archived: true,
+    });
+    unsubscribe();
+    notifySessionListChanged({ workspaceId: "workspace-1", sessionId: "session-2" });
+
+    expect(received).toEqual([
+      { workspaceId: "workspace-1", sessionId: "session-1", archived: true },
+    ]);
+  });
+});

--- a/apps/web/src/lib/session-list-invalidation.test.ts
+++ b/apps/web/src/lib/session-list-invalidation.test.ts
@@ -3,9 +3,21 @@ import { describe, expect, test } from "bun:test";
 import {
   notifySessionListChanged,
   subscribeToSessionListChanges,
+  subscribeToWorkspaceSessionListChanges,
 } from "./session-list-invalidation";
 
 describe("session list invalidation", () => {
+  test("keeps SessionList on the workspace-filtered refresh seam", async () => {
+    const sessionListSource = await Bun.file(
+      new URL("../components/rail/session-list.tsx", import.meta.url),
+    ).text();
+
+    expect(sessionListSource).toContain(
+      "subscribeToWorkspaceSessionListChanges(rail.workspaceId, (invalidation) =>",
+    );
+    expect(sessionListSource).toContain("void refreshSessionPages();");
+  });
+
   test("notifies mounted consumers and stops after unsubscribe", () => {
     const received: Array<{ workspaceId: string; sessionId: string; archived?: boolean }> = [];
     const unsubscribe = subscribeToSessionListChanges((invalidation) => {
@@ -23,5 +35,18 @@ describe("session list invalidation", () => {
     expect(received).toEqual([
       { workspaceId: "workspace-1", sessionId: "session-1", archived: true },
     ]);
+  });
+
+  test("delivers only invalidations for the subscribed workspace", () => {
+    const received: string[] = [];
+    const unsubscribe = subscribeToWorkspaceSessionListChanges("workspace-1", (invalidation) => {
+      received.push(invalidation.sessionId);
+    });
+
+    notifySessionListChanged({ workspaceId: "workspace-2", sessionId: "session-2" });
+    notifySessionListChanged({ workspaceId: "workspace-1", sessionId: "session-1" });
+    unsubscribe();
+
+    expect(received).toEqual(["session-1"]);
   });
 });

--- a/apps/web/src/lib/session-list-invalidation.ts
+++ b/apps/web/src/lib/session-list-invalidation.ts
@@ -1,0 +1,23 @@
+export type SessionListInvalidation = {
+  workspaceId: string;
+  sessionId: string;
+  archived?: boolean;
+};
+
+const listeners = new Set<(invalidation: SessionListInvalidation) => void>();
+
+/**
+ * Tell other mounted session-list consumers that a confirmed mutation changed
+ * whether one root belongs in their current projection. Durable server state
+ * remains authoritative; this is only a same-tab prompt to re-read it.
+ */
+export function notifySessionListChanged(invalidation: SessionListInvalidation): void {
+  for (const listener of listeners) listener(invalidation);
+}
+
+export function subscribeToSessionListChanges(
+  listener: (invalidation: SessionListInvalidation) => void,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/web/src/lib/session-list-invalidation.ts
+++ b/apps/web/src/lib/session-list-invalidation.ts
@@ -21,3 +21,12 @@ export function subscribeToSessionListChanges(
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
+
+export function subscribeToWorkspaceSessionListChanges(
+  workspaceId: string,
+  listener: (invalidation: SessionListInvalidation) => void,
+): () => void {
+  return subscribeToSessionListChanges((invalidation) => {
+    if (invalidation.workspaceId === workspaceId) listener(invalidation);
+  });
+}

--- a/apps/web/src/routes/priority.test.tsx
+++ b/apps/web/src/routes/priority.test.tsx
@@ -1,0 +1,235 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { Session } from "@/types";
+
+const WORKSPACE_ID = "00000000-0000-4000-8000-000000000001";
+const SESSION_ID = "00000000-0000-4000-8000-000000000002";
+
+let sessions: Session[] = [];
+let permissions = ["sessions:read", "sessions:control"];
+const refresh = mock(async () => undefined);
+const updateSessionArchive = mock(async (_workspaceId: string, _sessionId: string) => ({
+  ...sessions[0]!,
+  archived: true,
+  archivedAt: "2026-08-31T12:00:00.000Z",
+  archiveVersion: 1,
+}));
+const cancelSession = mock(
+  async (
+    _workspaceId: string,
+    _sessionId: string,
+    _options: {
+      clientEventId: string;
+      reason: string;
+      expectedControlEtag: string;
+    },
+  ) => ({
+    effectiveControl: sessions[0]!.effectiveControl,
+  }),
+);
+
+mock.module("@opengeni/react", () => ({
+  useWorkspaceSessions: () => ({
+    sessions,
+    nextCursor: null,
+    loading: false,
+    error: null,
+    refresh,
+  }),
+  useChannels: () => ({ channels: [] }),
+}));
+
+mock.module("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
+}));
+
+mock.module("@/context", () => ({
+  useAppContext: () => ({
+    client: { updateSessionArchive, cancelSession },
+    accessContext: {
+      workspaceGrants: [{ workspaceId: WORKSPACE_ID, permissions }],
+    },
+  }),
+}));
+
+mock.module("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: (props: {
+    open: boolean;
+    title: ReactNode;
+    description?: ReactNode;
+    confirmLabel: string;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void | boolean | Promise<void | boolean>;
+  }) =>
+    props.open ? (
+      <div role="dialog">
+        <div>{props.title}</div>
+        <div>{props.description}</div>
+        <button
+          type="button"
+          onClick={() => {
+            void Promise.resolve(props.onConfirm()).then((result) => {
+              if (result !== false) props.onOpenChange(false);
+            });
+          }}
+        >
+          {props.confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+mock.module("sonner", () => ({
+  toast: {
+    success: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { PriorityRoute } = await import("./priority");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+beforeEach(() => {
+  sessions = [brokenSession()];
+  permissions = ["sessions:read", "sessions:control"];
+  refresh.mockClear();
+  updateSessionArchive.mockClear();
+  cancelSession.mockClear();
+});
+
+function brokenSession(): Session {
+  return {
+    id: SESSION_ID,
+    accountId: "00000000-0000-4000-8000-000000000003",
+    workspaceId: WORKSPACE_ID,
+    initialMessage: "Repair the deployment",
+    title: "Broken deployment",
+    parentSessionId: null,
+    channelId: null,
+    status: "failed",
+    pinned: false,
+    pinnedAt: null,
+    pinVersion: 0,
+    unread: false,
+    activelyWorking: false,
+    attentionVersion: 0,
+    archived: false,
+    archivedAt: null,
+    archiveVersion: 0,
+    createdBy: { kind: "subject", subjectId: "user:test" },
+    effectiveControl: {
+      state: "active",
+      controlVersion: 4,
+      controlEtag: "active-4",
+      directState: "active",
+      primaryBlocker: null,
+      additionalBlockerCount: 0,
+      blockers: [],
+      resumeOptions: [],
+      override: null,
+      settlement: null,
+    },
+    treeStats: {
+      directChildren: 1,
+      totalDescendants: 1,
+      runningDescendants: 1,
+      queuedDescendants: 0,
+      attentionDescendants: 0,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+      truncated: false,
+    },
+    createdAt: "2026-08-31T10:00:00.000Z",
+    updatedAt: "2026-08-31T11:00:00.000Z",
+  } as unknown as Session;
+}
+
+function buttonWithText(container: HTMLElement, label: string): HTMLButtonElement | null {
+  return (
+    [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === label,
+    ) ?? null
+  );
+}
+
+async function renderPriorityRoute() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () => root.render(<PriorityRoute workspaceId={WORKSPACE_ID} />));
+  return { container, root };
+}
+
+describe("For you broken-session actions", () => {
+  test("dismisses a broken session into the personal archive", async () => {
+    const { container, root } = await renderPriorityRoute();
+    try {
+      expect(container.textContent).toContain("Broken deployment");
+      await act(async () => {
+        buttonWithText(container, "Dismiss")!.click();
+        await Promise.resolve();
+      });
+
+      expect(updateSessionArchive).toHaveBeenCalledWith(WORKSPACE_ID, SESSION_ID, {
+        archived: true,
+        expectedVersion: 0,
+      });
+      expect(container.textContent).not.toContain("Broken deployment");
+      expect(refresh).toHaveBeenCalled();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("confirms a terminal stop with one stable command id", async () => {
+    const { container, root } = await renderPriorityRoute();
+    try {
+      await act(async () => buttonWithText(container, "Stop workstream")!.click());
+      const dialog = container.querySelector<HTMLElement>('[role="dialog"]');
+      expect(dialog?.textContent).toContain("1 spawned session");
+
+      await act(async () => {
+        buttonWithText(dialog!, "Stop workstream")!.click();
+        await Promise.resolve();
+      });
+
+      expect(cancelSession).toHaveBeenCalledTimes(1);
+      expect(cancelSession.mock.calls[0]?.[0]).toBe(WORKSPACE_ID);
+      expect(cancelSession.mock.calls[0]?.[1]).toBe(SESSION_ID);
+      expect(cancelSession.mock.calls[0]?.[2]).toMatchObject({
+        reason: "Stopped from For you",
+        expectedControlEtag: "active-4",
+      });
+      expect(cancelSession.mock.calls[0]?.[2]?.clientEventId).toBeString();
+      expect(container.textContent).not.toContain("Broken deployment");
+      expect(updateSessionArchive).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("keeps personal dismissal available without shared session control", async () => {
+    permissions = ["sessions:read"];
+    const { container, root } = await renderPriorityRoute();
+    try {
+      expect(buttonWithText(container, "Dismiss")).not.toBeNull();
+      expect(buttonWithText(container, "Stop workstream")).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/routes/priority.test.tsx
+++ b/apps/web/src/routes/priority.test.tsx
@@ -3,6 +3,7 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useEffect, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 
+import { ApiError } from "@/api";
 import { subscribeToWorkspaceSessionListChanges } from "@/lib/session-list-invalidation";
 import type { Session } from "@/types";
 
@@ -248,6 +249,62 @@ describe("For you broken-session actions", () => {
           document.activeElement?.tagName ?? "none"
         }`,
       );
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("reopens a conflicted stop with the refreshed control ETag", async () => {
+    cancelSession.mockImplementationOnce(async () => {
+      throw new ApiError(409, "control changed");
+    });
+    refresh.mockImplementationOnce(async () => {
+      const refreshed = brokenSession();
+      sessions = [
+        {
+          ...refreshed,
+          effectiveControl: {
+            ...refreshed.effectiveControl,
+            controlVersion: 5,
+            controlEtag: "paused-5",
+            state: "paused",
+            directState: "paused",
+          },
+        },
+      ];
+    });
+    const { container, root } = await renderPriorityRoute();
+    try {
+      await act(async () => buttonWithText(container, "Stop workstream")!.click());
+      const firstDialog = document.body.querySelector<HTMLElement>('[role="dialog"]')!;
+      await act(async () => {
+        buttonWithText(firstDialog, "Stop workstream")!.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(
+        () => document.body.querySelector('[role="dialog"]') === null,
+        "Expected the stale confirmation to close after the control conflict",
+      );
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(cancelSession.mock.calls[0]?.[2]?.expectedControlEtag).toBe("active-4");
+      const firstClientEventId = cancelSession.mock.calls[0]?.[2]?.clientEventId;
+
+      await act(async () => buttonWithText(container, "Stop workstream")!.click());
+      const secondDialog = document.body.querySelector<HTMLElement>('[role="dialog"]')!;
+      await act(async () => {
+        buttonWithText(secondDialog, "Stop workstream")!.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(cancelSession).toHaveBeenCalledTimes(2);
+      expect(cancelSession.mock.calls[1]?.[2]).toMatchObject({
+        expectedControlEtag: "paused-5",
+      });
+      expect(cancelSession.mock.calls[1]?.[2]?.clientEventId).not.toBe(firstClientEventId);
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/priority.test.tsx
+++ b/apps/web/src/routes/priority.test.tsx
@@ -1,16 +1,20 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act, type ReactNode } from "react";
+import { act, useEffect, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 
+import { subscribeToWorkspaceSessionListChanges } from "@/lib/session-list-invalidation";
 import type { Session } from "@/types";
 
 const WORKSPACE_ID = "00000000-0000-4000-8000-000000000001";
 const SESSION_ID = "00000000-0000-4000-8000-000000000002";
+const OTHER_WORKSPACE_ID = "00000000-0000-4000-8000-000000000004";
 
 let sessions: Session[] = [];
 let permissions = ["sessions:read", "sessions:control"];
 const refresh = mock(async () => undefined);
+const railRefresh = mock(async () => undefined);
+const otherWorkspaceRailRefresh = mock(async () => undefined);
 const updateSessionArchive = mock(async (_workspaceId: string, _sessionId: string) => ({
   ...sessions[0]!,
   archived: true,
@@ -55,33 +59,6 @@ mock.module("@/context", () => ({
   }),
 }));
 
-mock.module("@/components/ui/confirm-dialog", () => ({
-  ConfirmDialog: (props: {
-    open: boolean;
-    title: ReactNode;
-    description?: ReactNode;
-    confirmLabel: string;
-    onOpenChange: (open: boolean) => void;
-    onConfirm: () => void | boolean | Promise<void | boolean>;
-  }) =>
-    props.open ? (
-      <div role="dialog">
-        <div>{props.title}</div>
-        <div>{props.description}</div>
-        <button
-          type="button"
-          onClick={() => {
-            void Promise.resolve(props.onConfirm()).then((result) => {
-              if (result !== false) props.onOpenChange(false);
-            });
-          }}
-        >
-          {props.confirmLabel}
-        </button>
-      </div>
-    ) : null,
-}));
-
 mock.module("sonner", () => ({
   toast: {
     success: mock(() => undefined),
@@ -89,14 +66,13 @@ mock.module("sonner", () => ({
   },
 }));
 
+GlobalRegistrator.register();
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 const { PriorityRoute } = await import("./priority");
 
-beforeAll(() => {
-  GlobalRegistrator.register();
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-});
-
 afterAll(() => {
+  mock.restore();
   GlobalRegistrator.unregister();
 });
 
@@ -104,6 +80,8 @@ beforeEach(() => {
   sessions = [brokenSession()];
   permissions = ["sessions:read", "sessions:control"];
   refresh.mockClear();
+  railRefresh.mockClear();
+  otherWorkspaceRailRefresh.mockClear();
   updateSessionArchive.mockClear();
   cancelSession.mockClear();
 });
@@ -167,8 +145,46 @@ async function renderPriorityRoute() {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
-  await act(async () => root.render(<PriorityRoute workspaceId={WORKSPACE_ID} />));
+  await act(async () =>
+    root.render(
+      <>
+        <PriorityRoute workspaceId={WORKSPACE_ID} />
+        <SessionListRefreshProbe workspaceId={WORKSPACE_ID} refresh={railRefresh} />
+        <SessionListRefreshProbe
+          workspaceId={OTHER_WORKSPACE_ID}
+          refresh={otherWorkspaceRailRefresh}
+        />
+      </>,
+    ),
+  );
   return { container, root };
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+}
+
+function SessionListRefreshProbe({
+  workspaceId,
+  refresh: refreshProbe,
+}: {
+  workspaceId: string;
+  refresh: () => Promise<void>;
+}) {
+  useEffect(
+    () =>
+      subscribeToWorkspaceSessionListChanges(workspaceId, () => {
+        void refreshProbe();
+      }),
+    [refreshProbe, workspaceId],
+  );
+  return null;
 }
 
 describe("For you broken-session actions", () => {
@@ -187,21 +203,26 @@ describe("For you broken-session actions", () => {
       });
       expect(container.textContent).not.toContain("Broken deployment");
       expect(refresh).toHaveBeenCalled();
+      expect(railRefresh).toHaveBeenCalledTimes(1);
+      expect(otherWorkspaceRailRefresh).not.toHaveBeenCalled();
     } finally {
       await act(async () => root.unmount());
       container.remove();
     }
   });
 
-  test("confirms a terminal stop with one stable command id", async () => {
+  test("confirms a terminal stop, refreshes the rail, and restores stable focus", async () => {
     const { container, root } = await renderPriorityRoute();
     try {
-      await act(async () => buttonWithText(container, "Stop workstream")!.click());
-      const dialog = container.querySelector<HTMLElement>('[role="dialog"]');
+      const trigger = buttonWithText(container, "Stop workstream")!;
+      trigger.focus();
+      await act(async () => trigger.click());
+      const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]');
       expect(dialog?.textContent).toContain("1 spawned session");
 
       await act(async () => {
         buttonWithText(dialog!, "Stop workstream")!.click();
+        await Promise.resolve();
         await Promise.resolve();
       });
 
@@ -215,6 +236,43 @@ describe("For you broken-session actions", () => {
       expect(cancelSession.mock.calls[0]?.[2]?.clientEventId).toBeString();
       expect(container.textContent).not.toContain("Broken deployment");
       expect(updateSessionArchive).not.toHaveBeenCalled();
+      expect(railRefresh).toHaveBeenCalledTimes(1);
+      expect(otherWorkspaceRailRefresh).not.toHaveBeenCalled();
+      expect(trigger.isConnected).toBe(false);
+      const heading = container.querySelector("h1");
+      await waitFor(
+        () =>
+          document.body.querySelector('[role="dialog"]') === null &&
+          document.activeElement === heading,
+        `Expected focus on the For you heading after dialog close; active element was ${
+          document.activeElement?.tagName ?? "none"
+        }`,
+      );
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("describes a truncated descendant count as a lower bound", async () => {
+    const session = brokenSession();
+    sessions = [
+      {
+        ...session,
+        treeStats: {
+          ...session.treeStats!,
+          totalDescendants: 1_000,
+          truncated: true,
+        },
+      },
+    ];
+    const { container, root } = await renderPriorityRoute();
+    try {
+      await act(async () => buttonWithText(container, "Stop workstream")!.click());
+      const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]');
+
+      expect(dialog?.textContent).toContain("at least 1,000 spawned sessions");
+      expect(dialog?.textContent).not.toContain("its 1,000 spawned sessions");
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/priority.tsx
+++ b/apps/web/src/routes/priority.tsx
@@ -5,7 +5,7 @@
 import { useChannels, useWorkspaceSessions } from "@opengeni/react";
 import { Link } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 
 import { CreatorMonogram } from "@/components/creator-monogram";
@@ -16,9 +16,10 @@ import { hasWorkspacePermission } from "@/lib/permissions";
 import { sessionDisplayTitle } from "@/lib/session-rename";
 import {
   notifySessionListChanged,
-  subscribeToSessionListChanges,
+  subscribeToWorkspaceSessionListChanges,
 } from "@/lib/session-list-invalidation";
 import { relativeTimeLabel } from "@/lib/sessions-group";
+import { sessionDescendantCountText } from "@/lib/session-tree-count";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
 
@@ -31,7 +32,7 @@ type BrokenActions = {
   canControl: boolean;
   dismissing: ReadonlySet<string>;
   onDismiss: (session: Session) => Promise<void>;
-  onRequestStop: (session: Session) => void;
+  onRequestStop: (session: Session, trigger: HTMLButtonElement) => void;
 };
 
 export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
@@ -44,11 +45,12 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
   const [locallyHidden, setLocallyHidden] = useState<ReadonlySet<string>>(() => new Set());
   const [dismissing, setDismissing] = useState<ReadonlySet<string>>(() => new Set());
   const [pendingStop, setPendingStop] = useState<PendingStop | null>(null);
+  const stopTriggerRef = useRef<HTMLElement | null>(null);
+  const stopFocusFallbackRef = useRef<HTMLHeadingElement | null>(null);
   const canControl = hasWorkspacePermission(context.accessContext, workspaceId, "sessions:control");
   useEffect(
     () =>
-      subscribeToSessionListChanges((invalidation) => {
-        if (invalidation.workspaceId !== workspaceId) return;
+      subscribeToWorkspaceSessionListChanges(workspaceId, (invalidation) => {
         if (invalidation.archived !== undefined) {
           setLocallyHidden((current) => {
             const next = new Set(current);
@@ -121,6 +123,10 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
         reason: "Stopped from For you",
         expectedControlEtag: session.effectiveControl.controlEtag,
       });
+      // Closing autofocus can run before React removes the hidden row. Clear
+      // the doomed opener explicitly so the dialog selects the stable heading
+      // instead of briefly focusing a node that is about to disconnect.
+      stopTriggerRef.current = null;
       setLocallyHidden((current) => new Set(current).add(session.id));
       notifySessionListChanged({ workspaceId, sessionId: session.id });
       toast.success("Workstream stopped");
@@ -133,7 +139,8 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
       return false;
     }
   }, [context.client, pendingStop, refresh, workspaceId]);
-  const requestStop = useCallback((session: Session) => {
+  const requestStop = useCallback((session: Session, trigger: HTMLButtonElement) => {
+    stopTriggerRef.current = trigger;
     setPendingStop({ session, clientEventId: crypto.randomUUID() });
   }, []);
   // The date caption changes once a day; don't rebuild the Intl formatter on
@@ -157,7 +164,13 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
     <div data-workspace-scroll-owner="self-managed" className="min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-6 pb-16 pt-8">
         <header className="flex items-baseline gap-3 pb-6">
-          <h1 className="text-lg font-semibold tracking-[-0.01em]">For you</h1>
+          <h1
+            ref={stopFocusFallbackRef}
+            tabIndex={-1}
+            className="text-lg font-semibold tracking-[-0.01em]"
+          >
+            For you
+          </h1>
           <span className="ml-auto font-mono text-2xs text-fg-subtle">
             sorted by agent-time lost
           </span>
@@ -271,6 +284,8 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
         description={stopDescription(pendingStop?.session ?? null)}
         confirmLabel="Stop workstream"
         cancelAutoFocus
+        restoreFocusRef={stopTriggerRef}
+        restoreFocusFallbackRef={stopFocusFallbackRef}
         onConfirm={stopBroken}
       />
     </div>
@@ -279,9 +294,13 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
 
 function stopDescription(session: Session | null): string {
   const descendants = session?.treeStats?.totalDescendants ?? 0;
+  const truncated = session?.treeStats?.truncated ?? false;
+  const formattedDescendants = sessionDescendantCountText(descendants, false);
   return descendants > 0
-    ? `This permanently stops the workstream and its ${descendants} spawned session${
-        descendants === 1 ? "" : "s"
+    ? `This permanently stops the workstream and ${
+        truncated ? `at least ${formattedDescendants}` : `its ${formattedDescendants}`
+      } spawned session${
+        descendants === 1 && !truncated ? "" : "s"
       }. You won't be able to continue them.`
     : "This permanently stops the workstream. You won't be able to continue it.";
 }
@@ -423,7 +442,9 @@ function PriorityRow(props: {
             <button
               type="button"
               className="inline-flex min-h-7 items-center text-xs font-medium text-status-failed hover:underline pointer-coarse:min-h-11"
-              onClick={() => props.brokenActions?.onRequestStop(session)}
+              onClick={(event: MouseEvent<HTMLButtonElement>) =>
+                props.brokenActions?.onRequestStop(session, event.currentTarget)
+              }
             >
               Stop workstream
             </button>

--- a/apps/web/src/routes/priority.tsx
+++ b/apps/web/src/routes/priority.tsx
@@ -8,6 +8,7 @@ import { ChevronRightIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 
+import { isApiErrorStatus } from "@/api";
 import { CreatorMonogram } from "@/components/creator-monogram";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useAppContext } from "@/context";
@@ -135,7 +136,12 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
       toast.error("Couldn't stop the workstream.", {
         description: stopError instanceof Error ? stopError.message : String(stopError),
       });
-      void refresh();
+      if (isApiErrorStatus(stopError, 409)) {
+        await refresh();
+        setPendingStop(null);
+      } else {
+        void refresh();
+      }
       return false;
     }
   }, [context.client, pendingStop, refresh, workspaceId]);

--- a/apps/web/src/routes/priority.tsx
+++ b/apps/web/src/routes/priority.tsx
@@ -5,26 +5,137 @@
 import { useChannels, useWorkspaceSessions } from "@opengeni/react";
 import { Link } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { CreatorMonogram } from "@/components/creator-monogram";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useAppContext } from "@/context";
 import { buildPriorityFeed, formatAgentMinutes, type PriorityEntry } from "@/lib/priority-feed";
+import { hasWorkspacePermission } from "@/lib/permissions";
 import { sessionDisplayTitle } from "@/lib/session-rename";
+import {
+  notifySessionListChanged,
+  subscribeToSessionListChanges,
+} from "@/lib/session-list-invalidation";
 import { relativeTimeLabel } from "@/lib/sessions-group";
 import { cn } from "@/lib/utils";
+import type { Session } from "@/types";
+
+type PendingStop = {
+  session: Session;
+  clientEventId: string;
+};
+
+type BrokenActions = {
+  canControl: boolean;
+  dismissing: ReadonlySet<string>;
+  onDismiss: (session: Session) => Promise<void>;
+  onRequestStop: (session: Session) => void;
+};
 
 export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
+  const context = useAppContext();
   const { sessions, nextCursor, loading, error, refresh } = useWorkspaceSessions({
     limit: 50,
     parentSessionId: null,
     pollIntervalMs: 15_000,
   });
+  const [locallyHidden, setLocallyHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [dismissing, setDismissing] = useState<ReadonlySet<string>>(() => new Set());
+  const [pendingStop, setPendingStop] = useState<PendingStop | null>(null);
+  const canControl = hasWorkspacePermission(context.accessContext, workspaceId, "sessions:control");
+  useEffect(
+    () =>
+      subscribeToSessionListChanges((invalidation) => {
+        if (invalidation.workspaceId !== workspaceId) return;
+        if (invalidation.archived !== undefined) {
+          setLocallyHidden((current) => {
+            const next = new Set(current);
+            if (invalidation.archived) next.add(invalidation.sessionId);
+            else next.delete(invalidation.sessionId);
+            return next;
+          });
+        }
+        void refresh();
+      }),
+    [refresh, workspaceId],
+  );
+  useEffect(() => {
+    const listedIds = new Set(sessions.map((session) => session.id));
+    setLocallyHidden((current) => {
+      const next = new Set([...current].filter((sessionId) => !listedIds.has(sessionId)));
+      if (next.size === current.size) return current;
+      return next;
+    });
+  }, [sessions]);
   const { channels } = useChannels({ pollIntervalMs: 60_000 });
   const channelNames = useMemo(
     () => new Map(channels.map((channel) => [channel.id, channel.name])),
     [channels],
   );
-  const feed = useMemo(() => buildPriorityFeed(sessions), [sessions]);
+  const visibleSessions = useMemo(
+    () => sessions.filter((session) => !locallyHidden.has(session.id)),
+    [locallyHidden, sessions],
+  );
+  const feed = useMemo(() => buildPriorityFeed(visibleSessions), [visibleSessions]);
+  const dismissBroken = useCallback(
+    async (session: Session): Promise<void> => {
+      if (dismissing.has(session.id)) return;
+      setDismissing((current) => new Set(current).add(session.id));
+      try {
+        const updated = await context.client.updateSessionArchive(workspaceId, session.id, {
+          archived: true,
+          expectedVersion: session.archiveVersion ?? 0,
+        });
+        setLocallyHidden((current) => new Set(current).add(session.id));
+        notifySessionListChanged({
+          workspaceId,
+          sessionId: session.id,
+          archived: updated.archived,
+        });
+        toast.success("Removed from For you", {
+          description: "You can restore it from Archived.",
+        });
+      } catch (dismissError) {
+        toast.error("Couldn't dismiss the workstream.", {
+          description: dismissError instanceof Error ? dismissError.message : String(dismissError),
+        });
+        void refresh();
+      } finally {
+        setDismissing((current) => {
+          const next = new Set(current);
+          next.delete(session.id);
+          return next;
+        });
+      }
+    },
+    [context.client, dismissing, refresh, workspaceId],
+  );
+  const stopBroken = useCallback(async (): Promise<boolean> => {
+    if (!pendingStop) return false;
+    const { session, clientEventId } = pendingStop;
+    try {
+      await context.client.cancelSession(workspaceId, session.id, {
+        clientEventId,
+        reason: "Stopped from For you",
+        expectedControlEtag: session.effectiveControl.controlEtag,
+      });
+      setLocallyHidden((current) => new Set(current).add(session.id));
+      notifySessionListChanged({ workspaceId, sessionId: session.id });
+      toast.success("Workstream stopped");
+      return true;
+    } catch (stopError) {
+      toast.error("Couldn't stop the workstream.", {
+        description: stopError instanceof Error ? stopError.message : String(stopError),
+      });
+      void refresh();
+      return false;
+    }
+  }, [context.client, pendingStop, refresh, workspaceId]);
+  const requestStop = useCallback((session: Session) => {
+    setPendingStop({ session, clientEventId: crypto.randomUUID() });
+  }, []);
   // The date caption changes once a day; don't rebuild the Intl formatter on
   // every 15s poll re-render.
   const today = useMemo(
@@ -94,6 +205,12 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
                   entries={feed.broken}
                   workspaceId={workspaceId}
                   channelNames={channelNames}
+                  brokenActions={{
+                    canControl,
+                    dismissing,
+                    onDismiss: dismissBroken,
+                    onRequestStop: requestStop,
+                  }}
                 />
                 <PriorityTierSection
                   title="Recently finished"
@@ -145,8 +262,28 @@ export function PriorityRoute({ workspaceId }: { workspaceId: string }) {
           </>
         )}
       </div>
+      <ConfirmDialog
+        open={pendingStop !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingStop(null);
+        }}
+        title={<>Stop “{pendingStop ? sessionDisplayTitle(pendingStop.session) : ""}”?</>}
+        description={stopDescription(pendingStop?.session ?? null)}
+        confirmLabel="Stop workstream"
+        cancelAutoFocus
+        onConfirm={stopBroken}
+      />
     </div>
   );
+}
+
+function stopDescription(session: Session | null): string {
+  const descendants = session?.treeStats?.totalDescendants ?? 0;
+  return descendants > 0
+    ? `This permanently stops the workstream and its ${descendants} spawned session${
+        descendants === 1 ? "" : "s"
+      }. You won't be able to continue them.`
+    : "This permanently stops the workstream. You won't be able to continue it.";
 }
 
 function PriorityTierSection(props: {
@@ -155,6 +292,7 @@ function PriorityTierSection(props: {
   entries: PriorityEntry[];
   workspaceId: string;
   channelNames: ReadonlyMap<string, string>;
+  brokenActions?: BrokenActions;
 }) {
   if (props.entries.length === 0) return null;
   return (
@@ -176,6 +314,7 @@ function PriorityTierSection(props: {
             first={index === 0}
             workspaceId={props.workspaceId}
             channelNames={props.channelNames}
+            brokenActions={props.brokenActions}
           />
         ))}
       </div>
@@ -227,6 +366,7 @@ function PriorityRow(props: {
   first: boolean;
   workspaceId: string;
   channelNames: ReadonlyMap<string, string>;
+  brokenActions?: BrokenActions;
 }) {
   const { entry } = props;
   const session = entry.session;
@@ -271,14 +411,34 @@ function PriorityRow(props: {
           />
           {entry.reason}
         </p>
-        <div className="flex gap-4 pt-0.5">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pt-0.5">
           <Link
             to="/workspaces/$workspaceId/sessions/$sessionId"
             params={{ workspaceId: props.workspaceId, sessionId: session.id }}
-            className="text-xs font-medium text-brand hover:underline"
+            className="inline-flex min-h-7 items-center text-xs font-medium text-brand hover:underline pointer-coarse:min-h-11"
           >
             Open session
           </Link>
+          {entry.tier === "broken" && props.brokenActions?.canControl ? (
+            <button
+              type="button"
+              className="inline-flex min-h-7 items-center text-xs font-medium text-status-failed hover:underline pointer-coarse:min-h-11"
+              onClick={() => props.brokenActions?.onRequestStop(session)}
+            >
+              Stop workstream
+            </button>
+          ) : null}
+          {entry.tier === "broken" && props.brokenActions ? (
+            <button
+              type="button"
+              className="inline-flex min-h-7 items-center text-xs font-medium text-fg-subtle hover:text-fg-muted hover:underline disabled:cursor-wait disabled:opacity-50 pointer-coarse:min-h-11"
+              title="Remove from For you and move to Archived"
+              disabled={props.brokenActions.dismissing.has(session.id)}
+              onClick={() => void props.brokenActions?.onDismiss(session)}
+            >
+              {props.brokenActions.dismissing.has(session.id) ? "Dismissing…" : "Dismiss"}
+            </button>
+          ) : null}
         </div>
       </div>
       <div className="grid w-32 shrink-0 gap-0.5 pt-0.5 text-right">


### PR DESCRIPTION
## Summary

- Add explicit Stop workstream and Dismiss actions to broken rows in For You.
- Stop performs a confirmed terminal cancellation of the full session tree and is limited to users with `sessions:control`.
- Dismiss moves the root to the personal Archive without stopping shared work.
- Refresh For You and rail session projections immediately after archive, restore, or stop mutations.

## Testing

- [x] `cd apps/web && bun run typecheck`
- [x] `cd apps/web && bun test src/routes/priority.test.tsx src/lib/session-list-invalidation.test.ts src/lib/priority-feed.test.ts` (12 passing)
- [x] `cd apps/web && bun run build` (bundle budgets passing)
- [x] Targeted `oxfmt --check`, `oxlint --deny-warnings`, and `git diff --check`
- [x] Desktop visual inspection at 1280x900, including the destructive confirmation dialog; no console or page errors

## Delivery integrity

- [x] This PR contains substantive source changes and targets `main`.

## Notes

- Read-only users retain personal Dismiss but do not see the shared Stop action.
- Dismissed sessions can be restored from Archived.

## Summary by Sourcery

Fix persistently stuck broken sessions in For You by adding Stop and Dismiss actions and cross-component refresh signaling.

New Features:
- Add a confirmed 'Stop workstream' action on broken For You rows that terminally cancels the full session tree, gated by the sessions:control permission.
- Add a personal 'Dismiss' action on broken For You rows that archives the root session without stopping the underlying work, restorable from Archived.

Bug Fixes:
- Prevent broken sessions from persisting indefinitely in For You after being archived, restored, or stopped elsewhere.

Enhancements:
- Introduce a shared session-list invalidation event bus so For You and the rail session list refresh their projections immediately after archive, restore, or stop mutations.
- Optimistically hide dismissed or stopped sessions locally while the underlying data refreshes.

Tests:
- Add tests covering the session-list invalidation pub/sub mechanism and the For You broken-session Stop/Dismiss flows, including permission gating, focus restoration, and control-conflict retry behavior.