### PR TITLE
fix(api): bound connected machine heartbeat backlog

### DIFF
--- a/.changeset/bound-connected-machine-heartbeat-backlog.md
+++ b/.changeset/bound-connected-machine-heartbeat-backlog.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Bound Connected Machine event backlogs per exact runner. Separate connections now ingest with bounded concurrency, while consecutive queued heartbeats collapse to the newest sample without reordering lifecycle events.

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -28,7 +28,11 @@
 // Both consumers are BEST-EFFORT and fail-soft: a decode/DB error for one message
 // is logged + swallowed (the bus subscription already swallows handler throws) so
 // a metrics blip / a display-refresh write failure never tears down the consumer,
-// back-pressures the agent, or breaks its connect.
+// back-pressures the agent, or breaks its connect. Event ingestion drains the NATS
+// subscription immediately into exact-subject queues: different runner connections
+// progress concurrently, one runner's ordering is preserved, and consecutive queued
+// heartbeats collapse latest-wins. A delayed heartbeat backlog therefore cannot keep
+// renewing a dead runner's short connection lease one stale message at a time.
 
 import {
   clearEnrollmentWentOffline,
@@ -73,6 +77,141 @@ export const AGENT_EVENTS_SUBJECT = "agent.*.*.connection.*.events";
 
 /** The wildcard subject the agent publishes its connect Hello on. */
 export const AGENT_HELLO_SUBJECT = "agent.*.*.connection.*.hello";
+
+type QueuedAgentEvent = {
+  payload: Uint8Array;
+  subject: string;
+  heartbeat: boolean;
+};
+
+type AgentEventQueueState = {
+  scheduled: boolean;
+  pending: QueuedAgentEvent[];
+};
+
+type ScheduledAgentEventQueue = {
+  subject: string;
+  state: AgentEventQueueState;
+};
+
+export type AgentEventIngestionScheduler = {
+  enqueue: (payload: Uint8Array, subject: string) => void;
+  whenIdle: () => Promise<void>;
+  close: () => void;
+};
+
+function payloadIsHeartbeat(payload: Uint8Array): boolean {
+  try {
+    return AgentEvent.decode(payload).event?.$case === "heartbeat";
+  } catch {
+    // Preserve the normal decoder/logging path for malformed events. They are
+    // barriers rather than heartbeat-coalescing candidates.
+    return false;
+  }
+}
+
+/**
+ * Drain agent events without making every Connected Machine wait behind one
+ * deployment-wide serial DB queue. Each exact process subject retains FIFO order;
+ * separate subjects drain concurrently. Consecutive pending heartbeats for one
+ * subject are latest-wins because they are point-in-time liveness/metrics samples,
+ * while GoingOffline and update-progress events remain ordered barriers.
+ */
+export function createAgentEventIngestionScheduler(
+  handler: (payload: Uint8Array, subject: string) => void | Promise<void>,
+  options: { maxConcurrentSubjects?: number; onHeartbeatCoalesced?: () => void } = {},
+): AgentEventIngestionScheduler {
+  const maxConcurrentSubjects = options.maxConcurrentSubjects ?? 32;
+  if (!Number.isSafeInteger(maxConcurrentSubjects) || maxConcurrentSubjects <= 0) {
+    throw new RangeError("maxConcurrentSubjects must be a positive safe integer");
+  }
+
+  const states = new Map<string, AgentEventQueueState>();
+  const readySubjects: ScheduledAgentEventQueue[] = [];
+  const idleWaiters = new Set<() => void>();
+  let accepting = true;
+  let activeSubjects = 0;
+
+  const resolveIdleWaiters = (): void => {
+    if (states.size !== 0) return;
+    for (const resolve of idleWaiters) resolve();
+    idleWaiters.clear();
+  };
+
+  async function drain(subject: string, state: AgentEventQueueState): Promise<void> {
+    while (true) {
+      const event = state.pending.shift();
+      if (!event) break;
+      try {
+        await handler(event.payload, event.subject);
+      } catch {
+        // Agent-event ingestion is best-effort. One bad event must not strand the
+        // exact-subject queue or prevent later heartbeats from restoring liveness.
+      }
+    }
+
+    activeSubjects -= 1;
+    state.scheduled = false;
+    if (state.pending.length > 0) {
+      schedule(subject, state);
+    } else {
+      if (states.get(subject) === state) states.delete(subject);
+      resolveIdleWaiters();
+    }
+    pump();
+  }
+
+  function pump(): void {
+    while (activeSubjects < maxConcurrentSubjects) {
+      const next = readySubjects.shift();
+      if (!next) return;
+      if (states.get(next.subject) !== next.state || !next.state.scheduled) continue;
+      activeSubjects += 1;
+      void drain(next.subject, next.state);
+    }
+  }
+
+  function schedule(subject: string, state: AgentEventQueueState): void {
+    if (state.scheduled) return;
+    state.scheduled = true;
+    readySubjects.push({ subject, state });
+    pump();
+  }
+
+  return {
+    enqueue(payload, subject) {
+      if (!accepting) return;
+      const heartbeat = payloadIsHeartbeat(payload);
+      let state = states.get(subject);
+      if (!state) {
+        state = { scheduled: false, pending: [] };
+        states.set(subject, state);
+      }
+
+      const queued = { payload, subject, heartbeat };
+      const lastIndex = state.pending.length - 1;
+      if (heartbeat && lastIndex >= 0 && state.pending[lastIndex]!.heartbeat) {
+        state.pending[lastIndex] = queued;
+        options.onHeartbeatCoalesced?.();
+      } else {
+        state.pending.push(queued);
+      }
+
+      schedule(subject, state);
+    },
+    async whenIdle() {
+      if (states.size === 0) return;
+      await new Promise<void>((resolve) => idleWaiters.add(resolve));
+    },
+    close() {
+      accepting = false;
+      for (const state of states.values()) {
+        state.pending.length = 0;
+      }
+      resolveIdleWaiters();
+    },
+  };
+}
 
 /**
  * Parse `agent.<ws>.<id>.connection.<instance>.<tail>` into its exact authority,
@@ -521,9 +660,24 @@ export function startMetricsIngestion(deps: {
   bus: EventBus;
   observability?: Observability;
 }): () => void {
-  return deps.bus.subscribeAgentEvents(AGENT_EVENTS_SUBJECT, (payload, subject) =>
-    handleAgentEventPayload(deps.db, deps.observability, payload, subject, deps.bus),
+  const scheduler = createAgentEventIngestionScheduler(
+    (payload, subject) =>
+      handleAgentEventPayload(deps.db, deps.observability, payload, subject, deps.bus),
+    {
+      onHeartbeatCoalesced: () =>
+        deps.observability?.incrementCounter({
+          name: "opengeni_machine_heartbeat_coalesced_total",
+          help: "Connected Machine heartbeats collapsed while an exact runner event queue was busy.",
+        }),
+    },
   );
+  const unsubscribe = deps.bus.subscribeAgentEvents(AGENT_EVENTS_SUBJECT, (payload, subject) => {
+    scheduler.enqueue(payload, subject);
+  });
+  return () => {
+    unsubscribe();
+    scheduler.close();
+  };
 }
 
 // ── Connect-Hello display refresh ─────────────────────────────────────────────

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -134,6 +134,21 @@ async function claimConnection(workspaceId: string, enrollmentId: string): Promi
   expect(claimed.claimed).toBe(true);
 }
 
+async function waitForValue<T>(
+  read: () => Promise<T>,
+  matches: (value: T) => boolean,
+  description: string,
+  timeoutMs = 5_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const value = await read();
+    if (matches(value)) return value;
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${description}`);
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 class SlowProbeBus extends MemoryEventBus {
   startedSubjects: string[] = [];
   completed = 0;
@@ -210,6 +225,18 @@ async function emitHeartbeat(
     `agent.${workspaceId}.${agentId}.connection.${CONNECTION_INSTANCE_ID}.events`,
     event,
   );
+  await waitForValue(
+    async () => {
+      const [sample] = await admin<Array<{ cpuPercent: string | number | null }>>`
+        select cpu_percent as "cpuPercent"
+        from machine_metrics_latest
+        where enrollment_id = ${agentId}
+      `;
+      return sample?.cpuPercent ?? null;
+    },
+    (value) => Number(value) === cpuPct,
+    `heartbeat metrics for enrollment ${agentId}`,
+  );
 }
 
 async function emitHeartbeatWithoutMetrics(
@@ -233,6 +260,11 @@ async function emitHeartbeatWithoutMetrics(
     `agent.${workspaceId}.${agentId}.connection.${CONNECTION_INSTANCE_ID}.events`,
     event,
   );
+  await waitForValue(
+    () => getEnrollment(db, workspaceId, agentId),
+    (enrollment) => enrollment?.lastSeenAt != null,
+    `heartbeat liveness for enrollment ${agentId}`,
+  );
 }
 
 /** Emit a clean GoingOffline AgentEvent, driving the ingestion consumer to stamp
@@ -250,6 +282,11 @@ async function emitGoingOffline(
   await bus.emitAgentEvent(
     `agent.${workspaceId}.${agentId}.connection.${CONNECTION_INSTANCE_ID}.events`,
     event,
+  );
+  await waitForValue(
+    () => getEnrollment(db, workspaceId, agentId),
+    (enrollment) => enrollment?.wentOfflineAt != null,
+    `going-offline marker for enrollment ${agentId}`,
   );
 }
 
@@ -1049,10 +1086,14 @@ describe("Connected Machine signed self-update orchestration", () => {
           },
         }).finish(),
       );
-      expect(
-        (await getEnrollment(db, machine.originWorkspaceId, machine.enrollmentId))?.agentUpdate
-          ?.status,
-      ).toBe("restarting");
+      const restarting = await waitForValue(
+        async () =>
+          (await getEnrollment(db, machine.originWorkspaceId, machine.enrollmentId))?.agentUpdate
+            ?.status,
+        (status) => status === "restarting",
+        `restarting update ${operationId}`,
+      );
+      expect(restarting).toBe("restarting");
       await handleHelloPayload(
         db,
         undefined,
@@ -1155,9 +1196,12 @@ describe("Connected Machine signed self-update orchestration", () => {
         },
       }).finish(),
     );
-    expect((await getEnrollment(db, workspaceId, enrollment.id))?.agentUpdate?.status).toBe(
-      "restarting",
+    const restarting = await waitForValue(
+      async () => (await getEnrollment(db, workspaceId, enrollment.id))?.agentUpdate?.status,
+      (status) => status === "restarting",
+      `restarting update ${body.operationId}`,
     );
+    expect(restarting).toBe("restarting");
 
     // A reconnect alone is insufficient: the exact signed artifact digest is
     // part of the success proof.
@@ -1362,7 +1406,11 @@ describe("machine.link.* fan-out — link-plane session events on going-offline 
       GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE,
     );
 
-    const events = await machineLinkEvents(session.id);
+    const events = await waitForValue(
+      () => machineLinkEvents(session.id),
+      (current) => current.length === 2,
+      `machine link-loss events for session ${session.id}`,
+    );
     expect(events.map((e) => e.type)).toEqual(["machine.link.lost", "machine.runner.restarted"]);
     // Both are stamped on the session's OWN running turn.
     expect(events.every((e) => e.turn_id === turnId)).toBe(true);
@@ -1382,7 +1430,12 @@ describe("machine.link.* fan-out — link-plane session events on going-offline 
       GoingOfflineReason.GOING_OFFLINE_REASON_HOST_SHUTDOWN,
     );
 
-    expect((await machineLinkEvents(session.id)).map((e) => e.type)).toEqual(["machine.link.lost"]);
+    const events = await waitForValue(
+      () => machineLinkEvents(session.id),
+      (current) => current.length === 1,
+      `machine link-loss event for session ${session.id}`,
+    );
+    expect(events.map((e) => e.type)).toEqual(["machine.link.lost"]);
   }, 90_000);
 
   test("a reconnect Hello after a lost fans out link.restored; a second Hello (marker already cleared) emits nothing more", async () => {
@@ -1398,6 +1451,11 @@ describe("machine.link.* fan-out — link-plane session events on going-offline 
       workspaceId,
       enrollment.id,
       GoingOfflineReason.GOING_OFFLINE_REASON_USER_STOP,
+    );
+    await waitForValue(
+      () => machineLinkEvents(session.id),
+      (events) => events.some((event) => event.type === "machine.link.lost"),
+      `machine link-loss event for session ${session.id}`,
     );
 
     // Reconnect: the Hello clears the marker → emits link.restored on the turn.
@@ -1432,13 +1490,18 @@ describe("machine.link.* fan-out — link-plane session events on going-offline 
     // seed() creates a session but does NOT point it at the machine / give it a
     // running turn, so the fan-out query matches nothing.
     const { workspaceId, session, enrollment, bus } = await seed();
-    appFor(bus);
-
-    await emitGoingOffline(
+    await handleAgentEventPayload(
+      db,
+      undefined,
+      AgentEvent.encode({
+        agentId: enrollment.id,
+        event: {
+          $case: "goingOffline",
+          goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE },
+        },
+      }).finish(),
+      `agent.${workspaceId}.${enrollment.id}.connection.${CONNECTION_INSTANCE_ID}.events`,
       bus,
-      workspaceId,
-      enrollment.id,
-      GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE,
     );
 
     expect(await machineLinkEvents(session.id)).toEqual([]);

--- a/apps/api/test/metrics-ingestion.test.ts
+++ b/apps/api/test/metrics-ingestion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createAgentEventIngestionScheduler,
   handleAgentEventPayload,
   parseAgentEventSubject,
   wireAttachedBrowserInventoryToContract,
@@ -82,6 +83,140 @@ describe("handleAgentEventPayload — GoingOffline machine-plane recording", () 
       "not.an.events.subject",
     );
     expect(counters).toHaveLength(0);
+  });
+});
+
+describe("Connected Machine event ingestion scheduling", () => {
+  const subjectA =
+    "agent.11111111-1111-4111-8111-111111111111.aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.connection.bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.events";
+  const subjectB =
+    "agent.22222222-2222-4222-8222-222222222222.cccccccc-cccc-4ccc-8ccc-cccccccccccc.connection.dddddddd-dddd-4ddd-8ddd-dddddddddddd.events";
+
+  function heartbeat(seq: number): Uint8Array {
+    return AgentEvent.encode({
+      event: {
+        $case: "heartbeat",
+        heartbeat: {
+          seq: String(seq),
+          uptimeMs: String(seq * 5_000),
+          activeSessions: 0,
+          draining: false,
+        },
+      },
+    }).finish();
+  }
+
+  function goingOffline(): Uint8Array {
+    return AgentEvent.encode({
+      event: {
+        $case: "goingOffline",
+        goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_HOST_SHUTDOWN },
+      },
+    }).finish();
+  }
+
+  test("drains separate runners concurrently and bounds a busy runner to the latest consecutive heartbeat", async () => {
+    const handledA: string[] = [];
+    const handledB: string[] = [];
+    let releaseFirst!: () => void;
+    let firstStarted!: () => void;
+    let runnerBHandled!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstStartedPromise = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const runnerBHandledPromise = new Promise<void>((resolve) => {
+      runnerBHandled = resolve;
+    });
+    let coalesced = 0;
+
+    const scheduler = createAgentEventIngestionScheduler(
+      async (payload, subject) => {
+        const event = AgentEvent.decode(payload).event;
+        const label =
+          event?.$case === "heartbeat" ? `heartbeat:${event.heartbeat.seq}` : "goingOffline";
+        if (subject === subjectA) {
+          handledA.push(label);
+          if (label === "heartbeat:1") {
+            firstStarted();
+            await firstGate;
+          }
+        } else {
+          handledB.push(label);
+          runnerBHandled();
+        }
+      },
+      { onHeartbeatCoalesced: () => (coalesced += 1) },
+    );
+
+    scheduler.enqueue(heartbeat(1), subjectA);
+    await firstStartedPromise;
+    for (let seq = 2; seq <= 100; seq += 1) scheduler.enqueue(heartbeat(seq), subjectA);
+    scheduler.enqueue(goingOffline(), subjectA);
+    for (let seq = 101; seq <= 200; seq += 1) scheduler.enqueue(heartbeat(seq), subjectA);
+
+    scheduler.enqueue(heartbeat(7), subjectB);
+    await runnerBHandledPromise;
+    expect(handledB).toEqual(["heartbeat:7"]);
+
+    releaseFirst();
+    await scheduler.whenIdle();
+    expect(handledA).toEqual(["heartbeat:1", "heartbeat:100", "goingOffline", "heartbeat:200"]);
+    expect(coalesced).toBe(197);
+  });
+
+  test("a rejected event does not strand later liveness for the same runner", async () => {
+    const handled: string[] = [];
+    const scheduler = createAgentEventIngestionScheduler(async (payload) => {
+      const event = AgentEvent.decode(payload).event;
+      if (event?.$case === "heartbeat") handled.push(event.heartbeat.seq);
+    });
+
+    scheduler.enqueue(Uint8Array.from([0xff]), subjectA);
+    scheduler.enqueue(heartbeat(2), subjectA);
+    await scheduler.whenIdle();
+    expect(handled).toEqual(["2"]);
+  });
+
+  test("bounds cross-runner database concurrency without serializing every runner", async () => {
+    let releaseHandlers!: () => void;
+    let fourHandlersStarted!: () => void;
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandlers = resolve;
+    });
+    const fourHandlersStartedPromise = new Promise<void>((resolve) => {
+      fourHandlersStarted = resolve;
+    });
+    let active = 0;
+    let peak = 0;
+    let handled = 0;
+
+    const scheduler = createAgentEventIngestionScheduler(
+      async () => {
+        active += 1;
+        handled += 1;
+        peak = Math.max(peak, active);
+        if (handled === 4) fourHandlersStarted();
+        await handlerGate;
+        active -= 1;
+      },
+      { maxConcurrentSubjects: 4 },
+    );
+
+    for (let index = 0; index < 12; index += 1) {
+      scheduler.enqueue(heartbeat(index + 1), `runner-${index}`);
+    }
+
+    await fourHandlersStartedPromise;
+    expect(peak).toBe(4);
+    expect(handled).toBe(4);
+
+    releaseHandlers();
+    await scheduler.whenIdle();
+    expect(handled).toBe(12);
+    expect(peak).toBe(4);
   });
 });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,6 +343,17 @@ or turn use it. This is an intentional user route change, not an
 offline-machine fallback; deployments configured with only `none` or
 `selfhosted` expose no managed group.
 
+Connected Machine event ingestion cannot make every runner wait behind one
+global database queue. The API drains the NATS event subscription immediately
+into exact-process queues: different connection subjects progress concurrently
+within a fixed database-concurrency bound, each subject preserves event order,
+and only consecutive pending heartbeats collapse latest-wins. GoingOffline and
+update-progress events remain ordering barriers. A database slowdown can
+therefore delay current telemetry, but a backlog of old heartbeats from a killed
+runner cannot renew its short ownership lease once per stale sample for minutes.
+Canonical:
+`apps/api/src/sandbox/metrics-ingestion.ts`.
+
 Canonical: `packages/runtime/src/sandbox/selfhosted/`,
 `apps/worker/src/activities/agent-turn/sandbox-establish.ts`,
 `packages/core/src/domain/scheduled-tasks.ts`,


### PR DESCRIPTION
## Summary

- drain Connected Machine events into exact-subject queues instead of awaiting all runners through one global subscription loop
- coalesce consecutive queued heartbeats latest-wins while preserving lifecycle-event barriers and per-runner FIFO ordering
- cap cross-runner handler concurrency and expose a heartbeat-coalescing counter

## Verification

- `bun test apps/api/test/metrics-ingestion.test.ts`
- `bun run --filter @opengeni/api-router typecheck`
- `bun x oxlint apps/api/src/sandbox/metrics-ingestion.ts apps/api/test/metrics-ingestion.test.ts`
- `bun x oxfmt --check apps/api/src/sandbox/metrics-ingestion.ts apps/api/test/metrics-ingestion.test.ts`
- `git diff --check`

## Summary by Sourcery

Bound Connected Machine event ingestion so stale heartbeat backlogs cannot delay liveness recovery or overwhelm the database.

Bug Fixes:
- Prevent stale Connected Machine heartbeat backlogs from repeatedly renewing dead runner connection leases.

Enhancements:
- Process Connected Machine events in per-runner ordered queues with bounded cross-runner concurrency and latest-wins coalescing for consecutive heartbeats.
- Expose a metric for coalesced heartbeats and improve asynchronous test synchronization around event ingestion.

Documentation:
- Document the per-runner Connected Machine event-ingestion scheduling and backlog behavior.

Tests:
- Add coverage for per-runner ordering, heartbeat coalescing, handler failure recovery, and concurrency limits.