### PR TITLE
fix(worker): reset provider recovery streak after progress

### DIFF
--- a/.changeset/calm-turns-recover.md
+++ b/.changeset/calm-turns-recover.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Reset provider recovery backoff after a fenced successful model request so intermittent outages cannot exhaust a long-running turn's consecutive retry budget.

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -154,6 +154,13 @@ export function providerRecoveryCountFromMetadata(metadata: Record<string, unkno
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : 0;
 }
 
+export function providerRecoveryCountAfterModelRequestPhase(
+  currentCount: number,
+  phase: string,
+): number {
+  return phase === "completed" ? 0 : currentCount;
+}
+
 export function headerValue(headers: unknown, name: string): string | null {
   if (!headers || typeof headers !== "object") return null;
   const getter = (headers as { get?: unknown }).get;

--- a/apps/worker/src/activities/agent-turn/run.ts
+++ b/apps/worker/src/activities/agent-turn/run.ts
@@ -45,6 +45,7 @@ import { createTurnCredentialLeases } from "./credential-leases";
 import { createTurnMediaArtifacts } from "./media-artifacts";
 import { createTurnHistorySink } from "./history-sink";
 import { checkpointHistoryBeforeProviderDispatch } from "./provider-dispatch-barrier";
+import { providerRecoveryCountAfterModelRequestPhase } from "./errors";
 import { sandboxRunAs } from "@opengeni/runtime";
 import { randomUUID } from "node:crypto";
 import { createModelCheckpointMemoryCollector } from "../../model-checkpoint-memory-collector";
@@ -599,6 +600,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                         },
                       },
                     ]);
+                    attempt.providerRecoveryCount = providerRecoveryCountAfterModelRequestPhase(
+                      attempt.providerRecoveryCount,
+                      event.phase,
+                    );
                   } catch (error) {
                     auditOutcome = "failed";
                     throw error;
@@ -744,6 +749,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   },
                 },
               ]);
+              attempt.providerRecoveryCount = providerRecoveryCountAfterModelRequestPhase(
+                attempt.providerRecoveryCount,
+                event.phase,
+              );
             } catch (error) {
               auditOutcome = "failed";
               throw error;

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -505,6 +505,7 @@ export async function runTurnStreamAttempt(
       resolvedModel?.provider.kind === "codex-subscription" ||
       resolvedModel?.provider.kind === "xai-subscription";
     let fallbackProviderRequestStartedAt: number | null = null;
+    let fallbackProviderRequestLifecycleStartedAt: number | null = null;
     const recordFallbackProviderDispatchAtWire = async (): Promise<void> => {
       await checkpointHistoryBeforeProviderDispatch(historySink);
       if (
@@ -552,6 +553,7 @@ export async function runTurnStreamAttempt(
           },
         ]);
         fallbackProviderRequestStartedAt = performance.now();
+        fallbackProviderRequestLifecycleStartedAt = fallbackProviderRequestStartedAt;
       } catch (error) {
         auditOutcome = "failed";
         throw error;
@@ -925,6 +927,31 @@ export async function runTurnStreamAttempt(
           ...(resolvedModel?.provider.id ? { providerId: resolvedModel.provider.id } : {}),
         });
         if (responseResult.status === "processed") {
+          if (
+            !providerPublishesNativeRequestEvents &&
+            fallbackProviderRequestLifecycleStartedAt !== null
+          ) {
+            const durationMs = Math.max(
+              0,
+              performance.now() - fallbackProviderRequestLifecycleStartedAt,
+            );
+            fallbackProviderRequestLifecycleStartedAt = null;
+            await eventing.publish!([
+              {
+                type: "agent.model.request",
+                payload: {
+                  phase: "completed",
+                  provider: streamProvider,
+                  durationMs: Math.round(durationMs),
+                  turnId: activeTurnId,
+                  attemptId: input.attemptId,
+                  dispatchId,
+                  executionGeneration: attempt.executionGeneration,
+                },
+              },
+            ]);
+            attempt.providerRecoveryCount = 0;
+          }
           const rawStreamHistory = (eventing.stream.state as { history?: unknown[] }).history;
           if (Array.isArray(rawStreamHistory)) {
             // The completed image item is normally retained from its own
@@ -1207,9 +1234,13 @@ export async function runTurnStreamAttempt(
         }
       }
     } catch (error) {
-      if (fallbackProviderRequestStartedAt !== null) {
-        const durationMs = Math.max(0, performance.now() - fallbackProviderRequestStartedAt);
+      if (fallbackProviderRequestLifecycleStartedAt !== null) {
+        const durationMs = Math.max(
+          0,
+          performance.now() - fallbackProviderRequestLifecycleStartedAt,
+        );
         fallbackProviderRequestStartedAt = null;
+        fallbackProviderRequestLifecycleStartedAt = null;
         await eventing.publish!([
           {
             type: "agent.model.request",

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -96,6 +96,7 @@ import {
   persistOrSignalSessionAttemptQuiescence,
   preClaimAdmissionFailure,
   PROVIDER_BACKPRESSURE_DELAY_MS,
+  providerRecoveryCountAfterModelRequestPhase,
   providerRecoveryCountFromMetadata,
   providerRetryAfterMs,
   providerRecoveryResult,
@@ -5256,6 +5257,9 @@ describe("transient provider error classifier", () => {
     expect(providerRecoveryCountFromMetadata({})).toBe(0);
     expect(providerRecoveryCountFromMetadata({ providerRecoveryCount: 3 })).toBe(3);
     expect(providerRecoveryCountFromMetadata({ providerRecoveryCount: -1 })).toBe(0);
+    expect(providerRecoveryCountAfterModelRequestPhase(4, "failed")).toBe(4);
+    expect(providerRecoveryCountAfterModelRequestPhase(4, "first_byte")).toBe(4);
+    expect(providerRecoveryCountAfterModelRequestPhase(4, "completed")).toBe(0);
   });
 
   test("classifies only definitive marked SuperGrok account refusals for rotation", () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -626,6 +626,13 @@ the exact active attempt follows the same transition. Permanent database or
 state failures remain terminal, and no model, tool, or provider work is replayed
 or converted into a new queue item.
 
+Transient provider recovery is bounded by a durable consecutive-failure streak,
+not lifetime failures accumulated across a long turn. A completed model request
+from the exact current attempt clears the durable streak atomically with its
+timeline event, and the worker clears its in-memory copy only after that commit;
+late attempt evidence cannot replenish the retry budget. See
+[`run-lifecycle.md`](run-lifecycle.md) for pacing and exhaustion semantics.
+
 ### 5.3 Goals, schedules, automations, and child work
 
 These producers all converge on the ordinary session/turn runtime:

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -499,11 +499,17 @@ catalog identity.
 
 Retryable provider connectivity and 5xx failures recover the same accepted turn
 after a durable 2 s, 5 s, 15 s, 30 s, then 60 s capped delay, indexed by that
-turn's durable provider-recovery count rather than unrelated execution attempts.
+turn's durable consecutive provider-recovery count rather than unrelated
+execution attempts. A fenced current-attempt `agent.model.request` completion
+atomically clears that durable count with its event; only after the commit does
+the worker clear its in-memory copy. Failed requests and late/zombie completion
+events cannot reset the streak. Successful inference between transient outages
+therefore starts the next outage at the first backoff step instead of consuming
+a lifetime budget for a long-running turn.
 An explicit provider retry hint is a lower bound. Rate limits use the provider's
 `Retry-After` when present and otherwise wait 60 s; other retryable classes keep
 their existing pacing. Automatic same-turn provider/MCP recovery is finite: five
-replacement attempts may be scheduled, and a sixth retryable failure settles the
+consecutive replacement attempts may be scheduled, and a sixth retryable failure settles the
 same logical turn as failed with the original typed cause plus explicit recovery-
 exhaustion evidence. This is an infrastructure retry budget, not a goal,
 continuation, model-call, or run-length cap; a later human/API prompt may retry as

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -64373,6 +64373,37 @@ function metadataWithoutTurnDispatchAttempt(
   return next;
 }
 
+function providerRecoveryCountFromTurnMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): number {
+  const value = metadata?.providerRecoveryCount;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function metadataWithoutProviderRecoveryCount(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const next = { ...(metadata ?? {}) };
+  delete next.providerRecoveryCount;
+  return next;
+}
+
+function hasCompletedCurrentModelRequest(
+  events: ReadonlyArray<
+    Pick<
+      typeof schema.sessionEvents.$inferSelect,
+      "type" | "payload" | "payloadCodecVersion" | "turnAssociation"
+    >
+  >,
+): boolean {
+  return events.some(
+    (event) =>
+      event.turnAssociation === "current" &&
+      event.type === "agent.model.request" &&
+      sessionEventPayloadRecord(event.payload, event.payloadCodecVersion).phase === "completed",
+  );
+}
+
 type WorkerDeathRedispatchMetadata =
   | { kind: "valid"; count: number }
   | { kind: "malformed"; reason: string };
@@ -69972,6 +70003,34 @@ export async function mutateAndAppendSessionEventsForTurnAttempt(
                         now,
                       },
                     );
+                    if (
+                      providerRecoveryCountFromTurnMetadata(fence.turn!.metadata) > 0 &&
+                      hasCompletedCurrentModelRequest(inserted)
+                    ) {
+                      const [resetTurn] = await tx
+                        .update(schema.sessionTurns)
+                        .set({
+                          metadata: metadataWithoutProviderRecoveryCount(fence.turn!.metadata),
+                          version: fence.turn!.version + 1,
+                          updatedAt: now,
+                        })
+                        .where(
+                          and(
+                            eq(schema.sessionTurns.workspaceId, workspaceId),
+                            eq(schema.sessionTurns.sessionId, sessionId),
+                            eq(schema.sessionTurns.id, turnId),
+                            eq(schema.sessionTurns.status, "running"),
+                            eq(schema.sessionTurns.executionGeneration, executionGeneration),
+                            eq(schema.sessionTurns.activeAttemptId, attemptId),
+                          ),
+                        )
+                        .returning({ id: schema.sessionTurns.id });
+                      if (!resetTurn) {
+                        throw new Error(
+                          `Completed provider request lost its active turn fence: ${turnId}`,
+                        );
+                      }
+                    }
                   }
                   return milestones;
                 },

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -2654,6 +2654,92 @@ describe("clean session control plane", () => {
     ).toMatchObject({ action: "stale", events: [] });
   });
 
+  test("a completed current model request resets only the consecutive provider recovery budget", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "continue through intermittent provider overloads");
+    const firstAttemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: firstAttemptId },
+    );
+    if (!first) throw new Error("provider recovery reset test turn was not claimed");
+
+    expect(
+      await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        turnId: first.id,
+        triggerEventId: first.triggerEventId,
+        attemptId: firstAttemptId,
+        reason: "provider_unavailable",
+        providerRecoveryCount: 4,
+        detail: {
+          code: "provider_unavailable",
+          retryable: true,
+          continueDelayMs: 30_000,
+          providerRecoveryCount: 4,
+        },
+      }),
+    ).toMatchObject({ action: "recovering" });
+
+    const secondAttemptId = crypto.randomUUID();
+    const second = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: secondAttemptId },
+    );
+    if (!second) throw new Error("provider recovery reset test turn was not reclaimed");
+    expect(await getSessionTurn(client.db, grant.workspaceId!, second.id)).toMatchObject({
+      metadata: { providerRecoveryCount: 4 },
+    });
+
+    const rejectedLateCompletion = await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      first.id,
+      first.executionGeneration,
+      firstAttemptId,
+      [{ type: "agent.model.request", payload: { phase: "completed" } }],
+    );
+    expect(rejectedLateCompletion.accepted).toBe(false);
+    expect(await getSessionTurn(client.db, grant.workspaceId!, second.id)).toMatchObject({
+      metadata: { providerRecoveryCount: 4 },
+    });
+
+    const failedCurrentRequest = await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      second.id,
+      second.executionGeneration,
+      secondAttemptId,
+      [{ type: "agent.model.request", payload: { phase: "failed" } }],
+    );
+    expect(failedCurrentRequest.accepted).toBe(true);
+    expect(await getSessionTurn(client.db, grant.workspaceId!, second.id)).toMatchObject({
+      metadata: { providerRecoveryCount: 4 },
+    });
+
+    const completedCurrentRequest = await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      second.id,
+      second.executionGeneration,
+      secondAttemptId,
+      [{ type: "agent.model.request", payload: { phase: "completed" } }],
+    );
+    expect(completedCurrentRequest.accepted).toBe(true);
+    expect(
+      (await getSessionTurn(client.db, grant.workspaceId!, second.id))?.metadata,
+    ).not.toHaveProperty("providerRecoveryCount");
+  });
+
   test("recovery preserves reverse-completed parallel results and interrupts only their unresolved sibling", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "run A and B in parallel");

--- a/packages/sdk/test/browser-client-surface.test.ts
+++ b/packages/sdk/test/browser-client-surface.test.ts
@@ -11,7 +11,6 @@ const legacyBrowserUnusedMethods = [
   "addDocument",
   "advanceExternalBrowserAuthRun",
   "applyGoalRevision",
-  "cancelSession",
   "captureComputerTarget",
   "codexAccountUsage",
   "codexDisconnect",


### PR DESCRIPTION
## Root cause

`providerRecoveryCount` accumulated across an entire logical turn. Session `7cb5dd86-a995-4779-8e9a-a606286ae527` made 101 successful model requests between five overload recoveries, but the next unrelated overload still exhausted the lifetime count and failed healthy work.

## Fix

- clear the durable recovery streak atomically with a fenced current-attempt `agent.model.request` completion
- clear the worker in-memory streak only after the durable event commit
- reject late/zombie completions and failed requests as reset evidence
- emit equivalent completion evidence for providers without native request lifecycle events
- document the consecutive-failure invariant

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun test apps/worker/test/agent-turn.test.ts` (204 pass)
- `bun test packages/db/test/session-control-plane.test.ts` (88 pass)