### PR TITLE
fix(runtime): materialize files in sandbox workspace root

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7371,9 +7371,10 @@ export async function materializeSandboxFileDownloads(
     return { failures: [] };
   }
   const failures: SandboxFileDownloadFailure[] = [];
+  const workspaceRoot = sandboxSessionWorkspaceRoot(session);
   for (const download of normalizedDownloads) {
     const targetRelativePath = sandboxDownloadRelativePath(download);
-    const targetPath = sandboxDownloadLogicalPath(download);
+    const targetPath = sandboxDownloadLogicalPath(download, workspaceRoot);
     const payload = {
       fileId: download.fileId,
       path: targetPath,
@@ -7407,7 +7408,7 @@ export async function materializeSandboxFileDownloads(
         session,
         {
           cmd: sandboxFileDownloadCommand(download, targetRelativePath),
-          workdir: "/workspace",
+          workdir: workspaceRoot,
           ...(context.runAs ? { runAs: context.runAs } : {}),
           yieldTimeMs: SANDBOX_LIFECYCLE_COMMAND_TIMEOUT_MS,
           maxOutputTokens: 20_000,
@@ -7760,8 +7761,16 @@ function sandboxDownloadRelativePath(download: SandboxFileDownload): string {
   return posixPath.join(download.mountPath, download.filename);
 }
 
-function sandboxDownloadLogicalPath(download: SandboxFileDownload): string {
-  return posixPath.join("/workspace", sandboxDownloadRelativePath(download));
+function sandboxSessionWorkspaceRoot(session: SandboxSessionLike): string {
+  const root = (session as { state?: { manifest?: { root?: unknown } } }).state?.manifest?.root;
+  return typeof root === "string" && posixPath.isAbsolute(root) ? root : "/workspace";
+}
+
+function sandboxDownloadLogicalPath(
+  download: SandboxFileDownload,
+  workspaceRoot = "/workspace",
+): string {
+  return posixPath.join(workspaceRoot, sandboxDownloadRelativePath(download));
 }
 
 function sandboxFileDownloadCommand(download: SandboxFileDownload, targetPath: string): string {

--- a/packages/runtime/test/lazy-provisioning.test.ts
+++ b/packages/runtime/test/lazy-provisioning.test.ts
@@ -276,13 +276,13 @@ describe("lazy provisioning synthetic manifest", () => {
     });
 
     expect(commands).toHaveLength(1);
-    expect(commands[0]?.workdir).toBe("/workspace");
+    expect(commands[0]?.workdir).toBe("/srv/project");
     expect(commands[0]?.cmd).toContain(".opengeni/files/file-1/input.txt");
     expect(commands[0]?.cmd).not.toContain("/workspace/.opengeni/files/file-1/input.txt");
     expect(commands[0]?.cmd).not.toContain("platform-hook-ran");
     expect(commands[0]?.cmd).toContain('actual_size=$(wc -c < "$candidate"');
     expect(commands[0]?.cmd).toContain('actual_sha=$(sha256sum "$candidate"');
-    expect(JSON.stringify(events)).toContain("/workspace/.opengeni/files/file-1/input.txt");
+    expect(JSON.stringify(events)).toContain("/srv/project/.opengeni/files/file-1/input.txt");
     expect(JSON.stringify(events)).not.toContain("sig=secret");
   });
 


### PR DESCRIPTION
## Summary
- derive file materialization workdir from the established sandbox manifest
- keep `/workspace` as the compatibility fallback
- report the truthful absolute target path

## Why
Connected Machine manifests can use a host-native workspace root. Attachment setup still executed with `/workspace` as its command workdir, so delivery failed before the agent began even though later sandbox operations used the correct root.

## Verification
- `bun test packages/runtime/test/lazy-provisioning.test.ts packages/runtime/test/runtime.test.ts` (301 pass)
- `bun run typecheck` (31 projects)
- `bun x oxfmt --check packages/runtime/src/index.ts packages/runtime/test/lazy-provisioning.test.ts`

## Summary by Sourcery

Materialize sandbox file downloads using the sandbox session's actual workspace root instead of a hardcoded `/workspace` path.

Bug Fixes:
- Fix file materialization failing on Connected Machine manifests that use a host-native workspace root by deriving the command workdir and reported target path from the sandbox session's manifest root, falling back to `/workspace` for compatibility.

Tests:
- Update lazy provisioning tests to expect the workspace-derived path (e.g. `/srv/project`) instead of the hardcoded `/workspace` path.