### PR TITLE
fix(schedules): refresh occurrences and name spawned sessions

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -39,6 +39,7 @@ import {
   SESSION_GOAL_SUCCESS_CRITERIA_MAX_BYTES,
   SESSION_GOAL_TEXT_MAX_BYTES,
   SESSION_INSTRUCTIONS_MAX_CHARACTERS,
+  SESSION_TITLE_MAX_CHARACTERS,
   MAX_SELECTED_VARIABLE_SETS,
   sessionGoalUtf8Bytes,
   TASK_NOTE_LIST_DEFAULT_LIMIT,
@@ -4814,6 +4815,14 @@ function registerWorkspaceOrchestrationTools(
     const sessionCreateInput = z4
       .object({
         initialMessage: z4.string().min(1),
+        title: z4
+          .string()
+          .min(1)
+          .max(SESSION_TITLE_MAX_CHARACTERS)
+          .optional()
+          .describe(
+            "Concise semantic title for the child session. Omit only when the delegated goal or initial message already provides a suitable title; OpenGeni derives a sensitive-safe bounded fallback from that text.",
+          ),
         instructions: z4.string().min(1).max(SESSION_INSTRUCTIONS_MAX_CHARACTERS).optional(),
         goal: z4.unknown().optional(),
         resources: z4.array(z4.unknown()).optional(),
@@ -4896,7 +4905,7 @@ function registerWorkspaceOrchestrationTools(
       "session_create",
       {
         description:
-          "Spawn a new agent session (a worker) only for a concrete, bounded subtask that can run independently and has a defined integration point in your current work. Do not delegate work you will also perform yourself; track the child and join its actual result before completing dependent work. The child inherits this session's visibility; a private session can only create a same-owner private child. Give a goal-bearing child its delegated objective. Its goal.rootConstraints may be an exact applicable subset of this accepted turn's frozen root constraints; omit that field to inherit all of them. Omit sandbox for the safe default: compatible children share the creator's box, while a different Variable Set, Rig, or machineTarget gets its own box. Use 'new' for deliberate isolation or {groupId} for a strict compatible sibling join. Put targetSandboxId and its optional workingDir together inside machineTarget; a machineTarget is always an own-box create even when the parent is backend none. To create a non-delegating leaf, pass a narrowed firstPartyMcpTools list that omits session_create; do not use a child-local depth override. Public REST/SDK callers retain advanced absolute depth and explicit shared-placement controls.",
+          "Spawn a new agent session (a worker) only for a concrete, bounded subtask that can run independently and has a defined integration point in your current work. Do not delegate work you will also perform yourself; track the child and join its actual result before completing dependent work. Give the child a concise semantic title; if omitted, OpenGeni derives one from its delegated goal or initial message. The child inherits this session's visibility; a private session can only create a same-owner private child. Give a goal-bearing child its delegated objective. Its goal.rootConstraints may be an exact applicable subset of this accepted turn's frozen root constraints; omit that field to inherit all of them. Omit sandbox for the safe default: compatible children share the creator's box, while a different Variable Set, Rig, or machineTarget gets its own box. Use 'new' for deliberate isolation or {groupId} for a strict compatible sibling join. Put targetSandboxId and its optional workingDir together inside machineTarget; a machineTarget is always an own-box create even when the parent is backend none. To create a non-delegating leaf, pass a narrowed firstPartyMcpTools list that omits session_create; do not use a child-local depth override. Public REST/SDK callers retain advanced absolute depth and explicit shared-placement controls.",
         inputSchema: sessionCreateInput,
       },
       async (args) => {
@@ -4909,18 +4918,25 @@ function registerWorkspaceOrchestrationTools(
           if (callerSessionId !== null) {
             await authorizeFirstPartySession(deps, grant, callerSessionId, "session.child.create");
           }
-          const { machineTarget, ...request } = args;
-          const result = await createSessionForRequestWithOutcome(deps, grant, grant.workspaceId, {
-            ...request,
-            ...(machineTarget
-              ? {
-                  targetSandboxId: machineTarget.targetSandboxId,
-                  ...(machineTarget.workingDir !== undefined
-                    ? { workingDir: machineTarget.workingDir }
-                    : {}),
-                }
-              : {}),
-          });
+          const { machineTarget, title, ...request } = args;
+          const result = await createSessionForRequestWithOutcome(
+            deps,
+            grant,
+            grant.workspaceId,
+            {
+              ...request,
+              ...(machineTarget
+                ? {
+                    targetSandboxId: machineTarget.targetSandboxId,
+                    ...(machineTarget.workingDir !== undefined
+                      ? { workingDir: machineTarget.workingDir }
+                      : {}),
+                  }
+                : {}),
+            },
+            undefined,
+            title === undefined ? {} : { automaticTitleCandidate: title },
+          );
           return json(sessionCreateMutationReceipt(result, Boolean(request.idempotencyKey)));
         } catch (error) {
           return orchestrationFailureResult("session_create", error);

--- a/apps/api/test/first-party-mcp-tool-policy.test.ts
+++ b/apps/api/test/first-party-mcp-tool-policy.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_SELECTED_VARIABLE_SETS,
   Permission,
   SESSION_INSTRUCTIONS_MAX_CHARACTERS,
+  SESSION_TITLE_MAX_CHARACTERS,
   WORK_DISCOVERY_QUERY_MAX_CHARS,
   type AccessGrant,
   type FirstPartyMcpToolName,
@@ -332,6 +333,7 @@ describe("first-party MCP tool visibility policy", () => {
       );
       expect(tool?.description).toContain("non-delegating leaf");
       expect(tool?.description).toContain("do not use a child-local depth override");
+      expect(tool?.description).toContain("concise semantic title");
       const serialized = JSON.stringify(tool?.inputSchema);
       expect(serialized).not.toContain("maxNestedAgentDepth");
       expect(serialized).not.toContain('"const":"shared"');
@@ -345,6 +347,7 @@ describe("first-party MCP tool visibility policy", () => {
       expect(tool?.inputSchema).toMatchObject({
         properties: {
           instructions: { maxLength: SESSION_INSTRUCTIONS_MAX_CHARACTERS },
+          title: { maxLength: SESSION_TITLE_MAX_CHARACTERS },
         },
       });
       for (const arguments_ of [

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -649,13 +649,14 @@ For an existing session, a scheduled turn that omits its turn-level `tools`
 field inherits the durable session tool policy; explicit `tools: []` remains an
 empty override.
 
-A claimed pure scheduled-occurrence batch is persisted in model-facing history
-as a direct `user`-role task boundary carrying the immutable scheduled task,
-run, and update ids. That role is conversation structure only: the logical turn
-still freezes the scheduler service as initiator, retains its causal-human and
-personal-connection authority snapshots, and remains a scheduled run in audit
-and settlement. Other machine-input batches keep the internal `system`-role
-envelope.
+A pure scheduled-occurrence batch that creates a standalone scheduler-owned
+turn is persisted in model-facing history as a direct `user`-role task boundary
+carrying the immutable scheduled task, run, and update ids. That role is
+conversation structure only: the logical turn still freezes the scheduler
+service as initiator, retains its causal-human and personal-connection authority
+snapshots, and remains a scheduled run in audit and settlement. Scheduled
+occurrences attached to an existing human/API turn, and all other machine-input
+batches, keep the internal `system`-role envelope.
 
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1165,7 +1165,7 @@ This index intentionally routes at subsystem granularity. Use
 | Schedules | `packages/core/src/domain/scheduled-tasks.ts`, `apps/worker/src/activities/scheduled-tasks.ts` | [`reliability-fixes.md`](reliability-fixes.md) |
 | Event-triggered automations | `packages/core/src/domain/automations.ts`, `apps/worker/src/activities/automations.ts` | [`automations.md`](automations.md) |
 | Child sessions or depth policy | `packages/core/src/domain/sessions.ts`, `packages/core/src/session-authorization.ts` | [`nested-agent-depth.md`](nested-agent-depth.md) |
-| Automatic or human session titles | `packages/contracts/src/session-titles.ts`, `apps/worker/src/activities/agent-turn/session-title.ts`, `packages/db/src/` | [`run-lifecycle.md`](run-lifecycle.md) |
+| Automatic or human session titles | `packages/contracts/src/session-titles.ts`, `apps/api/src/mcp/server.ts`, `packages/core/src/domain/sessions.ts`, `apps/worker/src/activities/agent-turn/session-title.ts`, `packages/db/src/` | [`run-lifecycle.md`](run-lifecycle.md) |
 | Realtime browser conversation | `packages/sdk/src/realtime.ts`, `packages/react/src/realtime/`, `apps/api/src/session-realtime-context.ts` | [`run-lifecycle.md`](run-lifecycle.md), package READMEs |
 
 ### Contracts, access, and persistence

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -649,6 +649,14 @@ For an existing session, a scheduled turn that omits its turn-level `tools`
 field inherits the durable session tool policy; explicit `tools: []` remains an
 empty override.
 
+A claimed pure scheduled-occurrence batch is persisted in model-facing history
+as a direct `user`-role task boundary carrying the immutable scheduled task,
+run, and update ids. That role is conversation structure only: the logical turn
+still freezes the scheduler service as initiator, retains its causal-human and
+personal-connection authority snapshots, and remains a scheduled run in audit
+and settlement. Other machine-input batches keep the internal `system`-role
+envelope.
+
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage
 boundaries.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -37,6 +37,16 @@ metadata, and obvious credential-, URL-, or identifier-shaped prefixes retain
 the generic marker. When the durable title changes, the client naturally yields
 to it.
 
+The first-party `session_create` tool is the bounded exception for an
+agent-created child: the manager may provide a concise semantic title, and an
+omission derives one from the delegated goal or initial message through the same
+sensitive-safe automatic-title normalizer. The title row mutation and
+`session.title_set` event commit in the child's atomic initial-state transaction,
+before its first turn can wake. Public REST/SDK creation does not gain a title
+field, and a human title still wins over every automatic write. If every child
+candidate is rejected as sensitive or unsuitable, the ordinary pending marker
+and first-turn self-heal path remain.
+
 While a session still has the pending marker, and its exact selected first-party
 tool and permission policy permits `set_session_title`, the worker projects only
 that exact operation through the attempt-local tool server and removes it from

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -15,12 +15,18 @@ internal-update batch is processed until the agent reaches a natural stopping
 point. Human/API prompts remain the only reorderable prompt rows. The same
 compact queue surface also projects canonical pending machine inputs, attached
 to the prompt they will join or grouped as standalone incoming updates. Goals,
-schedules, child results, and lifecycle notices never impersonate human
-messages. Codex capacity recovery preserves the current logical turn directly
-and is neither a queue row nor an internal update. One execution attempt runs as
-one non-retryable Temporal `runAgentTurn` activity. Inside the activity the
-OpenAI Agents SDK loop makes as many model calls and tool calls as the work
-needs.
+child results, and lifecycle notices remain internal machine inputs. A claimed
+pure scheduled-occurrence batch is the deliberate model-facing exception: its
+durable history item uses the `user` role so the model receives a fresh task
+boundary, with exact task/run/update ids and an instruction to refresh mutable
+external state. That conversational role never impersonates a human in backend
+authority: the turn initiator remains the scheduler service and its frozen
+causal-human, personal-connection, provider-account, audit, and settlement
+facts remain unchanged. Codex capacity recovery preserves the current logical
+turn directly and is neither a queue row nor an internal update. One execution
+attempt runs as one non-retryable Temporal `runAgentTurn` activity. Inside the
+activity the OpenAI Agents SDK loop makes as many model calls and tool calls as
+the work needs.
 
 Session display titles are durable session metadata, not a truncation of model
 history. Creation and migration use `New conversation` as the durable marker

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -15,18 +15,20 @@ internal-update batch is processed until the agent reaches a natural stopping
 point. Human/API prompts remain the only reorderable prompt rows. The same
 compact queue surface also projects canonical pending machine inputs, attached
 to the prompt they will join or grouped as standalone incoming updates. Goals,
-child results, and lifecycle notices remain internal machine inputs. A claimed
-pure scheduled-occurrence batch is the deliberate model-facing exception: its
-durable history item uses the `user` role so the model receives a fresh task
-boundary, with exact task/run/update ids and an instruction to refresh mutable
-external state. That conversational role never impersonates a human in backend
-authority: the turn initiator remains the scheduler service and its frozen
-causal-human, personal-connection, provider-account, audit, and settlement
-facts remain unchanged. Codex capacity recovery preserves the current logical
-turn directly and is neither a queue row nor an internal update. One execution
-attempt runs as one non-retryable Temporal `runAgentTurn` activity. Inside the
-activity the OpenAI Agents SDK loop makes as many model calls and tool calls as
-the work needs.
+child results, and lifecycle notices remain internal machine inputs. A pure
+scheduled-occurrence batch that creates a standalone scheduler-owned turn is
+the deliberate model-facing exception: its durable history item uses the `user`
+role so the model receives a fresh task boundary, with exact task/run/update ids
+and an instruction to refresh mutable external state. A scheduled occurrence
+attached to an existing human/API turn remains system-role context. The fresh
+task boundary never impersonates a human in backend authority: the turn
+initiator remains the scheduler service and its frozen causal-human,
+personal-connection, provider-account, audit, and settlement facts remain
+unchanged. Codex capacity recovery preserves the current logical turn directly
+and is neither a queue row nor an internal update. One execution attempt runs as
+one non-retryable Temporal `runAgentTurn` activity. Inside the activity the
+OpenAI Agents SDK loop makes as many model calls and tool calls as the work
+needs.
 
 Session display titles are durable session metadata, not a truncation of model
 history. Creation and migration use `New conversation` as the durable marker

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7717,9 +7717,12 @@ function renderScheduledOccurrenceTaskBatch(
 export function sessionSystemUpdateBatchHistoryItem(
   updates: Parameters<typeof renderSessionSystemUpdateBatch>[0],
   goalSnapshot?: SessionGoalSnapshot,
+  options: { promoteScheduledOccurrenceToUser?: boolean } = {},
 ): { type: "message"; role: "system" | "user"; content: string } {
   const goalContext = renderSessionGoalContext(goalSnapshot);
-  const scheduledTask = renderScheduledOccurrenceTaskBatch(updates);
+  const scheduledTask = options.promoteScheduledOccurrenceToUser
+    ? renderScheduledOccurrenceTaskBatch(updates)
+    : null;
   return {
     type: "message",
     role: scheduledTask ? "user" : "system",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7661,17 +7661,71 @@ export function renderSessionSystemUpdateBatch(
   ].join("\n");
 }
 
+export const SCHEDULED_OCCURRENCE_TASK_LABEL = "[OpenGeni scheduled task occurrence]" as const;
+
+/**
+ * A pure scheduled-occurrence batch is a new task boundary for the model, not
+ * merely background context. The user role here is conversational only: the
+ * owning turn retains its immutable scheduler/service initiator and frozen
+ * execution authority in the database.
+ *
+ * Malformed or mixed legacy batches fall back to the generic system envelope
+ * so this renderer never invents task identity from inconsistent payloads.
+ */
+function renderScheduledOccurrenceTaskBatch(
+  updates: Parameters<typeof renderSessionSystemUpdateBatch>[0],
+): string | null {
+  if (updates.length === 0 || updates.some((update) => update.kind !== "scheduled_occurrence")) {
+    return null;
+  }
+  const occurrences = updates.map((update) => {
+    const parsed = SessionSystemUpdatePayload.safeParse(update.payload);
+    if (
+      !parsed.success ||
+      parsed.data.type !== "scheduled_occurrence" ||
+      parsed.data.scheduledTaskRunId !== update.sourceId
+    ) {
+      return null;
+    }
+    return { update, payload: parsed.data };
+  });
+  if (occurrences.some((occurrence) => occurrence === null)) return null;
+
+  const introduction =
+    occurrences.length === 1
+      ? "A new scheduled occurrence has started. Execute the instructions below for this occurrence now."
+      : `${occurrences.length} new scheduled occurrences have started. Execute every instruction set below for this turn now.`;
+  return [
+    SCHEDULED_OCCURRENCE_TASK_LABEL,
+    introduction,
+    "The scheduled instructions below are the task for this turn. Earlier completed goals, occurrences, conversation, and tool outputs are historical context and do not complete this occurrence. When the task depends on mutable external state, query that state during this occurrence instead of reusing an earlier result.",
+    ...occurrences.flatMap((occurrence, index) => {
+      if (!occurrence) return [];
+      return [
+        "",
+        ...(occurrences.length > 1 ? [`Occurrence ${index + 1}:`] : []),
+        `Scheduled task ID: ${occurrence.payload.scheduledTaskId}`,
+        `Scheduled task run ID: ${occurrence.payload.scheduledTaskRunId}`,
+        `Update ID: ${occurrence.update.id}`,
+        "Instructions:",
+        occurrence.payload.text,
+      ];
+    }),
+  ].join("\n");
+}
+
 export function sessionSystemUpdateBatchHistoryItem(
   updates: Parameters<typeof renderSessionSystemUpdateBatch>[0],
   goalSnapshot?: SessionGoalSnapshot,
-): { type: "message"; role: "system"; content: string } {
+): { type: "message"; role: "system" | "user"; content: string } {
   const goalContext = renderSessionGoalContext(goalSnapshot);
+  const scheduledTask = renderScheduledOccurrenceTaskBatch(updates);
   return {
     type: "message",
-    role: "system",
+    role: scheduledTask ? "user" : "system",
     content: [
       ...(goalContext ? [`${SESSION_GOAL_CONTEXT_LABEL}\n${goalContext}`] : []),
-      renderSessionSystemUpdateBatch(updates),
+      scheduledTask ?? renderSessionSystemUpdateBatch(updates),
     ].join("\n\n"),
   };
 }

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -43,6 +43,7 @@ import {
   mergeToolRefs,
   MODEL_CONTEXT_LABEL,
   SESSION_GOAL_CONTEXT_LABEL,
+  SCHEDULED_OCCURRENCE_TASK_LABEL,
   ModelContextContributionSummaries,
   McpServerConnectionRef,
   ModelBillingAttributionV1,
@@ -1452,8 +1453,89 @@ describe("contracts", () => {
       lineage: {},
     };
     const internal = sessionSystemUpdateBatchHistoryItem([update], goalSnapshot);
+    expect(internal.role).toBe("system");
     expect(internal.content).toStartWith(`${SESSION_GOAL_CONTEXT_LABEL}\n${goalContext}`);
     expect(internal.content).toContain("[OpenGeni internal updates]");
+  });
+
+  test("renders scheduled occurrences as fresh user-role task boundaries", () => {
+    const scheduledTaskId = "33333333-3333-4333-8333-333333333333";
+    const scheduledTaskRunId = "44444444-4444-4444-8444-444444444444";
+    const updateId = "55555555-5555-4555-8555-555555555555";
+    const completedGoal = {
+      state: "completed" as const,
+      goalId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      objectiveRevision: 1,
+      text: "Review an earlier pull-request snapshot",
+      successCriteria: null,
+      rootConstraints: [],
+      mutationPolicy: "preserve_intent" as const,
+      capturedAt: "2026-08-31T05:00:00.000Z",
+    };
+    const completedGoalContext = renderSessionGoalContext(completedGoal)!;
+    const scheduled = sessionSystemUpdateBatchHistoryItem(
+      [
+        {
+          id: updateId,
+          kind: "scheduled_occurrence",
+          classification: "info",
+          sourceId: scheduledTaskRunId,
+          summary: "Review and merge pull requests",
+          payload: {
+            type: "scheduled_occurrence",
+            text: "Review every currently open pull request and merge the approved ones.",
+            scheduledTaskId,
+            scheduledTaskRunId,
+          },
+          lineage: {
+            scheduledTaskId,
+            scheduledTaskRunId,
+            causalHumanSubjectId: "user:owner",
+          },
+        },
+      ],
+      completedGoal,
+    );
+
+    expect(scheduled.role).toBe("user");
+    expect(scheduled.content).toStartWith(`${SESSION_GOAL_CONTEXT_LABEL}\n${completedGoalContext}`);
+    expect(scheduled.content.indexOf(SCHEDULED_OCCURRENCE_TASK_LABEL)).toBeGreaterThan(
+      scheduled.content.indexOf(SESSION_GOAL_CONTEXT_LABEL),
+    );
+    expect(scheduled.content).toContain(SCHEDULED_OCCURRENCE_TASK_LABEL);
+    expect(scheduled.content).toContain("Execute the instructions below for this occurrence now.");
+    expect(scheduled.content).toContain(`Scheduled task ID: ${scheduledTaskId}`);
+    expect(scheduled.content).toContain(`Scheduled task run ID: ${scheduledTaskRunId}`);
+    expect(scheduled.content).toContain(`Update ID: ${updateId}`);
+    expect(scheduled.content).toContain(
+      "Review every currently open pull request and merge the approved ones.",
+    );
+    expect(scheduled.content).toContain("Earlier completed goals");
+    expect(scheduled.content).toContain("query that state during this occurrence");
+    expect(scheduled.content).not.toContain("[OpenGeni internal updates]");
+    expect(scheduled.content).not.toContain("They are not human prompts");
+  });
+
+  test("keeps inconsistent scheduled occurrence identity on the system update path", () => {
+    const scheduled = sessionSystemUpdateBatchHistoryItem([
+      {
+        id: "66666666-6666-4666-8666-666666666666",
+        kind: "scheduled_occurrence",
+        classification: "info",
+        sourceId: "77777777-7777-4777-8777-777777777777",
+        summary: "Malformed legacy occurrence",
+        payload: {
+          type: "scheduled_occurrence",
+          text: "Do not manufacture authority.",
+          scheduledTaskId: "88888888-8888-4888-8888-888888888888",
+          scheduledTaskRunId: "99999999-9999-4999-8999-999999999999",
+        },
+        lineage: {},
+      },
+    ]);
+
+    expect(scheduled.role).toBe("system");
+    expect(scheduled.content).toContain("[OpenGeni internal updates]");
   });
 
   test("accepts client config payloads", () => {

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1473,29 +1473,33 @@ describe("contracts", () => {
       capturedAt: "2026-08-31T05:00:00.000Z",
     };
     const completedGoalContext = renderSessionGoalContext(completedGoal)!;
-    const scheduled = sessionSystemUpdateBatchHistoryItem(
-      [
-        {
-          id: updateId,
-          kind: "scheduled_occurrence",
-          classification: "info",
-          sourceId: scheduledTaskRunId,
-          summary: "Review and merge pull requests",
-          payload: {
-            type: "scheduled_occurrence",
-            text: "Review every currently open pull request and merge the approved ones.",
-            scheduledTaskId,
-            scheduledTaskRunId,
-          },
-          lineage: {
-            scheduledTaskId,
-            scheduledTaskRunId,
-            causalHumanSubjectId: "user:owner",
-          },
+    const updates = [
+      {
+        id: updateId,
+        kind: "scheduled_occurrence" as const,
+        classification: "info" as const,
+        sourceId: scheduledTaskRunId,
+        summary: "Review and merge pull requests",
+        payload: {
+          type: "scheduled_occurrence" as const,
+          text: "Review every currently open pull request and merge the approved ones.",
+          scheduledTaskId,
+          scheduledTaskRunId,
         },
-      ],
-      completedGoal,
-    );
+        lineage: {
+          scheduledTaskId,
+          scheduledTaskRunId,
+          causalHumanSubjectId: "user:owner",
+        },
+      },
+    ];
+    const attached = sessionSystemUpdateBatchHistoryItem(updates, completedGoal);
+    expect(attached.role).toBe("system");
+    expect(attached.content).toContain("[OpenGeni internal updates]");
+
+    const scheduled = sessionSystemUpdateBatchHistoryItem(updates, completedGoal, {
+      promoteScheduledOccurrenceToUser: true,
+    });
 
     expect(scheduled.role).toBe("user");
     expect(scheduled.content).toStartWith(`${SESSION_GOAL_CONTEXT_LABEL}\n${completedGoalContext}`);

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -616,6 +616,25 @@ type AgentChildSessionCreatePresentation = {
   automaticTitleCandidate?: string | null;
 };
 
+const AGENT_CHILD_AUTOMATIC_TITLE_CONTEXT_KEY = "agentChildAutomaticTitle" as const;
+
+/** @internal Exported for the keyed-create repair regression. */
+export function freezeAgentChildAutomaticTitleInCreatorContext(
+  context: TurnInitiatorContext | undefined,
+  title: string | null | undefined,
+): TurnInitiatorContext | undefined {
+  return title ? { ...(context ?? {}), [AGENT_CHILD_AUTOMATIC_TITLE_CONTEXT_KEY]: title } : context;
+}
+
+/** @internal Keyed repair must use the committed winner, not the retry payload. */
+export function initialAutomaticTitleForSessionStart(
+  session: Pick<Session, "createdByContext">,
+  requestedTitle: string | null | undefined,
+): string | null {
+  const frozenTitle = session.createdByContext[AGENT_CHILD_AUTOMATIC_TITLE_CONTEXT_KEY];
+  return typeof frozenTitle === "string" ? frozenTitle : (requestedTitle ?? null);
+}
+
 function automaticTitleForAgentChildCreate(
   presentation: AgentChildSessionCreatePresentation,
   goal: GoalSpec | null | undefined,
@@ -762,6 +781,10 @@ export async function createAndStartSessionWithOutcome(input: {
     reasoningEffort: input.reasoningEffort,
     ...(input.latencyMode !== undefined ? { latencyMode: input.latencyMode } : {}),
   };
+  const frozenCreatedByContext = freezeAgentChildAutomaticTitleInCreatorContext(
+    input.createdByContext,
+    input.initialAutomaticTitle,
+  );
   // Keyed creation is intentionally handled only by the database admission
   // transaction below. Its workspace/key lock replays either the successful
   // session or the committed denial atomically; an application-side lookup
@@ -780,7 +803,7 @@ export async function createAndStartSessionWithOutcome(input: {
       toolPolicy: input.toolPolicy,
       metadata: sessionMetadata,
       ...(input.createdBy ? { createdBy: input.createdBy } : {}),
-      ...(input.createdByContext ? { createdByContext: input.createdByContext } : {}),
+      ...(frozenCreatedByContext ? { createdByContext: frozenCreatedByContext } : {}),
       createdByActor: input.createdByActor ?? null,
       model: input.model,
       reasoningEffort: input.reasoningEffort,
@@ -852,7 +875,7 @@ export async function createAndStartSessionWithOutcome(input: {
       toolPolicy: input.toolPolicy,
       metadata: sessionMetadata,
       ...(input.createdBy ? { createdBy: input.createdBy } : {}),
-      ...(input.createdByContext ? { createdByContext: input.createdByContext } : {}),
+      ...(frozenCreatedByContext ? { createdByContext: frozenCreatedByContext } : {}),
       createdByActor: input.createdByActor ?? null,
       model: input.model,
       reasoningEffort: input.reasoningEffort,
@@ -1035,7 +1058,10 @@ async function finishStartSession(
             : {}),
         }
       : null,
-    initialAutomaticTitle: input.initialAutomaticTitle ?? null,
+    initialAutomaticTitle: initialAutomaticTitleForSessionStart(
+      session,
+      input.initialAutomaticTitle,
+    ),
     consumeNewSessionDraft: input.consumeNewSessionDraft ?? null,
     rememberNewSessionSelection: input.rememberNewSessionSelection ?? null,
     deferInitialTurn: input.deferInitialTurn === true,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -10,6 +10,7 @@ import {
   type Settings,
 } from "@opengeni/config";
 import {
+  AUTOMATIC_SESSION_TITLE_FALLBACK,
   CreateSessionRequest,
   DEFAULT_FIRST_PARTY_MCP_PERMISSIONS,
   DEFAULT_FIRST_PARTY_MCP_TOOLS,
@@ -20,6 +21,7 @@ import {
   ServiceTurnInitiator,
   ServiceTurnInitiatorContext,
   evaluateWorkspaceModelPolicy,
+  normalizeAutomaticSessionTitle,
   resolveWorkspaceSessionToolDefaults,
   stableJson,
   type AccessGrant,
@@ -608,6 +610,25 @@ export type CreateSessionRequestOutcome = CreateSessionOutcome & {
   usageRecording: "recorded" | "failed";
 };
 
+type AgentChildSessionCreatePresentation = {
+  /** Model-authored title candidate from the first-party `session_create` tool.
+   * This is deliberately separate from the public REST request contract. */
+  automaticTitleCandidate?: string | null;
+};
+
+function automaticTitleForAgentChildCreate(
+  presentation: AgentChildSessionCreatePresentation,
+  goal: GoalSpec | null | undefined,
+  initialMessage: string | null | undefined,
+): string | null {
+  for (const candidate of [presentation.automaticTitleCandidate, goal?.text, initialMessage]) {
+    if (typeof candidate !== "string") continue;
+    const normalized = normalizeAutomaticSessionTitle(candidate);
+    if (normalized && normalized !== AUTOMATIC_SESSION_TITLE_FALLBACK) return normalized;
+  }
+  return null;
+}
+
 export async function createAndStartSessionWithOutcome(input: {
   requestedSessionId?: string;
   db: Database;
@@ -653,6 +674,9 @@ export async function createAndStartSessionWithOutcome(input: {
   // resolved workspace-scoped by the caller). Null/omitted ⇒ unfiled (inbox).
   channelId?: string | null;
   goal?: GoalSpec | null;
+  /** Trusted sensitive-safe automatic title for an agent-created child. The
+   * atomic initializer commits the row mutation and `session.title_set`. */
+  initialAutomaticTitle?: string | null;
   // Per-session agent persona/system instructions (org-visible metadata, not a
   // secret). Persisted on the session row and composed system-level AFTER the
   // workspace agentInstructions at turn time; never emitted as a timeline event.
@@ -906,6 +930,7 @@ async function finishStartSession(
     sandboxBackend: Settings["sandboxBackend"];
     variableSets?: Array<{ id: string; name: string; scope: VariableSet["scope"] }>;
     goal?: GoalSpec | null;
+    initialAutomaticTitle?: string | null;
     sessionMcpServers?: SessionMcpServerMetadata[];
     seedTargetSandbox?: {
       sandboxId: string;
@@ -1010,6 +1035,7 @@ async function finishStartSession(
             : {}),
         }
       : null,
+    initialAutomaticTitle: input.initialAutomaticTitle ?? null,
     consumeNewSessionDraft: input.consumeNewSessionDraft ?? null,
     rememberNewSessionSelection: input.rememberNewSessionSelection ?? null,
     deferInitialTurn: input.deferInitialTurn === true,
@@ -1486,6 +1512,7 @@ export async function createSessionForRequestWithOutcome(
   workspaceId: string,
   rawPayload: unknown,
   authorization?: AccessGrantAuthorization,
+  agentChildPresentation?: AgentChildSessionCreatePresentation,
 ): Promise<CreateSessionRequestOutcome> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
   const payload = CreateSessionRequest.parse(rawPayload);
@@ -1613,6 +1640,14 @@ export async function createSessionForRequestWithOutcome(
       });
     }
   }
+  const initialAutomaticTitle =
+    parentSession && agentChildPresentation
+      ? automaticTitleForAgentChildCreate(
+          agentChildPresentation,
+          effectiveGoal,
+          payload.initialMessage,
+        )
+      : null;
   const personalResourceSubjectId = creationInitiator.actor
     ? (await requireLiveAgentAttemptAuthorization(db, grant, creationInitiator.actor.sessionId))
         .initiatingHumanSubjectId
@@ -2332,6 +2367,7 @@ export async function createSessionForRequestWithOutcome(
       rigVersionId: frozenRigVersionId,
       channelId,
       goal: effectiveGoal ?? null,
+      initialAutomaticTitle,
       // Per-session persona instructions (already trimmed/validated by the
       // contracts schema). Persisted on the row; composed system-level at turn
       // time. Not surfaced as an event.

--- a/packages/core/test/agent-child-session-title.test.ts
+++ b/packages/core/test/agent-child-session-title.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  freezeAgentChildAutomaticTitleInCreatorContext,
+  initialAutomaticTitleForSessionStart,
+} from "../src/domain/sessions";
+
+describe("agent child session title repair", () => {
+  test("uses the title frozen by the winning keyed create instead of a retry candidate", () => {
+    const createdByContext = freezeAgentChildAutomaticTitleInCreatorContext(
+      { callerSessionId: "manager" },
+      "Winning child title",
+    );
+    expect(createdByContext).toEqual({
+      callerSessionId: "manager",
+      agentChildAutomaticTitle: "Winning child title",
+    });
+    expect(
+      initialAutomaticTitleForSessionStart(
+        { createdByContext: createdByContext ?? {} },
+        "Losing retry title",
+      ),
+    ).toBe("Winning child title");
+  });
+
+  test("keeps legacy repair source-compatible when no frozen title exists", () => {
+    expect(
+      initialAutomaticTitleForSessionStart({ createdByContext: {} }, "Legacy retry title"),
+    ).toBe("Legacy retry title");
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -61716,12 +61716,22 @@ export async function claimSessionWorkForAttempt(
               frozenGoalSnapshot,
             );
           }
+          const scheduledOccurrenceHistoryItem =
+            !routingGoalUpdate &&
+            delivered.updates.length > 0 &&
+            delivered.updates.every((update) => update.kind === "scheduled_occurrence")
+              ? sessionSystemUpdateBatchHistoryItem(
+                  delivered.updates.map((update) => mapSessionSystemUpdate(update)),
+                  frozenGoalSnapshot,
+                  { promoteScheduledOccurrenceToUser: true },
+                )
+              : undefined;
           await persistDeliveredUpdateBatch(
             delivered,
             session.accountId,
             internalTurn.id,
             frozenGoalSnapshot,
-            goalContinuationHistoryItem,
+            goalContinuationHistoryItem ?? scheduledOccurrenceHistoryItem,
           );
           // The batch is now durable model memory. Every child it reports on has
           // been carried to this turn's initiating human, so their read fence on

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -58339,6 +58339,9 @@ export type InitializeSessionStartInput = {
   /** Trusted create-session policy. Omitted only by legacy low-level callers. */
   turnExecutionPolicy?: TurnExecutionPolicyV1;
   createdEventPayload: Record<string, unknown>;
+  /** Sensitive-safe semantic title supplied by the trusted agent-child create
+   * path. It is committed with the initial timeline, never as a bare row edit. */
+  initialAutomaticTitle?: string | null;
   goal?: {
     text: string;
     successCriteria?: string | null;
@@ -58435,6 +58438,39 @@ export async function initializeSessionStartAtomically(
           };
         }
 
+        const normalizedInitialAutomaticTitle =
+          typeof input.initialAutomaticTitle === "string"
+            ? normalizeAutomaticSessionTitle(input.initialAutomaticTitle)
+            : null;
+        let appliedInitialAutomaticTitle: string | null = null;
+        if (
+          normalizedInitialAutomaticTitle &&
+          normalizedInitialAutomaticTitle !== AUTOMATIC_SESSION_TITLE_FALLBACK &&
+          session.title === AUTOMATIC_SESSION_TITLE_FALLBACK &&
+          session.titleSource === "agent"
+        ) {
+          await tx.execute(
+            sql`select pg_catalog.set_config('opengeni.automatic_session_title_v1_candidate', ${normalizedInitialAutomaticTitle}, true)`,
+          );
+          const [updatedTitle] = await tx
+            .update(schema.sessions)
+            .set({
+              title: normalizedInitialAutomaticTitle,
+              titleSource: "agent",
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, session.id),
+                eq(schema.sessions.title, AUTOMATIC_SESSION_TITLE_FALLBACK),
+                eq(schema.sessions.titleSource, "agent"),
+              ),
+            )
+            .returning({ title: schema.sessions.title });
+          appliedInitialAutomaticTitle = updatedTitle?.title ?? null;
+        }
+
         let insertedGoal = false;
         let [goal] = await tx
           .select()
@@ -58503,6 +58539,21 @@ export async function initializeSessionStartAtomically(
                         createdBy: creator.initiator,
                       },
                     },
+                    ...(appliedInitialAutomaticTitle
+                      ? [
+                          {
+                            accountId: session.accountId,
+                            workspaceId: input.workspaceId,
+                            sessionId: session.id,
+                            sequence: ++sequence,
+                            type: "session.title_set" as const,
+                            payload: {
+                              title: appliedInitialAutomaticTitle,
+                              source: "agent",
+                            },
+                          },
+                        ]
+                      : []),
                     ...(goal
                       ? [
                           {
@@ -58534,6 +58585,29 @@ export async function initializeSessionStartAtomically(
               )
               .returning();
             initializedNow = true;
+          } else if (appliedInitialAutomaticTitle) {
+            const [titleEvent] = await tx
+              .insert(schema.sessionEvents)
+              .values(
+                withLosslessContentWriteVersion(
+                  {
+                    accountId: session.accountId,
+                    workspaceId: input.workspaceId,
+                    sessionId: session.id,
+                    sequence: ++sequence,
+                    type: "session.title_set",
+                    payload: {
+                      title: appliedInitialAutomaticTitle,
+                      source: "agent",
+                    },
+                  },
+                  "payload",
+                  "payloadCodecVersion",
+                ),
+              )
+              .returning();
+            if (!titleEvent) throw new Error("Failed to append initial session title event");
+            insertedEvents.push(titleEvent);
           }
           const deferredStatusNeedsRepair = initializedNow && session.status !== deferredStatus;
           const sessionNeedsRepair =
@@ -58638,6 +58712,21 @@ export async function initializeSessionStartAtomically(
                       createdBy: creator.initiator,
                     },
                   },
+                  ...(appliedInitialAutomaticTitle
+                    ? [
+                        {
+                          accountId: session.accountId,
+                          workspaceId: input.workspaceId,
+                          sessionId: session.id,
+                          sequence: ++sequence,
+                          type: "session.title_set" as const,
+                          payload: {
+                            title: appliedInitialAutomaticTitle,
+                            source: "agent",
+                          },
+                        },
+                      ]
+                    : []),
                   ...(goal
                     ? [
                         {
@@ -58696,6 +58785,29 @@ export async function initializeSessionStartAtomically(
           userEvent = rows.find((event) => event.type === "user.message");
           if (!userEvent) throw new Error("Failed to create initial user event");
           initializedNow = true;
+        } else if (appliedInitialAutomaticTitle) {
+          const [titleEvent] = await tx
+            .insert(schema.sessionEvents)
+            .values(
+              withLosslessContentWriteVersion(
+                {
+                  accountId: session.accountId,
+                  workspaceId: input.workspaceId,
+                  sessionId: session.id,
+                  sequence: ++sequence,
+                  type: "session.title_set",
+                  payload: {
+                    title: appliedInitialAutomaticTitle,
+                    source: "agent",
+                  },
+                },
+                "payload",
+                "payloadCodecVersion",
+              ),
+            )
+            .returning();
+          if (!titleEvent) throw new Error("Failed to append initial session title event");
+          insertedEvents.push(titleEvent);
         }
 
         let [turn] = await tx

--- a/packages/db/test/session-event-writer-audit.test.ts
+++ b/packages/db/test/session-event-writer-audit.test.ts
@@ -196,7 +196,7 @@ const expectedWriters: Record<string, ExpectedWriter> = {
     requiresControlRevalidation: true,
   },
   "packages/db/src/index.ts#initializeSessionStartAtomically": {
-    inserts: 4,
+    inserts: 6,
     contract: "canonical",
   },
   "packages/db/src/index.ts#claimSessionWorkForAttempt": {

--- a/packages/db/test/session-start-deferred-options.test.ts
+++ b/packages/db/test/session-start-deferred-options.test.ts
@@ -64,6 +64,69 @@ async function sessionFixture() {
 }
 
 describe("atomic deferred session initialization options (real PostgreSQL)", () => {
+  test("commits an automatic title before the ordinary initial user turn", async () => {
+    if (!client) return;
+    const { grant, session } = await sessionFixture();
+    const started = await initializeSessionStartAtomically(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: { source: "agent-child-title-turn-test" },
+      initialAutomaticTitle: "Inspect child session title creation",
+    });
+
+    expect(started.events.map((event) => event.type)).toEqual([
+      "session.created",
+      "session.title_set",
+      "user.message",
+      "session.status.changed",
+      "turn.queued",
+    ]);
+    expect(started.turn).toMatchObject({ status: "queued" });
+    expect(await getSession(client.db, grant.workspaceId, session.id)).toMatchObject({
+      title: "Inspect child session title creation",
+      titleSource: "agent",
+      lastSequence: 5,
+    });
+  });
+
+  test("commits an automatic child title with the initial timeline and replays idempotently", async () => {
+    if (!client) return;
+    const { grant, session } = await sessionFixture();
+    const input = {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      reasoningEffortFallback: "low" as const,
+      createdEventPayload: { source: "agent-child-title-test" },
+      initialAutomaticTitle: "Repair pull request accessibility defects",
+      goal: { text: "Repair the confirmed accessibility defects." },
+      deferInitialTurn: true,
+    };
+
+    const first = await initializeSessionStartAtomically(client.db, input);
+    expect(first.events.map((event) => [event.sequence, event.type])).toEqual([
+      [1, "session.created"],
+      [2, "session.title_set"],
+      [3, "goal.set"],
+    ]);
+    expect(first.events[1]?.payload).toEqual({
+      title: "Repair pull request accessibility defects",
+      source: "agent",
+    });
+    expect(await getSession(client.db, grant.workspaceId, session.id)).toMatchObject({
+      title: "Repair pull request accessibility defects",
+      titleSource: "agent",
+      lastSequence: 3,
+    });
+
+    const replay = await initializeSessionStartAtomically(client.db, input);
+    expect(replay.changed).toBe(false);
+    expect(replay.events).toEqual([]);
+    expect(await listSessionEvents(client.db, grant.workspaceId, session.id)).toHaveLength(3);
+  });
+
   test("preserves the legacy idle/api defaults and replays idempotently", async () => {
     if (!client) return;
     const { grant, session } = await sessionFixture();

--- a/packages/db/test/turn-initiator.test.ts
+++ b/packages/db/test/turn-initiator.test.ts
@@ -860,6 +860,58 @@ describe("immutable session turn initiators", () => {
     expect(scheduledHistoryContent).toContain(`Scheduled task run ID: ${scheduledRunId}`);
     expect(scheduledHistoryContent).toContain("Instructions:\nScheduled work");
 
+    const attachedTarget = await createSession(client.db, sessionInput(grant));
+    const sender = "user:scheduled-attachment-sender";
+    const sent = await withWorkspaceSubjectRls(client.db, grant.workspaceId!, sender, (db) =>
+      db.transaction((tx) =>
+        submitHumanPromptInTransaction(tx as unknown as typeof db, {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: attachedTarget.id,
+          subjectId: sender,
+          subjectLabel: "Scheduled attachment sender",
+          actor: { type: "human", subjectId: sender },
+          operationKey: crypto.randomUUID(),
+          delivery: "send",
+          text: "Keep this human task authoritative.",
+          resources: [],
+          reasoningEffortFallback: "low",
+          source: "user",
+        }),
+      ),
+    );
+    await addAcceptedScheduledOccurrence(grant, attachedTarget.id);
+    const attachedClaim = await claimSessionWorkForAttempt(client.db, grant.workspaceId!, {
+      sessionId: attachedTarget.id,
+      workflowId: `session-${attachedTarget.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    expect(attachedClaim.action).toBe("claimed");
+    if (attachedClaim.action !== "claimed") {
+      throw new Error("Human turn with an attached scheduled occurrence was not claimed");
+    }
+    expect(attachedClaim.turn.id).toBe(sent.turnId);
+    expect(attachedClaim.turn.initiator).toEqual({
+      kind: "subject",
+      subjectId: sender,
+      label: "Scheduled attachment sender",
+    });
+    expect(attachedClaim.turn.scheduledTaskRunId).toBeNull();
+    const attachedHistory = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db
+        .select({ item: schema.sessionHistoryItems.item })
+        .from(schema.sessionHistoryItems)
+        .where(eq(schema.sessionHistoryItems.turnId, attachedClaim.turn.id))
+        .orderBy(schema.sessionHistoryItems.position),
+    );
+    expect(attachedHistory.map(({ item }) => item.role)).toEqual(["user", "system"]);
+    expect(attachedHistory[0]?.item.content).toBe("Keep this human task authoritative.");
+    expect(attachedHistory[1]?.item.content).toContain("[OpenGeni internal updates]");
+    expect(attachedHistory[1]?.item.content).not.toContain("[OpenGeni scheduled task occurrence]");
+
     const mixedTarget = await createSession(client.db, sessionInput(grant));
     const goal = await createSessionGoal(client.db, {
       accountId: grant.accountId,

--- a/packages/db/test/turn-initiator.test.ts
+++ b/packages/db/test/turn-initiator.test.ts
@@ -822,7 +822,7 @@ describe("immutable session turn initiators", () => {
       ...sessionInput(grant),
       createdBy: { kind: "service", subjectId: "scheduler" },
     });
-    const { runId: scheduledRunId } = await addAcceptedScheduledOccurrence(
+    const { taskId: scheduledTaskId, runId: scheduledRunId } = await addAcceptedScheduledOccurrence(
       grant,
       scheduledTarget.id,
     );
@@ -842,7 +842,23 @@ describe("immutable session turn initiators", () => {
       label: "OpenGeni scheduler",
     });
     expect(scheduledClaim.turn.initiatingHumanSubjectId).toBeNull();
+    expect(scheduledClaim.turn.scheduledTaskRunId).toBe(scheduledRunId);
     expect(scheduledClaim.turn.initiatorContext.scheduledRunIds).toEqual([scheduledRunId]);
+    const [scheduledHistory] = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db
+        .select({ item: schema.sessionHistoryItems.item })
+        .from(schema.sessionHistoryItems)
+        .where(eq(schema.sessionHistoryItems.turnId, scheduledClaim.turn.id)),
+    );
+    expect(scheduledHistory?.item).toMatchObject({ type: "message", role: "user" });
+    const scheduledHistoryContent = scheduledHistory?.item.content;
+    if (typeof scheduledHistoryContent !== "string") {
+      throw new Error("Scheduled occurrence history item has no text content");
+    }
+    expect(scheduledHistoryContent).toContain("[OpenGeni scheduled task occurrence]");
+    expect(scheduledHistoryContent).toContain(`Scheduled task ID: ${scheduledTaskId}`);
+    expect(scheduledHistoryContent).toContain(`Scheduled task run ID: ${scheduledRunId}`);
+    expect(scheduledHistoryContent).toContain("Instructions:\nScheduled work");
 
     const mixedTarget = await createSession(client.db, sessionInput(grant));
     const goal = await createSessionGoal(client.db, {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -8680,9 +8680,21 @@ describe("API component integration", () => {
       "session_create",
       {
         initialMessage: "wait for manager control",
+        title: "Manager-controlled child",
         model: "scripted-model",
       },
     );
+    expect(
+      await requireSession(dbClient.db, grant.workspaceId, controlledChild.resource.id),
+    ).toMatchObject({
+      title: "Manager-controlled child",
+      titleSource: "agent",
+    });
+    expect(
+      (await listSessionEvents(dbClient.db, grant.workspaceId, controlledChild.resource.id, 0, 10))
+        .slice(0, 2)
+        .map((event) => event.type),
+    ).toEqual(["session.created", "session.title_set"]);
     const childAttemptId = crypto.randomUUID();
     const childClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
       sessionId: controlledChild.resource.id,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -645,7 +645,7 @@ describe("worker activities integration", () => {
             functionCall(
               "opengeni__session_create",
               {
-                initialMessage: "worker: reply ready then goal_complete",
+                initialMessage: "Verify spawned worker inheritance",
                 sandboxBackend: "none",
               },
               "call-spawn-1",
@@ -692,6 +692,25 @@ describe("worker activities integration", () => {
       expect(worker?.parentSessionId).toBe(manager.id);
       expect(worker?.model).toBe("scripted-model");
       expect(worker?.metadata.reasoningEffort).toBe("medium");
+      expect(worker).toMatchObject({
+        title: "Verify spawned worker inheritance",
+        titleSource: "agent",
+      });
+      const workerEvents = await listSessionEvents(
+        dbClient.db,
+        grant.workspaceId,
+        worker!.id,
+        0,
+        20,
+      );
+      expect(workerEvents.map((event) => event.type).slice(0, 2)).toEqual([
+        "session.created",
+        "session.title_set",
+      ]);
+      expect(workerEvents[1]?.payload).toEqual({
+        title: "Verify spawned worker inheritance",
+        source: "agent",
+      });
     } finally {
       server.stop(true);
     }


### PR DESCRIPTION
## Summary

- persist pure scheduled-occurrence batches as direct `user`-role task boundaries for model input
- include immutable task, run, and update identities plus explicit fresh-state guidance
- preserve scheduler/service initiator, causal authority, connection delegations, audit, and settlement semantics
- keep non-scheduled and malformed/mixed machine-input batches on the existing `system` envelope
- confirm `existing_session` schedules keep reusing their configured target session; the observed `New conversation` rows were child sessions spawned by the scheduled agent
- let first-party `session_create` accept a concise semantic child title and safely derive one from the delegated goal or initial message when omitted
- commit the child title row mutation and `session.title_set` event in the atomic initial-state transaction before the first child turn can wake
- keep public REST/SDK create-title authority unchanged and preserve human-title precedence

## Testing

- [x] `bun run typecheck` (31 projects)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test packages/contracts/test/contracts.test.ts`
- [x] `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/turn-initiator.test.ts`
- [x] `bun test packages/runtime/test/runtime.test.ts -t "keeps a durable machine-input batch as an exact prefix on later model requests"`
- [x] `bun test --timeout 30000 apps/api/test/first-party-mcp-tool-policy.test.ts`
- [x] `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-start-deferred-options.test.ts`
- [x] `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 ./test/integration/worker-activity.integration.ts -t "session_create links the worker and inherits the calling turn"`
- [x] `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 ./test/integration/api.integration.ts -t "registers manager orchestration MCP tools gated by session permissions"`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] The candidate head was created from and remains materially compatible with current `main`.

## Notes

- Newly claimed scheduled occurrences change model-facing role only; existing historical model-memory rows remain immutable.
- New agent-created child sessions receive the semantic title during initial-state installation. Existing historical fallback rows are not bulk-renamed and retain the established next-eligible-turn self-heal path.
- No database migration is required.

## Summary by Sourcery

Refresh standalone scheduled occurrences as explicit model task boundaries and name newly spawned child sessions without changing authority or public session-creation semantics.

New Features:
- Allow first-party agent-created child sessions to receive concise semantic titles, with safe fallback derivation when omitted.
- Persist agent-created child session titles and their title-set events atomically before the child’s first turn.

Bug Fixes:
- Present standalone scheduled occurrences as fresh model-facing task boundaries while preserving scheduler authority and existing handling for attached, mixed, or malformed machine inputs.

Enhancements:
- Include immutable scheduled task, run, and update identities plus explicit fresh-state guidance in promoted scheduled-occurrence history.

Documentation:
- Document scheduled-occurrence task boundaries and agent-created child-session title behavior.

Tests:
- Add coverage for scheduled-occurrence rendering, initiator preservation, title creation, atomic event ordering, and idempotent replay.