### PR TITLE
fix(organization): enable local self-host administration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,11 @@ For a map of every app, package, and how the parts fit together, start at [`docs
   personal-workspace pointer converge through the lifecycle SECURITY DEFINER
   seam. Bearer/delegated principals, API keys, and account or organization
   administrators receive no personal-workspace access through that exception.
+  The exact built-in `opengeni:local/default` + `dev` browser context is also
+  the sole organization administrator in single-user local mode. It may manage
+  organization metadata, shared workspaces, retention, company identity, and
+  the organization Codex pool; subject names alone, configured access, bearer
+  tokens, API keys, services, and agents never inherit that exception.
   Because that workspace has no `workspace_memberships` row, a seam that fences
   on one denies its owner: `subjectHasLiveWorkspaceAuthorityInScope`
   (`packages/db/src/workspace-authority.ts`) is the single implementation of the

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -169,6 +169,7 @@ import {
   getManagedSession,
   hasPermission,
   requireAccessGrant,
+  requireCanonicalLocalAccountAdministrator,
   type ApiRouteDeps,
 } from "@opengeni/core";
 import type { Context, Hono } from "hono";
@@ -229,8 +230,17 @@ async function requireOrganizationCodexHuman(
 ): Promise<ManagedCookieHuman> {
   const parsed = z.string().uuid().safeParse(organizationId);
   if (!parsed.success) throw new HTTPException(422, { message: "invalid organization id" });
-  const human = await managedCookieHuman(c, deps);
-  if (!human) throw new HTTPException(401, { message: "managed human session required" });
+  let human = await managedCookieHuman(c, deps);
+  if (!human && deps.settings.productAccessMode === "local") {
+    const local = await requireCanonicalLocalAccountAdministrator(c, deps, organizationId);
+    human = {
+      subjectId: local.subjectId,
+      browserSessionHash: await hashCodexBrowserSession(`local:${local.subjectId}`),
+    };
+  }
+  if (!human) {
+    throw new HTTPException(401, { message: "organization administrator session required" });
+  }
   try {
     await getOrganizationCodexRotationSettings(deps.db, {
       organizationId,
@@ -271,13 +281,17 @@ function requireSameOriginBrowserMutation(c: Context, deps: ApiRouteDeps): void 
       message: "JSON browser request required",
     });
   }
-  if (!deps.settings.publicBaseUrl) {
+  if (deps.settings.productAccessMode !== "local" && !deps.settings.publicBaseUrl) {
     throw new HTTPException(503, {
       message: "managed browser origin is not configured",
     });
   }
-  const expectedOrigin = new URL(deps.settings.publicBaseUrl).origin;
-  if (c.req.header("origin") !== expectedOrigin) {
+  const origin = c.req.header("origin");
+  if (
+    deps.settings.productAccessMode === "local"
+      ? !localBrowserOriginMatchesRequest(c, origin)
+      : origin !== new URL(deps.settings.publicBaseUrl!).origin
+  ) {
     throw new HTTPException(403, {
       message: "same-origin browser request required",
     });
@@ -287,6 +301,41 @@ function requireSameOriginBrowserMutation(c: Context, deps: ApiRouteDeps): void 
       message: "same-origin fetch metadata required",
     });
   }
+}
+
+function localBrowserOriginMatchesRequest(c: Context, value: string | undefined): boolean {
+  if (!value) return false;
+  let origin: URL;
+  try {
+    origin = new URL(value);
+  } catch {
+    return false;
+  }
+  if (
+    origin.origin !== value ||
+    origin.origin === "null" ||
+    (origin.protocol !== "http:" && origin.protocol !== "https:")
+  ) {
+    return false;
+  }
+
+  const forwardedProtocol = c.req.header("x-forwarded-proto")?.trim().toLowerCase();
+  const protocol = forwardedProtocol ? `${forwardedProtocol}:` : new URL(c.req.url).protocol;
+  if (protocol !== "http:" && protocol !== "https:") return false;
+  const forwardedHost = c.req.header("x-forwarded-host") ?? c.req.header("host");
+  if (!forwardedHost || /[\s,/?#@\\]/u.test(forwardedHost)) return false;
+
+  let request: URL;
+  try {
+    request = new URL(`${protocol}//${forwardedHost}`);
+  } catch {
+    return false;
+  }
+  return (
+    origin.protocol === request.protocol &&
+    origin.hostname === request.hostname &&
+    (request.port === "" || origin.port === request.port)
+  );
 }
 
 async function requireRedemptionHuman(

--- a/apps/api/src/routes/organization-memberships.ts
+++ b/apps/api/src/routes/organization-memberships.ts
@@ -33,6 +33,7 @@ import {
 import {
   getManagedSession,
   organizationMembershipHttpStatus,
+  requireCanonicalLocalAccountAdministrator,
   type ApiRouteDeps,
 } from "@opengeni/core";
 import {
@@ -98,6 +99,25 @@ async function requireManagedHuman(context: Context, deps: ApiRouteDeps) {
     throw new HTTPException(401, { message: "managed human session required" });
   }
   return { session, subjectId: `user:${session.user.id}` };
+}
+
+async function requireOrganizationAdministrator(
+  context: Context,
+  deps: ApiRouteDeps,
+  organizationId: string,
+): Promise<{ subjectId: string }> {
+  if (deps.settings.productAccessMode === "managed") {
+    return await requireManagedHuman(context, deps);
+  }
+  if (deps.settings.productAccessMode === "local") {
+    const { subjectId } = await requireCanonicalLocalAccountAdministrator(
+      context,
+      deps,
+      organizationId,
+    );
+    return { subjectId };
+  }
+  throw new HTTPException(401, { message: "organization administrator session required" });
 }
 
 async function parseBody<S extends z.ZodType>(context: Context, schema: S): Promise<z.infer<S>> {
@@ -213,12 +233,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.get("/v1/organizations/:organizationId/overview", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     try {
       return context.json(
         OrganizationAdministrationOverview.parse(
@@ -234,12 +254,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.patch("/v1/organizations/:organizationId", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     const payload = await parseBody(context, UpdateOrganizationNameRequest);
     try {
       return context.json(
@@ -257,12 +277,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.patch("/v1/organizations/:organizationId/workspaces/:workspaceId", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     const workspaceId = parseId(WorkspaceId, context.req.param("workspaceId"), "workspace id");
     const payload = await parseBody(context, UpdateOrganizationWorkspaceRequest);
     try {
@@ -284,12 +304,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.post("/v1/organizations/:organizationId/workspaces", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     const payload = await parseBody(context, CreateOrganizationWorkspaceRequest);
     try {
       return context.json(
@@ -311,12 +331,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   app.patch(
     "/v1/organizations/:organizationId/workspaces/:workspaceId/settings",
     async (context) => {
-      const { subjectId } = await requireManagedHuman(context, deps);
       const organizationId = parseId(
         OrganizationId,
         context.req.param("organizationId"),
         "organization id",
       );
+      const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
       const workspaceId = parseId(WorkspaceId, context.req.param("workspaceId"), "workspace id");
       const payload = await parseBody(context, UpdateWorkspaceSettingsRequest);
       try {
@@ -642,12 +662,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   );
 
   app.get("/v1/organizations/:organizationId/members", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     try {
       return context.json(
         ListOrganizationAdministrationMembersResponse.parse({
@@ -689,12 +709,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.get("/v1/organizations/:organizationId/retention-policy", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     try {
       return context.json(
         OrganizationRetentionPolicy.parse(
@@ -710,12 +730,12 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
   });
 
   app.patch("/v1/organizations/:organizationId/retention-policy", async (context) => {
-    const { subjectId } = await requireManagedHuman(context, deps);
     const organizationId = parseId(
       OrganizationId,
       context.req.param("organizationId"),
       "organization id",
     );
+    const { subjectId } = await requireOrganizationAdministrator(context, deps, organizationId);
     const payload = await parseBody(context, UpdateOrganizationRetentionPolicyRequest);
     try {
       return context.json(

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { ApiRouteDeps, ManagedEmailDeliveryResult, ManagedEmailMessage } from "@opengeni/core";
 import {
+  bootstrapWorkspace,
   claimOrganizationUserSetupDelivery,
   createDb,
   createOrganizationInvitation,
@@ -16,6 +17,7 @@ import {
 } from "@opengeni/testing";
 import { Hono } from "hono";
 import { registerManagedOnboardingRoutes } from "../src/routes/managed-onboarding";
+import { registerCodexRoutes } from "../src/routes/codex";
 import { registerOrganizationMembershipRoutes } from "../src/routes/organization-memberships";
 
 let shared: SharedTestDatabase | null = null;
@@ -113,6 +115,101 @@ afterAll(async () => {
 }, 60_000);
 
 describe("organization membership routes", () => {
+  test("lets only the canonical single-user local browser administer its organization", async () => {
+    if (!client) return;
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "opengeni:local",
+      accountExternalId: "default",
+      accountName: "Local",
+      workspaceExternalSource: "opengeni:local",
+      workspaceExternalId: "default",
+      workspaceName: "Local",
+      subjectId: "dev",
+      subjectLabel: "Local dev",
+    });
+    if (!access.defaultAccountId) throw new Error("local account was not returned");
+    const local = new Hono();
+    registerOrganizationMembershipRoutes(local, {
+      db: client.db,
+      settings: testSettings({ productAccessMode: "local" }),
+      managedAuth: null,
+    } as ApiRouteDeps);
+    registerCodexRoutes(local, {
+      db: client.db,
+      settings: testSettings({ productAccessMode: "local" }),
+      managedAuth: null,
+      githubStateSecret: "local-organization-codex-test-secret",
+    } as ApiRouteDeps);
+
+    const response = await local.request(
+      `http://x/v1/organizations/${access.defaultAccountId}/overview`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      organization: { id: access.defaultAccountId },
+    });
+    const codex = await local.request(
+      `http://x/v1/organizations/${access.defaultAccountId}/codex/accounts`,
+    );
+    expect(codex.status).toBe(200);
+    expect(await codex.json()).toMatchObject({ accounts: [] });
+
+    const realFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(
+          JSON.stringify({
+            device_auth_id: "local-device-auth",
+            user_code: "LOCAL-1234",
+            interval: "5",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )) as typeof fetch;
+      const start = await local.request(
+        `http://opengeni-api:8000/v1/organizations/${access.defaultAccountId}/codex/connect/start`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            host: "homeserver",
+            origin: "http://homeserver:30079",
+            "sec-fetch-site": "same-origin",
+            "x-forwarded-host": "homeserver",
+            "x-forwarded-proto": "http",
+          },
+          body: "{}",
+        },
+      );
+      expect(start.status).toBe(200);
+      expect(await start.json()).toMatchObject({ userCode: "LOCAL-1234" });
+
+      const crossOrigin = await local.request(
+        `http://opengeni-api:8000/v1/organizations/${access.defaultAccountId}/codex/connect/start`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            host: "homeserver",
+            origin: "http://attacker.example:30079",
+            "sec-fetch-site": "same-origin",
+            "x-forwarded-host": "homeserver",
+            "x-forwarded-proto": "http",
+          },
+          body: "{}",
+        },
+      );
+      expect(crossOrigin.status).toBe(403);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    const delegated = await local.request(
+      `http://x/v1/organizations/${access.defaultAccountId}/overview`,
+      { headers: { authorization: "Bearer not-a-valid-local-token" } },
+    );
+    expect(delegated.status).toBe(401);
+  });
+
   test("denies non-managed and delegated principals before database access", async () => {
     const configured = new Hono();
     registerOrganizationMembershipRoutes(configured, {

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -15,6 +15,7 @@ import type {
   CodexUsageWindow,
   WorkspaceCodexSubscriptionMode,
 } from "@opengeni/sdk";
+import { Link } from "@tanstack/react-router";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -1257,22 +1258,46 @@ export function CodexSubscriptionsCard({
       </div>
 
       {canManage && source?.workspaceKind === "shared" ? (
-        <label className="grid gap-1 rounded-md border border-border/70 px-3 py-2">
-          <span className="text-xs font-medium">Subscription source</span>
-          <select
-            className="h-8 rounded-md border border-border bg-surface px-2 text-xs"
-            value={source.mode}
-            disabled={busy}
-            onChange={(event) =>
-              void setSourceMode(event.target.value as WorkspaceCodexSubscriptionMode)
-            }
-          >
-            <option value="automatic">Automatic</option>
-            <option value="organization">Organization</option>
-            <option value="workspace">Workspace</option>
-            <option value="disabled">Disabled</option>
-          </select>
-        </label>
+        <div className="grid gap-2 rounded-md border border-border/70 px-3 py-2">
+          <label className="grid gap-1">
+            <span className="text-xs font-medium">Where this workspace gets Codex</span>
+            <select
+              className="h-8 rounded-md border border-border bg-surface px-2 text-xs"
+              value={source.mode}
+              disabled={busy}
+              onChange={(event) =>
+                void setSourceMode(event.target.value as WorkspaceCodexSubscriptionMode)
+              }
+            >
+              <option value="automatic">Automatic: prefer organization</option>
+              <option value="organization">
+                Organization subscription only
+                {source.organizationAvailable ? "" : " (not connected)"}
+              </option>
+              <option value="workspace">This workspace only</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </label>
+          <p className="text-2xs leading-4 text-fg-subtle">
+            {source.mode === "automatic"
+              ? "Automatic uses the organization subscription when one is connected, otherwise this workspace's subscription."
+              : source.mode === "organization"
+                ? "Sessions use the subscription managed once for the whole organization."
+                : source.mode === "workspace"
+                  ? "Sessions use subscriptions connected only in this workspace."
+                  : "Codex models are unavailable in this workspace."}
+          </p>
+          {source.effectiveSource === "organization" && !source.organizationAvailable ? (
+            <Link
+              to="/workspaces/$workspaceId/organization"
+              params={{ workspaceId }}
+              search={{ section: "models" }}
+              className="w-fit text-xs font-medium text-brand hover:underline"
+            >
+              Connect an organization subscription
+            </Link>
+          ) : null}
+        </div>
       ) : null}
 
       {accounts.length > 1 && canManage && workspaceManaged ? (

--- a/apps/web/src/components/organization-admin.test.tsx
+++ b/apps/web/src/components/organization-admin.test.tsx
@@ -490,6 +490,46 @@ describe("organization administration component fences", () => {
     container.remove();
   });
 
+  test("keeps local single-user workspace management free of managed member controls", async () => {
+    const listOrganizationAdministrationMembers = mock(async () => ({
+      members: [member(identityA, "overview")],
+    }));
+    const client = {
+      getOrganizationAdministrationOverview: mock(async () => overview(identityA)),
+      listOrganizationAdministrationMembers,
+    } as unknown as OpenGeniBrowserClient;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <OrganizationOverviewSection
+          client={client}
+          identity={identityA}
+          actorRole="owner"
+          managedSession
+          singleUser
+          accessibleWorkspaceIds={new Set(["workspace-company"])}
+          onOrganizationChanged={() => undefined}
+          onCreateWorkspace={async () => undefined}
+        />,
+      );
+    });
+    await flush();
+
+    expect(listOrganizationAdministrationMembers).not.toHaveBeenCalled();
+    expect(container.textContent).toContain(
+      "Access is managed automatically for the local administrator.",
+    );
+    expect(container.textContent).not.toContain("Add organization member");
+    expect(container.textContent).not.toContain("Fine-tune");
+    expect(button(container, "Create new workspace")).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
   test("uses the organization control plane for shared-workspace settings and access", async () => {
     const updateOrganizationWorkspace = mock(async () => ({
       id: "workspace-company",

--- a/apps/web/src/components/organization-admin.tsx
+++ b/apps/web/src/components/organization-admin.tsx
@@ -411,6 +411,7 @@ export function OrganizationOverviewSection(props: {
   identity: OrganizationAdminIdentity;
   actorRole: OrganizationMembershipRole | null;
   managedSession: boolean;
+  singleUser?: boolean;
   accessibleWorkspaceIds: ReadonlySet<string>;
   onOrganizationChanged: () => void | Promise<void>;
   onCreateWorkspace: (name: string, operationId: string) => Promise<void>;
@@ -524,7 +525,9 @@ export function OrganizationOverviewSection(props: {
     try {
       const [overview, memberPage] = await Promise.all([
         props.client.getOrganizationAdministrationOverview(props.identity.organizationId),
-        props.client.listOrganizationAdministrationMembers(props.identity.organizationId),
+        props.singleUser
+          ? Promise.resolve({ members: [] })
+          : props.client.listOrganizationAdministrationMembers(props.identity.organizationId),
       ]);
       if (!owns(operation)) return;
       const pendingRename = pendingRenameRef.current;
@@ -566,7 +569,16 @@ export function OrganizationOverviewSection(props: {
       });
       setOrganizationMembers([]);
     }
-  }, [canAdminister, claim, identityKey, owns, props.client, props.identity, props.managedSession]);
+  }, [
+    canAdminister,
+    claim,
+    identityKey,
+    owns,
+    props.client,
+    props.identity,
+    props.managedSession,
+    props.singleUser,
+  ]);
 
   useEffect(() => {
     void load();
@@ -989,7 +1001,9 @@ export function OrganizationOverviewSection(props: {
               </h2>
             )}
             <p className="mt-1 text-xs text-fg-muted">
-              Manage the shared workspaces and access that make up your company.
+              {props.singleUser
+                ? "Manage the shared workspaces in this single-user installation."
+                : "Manage the shared workspaces and access that make up your company."}
             </p>
           </div>
           {!editing ? (
@@ -1013,8 +1027,9 @@ export function OrganizationOverviewSection(props: {
           <div>
             <h2 className="text-sm font-medium">Workspaces &amp; access</h2>
             <p className="mt-1 text-xs text-fg-muted">
-              Create shared workspaces, then choose which organization members can use each one.
-              Personal workspaces stay private.
+              {props.singleUser
+                ? "Every workspace you create here is available to the local administrator."
+                : "Create shared workspaces, then choose which organization members can use each one. Personal workspaces stay private."}
             </p>
           </div>
           <Button type="button" size="sm" onClick={() => setCreateWorkspaceOpen(true)}>
@@ -1104,7 +1119,7 @@ export function OrganizationOverviewSection(props: {
                         Save name
                       </Button>
                     </form>
-                    {assignableMembers.length > 0 ? (
+                    {!props.singleUser && assignableMembers.length > 0 ? (
                       <div className="flex flex-wrap items-end gap-2 rounded-md border border-border/70 bg-surface/60 p-2">
                         <label className="grid min-w-56 flex-1 gap-1 text-xs text-fg-muted">
                           Add organization member
@@ -1163,7 +1178,11 @@ export function OrganizationOverviewSection(props: {
                         </Button>
                       </div>
                     ) : null}
-                    {workspace.members.length === 0 ? (
+                    {props.singleUser ? (
+                      <p className="py-2 text-xs text-fg-muted">
+                        Access is managed automatically for the local administrator.
+                      </p>
+                    ) : workspace.members.length === 0 ? (
                       <p className="py-2 text-xs text-fg-subtle">No direct workspace access.</p>
                     ) : (
                       <div className="grid gap-2">

--- a/apps/web/src/organization-admin-surface.test.ts
+++ b/apps/web/src/organization-admin-surface.test.ts
@@ -14,6 +14,9 @@ const recoverySource = await Bun.file(
 const organizationCodexSource = await Bun.file(
   `${import.meta.dir}/components/organization-codex-subscriptions.tsx`,
 ).text();
+const workspaceCodexSource = await Bun.file(
+  `${import.meta.dir}/components/codex-connection.tsx`,
+).text();
 const normalizedRecoverySource = recoverySource.replace(/\s+/gu, " ");
 const workspaceSettingsSource = await Bun.file(
   `${import.meta.dir}/routes/workspace-settings.tsx`,
@@ -47,12 +50,18 @@ describe("organization administration surface", () => {
     expect(routeSource).toContain("OrganizationKnowledgePrompt");
     expect(routeSource).toContain("OrganizationCompanyProfileAgentPolicy");
     expect(routeSource).toContain("canManageOrganizationCodex");
+    expect(routeSource).toContain('context.clientConfig.productAccessMode === "local"');
+    expect(routeSource).toContain("organizationAdministratorSession");
+    expect(routeSource).toContain("singleUser={singleUser}");
     expect(routeSource).toContain('actorRole === "owner" || actorRole === "admin"');
     expect(routeSource).toContain("showModels={canManageOrganizationCodex}");
     expect(shellSource).toContain('item.id !== "models" || showModels');
     expect(organizationCodexSource).toContain("setLoadError(message)");
     expect(organizationCodexSource).toContain('role="alert"');
     expect(organizationCodexSource).toContain("Retry");
+    expect(workspaceCodexSource).toContain("Where this workspace gets Codex");
+    expect(workspaceCodexSource).toContain("Automatic: prefer organization");
+    expect(workspaceCodexSource).toContain("Connect an organization subscription");
     expect(routeSource).toContain("canManageOrganizationKnowledge");
     expect(routeSource).toContain('accountGrant?.role === "owner"');
     expect(routeSource).toContain('"account:admin"');

--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -296,6 +296,8 @@ describe("Documents scope-first UX", () => {
       });
       await settleRoute();
 
+      expect(container.textContent).toContain("Organization documents");
+      expect(container.textContent).toContain("Back to organization knowledge");
       expect(container.textContent).toContain("Company knowledge");
       expect(container.textContent).toContain("Organization knowledge");
       expect(container.textContent).toContain("Company strategy");

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -525,7 +525,13 @@ export function DocumentsRoute({
       <section className="flex min-h-0 flex-1 flex-col text-left">
         <PageHeader
           icon={<FileSearchIcon className="size-4" />}
-          title={personalWorkspace ? "Your Documents" : "Documents"}
+          title={
+            authorityKind === "organization"
+              ? "Organization documents"
+              : personalWorkspace
+                ? "Your Documents"
+                : "Documents"
+          }
           description={
             authorityKind === "organization"
               ? canWriteOrganizationKnowledge
@@ -536,6 +542,15 @@ export function DocumentsRoute({
                 : "Add information agents can find when it is relevant."
           }
         />
+        {authorityKind === "organization" ? (
+          <a
+            href={`/workspaces/${encodeURIComponent(workspaceId)}/organization?section=knowledge`}
+            className="mt-6 inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
+          >
+            <ArrowLeftIcon className="size-3" />
+            Back to organization knowledge
+          </a>
+        ) : null}
         {returnToBrain ? (
           <Link
             to="/workspaces/$workspaceId/state"

--- a/apps/web/src/routes/org-settings-strict-mode.test.tsx
+++ b/apps/web/src/routes/org-settings-strict-mode.test.tsx
@@ -300,8 +300,10 @@ describe("organization billing StrictMode ownership", () => {
       'input[name="company-profile-agent-policy"][value="automatic"]',
     );
     if (!automatic) throw new Error("Missing Autonomous policy option");
-    await act(async () => automatic.click());
-    await act(async () => button(container, "Save autonomy mode").click());
+    await act(async () => {
+      automatic.click();
+      await Promise.resolve();
+    });
     await flush();
 
     expect(updateCompanyProfileAgentPolicy).toHaveBeenCalledTimes(1);
@@ -382,8 +384,10 @@ describe("organization billing StrictMode ownership", () => {
         'input[name="company-profile-agent-policy"][value="off"]',
       );
       if (!off) throw new Error("Missing Off policy option");
-      await act(async () => off.click());
-      await act(async () => button(container, "Save autonomy mode").click());
+      await act(async () => {
+        off.click();
+        await Promise.resolve();
+      });
       await flush();
       expect(updateCompanyProfileAgentPolicy).toHaveBeenCalledWith(
         otherWorkspaceId,

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -106,14 +106,15 @@ function OrganizationCompanyProfileAgentPolicy({ workspaceId }: { workspaceId: s
     void load();
   }, [load]);
 
-  const save = async (): Promise<void> => {
+  const save = async (nextMode: CompanyProfileAgentPolicyMode): Promise<void> => {
     if (!policy || saving) return;
+    setMode(nextMode);
     setSaving(true);
     setError(null);
     setMessage(null);
     try {
       const value = await client.updateCompanyProfileAgentPolicy(workspaceId, {
-        mode,
+        mode: nextMode,
         expectedVersion: policy.version,
         operationId: crypto.randomUUID(),
       });
@@ -127,6 +128,7 @@ function OrganizationCompanyProfileAgentPolicy({ workspaceId }: { workspaceId: s
             : "Agent-authored organization identity changes are off.",
       );
     } catch (saveError) {
+      setMode(policy.mode);
       setError(saveError instanceof Error ? saveError : new Error(String(saveError)));
     } finally {
       setSaving(false);
@@ -168,7 +170,7 @@ function OrganizationCompanyProfileAgentPolicy({ workspaceId }: { workspaceId: s
                       name="company-profile-agent-policy"
                       value={candidate}
                       checked={mode === candidate}
-                      onChange={() => setMode(candidate)}
+                      onChange={() => void save(candidate)}
                     />
                     {COMPANY_PROFILE_AGENT_MODE_COPY[candidate].label}
                   </span>
@@ -190,22 +192,15 @@ function OrganizationCompanyProfileAgentPolicy({ workspaceId }: { workspaceId: s
               {error.message}
             </p>
           ) : null}
-          {message ? (
+          {saving ? (
+            <p role="status" className="text-xs text-fg-muted">
+              <Loader2Icon className="mr-1 inline size-3.5 animate-spin" /> Saving autonomy mode…
+            </p>
+          ) : message ? (
             <p role="status" className="text-xs text-status-success">
               {message}
             </p>
           ) : null}
-          <div>
-            <Button
-              type="button"
-              size="sm"
-              disabled={saving || mode === policy.mode}
-              onClick={() => void save()}
-            >
-              {saving ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
-              Save autonomy mode
-            </Button>
-          </div>
         </>
       )}
     </section>
@@ -369,9 +364,11 @@ export function OrgSettingsRoute({
     accountGrant?.role === "member"
       ? accountGrant.role
       : null;
+  const singleUser = context.clientConfig.productAccessMode === "local";
+  const organizationAdministratorSession =
+    context.clientConfig.auth.mode === "managedSession" || singleUser;
   const canManageOrganizationCodex =
-    context.clientConfig.auth.mode === "managedSession" &&
-    (actorRole === "owner" || actorRole === "admin");
+    organizationAdministratorSession && (actorRole === "owner" || actorRole === "admin");
   const adminIdentity = useMemo<OrganizationAdminIdentity>(
     () => ({
       principalGeneration: context.accessKeyVersion,
@@ -572,35 +569,50 @@ export function OrgSettingsRoute({
               client={client}
               identity={adminIdentity}
               actorRole={actorRole}
-              managedSession={context.clientConfig.auth.mode === "managedSession"}
+              managedSession={organizationAdministratorSession}
+              singleUser={singleUser}
               accessibleWorkspaceIds={new Set(context.workspaces.map((workspace) => workspace.id))}
               onOrganizationChanged={context.revalidatePrincipalAccess}
               onCreateWorkspace={async (name, operationId) => {
-                await client.createOrganizationWorkspace(accountId, {
-                  name,
-                  operationId,
-                });
+                if (singleUser) {
+                  const created = await context.createWorkspace({ accountId, name });
+                  if (!created) throw new Error("workspace creation did not complete");
+                } else {
+                  await client.createOrganizationWorkspace(accountId, {
+                    name,
+                    operationId,
+                  });
+                }
               }}
             />
-            <OrganizationPrivateSessionsSection
-              key={`${identityKey}:private-sessions`}
-              client={client}
-              identity={adminIdentity}
-              actorRole={actorRole}
-              managedSession={context.clientConfig.auth.mode === "managedSession"}
-            />
+            {!singleUser ? (
+              <OrganizationPrivateSessionsSection
+                key={`${identityKey}:private-sessions`}
+                client={client}
+                identity={adminIdentity}
+                actorRole={actorRole}
+                managedSession
+              />
+            ) : null}
           </>
         ) : null}
 
         {section === "people" ? (
-          <OrganizationPeopleSection
-            key={identityKey}
-            client={client}
-            identity={adminIdentity}
-            actorRole={actorRole}
-            managedSession={context.clientConfig.auth.mode === "managedSession"}
-            onAuthorityChanged={context.revalidatePrincipalAccess}
-          />
+          singleUser ? (
+            <p className="text-sm leading-6 text-fg-muted">
+              This installation has one local administrator. People, invitations, and private user
+              workspaces become available when managed sign-in is enabled.
+            </p>
+          ) : (
+            <OrganizationPeopleSection
+              key={identityKey}
+              client={client}
+              identity={adminIdentity}
+              actorRole={actorRole}
+              managedSession
+              onAuthorityChanged={context.revalidatePrincipalAccess}
+            />
+          )
         ) : null}
 
         {section === "models" && canManageOrganizationCodex ? (
@@ -613,7 +625,7 @@ export function OrgSettingsRoute({
         {section === "models" && !canManageOrganizationCodex ? (
           <p className="text-xs leading-5 text-fg-muted">
             Organization model subscriptions can be managed only by organization owners and admins
-            using a managed session.
+            using an organization administrator session.
           </p>
         ) : null}
 
@@ -677,17 +689,24 @@ export function OrgSettingsRoute({
             client={client}
             identity={adminIdentity}
             actorRole={actorRole}
-            managedSession={context.clientConfig.auth.mode === "managedSession"}
+            managedSession={organizationAdministratorSession}
           />
         ) : null}
 
         {section === "recovery" ? (
-          <OrganizationRecoverySection
-            key={`${identityKey}:recovery`}
-            client={client}
-            identity={adminIdentity}
-            managedSession={context.clientConfig.auth.mode === "managedSession"}
-          />
+          singleUser ? (
+            <p className="text-sm leading-6 text-fg-muted">
+              Organization recovery protects managed multi-user accounts. This single-user local
+              installation is recovered through its server backup and deployment configuration.
+            </p>
+          ) : (
+            <OrganizationRecoverySection
+              key={`${identityKey}:recovery`}
+              client={client}
+              identity={adminIdentity}
+              managedSession
+            />
+          )
         ) : null}
 
         {section === "developer" ? (

--- a/apps/web/src/routes/workspace-learning-admin.test.tsx
+++ b/apps/web/src/routes/workspace-learning-admin.test.tsx
@@ -162,15 +162,9 @@ describe("Learning & autonomy", () => {
       expect(autonomous).not.toBeNull();
       await act(async () => {
         autonomous!.click();
-      });
-      const save = [...container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Save learning mode"),
-      );
-      expect(save).toBeDefined();
-      await act(async () => {
-        save!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
+      expect(container.textContent).not.toContain("Save learning mode");
       expect(createRevision).toHaveBeenCalledTimes(1);
       expect(createRevision).toHaveBeenCalledWith(
         workspaceId,
@@ -224,12 +218,6 @@ describe("Learning & autonomy", () => {
       const reviewFirst = container.querySelector<HTMLInputElement>('input[value="suggest"]');
       await act(async () => {
         reviewFirst!.click();
-      });
-      const save = [...container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Save learning mode"),
-      );
-      await act(async () => {
-        save!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
       expect(createRevision).toHaveBeenCalledTimes(1);
@@ -270,10 +258,7 @@ describe("Learning & autonomy", () => {
       expect(container.textContent).toContain(
         "Workspace admin access is required to change learning policy.",
       );
-      const save = [...container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Save learning mode"),
-      );
-      expect(save?.disabled).toBe(true);
+      expect(container.querySelector<HTMLFieldSetElement>("fieldset")?.disabled).toBe(true);
     } finally {
       await act(async () => root.unmount());
       context.accessContext.workspaceGrants = previousGrants;

--- a/apps/web/src/routes/workspace-learning-admin.tsx
+++ b/apps/web/src/routes/workspace-learning-admin.tsx
@@ -39,8 +39,9 @@ export function WorkspaceLearningAdministration({ workspaceId }: { workspaceId: 
     setMode(activeRevision?.workspaceMode ?? "off");
   }, [activeRevision]);
 
-  const save = async (): Promise<void> => {
+  const save = async (nextMode: WorkspaceLearningMode): Promise<void> => {
     if (!canEdit || saving) return;
+    setMode(nextMode);
     setSaving(true);
     setMessage(null);
     setMutationError(null);
@@ -52,7 +53,7 @@ export function WorkspaceLearningAdministration({ workspaceId }: { workspaceId: 
       ).map(({ kind, id, mode: overrideMode }) => ({ kind, id, mode: overrideMode }));
       const revision = await client.createWorkspaceLearningPolicyRevision(workspaceId, {
         operationId: crypto.randomUUID(),
-        workspaceMode: mode,
+        workspaceMode: nextMode,
         sourceOverrides,
         supersedesRevisionId: history.response?.head?.revisionId ?? null,
       });
@@ -65,6 +66,7 @@ export function WorkspaceLearningAdministration({ workspaceId }: { workspaceId: 
       await history.reload();
       setMessage("Learning mode saved. It applies from the next agent run.");
     } catch (error) {
+      setMode(activeRevision?.workspaceMode ?? "off");
       setMutationError(error instanceof Error ? error.message : String(error));
     } finally {
       setSaving(false);
@@ -109,7 +111,7 @@ export function WorkspaceLearningAdministration({ workspaceId }: { workspaceId: 
                 name="learning-mode"
                 value={candidate}
                 checked={mode === candidate}
-                onChange={() => setMode(candidate)}
+                onChange={() => void save(candidate)}
               />
               {MODE_COPY[candidate].label}
             </span>
@@ -130,19 +132,15 @@ export function WorkspaceLearningAdministration({ workspaceId }: { workspaceId: 
           {mutationError}
         </p>
       ) : null}
-      {message ? (
+      {saving ? (
+        <p role="status" className="mt-3 text-xs text-fg-muted">
+          Saving learning mode…
+        </p>
+      ) : message ? (
         <p role="status" className="mt-3 text-xs text-status-success">
           {message}
         </p>
       ) : null}
-      <button
-        type="button"
-        className="mt-4 rounded-md bg-brand px-3 py-2 text-sm font-medium text-white disabled:opacity-60"
-        disabled={!canEdit || saving}
-        onClick={() => void save()}
-      >
-        {saving ? "Saving…" : "Save learning mode"}
-      </button>
     </section>
   );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,6 +259,12 @@ initiating principal and the authority snapshots needed by later execution and
 recovery.
 
 Organization settings owns the cross-workspace roster and organization roles.
+A managed browser administrator is the ordinary authority. Single-user local
+deployments additionally admit only the access resolver's canonical
+`opengeni:local/default` + `dev` browser context to organization metadata,
+shared-workspace, retention, company-identity, and organization Codex controls.
+This is provenance-stamped authority, not a subject-name check; configured,
+delegated, API-key, service, and agent principals remain excluded.
 A shared workspace's Members page is deliberately narrower: a caller with
 `members:manage` may add an already-active human from the same organization and
 change or revoke access only in that workspace. Personal workspaces,

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -505,8 +505,13 @@ The managed-human API surface is:
   below that member route for the shared-workspace control plane; and
 - `GET|PATCH /v1/organizations/:organizationId/retention-policy`.
 
-These routes require a direct managed-human cookie session; API keys and
-delegated bearer requests are rejected.
+The organization overview, organization/shared-workspace metadata, member
+inventory, retention, and organization Codex routes require either a direct
+managed-human cookie session or the exact provenance-stamped single-user local
+administrator for `opengeni:local/default`. Invitation and member lifecycle,
+private-session, and recovery operations remain managed-human-only. API keys,
+configured access, delegated bearers, services, and agents are rejected from
+the local exception.
 
 ### Pre-registration invitations and signup convergence (0314)
 
@@ -774,9 +779,10 @@ path to `pg_catalog`, the selected data schema, then `pg_temp`.
 
 Migration `0332_organization_shared_workspace_control_plane.sql` makes the
 organization control plane authoritative rather than depending on an
-administrator also holding an operational workspace grant. The managed-cookie-
-only organization routes can create or update shared-workspace metadata/settings
-and add, update, or remove an active organization member's direct workspace access. Each
+administrator also holding an operational workspace grant. The direct
+organization routes can create or update shared-workspace metadata/settings
+and, in managed mode, add, update, or remove an active organization member's
+direct workspace access. Each
 mutation runs under an exact active owner/administrator organization membership
 and an organization-scoped transaction advisory fence. Missing,
 cross-organization, and Personal workspace ids are rejected through one

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -243,6 +243,37 @@ export function requireAccountAdminAuthorizationStamp(
   });
 }
 
+/**
+ * Resolve the exact built-in single-user local administrator for an account.
+ *
+ * This is intentionally narrower than checking `context.mode === "local"` or
+ * the `dev` subject name. Only the in-process local bootstrap branch can place
+ * the resolved context in `canonicalLocalHumanContexts`, so delegated bearer
+ * tokens and caller-constructed contexts cannot borrow this authority.
+ */
+export async function requireCanonicalLocalAccountAdministrator(
+  c: Context,
+  deps: AccessDeps,
+  accountId: string,
+): Promise<{ subjectId: string; authorization: AccessGrantAuthorization }> {
+  if (c.req.header("authorization")) {
+    throw new HTTPException(401, { message: "organization administrator session required" });
+  }
+  const context = await requireAccessContext(c, deps);
+  const grant = context.workspaceGrants.find((candidate) => candidate.accountId === accountId);
+  if (!grant) {
+    throw new HTTPException(403, {
+      message: "local organization administration is not authorized",
+    });
+  }
+  const authorization = accessGrantAuthorizationFromContext(context, grant);
+  if (!authorization.canonicalLocalHumanSession) {
+    throw new HTTPException(401, { message: "organization administrator session required" });
+  }
+  requireAccountAdminAuthorizationStamp(authorization);
+  return { subjectId: context.subjectId, authorization };
+}
+
 export async function requireAccessGrantAuthorization(
   c: Context,
   deps: AccessDeps,

--- a/packages/db/drizzle/0386_local_organization_administration.sql
+++ b/packages/db/drizzle/0386_local_organization_administration.sql
@@ -1,0 +1,157 @@
+-- deployment-mode: maintenance
+--
+-- The canonical single-user local bootstrap already grants `dev` account-owner
+-- authority in the application, but its durable organization membership was
+-- left at the default member role. Converge that exact built-in identity and
+-- admit it to organization Codex administration without broadening configured,
+-- delegated, API-key, service, or agent principals.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+CREATE OR REPLACE FUNCTION opengeni_private.assign_managed_self_organization_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM managed_accounts account
+    WHERE account.id = NEW.account_id
+      AND (
+        (
+          account.external_source = 'better-auth:user'
+          AND NEW.subject_id = 'user:' || account.external_id
+        ) OR (
+          account.external_source = 'opengeni:local'
+          AND account.external_id = 'default'
+          AND NEW.subject_id = 'dev'
+        )
+      )
+  ) THEN
+    NEW.role := 'owner';
+  END IF;
+  RETURN NEW;
+END
+$body$;
+
+DO $pin_local_owner_trigger$
+DECLARE data_schema text := current_schema();
+BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION opengeni_private.assign_managed_self_organization_owner() SET search_path = pg_catalog, %I, pg_temp',
+    data_schema
+  );
+END
+$pin_local_owner_trigger$;
+
+ALTER TABLE organization_memberships NO FORCE ROW LEVEL SECURITY;
+UPDATE organization_memberships membership
+SET role = 'owner',
+    authorization_revision = membership.authorization_revision + 1,
+    updated_at = clock_timestamp()
+FROM managed_accounts account
+WHERE account.id = membership.account_id
+  AND account.external_source = 'opengeni:local'
+  AND account.external_id = 'default'
+  AND membership.subject_id = 'dev'
+  AND membership.status = 'active'
+  AND membership.role <> 'owner';
+ALTER TABLE organization_memberships FORCE ROW LEVEL SECURITY;
+
+DO $codex_scope_visibility_schema$
+DECLARE data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION opengeni_private.codex_organization_scope_visible(
+      p_account_id uuid
+    ) RETURNS boolean
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $function$
+    DECLARE
+      workspace_value uuid := opengeni_private.current_workspace_id();
+      subject_value text := opengeni_private.current_subject_id();
+      visible boolean := false;
+      previous_lifecycle text := pg_catalog.current_setting(
+        'opengeni.organization_tenancy_lifecycle', true
+      );
+    BEGIN
+      IF p_account_id IS NULL
+        OR p_account_id IS DISTINCT FROM opengeni_private.current_account_id()
+      THEN
+        RETURN false;
+      END IF;
+      IF workspace_value IS NOT NULL THEN
+        PERFORM pg_catalog.set_config(
+          'opengeni.organization_tenancy_lifecycle',
+          'organization_membership_lifecycle', true
+        );
+        SELECT EXISTS (
+          SELECT 1 FROM %1$I.workspaces workspace
+          WHERE workspace.account_id = p_account_id AND workspace.id = workspace_value
+        ) AND NOT EXISTS (
+          SELECT 1 FROM %1$I.organization_memberships membership
+          WHERE membership.account_id = p_account_id
+            AND membership.personal_workspace_id = workspace_value
+        ) INTO visible;
+        PERFORM pg_catalog.set_config(
+          'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+        );
+        RETURN coalesce(visible, false);
+      END IF;
+      IF subject_value IS NULL OR NOT (
+        subject_value LIKE 'user:%%'
+        OR (
+          subject_value = 'dev'
+          AND EXISTS (
+            SELECT 1 FROM %1$I.managed_accounts account
+            WHERE account.id = p_account_id
+              AND account.external_source = 'opengeni:local'
+              AND account.external_id = 'default'
+          )
+        )
+      ) THEN
+        RETURN false;
+      END IF;
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle',
+        'organization_membership_lifecycle', true
+      );
+      SELECT EXISTS (
+        SELECT 1 FROM %1$I.organization_memberships membership
+        WHERE membership.account_id = p_account_id
+          AND membership.subject_id = subject_value
+          AND membership.status = 'active'
+          AND membership.role IN ('owner', 'admin')
+      ) INTO visible;
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+      );
+      RETURN coalesce(visible, false);
+    EXCEPTION WHEN OTHERS THEN
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+      );
+      RAISE;
+    END
+    $function$
+  $ddl$, data_schema);
+END
+$codex_scope_visibility_schema$;
+
+REVOKE ALL ON FUNCTION opengeni_private.assign_managed_self_organization_owner() FROM PUBLIC;
+REVOKE ALL ON FUNCTION opengeni_private.codex_organization_scope_visible(uuid) FROM PUBLIC;
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.assign_managed_self_organization_owner()
+      TO opengeni_app;
+    GRANT EXECUTE ON FUNCTION opengeni_private.codex_organization_scope_visible(uuid)
+      TO opengeni_app;
+  END IF;
+END
+$grants$;

--- a/packages/db/test/migration-0386-local-organization-administration.test.ts
+++ b/packages/db/test/migration-0386-local-organization-administration.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+
+import { bootstrapWorkspace, createDb, type DbClient } from "../src";
+import { migrate } from "../src/migrate";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let client: DbClient;
+let admin: ReturnType<typeof postgres> | null = null;
+let app: ReturnType<typeof postgres> | null = null;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("local_organization_administration");
+  if (!shared) {
+    available = false;
+    console.warn("[local-organization-administration] docker unavailable, skipping");
+    return;
+  }
+  await migrate(shared.adminUrl);
+  client = createDb(shared.appUrl);
+  admin = postgres(shared.adminUrl, { max: 1 });
+  app = postgres(shared.appUrl, { max: 1 });
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close().catch(() => undefined);
+  await admin?.end().catch(() => undefined);
+  await app?.end().catch(() => undefined);
+  await shared?.release();
+}, 180_000);
+
+describe("migration 0386 local organization administration", () => {
+  test("keeps the local exception exact and restores forced RLS", async () => {
+    const source = await Bun.file(
+      new URL("../drizzle/0386_local_organization_administration.sql", import.meta.url),
+    ).text();
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: maintenance");
+    expect(source).toContain("account.external_source = 'opengeni:local'");
+    expect(source).toContain("account.external_id = 'default'");
+    expect(source).toContain("NEW.subject_id = 'dev'");
+    expect(source).toContain("membership.authorization_revision + 1");
+    expect(source).toContain("ALTER TABLE organization_memberships FORCE ROW LEVEL SECURITY");
+    expect(source).toContain(
+      "ALTER FUNCTION opengeni_private.assign_managed_self_organization_owner() SET search_path = pg_catalog, %I, pg_temp",
+    );
+    expect(source).toContain("subject_value LIKE 'user:%%'");
+    expect(source).not.toContain("subject_value LIKE 'dev%'");
+  });
+
+  test("bootstraps the exact local user as owner with organization Codex visibility", async () => {
+    if (!available || !admin || !app) return;
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "opengeni:local",
+      accountExternalId: "default",
+      accountName: "OpenGeni Local",
+      workspaceExternalSource: "opengeni:local",
+      workspaceExternalId: "default",
+      workspaceName: "Local workspace",
+      subjectId: "dev",
+      subjectLabel: "Local user",
+    });
+    const accountId = access.defaultAccountId;
+    if (!accountId) throw new Error("local account was not returned");
+
+    const [membership] = await admin<
+      {
+        role: string;
+        status: string;
+        authorization_revision: number;
+      }[]
+    >`
+      select role, status, authorization_revision
+      from organization_memberships
+      where account_id = ${accountId} and subject_id = 'dev'
+    `;
+    expect(membership).toMatchObject({ role: "owner", status: "active" });
+
+    await app`select set_config('opengeni.account_id', ${accountId}, false)`;
+    await app`select set_config('opengeni.workspace_id', '', false)`;
+    await app`select set_config('opengeni.subject_id', 'dev', false)`;
+    const [visible] = await app<{ allowed: boolean }[]>`
+      select opengeni_private.codex_organization_scope_visible(${accountId}) as allowed
+    `;
+    expect(visible?.allowed).toBe(true);
+
+    await app`select set_config('opengeni.subject_id', 'dev-delegated', false)`;
+    const [rejected] = await app<{ allowed: boolean }[]>`
+      select opengeni_private.codex_organization_scope_visible(${accountId}) as allowed
+    `;
+    expect(rejected?.allowed).toBe(false);
+  }, 60_000);
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -218,6 +218,9 @@ describe("release schema contract", () => {
     const connectedMachineLegacyTildeWorkdirs = completeSourceContract.migrations.some(
       (migration) => migration.path === "0385_connected_machine_legacy_tilde_workdirs.sql",
     );
+    const localOrganizationAdministration = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0386_local_organization_administration.sql",
+    );
     const automaticSessionTitleMigrationPaths = new Set([
       "0353_automatic_session_title_policy_fence.sql",
       "0354_automatic_session_title_quarantine_index.sql",
@@ -252,6 +255,7 @@ describe("release schema contract", () => {
       "0383_codex_cooldown_reconciliation.sql",
       "0384_codex_cooldown_revision_guard_privileges.sql",
       "0385_connected_machine_legacy_tilde_workdirs.sql",
+      "0386_local_organization_administration.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -292,78 +296,81 @@ describe("release schema contract", () => {
         (organizationApiKeyProvenance ? 1 : 0) +
         (codexCooldownReconciliation ? 1 : 0) +
         (codexCooldownRevisionGuardPrivileges ? 1 : 0) +
-        (connectedMachineLegacyTildeWorkdirs ? 1 : 0),
-      latestMigration: connectedMachineLegacyTildeWorkdirs
-        ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-        : codexCooldownRevisionGuardPrivileges
-          ? "0384_codex_cooldown_revision_guard_privileges.sql"
-          : codexCooldownReconciliation
-            ? "0383_codex_cooldown_reconciliation.sql"
-            : organizationApiKeyProvenance
-              ? "0382_organization_api_key_provenance.sql"
-              : organizationCodexSubscriptionInheritance
-                ? "0381_organization_codex_subscription_inheritance.sql"
-                : autonomousCompanyProfileAgentPolicy
-                  ? "0380_autonomous_company_profile_agent_policy.sql"
-                  : sessionEventRawLaneActivation
-                    ? "0379_session_event_raw_lane_activation.sql"
-                    : scopedRigHealthAuditTimestamp
-                      ? "0378_scoped_rig_health_audit_timestamp.sql"
-                      : scopedRigHealthProjection
-                        ? "0377_scoped_rig_health_projection.sql"
-                        : organizationWorkspaceInventory
-                          ? "0376_organization_workspace_inventory.sql"
-                          : sessionRecoveryObservability
-                            ? "0375_session_recovery_observability.sql"
-                            : sessionEventCursors
-                              ? "0374_session_event_cursors.sql"
-                              : sandboxSharedPreparation
-                                ? "0373_sandbox_shared_preparation.sql"
-                                : orderedVariableSetRuntimeAuthority
-                                  ? "0372_ordered_variable_set_runtime_authority.sql"
-                                  : workspaceMemberCandidateInventory
-                                    ? "0371_workspace_member_candidate_inventory.sql"
-                                    : workspaceMemberManagementScope
-                                      ? "0370_workspace_member_management_scope.sql"
-                                      : localHumanPersonalAuthority
-                                        ? "0369_local_human_personal_authority.sql"
-                                        : sessionDiscoveryClaimSearchIndex
-                                          ? "0368_session_discovery_claim_search_index.sql"
-                                          : sessionDiscoveryGoalSearchIndex
-                                            ? "0367_session_discovery_goal_search_index.sql"
-                                            : sessionDiscoveryTitleSearchIndex
-                                              ? "0366_session_discovery_title_search_index.sql"
-                                              : permissionScopedWorkClaims
-                                                ? "0365_permission_scoped_work_claims.sql"
-                                                : workspaceLearningPolicySnapshotLockOrder
-                                                  ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                  : organizationRecoveryCustody
-                                                    ? "0363_organization_recovery_custody.sql"
-                                                    : managedAuthSessionSets
-                                                      ? "0362_managed_auth_session_sets.sql"
-                                                      : rememberKnowledgeMemoryMaterialization
-                                                        ? "0361_remember_knowledge_memory_materialization.sql"
-                                                        : organizationIdentityConfirmationPrompt
-                                                          ? "0360_organization_identity_confirmation_prompt.sql"
-                                                          : insightsForceRlsReadCapability
-                                                            ? "0359_insights_force_rls_read_capability.sql"
-                                                            : prReviewManagedGithubApp
-                                                              ? "0358_pr_review_managed_github_app.sql"
-                                                              : rigPlatformBaseOnly
-                                                                ? "0357_rig_platform_base_only.sql"
-                                                                : setBasedInsightsSessionVisibility
-                                                                  ? "0356_set_based_insights_session_visibility.sql"
-                                                                  : automaticSessionTitleQuarantine
-                                                                    ? "0355_automatic_session_title_quarantine.sql"
-                                                                    : automaticSessionTitleQuarantineIndex
-                                                                      ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                      : automaticSessionTitlePolicyFence
-                                                                        ? "0353_automatic_session_title_policy_fence.sql"
-                                                                        : sessionVariableSetAttachments
-                                                                          ? "0352_session_variable_set_attachments.sql"
-                                                                          : migrationsBeforeAutomaticSessionTitles.at(
-                                                                              -1,
-                                                                            )?.path,
+        (connectedMachineLegacyTildeWorkdirs ? 1 : 0) +
+        (localOrganizationAdministration ? 1 : 0),
+      latestMigration: localOrganizationAdministration
+        ? "0386_local_organization_administration.sql"
+        : connectedMachineLegacyTildeWorkdirs
+          ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+          : codexCooldownRevisionGuardPrivileges
+            ? "0384_codex_cooldown_revision_guard_privileges.sql"
+            : codexCooldownReconciliation
+              ? "0383_codex_cooldown_reconciliation.sql"
+              : organizationApiKeyProvenance
+                ? "0382_organization_api_key_provenance.sql"
+                : organizationCodexSubscriptionInheritance
+                  ? "0381_organization_codex_subscription_inheritance.sql"
+                  : autonomousCompanyProfileAgentPolicy
+                    ? "0380_autonomous_company_profile_agent_policy.sql"
+                    : sessionEventRawLaneActivation
+                      ? "0379_session_event_raw_lane_activation.sql"
+                      : scopedRigHealthAuditTimestamp
+                        ? "0378_scoped_rig_health_audit_timestamp.sql"
+                        : scopedRigHealthProjection
+                          ? "0377_scoped_rig_health_projection.sql"
+                          : organizationWorkspaceInventory
+                            ? "0376_organization_workspace_inventory.sql"
+                            : sessionRecoveryObservability
+                              ? "0375_session_recovery_observability.sql"
+                              : sessionEventCursors
+                                ? "0374_session_event_cursors.sql"
+                                : sandboxSharedPreparation
+                                  ? "0373_sandbox_shared_preparation.sql"
+                                  : orderedVariableSetRuntimeAuthority
+                                    ? "0372_ordered_variable_set_runtime_authority.sql"
+                                    : workspaceMemberCandidateInventory
+                                      ? "0371_workspace_member_candidate_inventory.sql"
+                                      : workspaceMemberManagementScope
+                                        ? "0370_workspace_member_management_scope.sql"
+                                        : localHumanPersonalAuthority
+                                          ? "0369_local_human_personal_authority.sql"
+                                          : sessionDiscoveryClaimSearchIndex
+                                            ? "0368_session_discovery_claim_search_index.sql"
+                                            : sessionDiscoveryGoalSearchIndex
+                                              ? "0367_session_discovery_goal_search_index.sql"
+                                              : sessionDiscoveryTitleSearchIndex
+                                                ? "0366_session_discovery_title_search_index.sql"
+                                                : permissionScopedWorkClaims
+                                                  ? "0365_permission_scoped_work_claims.sql"
+                                                  : workspaceLearningPolicySnapshotLockOrder
+                                                    ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                    : organizationRecoveryCustody
+                                                      ? "0363_organization_recovery_custody.sql"
+                                                      : managedAuthSessionSets
+                                                        ? "0362_managed_auth_session_sets.sql"
+                                                        : rememberKnowledgeMemoryMaterialization
+                                                          ? "0361_remember_knowledge_memory_materialization.sql"
+                                                          : organizationIdentityConfirmationPrompt
+                                                            ? "0360_organization_identity_confirmation_prompt.sql"
+                                                            : insightsForceRlsReadCapability
+                                                              ? "0359_insights_force_rls_read_capability.sql"
+                                                              : prReviewManagedGithubApp
+                                                                ? "0358_pr_review_managed_github_app.sql"
+                                                                : rigPlatformBaseOnly
+                                                                  ? "0357_rig_platform_base_only.sql"
+                                                                  : setBasedInsightsSessionVisibility
+                                                                    ? "0356_set_based_insights_session_visibility.sql"
+                                                                    : automaticSessionTitleQuarantine
+                                                                      ? "0355_automatic_session_title_quarantine.sql"
+                                                                      : automaticSessionTitleQuarantineIndex
+                                                                        ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                        : automaticSessionTitlePolicyFence
+                                                                          ? "0353_automatic_session_title_policy_fence.sql"
+                                                                          : sessionVariableSetAttachments
+                                                                            ? "0352_session_variable_set_attachments.sql"
+                                                                            : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                -1,
+                                                                              )?.path,
     });
   });
 
@@ -487,6 +494,7 @@ describe("release schema contract", () => {
       "0383_codex_cooldown_reconciliation.sql",
       "0384_codex_cooldown_revision_guard_privileges.sql",
       "0385_connected_machine_legacy_tilde_workdirs.sql",
+      "0386_local_organization_administration.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -628,6 +636,9 @@ describe("release schema contract", () => {
     const connectedMachineLegacyTildeWorkdirs = completeSourceContract.migrations.some(
       (migration) => migration.path === "0385_connected_machine_legacy_tilde_workdirs.sql",
     );
+    const localOrganizationAdministration = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0386_local_organization_administration.sql",
+    );
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
@@ -668,88 +679,91 @@ describe("release schema contract", () => {
         (organizationApiKeyProvenance ? 1 : 0) +
         (codexCooldownReconciliation ? 1 : 0) +
         (codexCooldownRevisionGuardPrivileges ? 1 : 0) +
-        (connectedMachineLegacyTildeWorkdirs ? 1 : 0),
-      latestMigration: connectedMachineLegacyTildeWorkdirs
-        ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-        : codexCooldownRevisionGuardPrivileges
-          ? "0384_codex_cooldown_revision_guard_privileges.sql"
-          : codexCooldownReconciliation
-            ? "0383_codex_cooldown_reconciliation.sql"
-            : organizationApiKeyProvenance
-              ? "0382_organization_api_key_provenance.sql"
-              : organizationCodexSubscriptionInheritance
-                ? "0381_organization_codex_subscription_inheritance.sql"
-                : autonomousCompanyProfileAgentPolicy
-                  ? "0380_autonomous_company_profile_agent_policy.sql"
-                  : sessionEventRawLaneActivation
-                    ? "0379_session_event_raw_lane_activation.sql"
-                    : scopedRigHealthAuditTimestamp
-                      ? "0378_scoped_rig_health_audit_timestamp.sql"
-                      : scopedRigHealthProjection
-                        ? "0377_scoped_rig_health_projection.sql"
-                        : organizationWorkspaceInventory
-                          ? "0376_organization_workspace_inventory.sql"
-                          : sessionRecoveryObservability
-                            ? "0375_session_recovery_observability.sql"
-                            : sessionEventCursors
-                              ? "0374_session_event_cursors.sql"
-                              : sandboxSharedPreparation
-                                ? "0373_sandbox_shared_preparation.sql"
-                                : orderedVariableSetRuntimeAuthority
-                                  ? "0372_ordered_variable_set_runtime_authority.sql"
-                                  : workspaceMemberCandidateInventory
-                                    ? "0371_workspace_member_candidate_inventory.sql"
-                                    : workspaceMemberManagementScope
-                                      ? "0370_workspace_member_management_scope.sql"
-                                      : localHumanPersonalAuthority
-                                        ? "0369_local_human_personal_authority.sql"
-                                        : sessionDiscoveryClaimSearchIndex
-                                          ? "0368_session_discovery_claim_search_index.sql"
-                                          : sessionDiscoveryGoalSearchIndex
-                                            ? "0367_session_discovery_goal_search_index.sql"
-                                            : sessionDiscoveryTitleSearchIndex
-                                              ? "0366_session_discovery_title_search_index.sql"
-                                              : permissionScopedWorkClaims
-                                                ? "0365_permission_scoped_work_claims.sql"
-                                                : workspaceLearningPolicySnapshotLockOrder
-                                                  ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                  : organizationRecoveryCustody
-                                                    ? "0363_organization_recovery_custody.sql"
-                                                    : managedAuthSessionSets
-                                                      ? "0362_managed_auth_session_sets.sql"
-                                                      : sessionVariableSetAttachments
-                                                        ? "0352_session_variable_set_attachments.sql"
-                                                        : organizationUserSetupDelivery
-                                                          ? "0351_organization_user_setup_delivery.sql"
-                                                          : organizationSharedWorkspaceAdministration
-                                                            ? "0350_organization_shared_workspace_administration.sql"
-                                                            : greenfieldSessionTenancyActivation
-                                                              ? "0349_greenfield_session_tenancy_activation.sql"
-                                                              : namedSignupAndUserSetup
-                                                                ? "0348_named_signup_and_user_setup.sql"
-                                                                : connectionAuthorityConvergenceEvidence
-                                                                  ? "0347_connection_authority_convergence_evidence.sql"
-                                                                  : documentMigrationAuditSurface
-                                                                    ? "0346_document_migration_audit_surface.sql"
-                                                                    : tenantScopedSessionTenancyFence
-                                                                      ? "0345_tenant_scoped_session_tenancy_fence.sql"
-                                                                      : privateSessionVisibilityTransitionGate
-                                                                        ? "0344_private_session_visibility_transition_gate.sql"
-                                                                        : personalDocumentForceRlsRepair
-                                                                          ? "0343_personal_document_force_rls_lock_repair.sql"
-                                                                          : slackRoutePromptSinglePending
-                                                                            ? "0342_slack_route_prompt_single_pending.sql"
-                                                                            : slackRoutingProbeFence
-                                                                              ? "0341_slack_routing_probe_organization_fence.sql"
-                                                                              : tenancyBackfillActivationEvidence
-                                                                                ? "0340_tenancy_backfill_activation_evidence.sql"
-                                                                                : documentAuthorityReclassification
-                                                                                  ? "0339_document_authority_reclassification.sql"
-                                                                                  : atomicConnectedMachineAttachments
-                                                                                    ? "0338_atomic_connected_machine_attachments.sql"
-                                                                                    : routedSlackHandles
-                                                                                      ? "0337_slack_routed_action_handles.sql"
-                                                                                      : "0336_atomic_session_fork_visibility.sql",
+        (connectedMachineLegacyTildeWorkdirs ? 1 : 0) +
+        (localOrganizationAdministration ? 1 : 0),
+      latestMigration: localOrganizationAdministration
+        ? "0386_local_organization_administration.sql"
+        : connectedMachineLegacyTildeWorkdirs
+          ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+          : codexCooldownRevisionGuardPrivileges
+            ? "0384_codex_cooldown_revision_guard_privileges.sql"
+            : codexCooldownReconciliation
+              ? "0383_codex_cooldown_reconciliation.sql"
+              : organizationApiKeyProvenance
+                ? "0382_organization_api_key_provenance.sql"
+                : organizationCodexSubscriptionInheritance
+                  ? "0381_organization_codex_subscription_inheritance.sql"
+                  : autonomousCompanyProfileAgentPolicy
+                    ? "0380_autonomous_company_profile_agent_policy.sql"
+                    : sessionEventRawLaneActivation
+                      ? "0379_session_event_raw_lane_activation.sql"
+                      : scopedRigHealthAuditTimestamp
+                        ? "0378_scoped_rig_health_audit_timestamp.sql"
+                        : scopedRigHealthProjection
+                          ? "0377_scoped_rig_health_projection.sql"
+                          : organizationWorkspaceInventory
+                            ? "0376_organization_workspace_inventory.sql"
+                            : sessionRecoveryObservability
+                              ? "0375_session_recovery_observability.sql"
+                              : sessionEventCursors
+                                ? "0374_session_event_cursors.sql"
+                                : sandboxSharedPreparation
+                                  ? "0373_sandbox_shared_preparation.sql"
+                                  : orderedVariableSetRuntimeAuthority
+                                    ? "0372_ordered_variable_set_runtime_authority.sql"
+                                    : workspaceMemberCandidateInventory
+                                      ? "0371_workspace_member_candidate_inventory.sql"
+                                      : workspaceMemberManagementScope
+                                        ? "0370_workspace_member_management_scope.sql"
+                                        : localHumanPersonalAuthority
+                                          ? "0369_local_human_personal_authority.sql"
+                                          : sessionDiscoveryClaimSearchIndex
+                                            ? "0368_session_discovery_claim_search_index.sql"
+                                            : sessionDiscoveryGoalSearchIndex
+                                              ? "0367_session_discovery_goal_search_index.sql"
+                                              : sessionDiscoveryTitleSearchIndex
+                                                ? "0366_session_discovery_title_search_index.sql"
+                                                : permissionScopedWorkClaims
+                                                  ? "0365_permission_scoped_work_claims.sql"
+                                                  : workspaceLearningPolicySnapshotLockOrder
+                                                    ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                    : organizationRecoveryCustody
+                                                      ? "0363_organization_recovery_custody.sql"
+                                                      : managedAuthSessionSets
+                                                        ? "0362_managed_auth_session_sets.sql"
+                                                        : sessionVariableSetAttachments
+                                                          ? "0352_session_variable_set_attachments.sql"
+                                                          : organizationUserSetupDelivery
+                                                            ? "0351_organization_user_setup_delivery.sql"
+                                                            : organizationSharedWorkspaceAdministration
+                                                              ? "0350_organization_shared_workspace_administration.sql"
+                                                              : greenfieldSessionTenancyActivation
+                                                                ? "0349_greenfield_session_tenancy_activation.sql"
+                                                                : namedSignupAndUserSetup
+                                                                  ? "0348_named_signup_and_user_setup.sql"
+                                                                  : connectionAuthorityConvergenceEvidence
+                                                                    ? "0347_connection_authority_convergence_evidence.sql"
+                                                                    : documentMigrationAuditSurface
+                                                                      ? "0346_document_migration_audit_surface.sql"
+                                                                      : tenantScopedSessionTenancyFence
+                                                                        ? "0345_tenant_scoped_session_tenancy_fence.sql"
+                                                                        : privateSessionVisibilityTransitionGate
+                                                                          ? "0344_private_session_visibility_transition_gate.sql"
+                                                                          : personalDocumentForceRlsRepair
+                                                                            ? "0343_personal_document_force_rls_lock_repair.sql"
+                                                                            : slackRoutePromptSinglePending
+                                                                              ? "0342_slack_route_prompt_single_pending.sql"
+                                                                              : slackRoutingProbeFence
+                                                                                ? "0341_slack_routing_probe_organization_fence.sql"
+                                                                                : tenancyBackfillActivationEvidence
+                                                                                  ? "0340_tenancy_backfill_activation_evidence.sql"
+                                                                                  : documentAuthorityReclassification
+                                                                                    ? "0339_document_authority_reclassification.sql"
+                                                                                    : atomicConnectedMachineAttachments
+                                                                                      ? "0338_atomic_connected_machine_attachments.sql"
+                                                                                      : routedSlackHandles
+                                                                                        ? "0337_slack_routed_action_handles.sql"
+                                                                                        : "0336_atomic_session_fork_visibility.sql",
     });
     expect(
       completeSourceContract.migrations.find(


### PR DESCRIPTION
## Summary

- admit only the canonical single-user local browser administrator to organization metadata, shared workspace, retention, company identity, and organization Codex controls
- backfill the exact local administrator as organization owner and preserve managed/delegated/API-key boundaries
- make Codex source choices, organization documents, and single-user organization behavior explicit in the UI
- make workspace learning and organization identity autonomy save consistently on selection
- accept local same-origin Codex setup through the one-port self-host proxy without accepting a different hostname

Linear: OPE-415

## Testing

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`
- [x] focused API, web, migration, schema-contract, and authorization suites (146 tests)
- [x] broad unit run: 12,781 passed; 25 unrelated resource/concurrency failures; every affected file reran serially with 104 passed, 2 skipped, 0 failed
- [x] docs references, public-repository hygiene, migration ordinals, migration RLS backfill, release schema contract, and test budgets

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] `main` advanced after the candidate froze. The current merge tree is conflict-free; incoming #2077/#2080 runtime, database, and documentation changes are materially compatible and no migration ordinal was added.

## Notes

- Managed multi-user invitation, member lifecycle, private-session, and recovery controls remain managed-session-only.
- Organization Codex credentials are not copied from an existing workspace. The local administrator connects one organization subscription interactively after deployment.