### PR TITLE
fix(db): hand off quiesced shared preparation

### DIFF
--- a/.changeset/quick-rigs-handoff.md
+++ b/.changeset/quick-rigs-handoff.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Release abandoned shared rig setup ownership as soon as the superseded turn proves its sandbox writers are physically quiesced.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43773,6 +43773,28 @@ export async function releaseLeaseHolder(
         const row = rows[0];
         if (!row) return null; // already cold-and-reaped; release is an idempotent no-op
 
+        // Cancellation can delete the holder before the shared rig coordinator
+        // catches its abort. That coordinator must then fail closed because its
+        // ordinary settlement requires the holder to remain present. Once the
+        // later proof-bearing release confirms every attempt-owned sandbox
+        // writer is physically quiesced, close the abandoned single-flight too.
+        // Matching the canonical holder to the durable owner attempt keeps this
+        // idempotent and prevents an eager, proof-free release from admitting a
+        // replacement while the old rig command may still be running.
+        if (input.kind === "turn" && input.workspaceWritersQuiesced === true) {
+          await tx.execute(sql`
+            update sandbox_leases
+            set shared_preparation_status = 'failed',
+                shared_preparation_revision = shared_preparation_revision + 1,
+                shared_preparation_settled_at = now(),
+                updated_at = now()
+            where id = ${row.id}
+              and shared_preparation_status = 'running'
+              and lower(${input.holderId}) =
+                'turn-attempt:' || shared_preparation_owner_attempt_id::text
+          `);
+        }
+
         // Idempotent: deleting an already-gone holder affects 0 rows, fine.
         await tx.execute(sql`
         delete from sandbox_lease_holders

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -1008,6 +1008,150 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     expect(reused.role).toBe("reused");
   }, 60_000);
 
+  test("quiesced owner release immediately hands off abandoned shared preparation", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const ownerAttemptId = crypto.randomUUID();
+    const siblingAttemptId = crypto.randomUUID();
+    const ownerHolderId = `turn-attempt:${ownerAttemptId}`;
+    const siblingHolderId = `turn-attempt:${siblingAttemptId}`;
+    const acquired = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: ownerHolderId,
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(acquired.role).toBe("spawner");
+    const instanceId = "shared-preparation-quiesced-handoff";
+    const committed = await commitWarmingToWarm(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: acquired.lease.leaseEpoch,
+      instanceId,
+      dataPlaneUrl: null,
+      resumeBackendId: "modal",
+      resumeState: { backendId: "modal", sessionState: {} },
+      leaseTtlMs: 45_000,
+    });
+    expect(committed.committed).toBe(true);
+    const warmLeaseEpoch = committed.lease!.leaseEpoch;
+    const siblingLease = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: siblingHolderId,
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(siblingLease.role).toBe("attached");
+
+    const specHash = `sha256:${"b".repeat(64)}`;
+    const ownerClaimId = crypto.randomUUID();
+    const siblingClaimId = crypto.randomUUID();
+    expect(
+      (
+        await claimSandboxSharedPreparation(db, {
+          accountId,
+          workspaceId,
+          sandboxGroupId: groupId,
+          expectedLeaseEpoch: warmLeaseEpoch,
+          expectedInstanceId: instanceId,
+          specHash,
+          holderId: ownerHolderId,
+          claimId: ownerClaimId,
+          ownerAttemptId,
+          timeoutMs: 60_000,
+        })
+      ).role,
+    ).toBe("owner");
+    expect(
+      (
+        await claimSandboxSharedPreparation(db, {
+          accountId,
+          workspaceId,
+          sandboxGroupId: groupId,
+          expectedLeaseEpoch: warmLeaseEpoch,
+          expectedInstanceId: instanceId,
+          specHash,
+          holderId: siblingHolderId,
+          claimId: siblingClaimId,
+          ownerAttemptId: siblingAttemptId,
+          timeoutMs: 60_000,
+        })
+      ).role,
+    ).toBe("joined");
+
+    await releaseLeaseHolder(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: ownerHolderId,
+      idleGraceMs: 30_000,
+    });
+    const stillRunning = await readSandboxSharedPreparation(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedLeaseEpoch: warmLeaseEpoch,
+      expectedInstanceId: instanceId,
+      specHash,
+      holderId: siblingHolderId,
+    });
+    expect(stillRunning.status).toBe("available");
+    if (stillRunning.status === "available") {
+      expect(stillRunning.preparation.status).toBe("running");
+    }
+
+    // The proof-bearing pass remains effective after the eager release already
+    // removed the owner holder.
+    await releaseLeaseHolder(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: ownerHolderId,
+      idleGraceMs: 30_000,
+      workspaceWritersQuiesced: true,
+    });
+    const failed = await readSandboxSharedPreparation(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedLeaseEpoch: warmLeaseEpoch,
+      expectedInstanceId: instanceId,
+      specHash,
+      holderId: siblingHolderId,
+    });
+    expect(failed.status).toBe("available");
+    if (failed.status === "available") {
+      expect(failed.preparation.status).toBe("failed");
+    }
+
+    const takeover = await claimSandboxSharedPreparation(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedLeaseEpoch: warmLeaseEpoch,
+      expectedInstanceId: instanceId,
+      specHash,
+      holderId: siblingHolderId,
+      claimId: siblingClaimId,
+      ownerAttemptId: siblingAttemptId,
+      timeoutMs: 60_000,
+    });
+    expect(takeover.role).toBe("owner");
+    if (takeover.role === "owner") {
+      expect(takeover.preparation.attempt).toBe(2);
+      expect(takeover.preparation.ownerAttemptId).toBe(siblingAttemptId);
+    }
+  }, 60_000);
+
   test("(0281) a viewer acquire records the authority claims; re-acquire is monotone", async () => {
     if (!available) return;
     const { accountId, workspaceId, groupId } = await freshWorkspace();


### PR DESCRIPTION
## Why
A superseded turn can drop its sandbox holder before the shared rig coordinator records failure. The replacement then joins the abandoned claim until its 10-minute deadline.

## Fix
- fail the exact owner claim during the later proof-bearing, writer-quiesced release
- preserve fail-closed behavior for eager cancellation
- cover eager release, physical quiescence, and immediate sibling takeover

## Validation
- `bun run typecheck`
- targeted worker release/quiescence tests (12 pass)
- targeted DB regression test (local Docker unavailable; real-DB CI exercises it)

## Summary by Sourcery

Allow quiesced turn releases to hand off abandoned shared preparation ownership while preserving fail-closed behavior during eager cancellation.

Bug Fixes:
- Release abandoned shared preparation claims after a superseded turn confirms its sandbox writers are physically quiesced, allowing immediate sibling takeover instead of waiting for claim expiry.

Tests:
- Add regression coverage for eager release, proof-bearing quiesced release, and immediate shared-preparation takeover.