### PR TITLE
fix(web): stop reconnect badge layout flicker

### DIFF
--- a/apps/web/src/components/common.test.tsx
+++ b/apps/web/src/components/common.test.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, jest, test } from "bun:test";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -7,15 +7,48 @@ import { ConnectionPill } from "./common";
 
 registerDom();
 
-test("reconnects use the delayed-reveal treatment", async () => {
+test("transient reconnects do not mount or shift surrounding layout", async () => {
+  jest.useFakeTimers();
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
 
-  await act(async () => root.render(<ConnectionPill state="reconnecting" />));
-  expect(container.textContent).toContain("Reconnecting");
-  expect(container.querySelector("span")?.classList).toContain("og-connection-pill-reconnect");
+  try {
+    await act(async () => root.render(<ConnectionPill state="reconnecting" />));
+    expect(container.firstElementChild).toBeNull();
 
-  await act(async () => root.unmount());
-  container.remove();
+    await act(async () => jest.advanceTimersByTime(1_499));
+    expect(container.firstElementChild).toBeNull();
+
+    await act(async () => root.render(<ConnectionPill state="live" />));
+    await act(async () => jest.advanceTimersByTime(1));
+    expect(container.firstElementChild).toBeNull();
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    jest.useRealTimers();
+  }
+});
+
+test("a stalled reconnect becomes visible after the grace period", async () => {
+  jest.useFakeTimers();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  try {
+    await act(async () => root.render(<ConnectionPill state="reconnecting" />));
+    expect(container.firstElementChild).toBeNull();
+
+    await act(async () => jest.advanceTimersByTime(1_500));
+    expect(container.textContent).toContain("Reconnecting");
+
+    await act(async () => root.render(<ConnectionPill state="live" />));
+    await act(async () => root.render(<ConnectionPill state="reconnecting" />));
+    expect(container.firstElementChild).toBeNull();
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    jest.useRealTimers();
+  }
 });

--- a/apps/web/src/components/common.tsx
+++ b/apps/web/src/components/common.tsx
@@ -1,9 +1,20 @@
 import type { SessionEventsConnectionState } from "@opengeni/react";
 import { AlertTriangleIcon, CopyIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
+
+const RECONNECT_PILL_REVEAL_DELAY_MS = 1_500;
+
+type ConnectionPillMeta = { label: string; dot: string; text: string };
+
+const degradedConnectionStates: Partial<Record<SessionEventsConnectionState, ConnectionPillMeta>> =
+  {
+    connecting: { label: "Connecting…", dot: "bg-status-running", text: "text-status-running" },
+    reconnecting: { label: "Reconnecting…", dot: "bg-status-running", text: "text-status-running" },
+    error: { label: "Stream error", dot: "bg-status-failed", text: "text-status-failed" },
+  };
 
 export function LoadingPanel({ label }: { label: string }) {
   return (
@@ -33,26 +44,36 @@ export function ProblemPanel(props: { title: string; description: ReactNode; act
  * Connection health, shown only when it needs a word (doctrine D2). Healthy
  * states (live / idle / ended) render nothing — the session status badge is the
  * single persistent pill, so there is no "live" + "Idle" double-green. The pill
- * surfaces only while the stream is degraded, in sentence case.
+ * surfaces only while the stream is degraded, in sentence case. Routine HTTP/1
+ * stream cycling never mounts the reconnect pill, so its hidden content cannot
+ * shift the surrounding header controls.
  */
 export function ConnectionPill({ state }: { state: SessionEventsConnectionState }) {
-  const degraded: Partial<
-    Record<SessionEventsConnectionState, { label: string; dot: string; text: string }>
-  > = {
-    connecting: { label: "Connecting…", dot: "bg-status-running", text: "text-status-running" },
-    reconnecting: { label: "Reconnecting…", dot: "bg-status-running", text: "text-status-running" },
-    error: { label: "Stream error", dot: "bg-status-failed", text: "text-status-failed" },
-  };
-  const meta = degraded[state];
+  const meta = degradedConnectionStates[state];
   if (!meta) {
     return null;
   }
+  if (state === "reconnecting") {
+    return <DelayedReconnectPill meta={meta} />;
+  }
+  return <ConnectionPillContent meta={meta} />;
+}
+
+function DelayedReconnectPill({ meta }: { meta: ConnectionPillMeta }) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), RECONNECT_PILL_REVEAL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  return visible ? <ConnectionPillContent meta={meta} /> : null;
+}
+
+function ConnectionPillContent({ meta }: { meta: ConnectionPillMeta }) {
   return (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-1 text-xs font-medium",
         meta.text,
-        state === "reconnecting" && "og-connection-pill-reconnect",
       )}
     >
       <span className={cn("size-2 rounded-full motion-safe:animate-pulse", meta.dot)} />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -283,19 +283,6 @@ body {
   }
 }
 
-/* HTTP/1 streams intentionally cycle to free the browser-wide connection
-   pool. Hide only the healthy sub-second handoff; a stalled reconnect appears. */
-.og-connection-pill-reconnect {
-  visibility: hidden;
-  animation: connection-pill-reveal 0s 1.5s forwards;
-}
-
-@keyframes connection-pill-reveal {
-  to {
-    visibility: visible;
-  }
-}
-
 .pending-dot {
   animation: pending-dot 1.2s infinite ease-in-out both;
 }


### PR DESCRIPTION
## Summary

- keep routine HTTP/1 stream reconnects completely out of the DOM during the existing 1.5-second grace period
- preserve the visible `Reconnecting…` warning for genuinely stalled reconnects
- remove the CSS visibility shim that hid the badge text while still reserving width in the session header
- cover transient, stalled, and subsequent reconnect episodes with component tests

## Verification

- `bun test apps/web/src/components/common.test.tsx apps/web/src/components/rail/session-header.test.tsx`
- `bun run --cwd apps/web typecheck`
- `bunx oxfmt --check apps/web/src/components/common.tsx apps/web/src/components/common.test.tsx apps/web/src/styles.css`
- `bunx oxlint --deny-warnings apps/web/src/components/common.tsx apps/web/src/components/common.test.tsx`
- `bun test --timeout 240000 ./test/e2e/session-header.browser.e2e.ts -t 'keeps deep ancestry, primary title, Back, and every action inside the shell'`

The full session-header browser file was also run. Its six-case responsive-header matrix passed; two later unrelated fixture-timing cases failed because ancestry remained in its loading state and a safe-area fixture did not expose the expected title element.

## Summary by Sourcery

Keep routine reconnects out of the DOM during the grace period while preserving visibility for stalled connections.

Bug Fixes:
- Prevent transient stream reconnects from mounting a badge that shifts the session header layout.
- Continue showing the reconnect warning when reconnection exceeds the grace period.

Enhancements:
- Centralize connection-state metadata and remove the CSS visibility workaround for reconnect badges.

Tests:
- Add component coverage for transient, stalled, and subsequent reconnect episodes.