### PR TITLE
fix(worker): read large stored image references

### DIFF
--- a/.changeset/fresh-images-page.md
+++ b/.changeset/fresh-images-page.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Read generated-image references in bounded object-storage pages so valid images larger than one MiB cannot fail the owning turn.

--- a/.changeset/fresh-images-page.md
+++ b/.changeset/fresh-images-page.md
@@ -2,4 +2,4 @@
 "@opengeni/worker-bundle": patch
 ---
 
-Read generated-image references in bounded object-storage pages so valid images larger than one MiB cannot fail the owning turn.
+Read generated-image references through the generic full-file storage API so valid images larger than one MiB cannot fail the owning turn.

--- a/apps/worker/src/activities/image-generation-references.ts
+++ b/apps/worker/src/activities/image-generation-references.ts
@@ -1,4 +1,8 @@
-import { type ImageGenerationReference, type FileAsset } from "@opengeni/contracts";
+import {
+  RETAINED_OUTPUT_MAX_PAGE_BYTES,
+  type ImageGenerationReference,
+  type FileAsset,
+} from "@opengeni/contracts";
 import { getGeneratedImageArtifact, requireFileForSubject, type Database } from "@opengeni/db";
 import type { ObjectStorage } from "@opengeni/storage";
 import {
@@ -200,21 +204,32 @@ async function referenceBytes(
     );
   }
   return {
-    bytes: await readStoredFile(input.objectStorage, file),
+    bytes: await readStoredImageReferenceFile(input.objectStorage, file),
     file,
   };
 }
 
-async function readStoredFile(objectStorage: ObjectStorage, file: FileAsset): Promise<Uint8Array> {
-  const bytes = await objectStorage.getFileRange(file, {
-    start: 0,
-    end: file.sizeBytes - 1,
-  });
-  if (!bytes) {
-    throw new ImageGenerationReferenceError(
-      "reference_unavailable",
-      "The durable image reference bytes are unavailable.",
-    );
+export async function readStoredImageReferenceFile(
+  objectStorage: Pick<ObjectStorage, "getFileRange">,
+  file: FileAsset,
+): Promise<Uint8Array> {
+  const bytes = new Uint8Array(file.sizeBytes);
+  for (let start = 0; start < file.sizeBytes; start += RETAINED_OUTPUT_MAX_PAGE_BYTES) {
+    const end = Math.min(file.sizeBytes - 1, start + RETAINED_OUTPUT_MAX_PAGE_BYTES - 1);
+    const page = await objectStorage.getFileRange(file, { start, end });
+    if (!page) {
+      throw new ImageGenerationReferenceError(
+        "reference_unavailable",
+        "The durable image reference bytes are unavailable.",
+      );
+    }
+    if (page.byteLength !== end - start + 1) {
+      throw new ImageGenerationReferenceError(
+        "reference_integrity_mismatch",
+        "The durable image reference bytes do not match their file metadata.",
+      );
+    }
+    bytes.set(page, start);
   }
   return bytes;
 }

--- a/apps/worker/src/activities/image-generation-references.ts
+++ b/apps/worker/src/activities/image-generation-references.ts
@@ -1,8 +1,4 @@
-import {
-  RETAINED_OUTPUT_MAX_PAGE_BYTES,
-  type ImageGenerationReference,
-  type FileAsset,
-} from "@opengeni/contracts";
+import { type ImageGenerationReference, type FileAsset } from "@opengeni/contracts";
 import { getGeneratedImageArtifact, requireFileForSubject, type Database } from "@opengeni/db";
 import type { ObjectStorage } from "@opengeni/storage";
 import {
@@ -210,26 +206,15 @@ async function referenceBytes(
 }
 
 export async function readStoredImageReferenceFile(
-  objectStorage: Pick<ObjectStorage, "getFileRange">,
+  objectStorage: Pick<ObjectStorage, "getFileBytes">,
   file: FileAsset,
 ): Promise<Uint8Array> {
-  const bytes = new Uint8Array(file.sizeBytes);
-  for (let start = 0; start < file.sizeBytes; start += RETAINED_OUTPUT_MAX_PAGE_BYTES) {
-    const end = Math.min(file.sizeBytes - 1, start + RETAINED_OUTPUT_MAX_PAGE_BYTES - 1);
-    const page = await objectStorage.getFileRange(file, { start, end });
-    if (!page) {
-      throw new ImageGenerationReferenceError(
-        "reference_unavailable",
-        "The durable image reference bytes are unavailable.",
-      );
-    }
-    if (page.byteLength !== end - start + 1) {
-      throw new ImageGenerationReferenceError(
-        "reference_integrity_mismatch",
-        "The durable image reference bytes do not match their file metadata.",
-      );
-    }
-    bytes.set(page, start);
+  const bytes = await objectStorage.getFileBytes(file);
+  if (bytes.byteLength !== file.sizeBytes) {
+    throw new ImageGenerationReferenceError(
+      "reference_integrity_mismatch",
+      "The durable image reference bytes do not match their file metadata.",
+    );
   }
   return bytes;
 }

--- a/apps/worker/test/image-generation-references.test.ts
+++ b/apps/worker/test/image-generation-references.test.ts
@@ -16,25 +16,30 @@ const PNG_1X1 = Uint8Array.from(
 describe("image generation references", () => {
   test("reads stored image references larger than one object page", async () => {
     const expected = Uint8Array.from({ length: 1024 * 1024 + 7 }, (_, index) => index % 251);
-    const ranges: Array<{ start: number; end: number }> = [];
+    const files: unknown[] = [];
     const bytes = await readStoredImageReferenceFile(
       {
-        getFileRange: async (_file, range) => {
-          ranges.push(range);
-          return expected.slice(range.start, range.end + 1);
+        getFileBytes: async (file) => {
+          files.push(file);
+          return expected;
         },
       },
       {
         sizeBytes: expected.byteLength,
         objectKey: "generated/reference.png",
-      } as never,
+      } as unknown as never,
     );
 
-    expect(ranges).toEqual([
-      { start: 0, end: 1024 * 1024 - 1 },
-      { start: 1024 * 1024, end: 1024 * 1024 + 6 },
-    ]);
+    expect(files).toHaveLength(1);
     expect(bytes).toEqual(expected);
+  });
+
+  test("rejects stored image bytes that disagree with file metadata", async () => {
+    await expect(
+      readStoredImageReferenceFile({ getFileBytes: async () => PNG_1X1 }, {
+        sizeBytes: PNG_1X1.byteLength + 1,
+      } as unknown as never),
+    ).rejects.toMatchObject({ code: "reference_integrity_mismatch" });
   });
 
   test("validates sandbox images and preserves caller order", async () => {

--- a/apps/worker/test/image-generation-references.test.ts
+++ b/apps/worker/test/image-generation-references.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ImageGenerationReferenceError,
+  readStoredImageReferenceFile,
   resolveImageGenerationReferences,
   resolveImageGenerationReferencesForTool,
 } from "../src/activities/image-generation-references";
@@ -13,6 +14,29 @@ const PNG_1X1 = Uint8Array.from(
 );
 
 describe("image generation references", () => {
+  test("reads stored image references larger than one object page", async () => {
+    const expected = Uint8Array.from({ length: 1024 * 1024 + 7 }, (_, index) => index % 251);
+    const ranges: Array<{ start: number; end: number }> = [];
+    const bytes = await readStoredImageReferenceFile(
+      {
+        getFileRange: async (_file, range) => {
+          ranges.push(range);
+          return expected.slice(range.start, range.end + 1);
+        },
+      },
+      {
+        sizeBytes: expected.byteLength,
+        objectKey: "generated/reference.png",
+      } as never,
+    );
+
+    expect(ranges).toEqual([
+      { start: 0, end: 1024 * 1024 - 1 },
+      { start: 1024 * 1024, end: 1024 * 1024 + 6 },
+    ]);
+    expect(bytes).toEqual(expected);
+  });
+
   test("validates sandbox images and preserves caller order", async () => {
     const paths: string[] = [];
     const references = await resolveImageGenerationReferences({


### PR DESCRIPTION
## Why
Valid generated-image references may exceed the storage range API’s 1 MiB single-page ceiling. Image resolution incorrectly requested the whole file through that page API, throwing before provider execution.

## Fix
- use the existing generic full-file object-storage read API
- retain the existing 30 MiB admission limit
- verify returned bytes match durable file size; existing image validation verifies SHA-256 and media type
- remove image-specific paging logic

## Validation
- `bun test apps/worker/test/image-generation-references.test.ts` (5 pass)
- `bun run --cwd apps/worker typecheck`
- focused format/lint checks