### PR TITLE
fix(github): allow installing another organization (OPE-417)

### DIFF
--- a/.changeset/calm-github-installations.md
+++ b/.changeset/calm-github-installations.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+---
+
+Keep the GitHub installation account chooser available when a workspace owner
+has exactly one existing installation, so they can install the App on another
+personal account or organization instead of being forced into the existing one.

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -428,14 +428,6 @@ export function registerGitHubRoutes(app: Hono, deps: ApiRouteDeps): void {
       if (candidates.length === 0) {
         return redirectToGitHubInstallation(c, deps, selectionState);
       }
-      if (candidates.length === 1) {
-        return redirectToExactGitHubAuthorization(
-          c,
-          deps,
-          selectionState,
-          candidates[0]!.installation.installationId,
-        );
-      }
       setGitHubStateCookie(c, deps, selectionState);
       return c.html(
         githubInstallationChooserHtml(

--- a/apps/api/test/github-binding-authority.test.ts
+++ b/apps/api/test/github-binding-authority.test.ts
@@ -99,8 +99,27 @@ async function startOAuth(app: Hono): Promise<{ state: string; browserHeader: st
     `http://test/v1/github/oauth/callback?code=discover&state=${encodeURIComponent(discoveryState!)}`,
     { headers: { cookie: discoveryCookie! } },
   );
-  expect(discovery.status).toBe(302);
-  const location = new URL(discovery.headers.get("location")!);
+  expect(discovery.status).toBe(200);
+  const html = await discovery.text();
+  expect(html).toContain("Choose a GitHub account");
+  expect(html).toContain("owner");
+  expect(html).toContain('value="new"');
+  const selectionState = html.match(/name="state" value="([^"]+)"/)?.[1];
+  const selectionCookie = discovery.headers.get("set-cookie")?.split(";", 1)[0];
+  expect(selectionState).toBeTruthy();
+  expect(selectionCookie).toBeTruthy();
+  expect(readSignedState(selectionState!, stateSecret)).toMatchObject({
+    accountId,
+    workspaceId,
+    allowedInstallationIds: [42],
+    intent: "installation_authority_selection",
+  });
+  const selection = await app.request(
+    `http://test/v1/workspaces/${workspaceId}/github/installations/select?state=${encodeURIComponent(selectionState!)}&installation_id=42`,
+    { headers: { cookie: selectionCookie! } },
+  );
+  expect(selection.status).toBe(302);
+  const location = new URL(selection.headers.get("location")!);
   const oauthState = location.searchParams.get("state");
   expect(oauthState).toBeTruthy();
   const payload = readSignedState(oauthState!, stateSecret);
@@ -110,7 +129,7 @@ async function startOAuth(app: Hono): Promise<{ state: string; browserHeader: st
     installationId: 42,
     intent: "installation_authority_oauth",
   });
-  const oauthCookie = discovery.headers.get("set-cookie")?.split(";", 1)[0];
+  const oauthCookie = selection.headers.get("set-cookie")?.split(";", 1)[0];
   expect(oauthCookie).toBeTruthy();
   return { state: oauthState!, browserHeader: oauthCookie! };
 }
@@ -193,9 +212,45 @@ describe("GitHub owner-authority binding routes", () => {
     expect(githubBindingStatus(true, [binding])).toBe("bound");
   });
 
-  test("existing owner installation discovery advances to exact fresh GitHub OAuth", async () => {
+  test("one existing owner installation still offers another account before exact OAuth", async () => {
     const app = appWithProvider();
     await startOAuth(app);
+  });
+
+  test("one existing owner installation can advance to a new account installation", async () => {
+    const app = appWithProvider();
+    const state = managerState();
+    const connect = await app.request(
+      `http://test/v1/workspaces/${workspaceId}/github/connect?state=${encodeURIComponent(state)}`,
+    );
+    const discoveryLocation = new URL(connect.headers.get("location")!);
+    const discoveryState = discoveryLocation.searchParams.get("state")!;
+    const discoveryCookie = connect.headers.get("set-cookie")!.split(";", 1)[0]!;
+    const discovery = await app.request(
+      `http://test/v1/github/oauth/callback?code=discover&state=${encodeURIComponent(discoveryState)}`,
+      { headers: { cookie: discoveryCookie } },
+    );
+    expect(discovery.status).toBe(200);
+    const html = await discovery.text();
+    const selectionState = html.match(/name="state" value="([^"]+)"/)?.[1];
+    const selectionCookie = discovery.headers.get("set-cookie")?.split(";", 1)[0];
+    expect(selectionState).toBeTruthy();
+    expect(selectionCookie).toBeTruthy();
+
+    const install = await app.request(
+      `http://test/v1/workspaces/${workspaceId}/github/installations/select?state=${encodeURIComponent(selectionState!)}&installation_id=new`,
+      { headers: { cookie: selectionCookie! } },
+    );
+    expect(install.status).toBe(302);
+    const installLocation = new URL(install.headers.get("location")!);
+    expect(installLocation.origin + installLocation.pathname).toBe(
+      "https://github.com/apps/opengeni-test/installations/new",
+    );
+    expect(readSignedState(installLocation.searchParams.get("state")!, stateSecret)).toMatchObject({
+      accountId,
+      workspaceId,
+      intent: "installation_authority_install",
+    });
   });
 
   test("no existing owner installation advances to GitHub installation", async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -932,6 +932,11 @@ Provider adapters may narrow destinations, credentials, and retry policy, but
 they must preserve the shared connection, approval, idempotency, and audit
 boundaries.
 
+GitHub App binding keeps account selection explicit whenever owner-authorized
+installations already exist: the owner may choose one of them or enter GitHub's
+new-installation flow for another personal account or organization. Both paths
+retain the same signed-state and exact owner revalidation boundaries.
+
 Canonical: [`capabilities.md`](capabilities.md),
 [`integrations-design.md`](integrations-design.md),
 [`mcp-surfaces.md`](mcp-surfaces.md), and [`credentials.md`](credentials.md).

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -36,10 +36,12 @@ Creating the App and binding an installation are distinct operations. A caller
 with `github:manage` receives a signed, ten-minute browser handoff and first
 authorizes the App as a GitHub user. OpenGeni discovers existing installations
 visible to that user, but retains only exact personal-account ownership or live
-active organization-owner membership. One retained installation advances
-directly; several produce an owner-only chooser; none enters GitHub's new
-installation UI. This order lets an existing installation connect without
-depending on GitHub's Configure page to return OpenGeni state.
+active organization-owner membership. Any retained installation produces an
+owner-only chooser that also offers installing the App on another account; none
+enters GitHub's new installation UI directly. This lets an existing installation
+connect without preventing the owner from adding a different personal account or
+organization, and does not depend on GitHub's Configure page to return OpenGeni
+state.
 
 The selected installation then receives a second, exact fresh GitHub user
 authorization immediately before binding. The second pass is deliberate: no


### PR DESCRIPTION
## Root cause

The discovery callback automatically selected the only existing owner-authorized GitHub App installation. With one installation, the chooser was skipped, so the owner had no OpenGeni path to install the App on another personal account or organization.

## Fix

- Show the existing account chooser for every nonempty discovery result, including exactly one installation.
- Preserve both choices: select an existing installation or open GitHub installation for another account.
- Keep the signed state, installation allowlist, exact second OAuth proof, owner revalidation, and repository allowlist unchanged.
- Update the architecture and GitHub App documentation and add an API-router patch changeset.

## Verification

- 21 GitHub route and browser-flow tests pass.
- Full repository typecheck passes across all 31 projects.
- Oxfmt, Oxlint, docs-reference guards, changeset validation, and diff checks pass.
- A disposable merge against current origin/main completed without conflicts.

Linear: OPE-417

## Summary by Sourcery

Keep the GitHub installation account chooser available after discovering existing owner-authorized installations.

New Features:
- Allow workspace owners to choose an existing GitHub installation or install the App on another personal account or organization when installations are discovered.

Bug Fixes:
- Prevent automatically forcing owners with exactly one existing installation into that installation.

Enhancements:
- Preserve the existing signed-state and owner-revalidation security boundaries across both installation paths.

Documentation:
- Document the GitHub account chooser behavior and supported installation paths in the architecture and GitHub App documentation.

Tests:
- Add coverage for selecting an existing installation and starting a new-account installation when exactly one installation exists.