### PR TITLE
fix(db): bound large host-export session events

### DIFF
--- a/.changeset/brave-host-export-boundary.md
+++ b/.changeset/brave-host-export-boundary.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Keep canonical large session-event payloads lossless while exporting an explicit bounded host projection, so optional host export cannot roll back session lifecycle settlement.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -852,6 +852,9 @@ deduplicate those keys. Session ordering is authoritative by `event.sequence`; c
 stable across sessions but deliberately not claimed to be causal. High-volume raw delta event types
 are excluded from the host stream; their completed semantic events remain. Event types are bounded
 but forward-tolerant so an older consumer can carry a newer writer's event during a rolling upgrade.
+Canonical session events remain lossless. When one payload exceeds the bounded host wire, the
+outbox carries a content-free truncation receipt keyed to the canonical event instead of blocking
+the source transaction or copying an unbounded payload into the host stream.
 Each session-bound event and usage fact also carries the immutable lineage `rootSessionId` captured
 with the outbox row in the source transaction. A host can therefore retain the immediate child id
 for audit while attributing usage or host-owned business signals to one root binding. Only a

--- a/packages/db/drizzle/0387_bound_host_export_session_payloads.sql
+++ b/packages/db/drizzle/0387_bound_host_export_session_payloads.sql
@@ -1,0 +1,165 @@
+-- deployment-mode: rolling
+-- Host export is an optional bounded projection. Canonical session_events keeps
+-- the complete lossless payload; an oversized projection must never roll back
+-- the source event or a later lifecycle transaction that closes pending work.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+DO $migration$
+DECLARE target_schema text := current_schema();
+BEGIN
+  EXECUTE format($create$
+    CREATE OR REPLACE FUNCTION opengeni_private.enqueue_host_session_event_export()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $function$
+    DECLARE
+      v_enabled boolean;
+      v_initiator jsonb;
+      v_context jsonb := '{}'::jsonb;
+      v_origin text;
+      v_source_payload_bytes integer;
+      v_export_payload jsonb;
+      v_export_payload_codec_version smallint;
+      v_payload_bytes integer;
+    BEGIN
+      IF NEW.type IN (
+        'agent.message.delta', 'agent.reasoning.delta',
+        'sandbox.command.output.delta', 'terminal.pty.output.delta'
+      ) THEN
+        RETURN NEW;
+      END IF;
+
+      SELECT c.session_events_enabled INTO v_enabled
+      FROM %1$I.host_export_config c WHERE c.id = 1
+      FOR SHARE;
+      IF coalesce(v_enabled, false) = false THEN
+        RETURN NEW;
+      END IF;
+
+      IF NEW.turn_id IS NOT NULL THEN
+        SELECT
+          CASE WHEN octet_length(t.initiator_subject_id) <= 1024 THEN
+            jsonb_strip_nulls(jsonb_build_object(
+              'kind', t.initiator_kind,
+              'subjectId', t.initiator_subject_id,
+              'label', CASE
+                WHEN jsonb_typeof(t.initiator_context -> 'label') = 'string'
+                THEN left(t.initiator_context ->> 'label', 256)
+                ELSE NULL
+              END
+            ))
+          ELSE NULL END,
+          jsonb_strip_nulls(jsonb_build_object(
+            'label', CASE
+              WHEN jsonb_typeof(t.initiator_context -> 'label') = 'string'
+              THEN left(t.initiator_context ->> 'label', 256)
+              ELSE NULL
+            END,
+            'backfill', CASE
+              WHEN jsonb_typeof(t.initiator_context -> 'backfill') = 'boolean'
+              THEN t.initiator_context -> 'backfill'
+              ELSE NULL
+            END,
+            'attributionOmitted', CASE
+              WHEN octet_length(t.initiator_subject_id) > 1024 THEN 'subject_id_too_large'
+              ELSE NULL
+            END
+          )),
+          t.source
+        INTO v_initiator, v_context, v_origin
+        FROM %1$I.session_turns t
+        WHERE t.workspace_id = NEW.workspace_id AND t.id = NEW.turn_id;
+      ELSIF NEW.type = 'session.created' THEN
+        SELECT
+          CASE WHEN octet_length(s.created_by_subject_id) <= 1024 THEN
+            jsonb_strip_nulls(jsonb_build_object(
+              'kind', s.created_by_kind,
+              'subjectId', s.created_by_subject_id,
+              'label', CASE
+                WHEN jsonb_typeof(s.created_by_context -> 'label') = 'string'
+                THEN left(s.created_by_context ->> 'label', 256)
+                ELSE NULL
+              END
+            ))
+          ELSE NULL END,
+          jsonb_strip_nulls(jsonb_build_object(
+            'label', CASE
+              WHEN jsonb_typeof(s.created_by_context -> 'label') = 'string'
+              THEN left(s.created_by_context ->> 'label', 256)
+              ELSE NULL
+            END,
+            'backfill', CASE
+              WHEN jsonb_typeof(s.created_by_context -> 'backfill') = 'boolean'
+              THEN s.created_by_context -> 'backfill'
+              ELSE NULL
+            END,
+            'attributionOmitted', CASE
+              WHEN octet_length(s.created_by_subject_id) > 1024 THEN 'subject_id_too_large'
+              ELSE NULL
+            END
+          )),
+          NULL
+        INTO v_initiator, v_context, v_origin
+        FROM %1$I.sessions s
+        WHERE s.workspace_id = NEW.workspace_id AND s.id = NEW.session_id;
+      END IF;
+
+      v_source_payload_bytes := octet_length(NEW.payload::text);
+      v_export_payload := NEW.payload;
+      v_export_payload_codec_version := NEW.payload_codec_version;
+      IF v_source_payload_bytes > 65536 THEN
+        v_export_payload := jsonb_build_object(
+          '_hostExport', jsonb_build_object(
+            'payloadMode', 'summary',
+            'payloadTruncated', true,
+            'originalBytes', v_source_payload_bytes,
+            'sourceEventId', NEW.id,
+            'fullPayload', 'retained in canonical session event'
+          ),
+          'preview', '[host-export payload omitted at bounded projection boundary]'
+        );
+        -- The projection is literal PostgreSQL JSON, not an application-codec
+        -- envelope. Preserve codec truth only when the original payload is kept.
+        v_export_payload_codec_version := NULL;
+      END IF;
+
+      v_payload_bytes := octet_length(v_export_payload::text)
+        + octet_length(NEW.type)
+        + coalesce(octet_length(NEW.client_event_id), 0)
+        + coalesce(octet_length(NEW.turn_association), 0)
+        + coalesce(octet_length(NEW.duplicate_reason), 0)
+        + octet_length(coalesce(v_initiator, 'null'::jsonb)::text)
+        + octet_length(v_context::text)
+        + 768;
+      INSERT INTO %1$I.host_export_outbox (
+        export_kind, source_id, account_id, workspace_id, session_id,
+        turn_id, turn_generation, turn_attempt_id, session_sequence,
+        client_event_id, turn_association, duplicate_of_event_id, duplicate_reason,
+        event_type, idempotency_key, initiator, initiator_context, origin,
+        payload, payload_codec_version, envelope_bytes, occurred_at,
+        source_recorded_at, enqueued_at
+      ) VALUES (
+        'session_event', NEW.id, NEW.account_id, NEW.workspace_id, NEW.session_id,
+        NEW.turn_id, NEW.turn_generation, NEW.turn_attempt_id, NEW.sequence,
+        NEW.client_event_id, NEW.turn_association, NEW.duplicate_of_event_id,
+        NEW.duplicate_reason,
+        NEW.type, 'session_event:' || NEW.id::text, v_initiator,
+        coalesce(v_context, '{}'::jsonb), v_origin, v_export_payload,
+        v_export_payload_codec_version, greatest(1, v_payload_bytes), NEW.occurred_at,
+        NEW.created_at, clock_timestamp()
+      )
+      ON CONFLICT (export_kind, source_id) DO NOTHING;
+      RETURN NEW;
+    END $function$;
+  $create$, target_schema);
+END
+$migration$;
+
+COMMENT ON COLUMN host_export_outbox.payload IS
+  'Immutable bounded host projection. Canonical session_events retains the complete payload; oversized host projections carry an explicit content-free truncation receipt.';
+COMMENT ON COLUMN host_export_outbox.payload_codec_version IS
+  'Codec truth for the stored host projection. NULL means literal SQL JSON, including oversized-payload projections; 1 means the original application-coded payload was retained exactly.';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11027,8 +11027,9 @@ export const hostExportConfig = pgTable(
 /**
  * Transactional delivery buffer. It intentionally has no tenant/source FKs:
  * a workspace deletion must not erase an already-committed, unacknowledged
- * host fact. Session-event payloads retain their exact storage bytes plus
- * explicit codec truth; usage payloads remain ordinary JSON.
+ * host fact. Session-event rows retain exact storage bytes while they fit the
+ * bounded host wire; larger canonical events carry an explicit content-free
+ * projection plus literal-JSON codec truth. Usage payloads remain ordinary JSON.
  */
 export const hostExportOutbox = pgTable(
   "host_export_outbox",

--- a/packages/db/test/host-export.test.ts
+++ b/packages/db/test/host-export.test.ts
@@ -292,6 +292,69 @@ describe("durable host export (real PostgreSQL)", () => {
       leaseToken: futureBatch!.leaseToken,
     });
 
+    const largeOutput = `large-output:${"x".repeat(160_000)}`;
+    const [largeEvent] = await appendSessionEvents(
+      app.db,
+      active.grant.workspaceId!,
+      active.session.id,
+      [
+        {
+          type: "agent.toolCall.output",
+          payload: { id: "large-call", output: largeOutput, isError: false },
+          turnId: active.turn.id,
+        },
+      ],
+    );
+    const [storedLargeEvent] = await shared.admin<
+      Array<{ payloadBytes: number; output: string; payloadCodecVersion: number | null }>
+    >`
+      select octet_length(payload::text)::integer as "payloadBytes",
+        payload ->> 'output' as output,
+        payload_codec_version as "payloadCodecVersion"
+      from session_events where id = ${largeEvent!.id}::uuid`;
+    expect(storedLargeEvent?.payloadBytes).toBeGreaterThan(150_000);
+    expect(storedLargeEvent?.output).toBe(largeOutput);
+    expect(storedLargeEvent?.payloadCodecVersion).toBe(1);
+
+    const [boundedOutbox] = await shared.admin<
+      Array<{
+        envelopeBytes: number;
+        payloadBytes: number;
+        payloadCodecVersion: number | null;
+        truncated: boolean;
+        originalBytes: number;
+      }>
+    >`
+      select envelope_bytes as "envelopeBytes",
+        pg_column_size(payload)::integer as "payloadBytes",
+        payload_codec_version as "payloadCodecVersion",
+        (payload #>> '{_hostExport,payloadTruncated}')::boolean as truncated,
+        (payload #>> '{_hostExport,originalBytes}')::integer as "originalBytes"
+      from host_export_outbox
+      where export_kind = 'session_event' and source_id = ${largeEvent!.id}::uuid`;
+    expect(boundedOutbox?.envelopeBytes).toBeLessThanOrEqual(98_304);
+    expect(boundedOutbox?.payloadBytes).toBeLessThanOrEqual(73_728);
+    expect(boundedOutbox?.payloadCodecVersion).toBeNull();
+    expect(boundedOutbox?.truncated).toBe(true);
+    expect(boundedOutbox?.originalBytes).toBe(storedLargeEvent?.payloadBytes);
+
+    const largeBatch = await claim("session_event", "host-test-events");
+    const largeExport = largeBatch?.events.find((item) => item.event.id === largeEvent!.id);
+    expect(largeExport?.event.payload).toMatchObject({
+      _hostExport: {
+        payloadMode: "summary",
+        payloadTruncated: true,
+        sourceEventId: largeEvent!.id,
+        fullPayload: "retained in canonical session event",
+      },
+    });
+    expect(JSON.stringify(largeExport?.event.payload)).not.toContain("large-output:");
+    await acknowledgeHostExportBatch(exporter.db, {
+      kind: "session_event",
+      consumerId: "host-test-events",
+      leaseToken: largeBatch!.leaseToken,
+    });
+
     const foreignSession = await createSession(app.db, {
       accountId: active.grant.accountId,
       workspaceId: active.grant.workspaceId!,

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -221,6 +221,9 @@ describe("release schema contract", () => {
     const localOrganizationAdministration = completeSourceContract.migrations.some(
       (migration) => migration.path === "0386_local_organization_administration.sql",
     );
+    const boundHostExportSessionPayloads = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0387_bound_host_export_session_payloads.sql",
+    );
     const automaticSessionTitleMigrationPaths = new Set([
       "0353_automatic_session_title_policy_fence.sql",
       "0354_automatic_session_title_quarantine_index.sql",
@@ -256,6 +259,7 @@ describe("release schema contract", () => {
       "0384_codex_cooldown_revision_guard_privileges.sql",
       "0385_connected_machine_legacy_tilde_workdirs.sql",
       "0386_local_organization_administration.sql",
+      "0387_bound_host_export_session_payloads.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -297,80 +301,83 @@ describe("release schema contract", () => {
         (codexCooldownReconciliation ? 1 : 0) +
         (codexCooldownRevisionGuardPrivileges ? 1 : 0) +
         (connectedMachineLegacyTildeWorkdirs ? 1 : 0) +
-        (localOrganizationAdministration ? 1 : 0),
-      latestMigration: localOrganizationAdministration
-        ? "0386_local_organization_administration.sql"
-        : connectedMachineLegacyTildeWorkdirs
-          ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-          : codexCooldownRevisionGuardPrivileges
-            ? "0384_codex_cooldown_revision_guard_privileges.sql"
-            : codexCooldownReconciliation
-              ? "0383_codex_cooldown_reconciliation.sql"
-              : organizationApiKeyProvenance
-                ? "0382_organization_api_key_provenance.sql"
-                : organizationCodexSubscriptionInheritance
-                  ? "0381_organization_codex_subscription_inheritance.sql"
-                  : autonomousCompanyProfileAgentPolicy
-                    ? "0380_autonomous_company_profile_agent_policy.sql"
-                    : sessionEventRawLaneActivation
-                      ? "0379_session_event_raw_lane_activation.sql"
-                      : scopedRigHealthAuditTimestamp
-                        ? "0378_scoped_rig_health_audit_timestamp.sql"
-                        : scopedRigHealthProjection
-                          ? "0377_scoped_rig_health_projection.sql"
-                          : organizationWorkspaceInventory
-                            ? "0376_organization_workspace_inventory.sql"
-                            : sessionRecoveryObservability
-                              ? "0375_session_recovery_observability.sql"
-                              : sessionEventCursors
-                                ? "0374_session_event_cursors.sql"
-                                : sandboxSharedPreparation
-                                  ? "0373_sandbox_shared_preparation.sql"
-                                  : orderedVariableSetRuntimeAuthority
-                                    ? "0372_ordered_variable_set_runtime_authority.sql"
-                                    : workspaceMemberCandidateInventory
-                                      ? "0371_workspace_member_candidate_inventory.sql"
-                                      : workspaceMemberManagementScope
-                                        ? "0370_workspace_member_management_scope.sql"
-                                        : localHumanPersonalAuthority
-                                          ? "0369_local_human_personal_authority.sql"
-                                          : sessionDiscoveryClaimSearchIndex
-                                            ? "0368_session_discovery_claim_search_index.sql"
-                                            : sessionDiscoveryGoalSearchIndex
-                                              ? "0367_session_discovery_goal_search_index.sql"
-                                              : sessionDiscoveryTitleSearchIndex
-                                                ? "0366_session_discovery_title_search_index.sql"
-                                                : permissionScopedWorkClaims
-                                                  ? "0365_permission_scoped_work_claims.sql"
-                                                  : workspaceLearningPolicySnapshotLockOrder
-                                                    ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                    : organizationRecoveryCustody
-                                                      ? "0363_organization_recovery_custody.sql"
-                                                      : managedAuthSessionSets
-                                                        ? "0362_managed_auth_session_sets.sql"
-                                                        : rememberKnowledgeMemoryMaterialization
-                                                          ? "0361_remember_knowledge_memory_materialization.sql"
-                                                          : organizationIdentityConfirmationPrompt
-                                                            ? "0360_organization_identity_confirmation_prompt.sql"
-                                                            : insightsForceRlsReadCapability
-                                                              ? "0359_insights_force_rls_read_capability.sql"
-                                                              : prReviewManagedGithubApp
-                                                                ? "0358_pr_review_managed_github_app.sql"
-                                                                : rigPlatformBaseOnly
-                                                                  ? "0357_rig_platform_base_only.sql"
-                                                                  : setBasedInsightsSessionVisibility
-                                                                    ? "0356_set_based_insights_session_visibility.sql"
-                                                                    : automaticSessionTitleQuarantine
-                                                                      ? "0355_automatic_session_title_quarantine.sql"
-                                                                      : automaticSessionTitleQuarantineIndex
-                                                                        ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                        : automaticSessionTitlePolicyFence
-                                                                          ? "0353_automatic_session_title_policy_fence.sql"
-                                                                          : sessionVariableSetAttachments
-                                                                            ? "0352_session_variable_set_attachments.sql"
-                                                                            : migrationsBeforeAutomaticSessionTitles.at(
-                                                                                -1,
-                                                                              )?.path,
+        (localOrganizationAdministration ? 1 : 0) +
+        (boundHostExportSessionPayloads ? 1 : 0),
+      latestMigration: boundHostExportSessionPayloads
+        ? "0387_bound_host_export_session_payloads.sql"
+        : localOrganizationAdministration
+          ? "0386_local_organization_administration.sql"
+          : connectedMachineLegacyTildeWorkdirs
+            ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+            : codexCooldownRevisionGuardPrivileges
+              ? "0384_codex_cooldown_revision_guard_privileges.sql"
+              : codexCooldownReconciliation
+                ? "0383_codex_cooldown_reconciliation.sql"
+                : organizationApiKeyProvenance
+                  ? "0382_organization_api_key_provenance.sql"
+                  : organizationCodexSubscriptionInheritance
+                    ? "0381_organization_codex_subscription_inheritance.sql"
+                    : autonomousCompanyProfileAgentPolicy
+                      ? "0380_autonomous_company_profile_agent_policy.sql"
+                      : sessionEventRawLaneActivation
+                        ? "0379_session_event_raw_lane_activation.sql"
+                        : scopedRigHealthAuditTimestamp
+                          ? "0378_scoped_rig_health_audit_timestamp.sql"
+                          : scopedRigHealthProjection
+                            ? "0377_scoped_rig_health_projection.sql"
+                            : organizationWorkspaceInventory
+                              ? "0376_organization_workspace_inventory.sql"
+                              : sessionRecoveryObservability
+                                ? "0375_session_recovery_observability.sql"
+                                : sessionEventCursors
+                                  ? "0374_session_event_cursors.sql"
+                                  : sandboxSharedPreparation
+                                    ? "0373_sandbox_shared_preparation.sql"
+                                    : orderedVariableSetRuntimeAuthority
+                                      ? "0372_ordered_variable_set_runtime_authority.sql"
+                                      : workspaceMemberCandidateInventory
+                                        ? "0371_workspace_member_candidate_inventory.sql"
+                                        : workspaceMemberManagementScope
+                                          ? "0370_workspace_member_management_scope.sql"
+                                          : localHumanPersonalAuthority
+                                            ? "0369_local_human_personal_authority.sql"
+                                            : sessionDiscoveryClaimSearchIndex
+                                              ? "0368_session_discovery_claim_search_index.sql"
+                                              : sessionDiscoveryGoalSearchIndex
+                                                ? "0367_session_discovery_goal_search_index.sql"
+                                                : sessionDiscoveryTitleSearchIndex
+                                                  ? "0366_session_discovery_title_search_index.sql"
+                                                  : permissionScopedWorkClaims
+                                                    ? "0365_permission_scoped_work_claims.sql"
+                                                    : workspaceLearningPolicySnapshotLockOrder
+                                                      ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                      : organizationRecoveryCustody
+                                                        ? "0363_organization_recovery_custody.sql"
+                                                        : managedAuthSessionSets
+                                                          ? "0362_managed_auth_session_sets.sql"
+                                                          : rememberKnowledgeMemoryMaterialization
+                                                            ? "0361_remember_knowledge_memory_materialization.sql"
+                                                            : organizationIdentityConfirmationPrompt
+                                                              ? "0360_organization_identity_confirmation_prompt.sql"
+                                                              : insightsForceRlsReadCapability
+                                                                ? "0359_insights_force_rls_read_capability.sql"
+                                                                : prReviewManagedGithubApp
+                                                                  ? "0358_pr_review_managed_github_app.sql"
+                                                                  : rigPlatformBaseOnly
+                                                                    ? "0357_rig_platform_base_only.sql"
+                                                                    : setBasedInsightsSessionVisibility
+                                                                      ? "0356_set_based_insights_session_visibility.sql"
+                                                                      : automaticSessionTitleQuarantine
+                                                                        ? "0355_automatic_session_title_quarantine.sql"
+                                                                        : automaticSessionTitleQuarantineIndex
+                                                                          ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                          : automaticSessionTitlePolicyFence
+                                                                            ? "0353_automatic_session_title_policy_fence.sql"
+                                                                            : sessionVariableSetAttachments
+                                                                              ? "0352_session_variable_set_attachments.sql"
+                                                                              : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                  -1,
+                                                                                )?.path,
     });
   });
 
@@ -495,6 +502,7 @@ describe("release schema contract", () => {
       "0384_codex_cooldown_revision_guard_privileges.sql",
       "0385_connected_machine_legacy_tilde_workdirs.sql",
       "0386_local_organization_administration.sql",
+      "0387_bound_host_export_session_payloads.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -639,6 +647,9 @@ describe("release schema contract", () => {
     const localOrganizationAdministration = completeSourceContract.migrations.some(
       (migration) => migration.path === "0386_local_organization_administration.sql",
     );
+    const boundHostExportSessionPayloads = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0387_bound_host_export_session_payloads.sql",
+    );
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
@@ -680,90 +691,93 @@ describe("release schema contract", () => {
         (codexCooldownReconciliation ? 1 : 0) +
         (codexCooldownRevisionGuardPrivileges ? 1 : 0) +
         (connectedMachineLegacyTildeWorkdirs ? 1 : 0) +
-        (localOrganizationAdministration ? 1 : 0),
-      latestMigration: localOrganizationAdministration
-        ? "0386_local_organization_administration.sql"
-        : connectedMachineLegacyTildeWorkdirs
-          ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-          : codexCooldownRevisionGuardPrivileges
-            ? "0384_codex_cooldown_revision_guard_privileges.sql"
-            : codexCooldownReconciliation
-              ? "0383_codex_cooldown_reconciliation.sql"
-              : organizationApiKeyProvenance
-                ? "0382_organization_api_key_provenance.sql"
-                : organizationCodexSubscriptionInheritance
-                  ? "0381_organization_codex_subscription_inheritance.sql"
-                  : autonomousCompanyProfileAgentPolicy
-                    ? "0380_autonomous_company_profile_agent_policy.sql"
-                    : sessionEventRawLaneActivation
-                      ? "0379_session_event_raw_lane_activation.sql"
-                      : scopedRigHealthAuditTimestamp
-                        ? "0378_scoped_rig_health_audit_timestamp.sql"
-                        : scopedRigHealthProjection
-                          ? "0377_scoped_rig_health_projection.sql"
-                          : organizationWorkspaceInventory
-                            ? "0376_organization_workspace_inventory.sql"
-                            : sessionRecoveryObservability
-                              ? "0375_session_recovery_observability.sql"
-                              : sessionEventCursors
-                                ? "0374_session_event_cursors.sql"
-                                : sandboxSharedPreparation
-                                  ? "0373_sandbox_shared_preparation.sql"
-                                  : orderedVariableSetRuntimeAuthority
-                                    ? "0372_ordered_variable_set_runtime_authority.sql"
-                                    : workspaceMemberCandidateInventory
-                                      ? "0371_workspace_member_candidate_inventory.sql"
-                                      : workspaceMemberManagementScope
-                                        ? "0370_workspace_member_management_scope.sql"
-                                        : localHumanPersonalAuthority
-                                          ? "0369_local_human_personal_authority.sql"
-                                          : sessionDiscoveryClaimSearchIndex
-                                            ? "0368_session_discovery_claim_search_index.sql"
-                                            : sessionDiscoveryGoalSearchIndex
-                                              ? "0367_session_discovery_goal_search_index.sql"
-                                              : sessionDiscoveryTitleSearchIndex
-                                                ? "0366_session_discovery_title_search_index.sql"
-                                                : permissionScopedWorkClaims
-                                                  ? "0365_permission_scoped_work_claims.sql"
-                                                  : workspaceLearningPolicySnapshotLockOrder
-                                                    ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                    : organizationRecoveryCustody
-                                                      ? "0363_organization_recovery_custody.sql"
-                                                      : managedAuthSessionSets
-                                                        ? "0362_managed_auth_session_sets.sql"
-                                                        : sessionVariableSetAttachments
-                                                          ? "0352_session_variable_set_attachments.sql"
-                                                          : organizationUserSetupDelivery
-                                                            ? "0351_organization_user_setup_delivery.sql"
-                                                            : organizationSharedWorkspaceAdministration
-                                                              ? "0350_organization_shared_workspace_administration.sql"
-                                                              : greenfieldSessionTenancyActivation
-                                                                ? "0349_greenfield_session_tenancy_activation.sql"
-                                                                : namedSignupAndUserSetup
-                                                                  ? "0348_named_signup_and_user_setup.sql"
-                                                                  : connectionAuthorityConvergenceEvidence
-                                                                    ? "0347_connection_authority_convergence_evidence.sql"
-                                                                    : documentMigrationAuditSurface
-                                                                      ? "0346_document_migration_audit_surface.sql"
-                                                                      : tenantScopedSessionTenancyFence
-                                                                        ? "0345_tenant_scoped_session_tenancy_fence.sql"
-                                                                        : privateSessionVisibilityTransitionGate
-                                                                          ? "0344_private_session_visibility_transition_gate.sql"
-                                                                          : personalDocumentForceRlsRepair
-                                                                            ? "0343_personal_document_force_rls_lock_repair.sql"
-                                                                            : slackRoutePromptSinglePending
-                                                                              ? "0342_slack_route_prompt_single_pending.sql"
-                                                                              : slackRoutingProbeFence
-                                                                                ? "0341_slack_routing_probe_organization_fence.sql"
-                                                                                : tenancyBackfillActivationEvidence
-                                                                                  ? "0340_tenancy_backfill_activation_evidence.sql"
-                                                                                  : documentAuthorityReclassification
-                                                                                    ? "0339_document_authority_reclassification.sql"
-                                                                                    : atomicConnectedMachineAttachments
-                                                                                      ? "0338_atomic_connected_machine_attachments.sql"
-                                                                                      : routedSlackHandles
-                                                                                        ? "0337_slack_routed_action_handles.sql"
-                                                                                        : "0336_atomic_session_fork_visibility.sql",
+        (localOrganizationAdministration ? 1 : 0) +
+        (boundHostExportSessionPayloads ? 1 : 0),
+      latestMigration: boundHostExportSessionPayloads
+        ? "0387_bound_host_export_session_payloads.sql"
+        : localOrganizationAdministration
+          ? "0386_local_organization_administration.sql"
+          : connectedMachineLegacyTildeWorkdirs
+            ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+            : codexCooldownRevisionGuardPrivileges
+              ? "0384_codex_cooldown_revision_guard_privileges.sql"
+              : codexCooldownReconciliation
+                ? "0383_codex_cooldown_reconciliation.sql"
+                : organizationApiKeyProvenance
+                  ? "0382_organization_api_key_provenance.sql"
+                  : organizationCodexSubscriptionInheritance
+                    ? "0381_organization_codex_subscription_inheritance.sql"
+                    : autonomousCompanyProfileAgentPolicy
+                      ? "0380_autonomous_company_profile_agent_policy.sql"
+                      : sessionEventRawLaneActivation
+                        ? "0379_session_event_raw_lane_activation.sql"
+                        : scopedRigHealthAuditTimestamp
+                          ? "0378_scoped_rig_health_audit_timestamp.sql"
+                          : scopedRigHealthProjection
+                            ? "0377_scoped_rig_health_projection.sql"
+                            : organizationWorkspaceInventory
+                              ? "0376_organization_workspace_inventory.sql"
+                              : sessionRecoveryObservability
+                                ? "0375_session_recovery_observability.sql"
+                                : sessionEventCursors
+                                  ? "0374_session_event_cursors.sql"
+                                  : sandboxSharedPreparation
+                                    ? "0373_sandbox_shared_preparation.sql"
+                                    : orderedVariableSetRuntimeAuthority
+                                      ? "0372_ordered_variable_set_runtime_authority.sql"
+                                      : workspaceMemberCandidateInventory
+                                        ? "0371_workspace_member_candidate_inventory.sql"
+                                        : workspaceMemberManagementScope
+                                          ? "0370_workspace_member_management_scope.sql"
+                                          : localHumanPersonalAuthority
+                                            ? "0369_local_human_personal_authority.sql"
+                                            : sessionDiscoveryClaimSearchIndex
+                                              ? "0368_session_discovery_claim_search_index.sql"
+                                              : sessionDiscoveryGoalSearchIndex
+                                                ? "0367_session_discovery_goal_search_index.sql"
+                                                : sessionDiscoveryTitleSearchIndex
+                                                  ? "0366_session_discovery_title_search_index.sql"
+                                                  : permissionScopedWorkClaims
+                                                    ? "0365_permission_scoped_work_claims.sql"
+                                                    : workspaceLearningPolicySnapshotLockOrder
+                                                      ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                      : organizationRecoveryCustody
+                                                        ? "0363_organization_recovery_custody.sql"
+                                                        : managedAuthSessionSets
+                                                          ? "0362_managed_auth_session_sets.sql"
+                                                          : sessionVariableSetAttachments
+                                                            ? "0352_session_variable_set_attachments.sql"
+                                                            : organizationUserSetupDelivery
+                                                              ? "0351_organization_user_setup_delivery.sql"
+                                                              : organizationSharedWorkspaceAdministration
+                                                                ? "0350_organization_shared_workspace_administration.sql"
+                                                                : greenfieldSessionTenancyActivation
+                                                                  ? "0349_greenfield_session_tenancy_activation.sql"
+                                                                  : namedSignupAndUserSetup
+                                                                    ? "0348_named_signup_and_user_setup.sql"
+                                                                    : connectionAuthorityConvergenceEvidence
+                                                                      ? "0347_connection_authority_convergence_evidence.sql"
+                                                                      : documentMigrationAuditSurface
+                                                                        ? "0346_document_migration_audit_surface.sql"
+                                                                        : tenantScopedSessionTenancyFence
+                                                                          ? "0345_tenant_scoped_session_tenancy_fence.sql"
+                                                                          : privateSessionVisibilityTransitionGate
+                                                                            ? "0344_private_session_visibility_transition_gate.sql"
+                                                                            : personalDocumentForceRlsRepair
+                                                                              ? "0343_personal_document_force_rls_lock_repair.sql"
+                                                                              : slackRoutePromptSinglePending
+                                                                                ? "0342_slack_route_prompt_single_pending.sql"
+                                                                                : slackRoutingProbeFence
+                                                                                  ? "0341_slack_routing_probe_organization_fence.sql"
+                                                                                  : tenancyBackfillActivationEvidence
+                                                                                    ? "0340_tenancy_backfill_activation_evidence.sql"
+                                                                                    : documentAuthorityReclassification
+                                                                                      ? "0339_document_authority_reclassification.sql"
+                                                                                      : atomicConnectedMachineAttachments
+                                                                                        ? "0338_atomic_connected_machine_attachments.sql"
+                                                                                        : routedSlackHandles
+                                                                                          ? "0337_slack_routed_action_handles.sql"
+                                                                                          : "0336_atomic_session_fork_visibility.sql",
     });
     expect(
       completeSourceContract.migrations.find(


### PR DESCRIPTION
## Incident

A valid large `agent.toolCall.output` payload exceeded the optional host-export outbox envelope check. Because capture runs as a deferred constraint trigger, interruption and terminal settlement rolled back at commit. Session `7cb5dd86-a995-4779-8e9a-a606286ae527` remained behind a zombie claimed attempt while Temporal retried the same settlement hundreds of times.

## Fix

- retain the complete lossless canonical `session_events` payload
- store an explicit content-free bounded projection in host export when the payload exceeds 64 KiB
- clear the application codec marker only for that literal SQL projection
- preserve exact bounded payloads and existing at-least-once cursor/idempotency semantics
- add real-PostgreSQL regression coverage for a 160 KB tool output

## Verification

- DB typecheck
- migration ordinals/RLS/schema/test-budget guards
- release schema contract: 7 pass
- oxfmt + oxlint
- real PostgreSQL test added; local Docker unavailable, mandatory CI real-service lane is authoritative

Linear: OPE-415

## Summary by Sourcery

Keep large canonical session events lossless while bounding optional host-export projections so event and lifecycle transactions remain reliable.

Bug Fixes:
- Prevent oversized session-event payloads from rolling back session lifecycle settlement by bounding their optional host-export representation.
- Retain complete canonical session-event payloads while emitting content-free truncation receipts for oversized host exports.

Enhancements:
- Preserve codec metadata for retained payloads and explicitly clear it for literal JSON truncation projections without changing host-export delivery semantics.

Deployment:
- Add a rolling database migration that bounds oversized session-event host-export projections and updates their schema documentation.

Documentation:
- Document lossless canonical event storage and bounded host-export behavior for oversized payloads.

Tests:
- Add real-PostgreSQL regression coverage for large tool outputs and update release schema migration contracts.