### PR TITLE
fix(runtime): contain connector binding rejections

### DIFF
--- a/.changeset/calm-connector-authority.md
+++ b/.changeset/calm-connector-authority.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Contain pre-execution connector authority mismatches as model-visible tool errors instead of failing the whole agent turn.

--- a/apps/worker/src/github-rest-mcp.ts
+++ b/apps/worker/src/github-rest-mcp.ts
@@ -31,6 +31,7 @@ import {
 import { createGitHubAppInstallationTokenWithExpiry, githubAppBotIdentity } from "@opengeni/github";
 import {
   type AttemptConnectorActionBinding,
+  ConnectorActionBindingRejectedError,
   type LocalMcpServerRegistration,
   prefixedMcpToolName,
 } from "@opengeni/runtime";
@@ -624,7 +625,7 @@ function githubConnectorBindings(
         const repository =
           typeof args.repository === "string" ? byName.get(args.repository.toLowerCase()) : null;
         if (!repository) {
-          throw new GitHubRestAuthorityError(
+          throw new ConnectorActionBindingRejectedError(
             "GitHub action repository does not match an accepted resource",
           );
         }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2683,9 +2683,17 @@ function installAttemptConnectorActionPolicy(
           if (!callId) {
             throw new Error("Attempt connector action is missing its durable approval identity");
           }
-          const preparation = await connectorActionPolicy.prepare(
-            binding.call(callId, parsedInput),
-          );
+          let call: ConnectorActionToolCall;
+          try {
+            call = binding.call(callId, parsedInput);
+          } catch {
+            // Exact-resource and connection bindings are evaluated before the
+            // provider can run. A model can name a repository outside the
+            // accepted turn resources; that is an ordinary rejected tool call,
+            // not an Agents SDK lifecycle failure.
+            return false;
+          }
+          const preparation = await connectorActionPolicy.prepare(call);
           if (!preparation.managed || preparation.decision === "block") return false;
           return (
             preparation.decision === "ask" ||
@@ -2706,7 +2714,21 @@ function installAttemptConnectorActionPolicy(
           } catch {
             throw new Error("Attempt connector action was not executed: malformed tool input");
           }
-          const admission = await connectorActionPolicy.begin(binding.call(callId, parsedInput));
+          let call: ConnectorActionToolCall;
+          try {
+            call = binding.call(callId, parsedInput);
+          } catch {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text" as const,
+                  text: "Connector action was not executed because its arguments are outside this turn's accepted authority.",
+                },
+              ],
+            };
+          }
+          const admission = await connectorActionPolicy.begin(call);
           if (!admission.allowed) {
             throw new Error(`Attempt connector action was not executed: ${admission.reason}`);
           }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1457,6 +1457,11 @@ export type ConnectorActionPolicyHooks = {
   }) => Promise<void>;
 };
 
+/** Expected rejection when model arguments do not match an attempt's frozen connector authority. */
+export class ConnectorActionBindingRejectedError extends Error {
+  override readonly name = "ConnectorActionBindingRejectedError";
+}
+
 /** Exact private binding for one attempt-local model tool backed by a connector action. */
 export type AttemptConnectorActionBinding = {
   modelName: string;
@@ -2686,7 +2691,8 @@ function installAttemptConnectorActionPolicy(
           let call: ConnectorActionToolCall;
           try {
             call = binding.call(callId, parsedInput);
-          } catch {
+          } catch (error) {
+            if (!(error instanceof ConnectorActionBindingRejectedError)) throw error;
             // Exact-resource and connection bindings are evaluated before the
             // provider can run. A model can name a repository outside the
             // accepted turn resources; that is an ordinary rejected tool call,
@@ -2717,7 +2723,8 @@ function installAttemptConnectorActionPolicy(
           let call: ConnectorActionToolCall;
           try {
             call = binding.call(callId, parsedInput);
-          } catch {
+          } catch (error) {
+            if (!(error instanceof ConnectorActionBindingRejectedError)) throw error;
             return {
               isError: true,
               content: [

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2366,6 +2366,95 @@ describe("runtime event normalization", () => {
       }
     });
 
+    test("attempt-local connector binding rejection becomes a tool error", async () => {
+      const executions: Record<string, unknown>[] = [];
+      const prepared = await prepareAgentTools(testSettings(), [], {
+        accountId: "11111111-1111-4111-8111-111111111111",
+        workspaceId: "22222222-2222-4222-8222-222222222222",
+        sessionId: "33333333-3333-4333-8333-333333333333",
+        turnId: "44444444-4444-4444-8444-444444444444",
+        attemptId: "55555555-5555-4555-8555-555555555555",
+        executionGeneration: 1,
+        attemptToolDefinitions: [
+          {
+            identity: { serverId: "github_app", toolName: "repository_get" },
+            modelName: "github_app__repository_get",
+            inputSchema: {
+              type: "object",
+              properties: { repository: { type: "string" } },
+              required: ["repository"],
+              additionalProperties: false,
+            },
+            source: "mcp",
+            approval: "policy",
+            execute: async (args) => {
+              executions.push(args);
+              return { content: [{ type: "text", text: "repository" }] };
+            },
+          },
+        ],
+      });
+      const policyCalls: string[] = [];
+      const hooks: ConnectorActionPolicyHooks = {
+        prepare: async () => {
+          policyCalls.push("prepare");
+          return { managed: false, decision: "unmanaged" };
+        },
+        begin: async () => {
+          policyCalls.push("begin");
+          return { allowed: true, managed: false };
+        },
+        complete: async () => {
+          policyCalls.push("complete");
+        },
+      };
+      const agent = buildOpenGeniAgent(testSettings(), [], {
+        mcpServers: prepared.mcpServers,
+        connectorActionPolicy: hooks,
+        attemptConnectorActionBindings: [
+          {
+            modelName: "github_app__repository_get",
+            call: () => {
+              throw new Error("repository is outside accepted resources");
+            },
+          },
+        ],
+      });
+      try {
+        const [tool] = (await agent.getMcpTools(new RunContext())).filter(
+          (candidate) =>
+            candidate.type === "function" && candidate.name === "github_app__repository_get",
+        );
+        if (!tool || tool.type !== "function") throw new Error("attempt connector tool missing");
+        expect(
+          await tool.needsApproval(
+            new RunContext(),
+            { repository: "Cloudgeni-ai/not-accepted" },
+            "call-rejected",
+          ),
+        ).toBe(false);
+        expect(
+          await tool.invoke(
+            new RunContext(),
+            JSON.stringify({ repository: "Cloudgeni-ai/not-accepted" }),
+            { toolCall: { callId: "call-rejected" } } as any,
+          ),
+        ).toEqual({
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Connector action was not executed because its arguments are outside this turn's accepted authority.",
+            },
+          ],
+        });
+        expect(executions).toEqual([]);
+        expect(policyCalls).toEqual([]);
+      } finally {
+        await prepared.close();
+      }
+    });
+
     test("attempt-local connector bindings preserve unmanaged read execution", async () => {
       const executions: Record<string, unknown>[] = [];
       const prepared = await prepareAgentTools(testSettings(), [], {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -51,6 +51,7 @@ import {
   buildManifest,
   compactMcpResultCustomDataRunState,
   composeAgentInstructions,
+  ConnectorActionBindingRejectedError,
   configureRuntimeMetricsHooks,
   connectMcpServersInBatches,
   coreInstructions,
@@ -2415,7 +2416,9 @@ describe("runtime event normalization", () => {
           {
             modelName: "github_app__repository_get",
             call: () => {
-              throw new Error("repository is outside accepted resources");
+              throw new ConnectorActionBindingRejectedError(
+                "repository is outside accepted resources",
+              );
             },
           },
         ],
@@ -2450,6 +2453,39 @@ describe("runtime event normalization", () => {
         });
         expect(executions).toEqual([]);
         expect(policyCalls).toEqual([]);
+
+        const bugAgent = buildOpenGeniAgent(testSettings(), [], {
+          mcpServers: prepared.mcpServers,
+          connectorActionPolicy: hooks,
+          attemptConnectorActionBindings: [
+            {
+              modelName: "github_app__repository_get",
+              call: () => {
+                throw new Error("unexpected binding bug");
+              },
+            },
+          ],
+        });
+        const [bugTool] = (await bugAgent.getMcpTools(new RunContext())).filter(
+          (candidate) =>
+            candidate.type === "function" && candidate.name === "github_app__repository_get",
+        );
+        if (!bugTool || bugTool.type !== "function")
+          throw new Error("attempt connector tool missing");
+        await expect(
+          bugTool.needsApproval(
+            new RunContext(),
+            { repository: "Cloudgeni-ai/not-accepted" },
+            "call-bug",
+          ),
+        ).rejects.toThrow("unexpected binding bug");
+        await expect(
+          bugTool.invoke(
+            new RunContext(),
+            JSON.stringify({ repository: "Cloudgeni-ai/not-accepted" }),
+            { toolCall: { callId: "call-bug" } } as any,
+          ),
+        ).rejects.toThrow("unexpected binding bug");
       } finally {
         await prepared.close();
       }


### PR DESCRIPTION
## Summary
- contain attempt-local connector binding rejection as a model-visible MCP tool error
- skip provider execution and approval-policy hooks for rejected authority
- add regression coverage for the full approval/invocation boundary

## Verification
- `bun test packages/runtime/test/runtime.test.ts` (293 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

## Summary by Sourcery

Contain rejected connector bindings at the tool boundary so unauthorized calls return safe tool errors without executing or invoking policy hooks.

Bug Fixes:
- Contain attempt-local connector authority mismatches as model-visible MCP tool errors instead of failing the agent turn.
- Skip connector provider execution and approval-policy hooks when tool arguments are outside the attempt's accepted authority.

Tests:
- Add regression coverage for rejected connector bindings across approval and invocation, including propagation of unexpected binding errors.