### PR TITLE
fix(web): remember the last workspace

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -512,18 +512,13 @@ export function App() {
 function RootIndexRoute() {
   const context = useAppContext();
   const { workspaceId: requestedWorkspaceId } = indexRoute.useSearch();
-  const listedWorkspaceIds = context.workspaces.map((workspace) => workspace.id);
-  const grantedWorkspaceIds = context.accessContext.workspaceGrants.map(
-    (grant) => grant.workspaceId,
-  );
   const workspaceId = resolveLandingWorkspaceId({
     requestedWorkspaceId,
     rememberedWorkspaceId: readLastWorkspaceId(
       workspaceNavigationPreferenceStorageId(context.accessContext.subjectId),
     ),
-    defaultWorkspaceId: context.accessContext.defaultWorkspaceId,
-    listedWorkspaceIds,
-    grantedWorkspaceIds,
+    workspaces: context.workspaces,
+    accessContext: context.accessContext,
   });
   if (!workspaceId) {
     return (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 // Route assembly only — components live under src/routes, shared state in
 // src/context.tsx, logic in src/lib. Route map:
-//   /                                        → default-workspace redirect
+//   /                                        → remembered/default workspace redirect
 //   /workspaces/:id                          → sessions redirect
 //   /workspaces/:id/agent                    → sessions redirect (legacy URL)
 //   /workspaces/:id/sessions                 → sessions index + create
@@ -40,6 +40,13 @@ import { ROUTER_PENDING_OPTIONS } from "@/components/route-pending";
 import { RootRouteComponent, useAppContext } from "@/context";
 import { parseComposerLaunchSearch, type ComposerLaunchSearch } from "@/lib/composer-launch";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
+import {
+  parseRootWorkspaceSearch,
+  readLastWorkspaceId,
+  resolveLandingWorkspaceId,
+  type RootWorkspaceSearch,
+  workspaceNavigationPreferenceStorageId,
+} from "@/lib/workspace-navigation-preference";
 import type { DocumentAuthorityKind } from "@opengeni/sdk";
 
 type OrganizationAdminSection =
@@ -145,6 +152,8 @@ const rootRoute = createRootRoute({
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
+  validateSearch: (search: Record<string, unknown>): RootWorkspaceSearch =>
+    parseRootWorkspaceSearch(search),
   component: RootIndexRoute,
 });
 const sessionDeepLinkRoute = createRoute({
@@ -502,10 +511,20 @@ export function App() {
 
 function RootIndexRoute() {
   const context = useAppContext();
-  const workspaceId =
-    context.accessContext.defaultWorkspaceId ??
-    context.workspaces[0]?.id ??
-    context.accessContext.workspaceGrants[0]?.workspaceId;
+  const { workspaceId: requestedWorkspaceId } = indexRoute.useSearch();
+  const listedWorkspaceIds = context.workspaces.map((workspace) => workspace.id);
+  const grantedWorkspaceIds = context.accessContext.workspaceGrants.map(
+    (grant) => grant.workspaceId,
+  );
+  const workspaceId = resolveLandingWorkspaceId({
+    requestedWorkspaceId,
+    rememberedWorkspaceId: readLastWorkspaceId(
+      workspaceNavigationPreferenceStorageId(context.accessContext.subjectId),
+    ),
+    defaultWorkspaceId: context.accessContext.defaultWorkspaceId,
+    listedWorkspaceIds,
+    grantedWorkspaceIds,
+  });
   if (!workspaceId) {
     return (
       <ProblemPanel

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -1010,9 +1010,7 @@ export function RootRouteComponent() {
   useEffect(() => {
     if (!accessContext) return;
     const workspaceId = /^\/workspaces\/([^/]+)/.exec(pathname)?.[1] ?? null;
-    const listedWorkspaceIds = workspaces.map((workspace) => workspace.id);
-    const grantedWorkspaceIds = accessContext.workspaceGrants.map((grant) => grant.workspaceId);
-    if (!isAuthorizedWorkspaceId(workspaceId, listedWorkspaceIds, grantedWorkspaceIds)) return;
+    if (!isAuthorizedWorkspaceId(workspaceId, workspaces, accessContext)) return;
     writeLastWorkspaceId(
       workspaceNavigationPreferenceStorageId(accessContext.subjectId),
       workspaceId,

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -79,6 +79,11 @@ import {
   SessionChannelProjectionAuthority,
 } from "@/lib/session-pins";
 import {
+  isAuthorizedWorkspaceId,
+  workspaceNavigationPreferenceStorageId,
+  writeLastWorkspaceId,
+} from "@/lib/workspace-navigation-preference";
+import {
   buildResources,
   buildOpenGeniUiTools,
   enabledWorkspaceCapabilityMcpServers,
@@ -997,6 +1002,22 @@ export function RootRouteComponent() {
     client,
     invalidatePrincipalWorkspaceState,
   ]);
+
+  // The workspace URL remains authoritative. This browser-local preference is
+  // only the landing target for a future visit to `/`, and is namespaced by the
+  // current subject so browser-account transitions cannot inherit each other's
+  // workspace selection.
+  useEffect(() => {
+    if (!accessContext) return;
+    const workspaceId = /^\/workspaces\/([^/]+)/.exec(pathname)?.[1] ?? null;
+    const listedWorkspaceIds = workspaces.map((workspace) => workspace.id);
+    const grantedWorkspaceIds = accessContext.workspaceGrants.map((grant) => grant.workspaceId);
+    if (!isAuthorizedWorkspaceId(workspaceId, listedWorkspaceIds, grantedWorkspaceIds)) return;
+    writeLastWorkspaceId(
+      workspaceNavigationPreferenceStorageId(accessContext.subjectId),
+      workspaceId,
+    );
+  }, [accessContext, pathname, workspaces]);
 
   // New-chat policy follows the active workspace. Explicit composer choices
   // remain local until the route moves to another workspace or its durable

--- a/apps/web/src/lib/workspace-navigation-preference.test.ts
+++ b/apps/web/src/lib/workspace-navigation-preference.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isAuthorizedWorkspaceId,
+  parseRootWorkspaceSearch,
+  readLastWorkspaceId,
+  resolveLandingWorkspaceId,
+  workspaceNavigationPreferenceStorageId,
+  writeLastWorkspaceId,
+} from "./workspace-navigation-preference";
+
+function memoryStorage(): Pick<Storage, "getItem" | "setItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("workspace navigation preference", () => {
+  test("scopes the remembered workspace to the authenticated subject", () => {
+    expect(workspaceNavigationPreferenceStorageId("user:one")).not.toBe(
+      workspaceNavigationPreferenceStorageId("user:two"),
+    );
+  });
+
+  test("round-trips one browser-local last workspace", () => {
+    const storage = memoryStorage();
+    const storageId = workspaceNavigationPreferenceStorageId("user:one");
+
+    expect(readLastWorkspaceId(storageId, storage)).toBeNull();
+    writeLastWorkspaceId(storageId, "workspace-b", storage);
+    expect(readLastWorkspaceId(storageId, storage)).toBe("workspace-b");
+  });
+
+  test("keeps navigation usable when browser storage is unavailable", () => {
+    const denied = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    };
+
+    expect(readLastWorkspaceId("preference", denied)).toBeNull();
+    expect(() => writeLastWorkspaceId("preference", "workspace-a", denied)).not.toThrow();
+  });
+
+  test("accepts one bounded callback workspace parameter", () => {
+    expect(parseRootWorkspaceSearch({ workspaceId: "workspace-a" })).toEqual({
+      workspaceId: "workspace-a",
+    });
+    expect(parseRootWorkspaceSearch({ workspaceId: ["workspace-a"] })).toEqual({});
+    expect(parseRootWorkspaceSearch({ workspaceId: "" })).toEqual({});
+    expect(parseRootWorkspaceSearch({ workspaceId: "x".repeat(257) })).toEqual({});
+  });
+
+  test("prefers an authorized callback target over the remembered workspace", () => {
+    expect(
+      resolveLandingWorkspaceId({
+        requestedWorkspaceId: "workspace-c",
+        rememberedWorkspaceId: "workspace-b",
+        defaultWorkspaceId: "workspace-personal",
+        listedWorkspaceIds: ["workspace-personal", "workspace-b", "workspace-c"],
+        grantedWorkspaceIds: [],
+      }),
+    ).toBe("workspace-c");
+  });
+
+  test("uses the remembered workspace before the Personal default", () => {
+    expect(
+      resolveLandingWorkspaceId({
+        rememberedWorkspaceId: "workspace-shared",
+        defaultWorkspaceId: "workspace-personal",
+        listedWorkspaceIds: ["workspace-personal", "workspace-shared"],
+        grantedWorkspaceIds: [],
+      }),
+    ).toBe("workspace-shared");
+  });
+
+  test("ignores callback and stored workspaces that are no longer authorized", () => {
+    expect(
+      resolveLandingWorkspaceId({
+        requestedWorkspaceId: "workspace-revoked",
+        rememberedWorkspaceId: "workspace-deleted",
+        defaultWorkspaceId: "workspace-personal",
+        listedWorkspaceIds: ["workspace-personal"],
+        grantedWorkspaceIds: [],
+      }),
+    ).toBe("workspace-personal");
+  });
+
+  test("recognizes workspace grants when the workspace inventory is sparse", () => {
+    expect(isAuthorizedWorkspaceId("workspace-granted", [], ["workspace-granted"])).toBe(true);
+    expect(
+      resolveLandingWorkspaceId({
+        rememberedWorkspaceId: "workspace-granted",
+        defaultWorkspaceId: null,
+        listedWorkspaceIds: [],
+        grantedWorkspaceIds: ["workspace-granted"],
+      }),
+    ).toBe("workspace-granted");
+  });
+});

--- a/apps/web/src/lib/workspace-navigation-preference.test.ts
+++ b/apps/web/src/lib/workspace-navigation-preference.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AccessContext, Workspace } from "@/types";
+
 import {
   isAuthorizedWorkspaceId,
   parseRootWorkspaceSearch,
@@ -14,6 +16,54 @@ function memoryStorage(): Pick<Storage, "getItem" | "setItem"> {
   return {
     getItem: (key) => values.get(key) ?? null,
     setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function workspace(id: string, accountId = "account-one"): Workspace {
+  return {
+    id,
+    accountId,
+    kind: "shared",
+    name: id,
+    slug: null,
+    externalSource: null,
+    externalId: null,
+    agentInstructions: null,
+    settings: {},
+    inferenceControl: {
+      state: "active",
+      revision: 0,
+      reason: null,
+      changedBy: null,
+      changedAt: null,
+    },
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+  };
+}
+
+function accessContext(
+  input: {
+    workspaceIds?: readonly string[];
+    defaultWorkspaceId?: string | null;
+    subjectId?: string;
+    accountId?: string;
+  } = {},
+): AccessContext {
+  const subjectId = input.subjectId ?? "subject-one";
+  const accountId = input.accountId ?? "account-one";
+  return {
+    mode: "managed",
+    subjectId,
+    accountGrants: [],
+    workspaceGrants: (input.workspaceIds ?? []).map((workspaceId) => ({
+      workspaceId,
+      accountId,
+      subjectId,
+      permissions: ["workspace:read"],
+    })),
+    defaultAccountId: accountId,
+    defaultWorkspaceId: input.defaultWorkspaceId ?? null,
   };
 }
 
@@ -57,49 +107,99 @@ describe("workspace navigation preference", () => {
   });
 
   test("prefers an authorized callback target over the remembered workspace", () => {
+    const workspaces = [
+      workspace("workspace-personal"),
+      workspace("workspace-b"),
+      workspace("workspace-c"),
+    ];
     expect(
       resolveLandingWorkspaceId({
         requestedWorkspaceId: "workspace-c",
         rememberedWorkspaceId: "workspace-b",
-        defaultWorkspaceId: "workspace-personal",
-        listedWorkspaceIds: ["workspace-personal", "workspace-b", "workspace-c"],
-        grantedWorkspaceIds: [],
+        workspaces,
+        accessContext: accessContext({
+          workspaceIds: workspaces.map((candidate) => candidate.id),
+          defaultWorkspaceId: "workspace-personal",
+        }),
       }),
     ).toBe("workspace-c");
   });
 
   test("uses the remembered workspace before the Personal default", () => {
+    const workspaces = [workspace("workspace-personal"), workspace("workspace-shared")];
     expect(
       resolveLandingWorkspaceId({
         rememberedWorkspaceId: "workspace-shared",
-        defaultWorkspaceId: "workspace-personal",
-        listedWorkspaceIds: ["workspace-personal", "workspace-shared"],
-        grantedWorkspaceIds: [],
+        workspaces,
+        accessContext: accessContext({
+          workspaceIds: workspaces.map((candidate) => candidate.id),
+          defaultWorkspaceId: "workspace-personal",
+        }),
       }),
     ).toBe("workspace-shared");
   });
 
   test("ignores callback and stored workspaces that are no longer authorized", () => {
+    const workspaces = [workspace("workspace-personal")];
     expect(
       resolveLandingWorkspaceId({
         requestedWorkspaceId: "workspace-revoked",
         rememberedWorkspaceId: "workspace-deleted",
-        defaultWorkspaceId: "workspace-personal",
-        listedWorkspaceIds: ["workspace-personal"],
-        grantedWorkspaceIds: [],
+        workspaces,
+        accessContext: accessContext({
+          workspaceIds: ["workspace-personal", "workspace-deleted"],
+          defaultWorkspaceId: "workspace-personal",
+        }),
       }),
     ).toBe("workspace-personal");
   });
 
-  test("recognizes workspace grants when the workspace inventory is sparse", () => {
-    expect(isAuthorizedWorkspaceId("workspace-granted", [], ["workspace-granted"])).toBe(true);
+  test("requires the live workspace row and its exact current-subject grant to agree", () => {
+    const listed = workspace("workspace-listed");
+    const exactAccess = accessContext({ workspaceIds: [listed.id] });
+    expect(isAuthorizedWorkspaceId(listed.id, [listed], exactAccess)).toBe(true);
+    expect(isAuthorizedWorkspaceId(listed.id, [listed], accessContext())).toBe(false);
+    expect(isAuthorizedWorkspaceId(listed.id, [], exactAccess)).toBe(false);
+    expect(
+      isAuthorizedWorkspaceId(listed.id, [listed], {
+        ...exactAccess,
+        workspaceGrants: [{ ...exactAccess.workspaceGrants[0]!, accountId: "account-other" }],
+      }),
+    ).toBe(false);
+    expect(
+      isAuthorizedWorkspaceId(listed.id, [listed], {
+        ...exactAccess,
+        workspaceGrants: [{ ...exactAccess.workspaceGrants[0]!, subjectId: "subject-other" }],
+      }),
+    ).toBe(false);
+  });
+
+  test("does not select a deleted default from a stale grant after access refresh fails", () => {
+    const available = workspace("workspace-available");
     expect(
       resolveLandingWorkspaceId({
-        rememberedWorkspaceId: "workspace-granted",
-        defaultWorkspaceId: null,
-        listedWorkspaceIds: [],
-        grantedWorkspaceIds: ["workspace-granted"],
+        rememberedWorkspaceId: "workspace-deleted",
+        workspaces: [available],
+        accessContext: accessContext({
+          workspaceIds: ["workspace-deleted", available.id],
+          defaultWorkspaceId: "workspace-deleted",
+        }),
       }),
-    ).toBe("workspace-granted");
+    ).toBe(available.id);
+  });
+
+  test("returns no landing target when only one-sided workspace evidence remains", () => {
+    const listed = workspace("workspace-listed");
+    expect(
+      resolveLandingWorkspaceId({
+        requestedWorkspaceId: "workspace-granted-only",
+        rememberedWorkspaceId: listed.id,
+        workspaces: [listed],
+        accessContext: accessContext({
+          workspaceIds: ["workspace-granted-only"],
+          defaultWorkspaceId: "workspace-granted-only",
+        }),
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/workspace-navigation-preference.ts
+++ b/apps/web/src/lib/workspace-navigation-preference.ts
@@ -1,0 +1,102 @@
+const WORKSPACE_NAVIGATION_PREFERENCE_VERSION = 1;
+const MAX_WORKSPACE_ID_LENGTH = 256;
+
+type WorkspaceNavigationStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type RootWorkspaceSearch = {
+  workspaceId?: string;
+};
+
+export function workspaceNavigationPreferenceStorageId(subjectId: string): string {
+  return [
+    "og.workspace.navigation",
+    `v${WORKSPACE_NAVIGATION_PREFERENCE_VERSION}`,
+    encodeURIComponent(subjectId),
+  ].join(":");
+}
+
+export function parseRootWorkspaceSearch(search: Record<string, unknown>): RootWorkspaceSearch {
+  const workspaceId = boundedWorkspaceId(search.workspaceId);
+  return workspaceId ? { workspaceId } : {};
+}
+
+export function readLastWorkspaceId(
+  preferenceStorageId: string,
+  storage: WorkspaceNavigationStorage | null = browserStorage(),
+): string | null {
+  if (!storage) return null;
+  try {
+    return boundedWorkspaceId(storage.getItem(preferenceStorageId));
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastWorkspaceId(
+  preferenceStorageId: string,
+  workspaceId: string,
+  storage: WorkspaceNavigationStorage | null = browserStorage(),
+): void {
+  if (!storage || !boundedWorkspaceId(workspaceId)) return;
+  try {
+    storage.setItem(preferenceStorageId, workspaceId);
+  } catch {
+    // Navigation remains URL-authoritative when storage is blocked or full.
+  }
+}
+
+export function isAuthorizedWorkspaceId(
+  workspaceId: string | null | undefined,
+  listedWorkspaceIds: readonly string[],
+  grantedWorkspaceIds: readonly string[],
+): workspaceId is string {
+  return Boolean(
+    workspaceId &&
+    (listedWorkspaceIds.includes(workspaceId) || grantedWorkspaceIds.includes(workspaceId)),
+  );
+}
+
+export function resolveLandingWorkspaceId(input: {
+  requestedWorkspaceId?: string | null;
+  rememberedWorkspaceId?: string | null;
+  defaultWorkspaceId?: string | null;
+  listedWorkspaceIds: readonly string[];
+  grantedWorkspaceIds: readonly string[];
+}): string | null {
+  if (
+    isAuthorizedWorkspaceId(
+      input.requestedWorkspaceId,
+      input.listedWorkspaceIds,
+      input.grantedWorkspaceIds,
+    )
+  ) {
+    return input.requestedWorkspaceId;
+  }
+  if (
+    isAuthorizedWorkspaceId(
+      input.rememberedWorkspaceId,
+      input.listedWorkspaceIds,
+      input.grantedWorkspaceIds,
+    )
+  ) {
+    return input.rememberedWorkspaceId;
+  }
+  return (
+    input.defaultWorkspaceId ?? input.listedWorkspaceIds[0] ?? input.grantedWorkspaceIds[0] ?? null
+  );
+}
+
+function boundedWorkspaceId(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_WORKSPACE_ID_LENGTH
+    ? value
+    : null;
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/workspace-navigation-preference.ts
+++ b/apps/web/src/lib/workspace-navigation-preference.ts
@@ -1,3 +1,7 @@
+import type { AccessContext, Workspace } from "@/types";
+
+import { authorizedWorkspaceFromList } from "./workspace-scope-context";
+
 const WORKSPACE_NAVIGATION_PREFERENCE_VERSION = 1;
 const MAX_WORKSPACE_ID_LENGTH = 256;
 
@@ -47,42 +51,44 @@ export function writeLastWorkspaceId(
 
 export function isAuthorizedWorkspaceId(
   workspaceId: string | null | undefined,
-  listedWorkspaceIds: readonly string[],
-  grantedWorkspaceIds: readonly string[],
+  workspaces: readonly Workspace[],
+  accessContext: AccessContext,
 ): workspaceId is string {
   return Boolean(
     workspaceId &&
-    (listedWorkspaceIds.includes(workspaceId) || grantedWorkspaceIds.includes(workspaceId)),
+    authorizedWorkspaceFromList({
+      workspaceId,
+      workspaces,
+      accessContext,
+    }),
   );
 }
 
 export function resolveLandingWorkspaceId(input: {
   requestedWorkspaceId?: string | null;
   rememberedWorkspaceId?: string | null;
-  defaultWorkspaceId?: string | null;
-  listedWorkspaceIds: readonly string[];
-  grantedWorkspaceIds: readonly string[];
+  workspaces: readonly Workspace[];
+  accessContext: AccessContext;
 }): string | null {
-  if (
-    isAuthorizedWorkspaceId(
-      input.requestedWorkspaceId,
-      input.listedWorkspaceIds,
-      input.grantedWorkspaceIds,
-    )
-  ) {
+  if (isAuthorizedWorkspaceId(input.requestedWorkspaceId, input.workspaces, input.accessContext)) {
     return input.requestedWorkspaceId;
   }
-  if (
-    isAuthorizedWorkspaceId(
-      input.rememberedWorkspaceId,
-      input.listedWorkspaceIds,
-      input.grantedWorkspaceIds,
-    )
-  ) {
+  if (isAuthorizedWorkspaceId(input.rememberedWorkspaceId, input.workspaces, input.accessContext)) {
     return input.rememberedWorkspaceId;
   }
+  if (
+    isAuthorizedWorkspaceId(
+      input.accessContext.defaultWorkspaceId,
+      input.workspaces,
+      input.accessContext,
+    )
+  ) {
+    return input.accessContext.defaultWorkspaceId;
+  }
   return (
-    input.defaultWorkspaceId ?? input.listedWorkspaceIds[0] ?? input.grantedWorkspaceIds[0] ?? null
+    input.workspaces.find((workspace) =>
+      isAuthorizedWorkspaceId(workspace.id, input.workspaces, input.accessContext),
+    )?.id ?? null
   );
 }
 


### PR DESCRIPTION
## Summary

- remember the last authorized workspace in browser-local storage, scoped to the authenticated subject
- make the root route prefer an authorized `workspaceId` callback target, then the remembered workspace, before the existing Personal/default fallback
- ignore stale, revoked, malformed, or unavailable preferences and preserve URL-authoritative navigation

## Testing

- [x] `cd apps/web && bun run typecheck`
- [x] `bun test apps/web/src/lib/workspace-navigation-preference.test.ts apps/web/src/App.test.ts`
- [x] `cd apps/web && bun run build`
- [x] targeted `oxfmt` and `oxlint`
- [ ] `bun test`

The full web test sweep completed with 1,228 passing tests and four unrelated concurrency-sensitive failures in `workspace-settings.test.tsx` and `priority.test.tsx`; all four passed when rerun individually.

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate head is based on current `origin/main` and remains frozen after validation.

## Notes

- browser-local by design; no database migration or deployment-specific configuration
- the existing GitHub callback `/?workspaceId=...` now returns to the intended authorized workspace

## Summary by Sourcery

Remember each user’s last authorized workspace while safely prioritizing valid callback and stored destinations over the default landing workspace.

New Features:
- Remember the last authorized workspace per authenticated user in browser-local storage.
- Honor authorized workspace callback targets and remembered workspaces when choosing the root landing destination.

Bug Fixes:
- Prevent stale, revoked, malformed, or unavailable workspace preferences from overriding safe fallback navigation.
- Preserve URL-authoritative navigation and handle blocked browser storage without disrupting routing.

Enhancements:
- Validate workspace selections against both current workspace data and the authenticated subject’s current grants.

Tests:
- Add coverage for preference scoping, storage failures, callback parsing, authorization validation, fallback ordering, and stale workspace handling.