### PR TITLE
fix(web): explain insecure attachment uploads

### DIFF
--- a/.changeset/secure-attachment-context.md
+++ b/.changeset/secure-attachment-context.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Fail browser uploads before any network request with a typed `secure_context_required` error when HTTPS-only Web Crypto is unavailable, and surface actionable HTTPS guidance directly on failed attachment cards.

--- a/apps/web/src/components/secure-context-warning.test.tsx
+++ b/apps/web/src/components/secure-context-warning.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  browserSecureContextIssue,
+  shouldShowSecureContextWarning,
+} from "./secure-context-warning";
+
+const secureEnvironment = {
+  window: { isSecureContext: true },
+  crypto: { subtle: { digest: () => undefined } },
+};
+
+describe("secure context warning", () => {
+  test("warns self-hosted deployments opened in an insecure browser context", () => {
+    const environment = {
+      ...secureEnvironment,
+      window: { isSecureContext: false },
+    };
+
+    expect(browserSecureContextIssue(environment)).toBe("insecure_context");
+    expect(shouldShowSecureContextWarning("local", environment)).toBe(true);
+    expect(shouldShowSecureContextWarning("configured", environment)).toBe(true);
+  });
+
+  test("warns when Web Crypto is unavailable even if the browser reports a secure context", () => {
+    const environment = {
+      window: { isSecureContext: true },
+      crypto: {},
+    };
+
+    expect(browserSecureContextIssue(environment)).toBe("web_crypto_unavailable");
+    expect(shouldShowSecureContextWarning("local", environment)).toBe(true);
+  });
+
+  test("does not warn secure, non-browser, or managed surfaces", () => {
+    expect(shouldShowSecureContextWarning("local", secureEnvironment)).toBe(false);
+    expect(shouldShowSecureContextWarning("local", {})).toBe(false);
+    expect(
+      shouldShowSecureContextWarning("managed", {
+        ...secureEnvironment,
+        window: { isSecureContext: false },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/secure-context-warning.tsx
+++ b/apps/web/src/components/secure-context-warning.tsx
@@ -1,0 +1,47 @@
+import type { ProductAccessMode } from "@opengeni/sdk";
+
+import { Notice } from "@/components/ui/notice";
+
+type BrowserSecurityEnvironment = {
+  window?: { isSecureContext?: boolean | undefined } | undefined;
+  crypto?: { subtle?: { digest?: unknown } | undefined } | undefined;
+};
+
+export type BrowserSecureContextIssue = "insecure_context" | "web_crypto_unavailable";
+
+export function browserSecureContextIssue(
+  environment: BrowserSecurityEnvironment = globalThis,
+): BrowserSecureContextIssue | null {
+  if (!environment.window) return null;
+  if (environment.window.isSecureContext === false) return "insecure_context";
+  if (typeof environment.crypto?.subtle?.digest !== "function") {
+    return "web_crypto_unavailable";
+  }
+  return null;
+}
+
+export function shouldShowSecureContextWarning(
+  productAccessMode: ProductAccessMode,
+  environment: BrowserSecurityEnvironment = globalThis,
+): boolean {
+  return productAccessMode !== "managed" && browserSecureContextIssue(environment) !== null;
+}
+
+export function SecureContextWarning({
+  productAccessMode,
+}: {
+  productAccessMode: ProductAccessMode;
+}) {
+  const issue = browserSecureContextIssue();
+  if (productAccessMode === "managed" || issue === null) return null;
+
+  return (
+    <div role="alert" className="shrink-0 px-3 pt-3">
+      <Notice tone="waiting" title="Secure connection required">
+        {issue === "insecure_context"
+          ? "OpenGeni is open over HTTP. Configure HTTPS or use a secure URL. File uploads, microphone access, voice recordings, and some artifact features may not work."
+          : "This browser does not expose secure cryptography. Use a current browser over HTTPS. File uploads and some voice or artifact features may not work."}
+      </Notice>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/organization-settings-shell.tsx
+++ b/apps/web/src/components/settings/organization-settings-shell.tsx
@@ -87,7 +87,7 @@ export function OrganizationSettingsShell({
   return (
     <div
       data-workspace-scroll-owner="self-managed"
-      className="h-dvh overflow-x-hidden overflow-y-auto overscroll-y-contain bg-bg text-fg lg:grid lg:min-h-0 lg:grid-cols-[15rem_minmax(0,1fr)] lg:overflow-hidden"
+      className="h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-y-contain bg-bg text-fg lg:grid lg:grid-cols-[15rem_minmax(0,1fr)] lg:overflow-hidden"
     >
       <a
         href="#organization-settings-content"
@@ -95,7 +95,7 @@ export function OrganizationSettingsShell({
       >
         Skip to organization settings
       </a>
-      <aside className="border-b border-border bg-surface/35 lg:sticky lg:top-0 lg:h-dvh lg:min-h-0 lg:overflow-y-auto lg:overscroll-y-contain lg:border-r lg:border-b-0">
+      <aside className="border-b border-border bg-surface/35 lg:sticky lg:top-0 lg:h-full lg:min-h-0 lg:overflow-y-auto lg:overscroll-y-contain lg:border-r lg:border-b-0">
         <div className="flex h-full min-h-0 flex-col px-3 py-3 lg:py-4">
           <Link
             to="/workspaces/$workspaceId/sessions"

--- a/apps/web/src/components/settings/workspace-settings-shell.tsx
+++ b/apps/web/src/components/settings/workspace-settings-shell.tsx
@@ -192,8 +192,8 @@ export function WorkspaceManagementShell({
   children: ReactNode;
 }) {
   return (
-    <div className="grid h-dvh min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-bg text-fg lg:grid-cols-[15rem_minmax(0,1fr)] lg:grid-rows-1">
-      <aside className="max-h-[50dvh] min-h-0 overflow-y-auto overscroll-y-contain border-b border-border bg-surface/35 lg:h-dvh lg:max-h-none lg:border-r lg:border-b-0">
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-bg text-fg lg:grid-cols-[15rem_minmax(0,1fr)] lg:grid-rows-1">
+      <aside className="max-h-[50dvh] min-h-0 overflow-y-auto overscroll-y-contain border-b border-border bg-surface/35 lg:h-full lg:max-h-none lg:border-r lg:border-b-0">
         <div className="flex h-full min-h-0 flex-col px-3 py-3 lg:py-4">
           <Link
             to="/workspaces/$workspaceId/sessions"

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/api";
 import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { OrganizationOnboardingPanel } from "@/components/organization-onboarding-panel";
+import { SecureContextWarning } from "@/components/secure-context-warning";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -2638,7 +2639,10 @@ export function RootRouteComponent() {
           />
         </Suspense>
       ) : null}
-      {actorFencedSurface}
+      {clientConfig ? (
+        <SecureContextWarning productAccessMode={clientConfig.productAccessMode} />
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{actorFencedSurface}</div>
     </main>
   );
 }

--- a/apps/web/src/workspace-route-scroll-contract.test.ts
+++ b/apps/web/src/workspace-route-scroll-contract.test.ts
@@ -108,6 +108,20 @@ describe("workspace route scroll ownership", () => {
     }
   });
 
+  test("settings shells consume the app canvas remainder instead of reclaiming the viewport", async () => {
+    for (const path of [
+      "components/settings/workspace-settings-shell.tsx",
+      "components/settings/organization-settings-shell.tsx",
+    ]) {
+      const shellSource = await source(path);
+      expect(shellSource, `${path} must fit below persistent app chrome`).toContain("h-full");
+      expect(
+        shellSource,
+        `${path} must not clip app chrome by reclaiming the viewport`,
+      ).not.toContain("h-dvh");
+    }
+  });
+
   test("legacy max-width wrappers cannot return as route scroll owners", async () => {
     const legacyWrapper =
       'className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8"';

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,7 +157,16 @@ HTTPS/WSS is the supported private-edge posture. The web bootstrap retains a
 cryptographically random UUID compatibility path so a private HTTP origin can
 render the core workspace UI and useful diagnostics instead of crashing, but
 that fallback does not make HTTP feature-complete: browsers still withhold APIs
-used by voice, clipboard, and encrypted browser-side artifact operations.
+used by uploads, voice, clipboard, and encrypted browser-side artifact
+operations. Treat HTTPS as required for every non-loopback browser address;
+localhost and loopback development URLs remain subject to the browser's secure
+context rules. On an insecure self-hosted origin, the stock console keeps a
+persistent warning visible, and picker, drag-and-drop, and pasted-image
+attachments all fail before any upload request with the typed SDK code
+`secure_context_required` plus HTTPS setup guidance on the attachment card.
+OpenGeni deliberately does not provide a hashing fallback that would make only
+uploads appear healthy while the rest of the secure-browser feature contract
+remains broken.
 
 For a tailnet-only deployment, `OPENGENI_AUTH_REQUIRED=false` and
 `OPENGENI_PRODUCT_ACCESS_MODE=local` mean there is no shared deployment access

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -1650,6 +1650,7 @@ function AttachmentChips({
     <div className="flex flex-wrap gap-2 px-3 py-2">
       {attachments.map((attachment) => {
         const failed = attachment.status === "failed";
+        const secureContextRequired = attachment.errorCode === "secure_context_required";
         const statusText =
           attachment.status === "uploading"
             ? messages.uploading
@@ -1660,10 +1661,15 @@ function AttachmentChips({
           <div
             key={attachment.id}
             className={cn(
-              "flex min-w-0 max-w-[240px] items-center gap-2 rounded-og-md border px-2 py-1.5 text-og-sm",
+              "flex min-w-0 items-center gap-2 rounded-og-md border px-2 py-1.5 text-og-sm",
               failed
-                ? "border-og-status-failed/40 bg-og-status-failed/10"
-                : "border-og-border bg-og-surface-2",
+                ? cn(
+                    "border-og-status-failed/40 bg-og-status-failed/10",
+                    secureContextRequired
+                      ? "max-w-full items-start sm:max-w-[32rem]"
+                      : "max-w-[240px]",
+                  )
+                : "max-w-[240px] border-og-border bg-og-surface-2",
             )}
           >
             {attachment.previewUrl && lightbox ? (
@@ -1706,7 +1712,11 @@ function AttachmentChips({
             )}
             <div className="min-w-0 flex-1">
               <div className="truncate font-medium text-og-fg">{attachment.name}</div>
-              {failed ? (
+              {secureContextRequired ? (
+                <div className="break-words text-og-xs leading-4 text-og-status-failed">
+                  {statusText}
+                </div>
+              ) : failed ? (
                 <ComposerTip tip={statusText}>
                   <div className="truncate text-og-xs text-og-status-failed">{statusText}</div>
                 </ComposerTip>
@@ -1717,7 +1727,7 @@ function AttachmentChips({
             {attachment.status === "uploading" ? (
               <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" />
             ) : null}
-            {failed && onRetry ? (
+            {failed && !secureContextRequired && onRetry ? (
               <ComposerTip tip={messages.retryUpload}>
                 <button
                   type="button"

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,8 +1,4 @@
-import {
-  OpenGeniSecureContextRequiredError,
-  type FileAsset,
-  type FileResourceRef,
-} from "@opengeni/sdk";
+import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   useEmbeddedFileAttachments,
@@ -81,6 +77,27 @@ export type UseFileAttachmentsResult = {
 };
 
 const isImage = (file: File): boolean => file.type.startsWith("image/");
+
+let fallbackAttachmentId = 0;
+
+function createAttachmentId(): string {
+  const cryptoSource = globalThis.crypto;
+  if (typeof cryptoSource?.randomUUID === "function") return cryptoSource.randomUUID();
+  fallbackAttachmentId += 1;
+  // This id is only a browser-local React key and retry lookup, never durable
+  // authority. Keep attachment tracking usable when HTTP withholds randomUUID
+  // or Web Crypto is unavailable so the SDK's typed failure reaches the card.
+  return `attachment:${Date.now().toString(36)}:${fallbackAttachmentId.toString(36)}`;
+}
+
+function secureContextRequiredErrorCode(error: unknown): "secure_context_required" | undefined {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "secure_context_required"
+    ? error.code
+    : undefined;
+}
 
 /**
  * Upload-and-track state for files attached to the next message. Owns the
@@ -219,8 +236,7 @@ export function useFileAttachments(
                 ? {
                     ...attachment,
                     status: "failed",
-                    errorCode:
-                      error instanceof OpenGeniSecureContextRequiredError ? error.code : undefined,
+                    errorCode: secureContextRequiredErrorCode(error),
                     error: error instanceof Error ? error.message : String(error),
                   }
                 : attachment,
@@ -234,7 +250,7 @@ export function useFileAttachments(
   const addFiles = useCallback(
     (files: Iterable<File>) => {
       for (const file of files) {
-        const id = crypto.randomUUID();
+        const id = createAttachmentId();
         sources.current.set(id, file);
         const previewUrl = isImage(file) ? URL.createObjectURL(file) : undefined;
         if (previewUrl) previewUrls.current.set(id, previewUrl);

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,4 +1,8 @@
-import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
+import {
+  OpenGeniSecureContextRequiredError,
+  type FileAsset,
+  type FileResourceRef,
+} from "@opengeni/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   useEmbeddedFileAttachments,
@@ -26,6 +30,8 @@ export type FileAttachment = {
   file?: FileAsset | undefined;
   /** Object-URL for an inline preview; minted for `image/*` files only. */
   previewUrl?: string | undefined;
+  /** Stable SDK failure code for UI behavior that must not parse error copy. */
+  errorCode?: "secure_context_required" | undefined;
   error?: string | undefined;
 };
 
@@ -198,6 +204,7 @@ export function useFileAttachments(
                     name: asset.filename,
                     contentType: asset.contentType,
                     sizeBytes: asset.sizeBytes,
+                    errorCode: undefined,
                     error: undefined,
                   }
                 : attachment,
@@ -212,6 +219,8 @@ export function useFileAttachments(
                 ? {
                     ...attachment,
                     status: "failed",
+                    errorCode:
+                      error instanceof OpenGeniSecureContextRequiredError ? error.code : undefined,
                     error: error instanceof Error ? error.message : String(error),
                   }
                 : attachment,
@@ -255,7 +264,7 @@ export function useFileAttachments(
       setAttachments((current) =>
         current.map((attachment) =>
           attachment.id === id
-            ? { ...attachment, status: "uploading", error: undefined }
+            ? { ...attachment, status: "uploading", errorCode: undefined, error: undefined }
             : attachment,
         ),
       );
@@ -305,6 +314,7 @@ export function useFileAttachments(
                 sizeBytes: file.sizeBytes,
                 status: "ready",
                 file,
+                errorCode: undefined,
                 error: undefined,
               }
             : {

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -4495,6 +4495,11 @@
       max-width: 12rem;
     }
   }
+:where(.og-root).sm\:max-w-\[32rem\],:where(.og-root) .sm\:max-w-\[32rem\] {
+    @media (width >= 40rem) {
+      max-width: 32rem;
+    }
+  }
 :where(.og-root).sm\:max-w-\[82\%\],:where(.og-root) .sm\:max-w-\[82\%\] {
     @media (width >= 40rem) {
       max-width: 82%;

--- a/packages/react/test/chat-composer-uploads.test.tsx
+++ b/packages/react/test/chat-composer-uploads.test.tsx
@@ -4,7 +4,7 @@
    that blocks BOTH the button and Enter while files are unresolved.
    -------------------------------------------------------------------------- */
 import { afterEach, describe, expect, test } from "bun:test";
-import { OpenGeniApiError } from "@opengeni/sdk";
+import { OpenGeniApiError, OpenGeniSecureContextRequiredError } from "@opengeni/sdk";
 import { act, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { ChatComposer } from "../src/components/chat-composer";
@@ -359,6 +359,34 @@ describe("ChatComposer attachments", () => {
       await Promise.resolve();
     });
     expect(sent).toBe(0);
+  });
+
+  test("shows secure-context guidance directly on the failed card without a futile retry", async () => {
+    const failure = new OpenGeniSecureContextRequiredError("insecure_context");
+    const attachments = makeAttachments({
+      hasUnresolved: true,
+      attachments: [
+        {
+          ...readyChip("dragged.png"),
+          status: "failed",
+          errorCode: failure.code,
+          error: failure.message,
+        },
+      ],
+    });
+    const container = await mount(
+      <ChatComposer composer={makeComposer()} attachments={attachments} />,
+    );
+
+    expect(container.textContent ?? "").toContain(
+      "Couldn’t attach this file because OpenGeni is open over HTTP.",
+    );
+    expect(container.textContent ?? "").toContain(
+      "Open the secure site or configure HTTPS for this deployment.",
+    );
+    expect(container.querySelector('[aria-label="Retry dragged.png"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Remove dragged.png"]')).not.toBeNull();
+    expect(sendButton(container)?.disabled).toBe(true);
   });
 
   test("removing the failed attachment unblocks send without dropping the typed prompt", async () => {

--- a/packages/react/test/use-file-attachments.test.tsx
+++ b/packages/react/test/use-file-attachments.test.tsx
@@ -5,7 +5,7 @@
    distinct progress (`uploading`) and loss-prevention (`hasUnresolved`) gates.
    -------------------------------------------------------------------------- */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { FileAsset } from "@opengeni/sdk";
+import { OpenGeniSecureContextRequiredError, type FileAsset } from "@opengeni/sdk";
 import { act, startTransition, Suspense } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
@@ -604,6 +604,31 @@ describe("useFileAttachments", () => {
     await flushing(() => hook.result.current.remove(attachment.id));
     expect(hook.result.current.attachments).toEqual([]);
     expect(hook.result.current.hasUnresolved).toBe(false);
+    await hook.unmount();
+  });
+
+  test("classifies a typed secure-context upload failure for the attachment card", async () => {
+    const failure = new OpenGeniSecureContextRequiredError("insecure_context");
+    const client = fakeClient({
+      uploadFile: async () => {
+        throw failure;
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() => hook.result.current.addFiles([imageFile("dragged.png")]));
+    await flush();
+
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      name: "dragged.png",
+      status: "failed",
+      errorCode: "secure_context_required",
+      error: failure.message,
+    });
+    expect(hook.result.current.hasUnresolved).toBe(true);
     await hook.unmount();
   });
 

--- a/packages/react/test/use-file-attachments.test.tsx
+++ b/packages/react/test/use-file-attachments.test.tsx
@@ -632,6 +632,75 @@ describe("useFileAttachments", () => {
     await hook.unmount();
   });
 
+  test("tracks the failed attachment when insecure HTTP withholds crypto.randomUUID", async () => {
+    const randomUuidDescriptor = Object.getOwnPropertyDescriptor(globalThis.crypto, "randomUUID");
+    Object.defineProperty(globalThis.crypto, "randomUUID", {
+      configurable: true,
+      value: undefined,
+    });
+    const failure = new OpenGeniSecureContextRequiredError("insecure_context");
+    let uploads = 0;
+    const client = fakeClient({
+      uploadFile: async () => {
+        uploads += 1;
+        throw failure;
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    try {
+      await flushing(() => hook.result.current.addFiles([imageFile("http.png")]));
+      await flush();
+
+      expect(uploads).toBe(1);
+      expect(hook.result.current.attachments).toHaveLength(1);
+      expect(hook.result.current.attachments[0]).toMatchObject({
+        name: "http.png",
+        status: "failed",
+        errorCode: "secure_context_required",
+        error: failure.message,
+      });
+      expect(hook.result.current.hasUnresolved).toBe(true);
+    } finally {
+      await hook.unmount();
+      if (randomUuidDescriptor) {
+        Object.defineProperty(globalThis.crypto, "randomUUID", randomUuidDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.crypto, "randomUUID");
+      }
+    }
+  });
+
+  test("classifies the stable secure-context code from a structurally compatible client", async () => {
+    const failure = Object.assign(new Error("Use HTTPS"), {
+      code: "secure_context_required" as const,
+      retryable: false,
+    });
+    const client = fakeClient({
+      uploadFile: async () => {
+        throw failure;
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() => hook.result.current.addFiles([imageFile("embedded.png")]));
+    await flush();
+
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      name: "embedded.png",
+      status: "failed",
+      errorCode: "secure_context_required",
+      error: "Use HTTPS",
+    });
+    await hook.unmount();
+  });
+
   test("retry(id) re-uploads a failed attachment in place -> ready, clearing its error", async () => {
     let calls = 0;
     let resolveRetry!: (value: FileAsset) => void;

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -13,9 +13,11 @@ export type {
 export {
   OpenGeniApiContractMismatchError,
   OpenGeniApiError,
+  OpenGeniSecureContextRequiredError,
   OpenGeniSessionListCursorError,
   OpenGeniStreamError,
   isRetryableStreamError,
 } from "./errors";
+export type { OpenGeniSecureContextRequiredReason } from "./errors";
 export { resolveWorkspaceVoiceInputEnabled } from "./transcription";
 export { OPENGENI_API_CONTRACT_HEADER, OPENGENI_API_CONTRACT_REVISION } from "./types";

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7796,7 +7796,17 @@ function mutationTransportError(correlationId: string): OpenGeniApiError {
 }
 
 function assertBrowserFileUploadSecureContext(): void {
-  if (typeof window !== "undefined" && window.isSecureContext === false) {
+  const secureContext =
+    typeof window !== "undefined"
+      ? window.isSecureContext
+      : typeof globalThis.isSecureContext === "boolean"
+        ? globalThis.isSecureContext
+        : undefined;
+  // The framework-agnostic SDK also runs in Node, Bun, Deno, and edge
+  // runtimes. Preserve their existing upload behavior; this typed HTTPS error
+  // is only meaningful where the browser exposes a secure-context state.
+  if (secureContext === undefined) return;
+  if (!secureContext) {
     throw new OpenGeniSecureContextRequiredError("insecure_context");
   }
   if (

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,7 @@
 import {
   OpenGeniApiContractMismatchError,
   OpenGeniApiError,
+  OpenGeniSecureContextRequiredError,
   OpenGeniSessionListCursorError,
 } from "./errors";
 import {
@@ -5570,6 +5571,7 @@ export class OpenGeniClient {
     ) {
       throw new Error("File upload timeout must be a positive number");
     }
+    assertBrowserFileUploadSecureContext();
     const withTimeout = async <T>(
       timeoutMs: number,
       operation: (signal: AbortSignal) => Promise<T>,
@@ -7791,6 +7793,18 @@ function mutationTransportError(correlationId: string): OpenGeniApiError {
     mutation: true,
     displayMessage: "OpenGeni could not confirm the request — reconcile before retrying.",
   });
+}
+
+function assertBrowserFileUploadSecureContext(): void {
+  if (typeof window !== "undefined" && window.isSecureContext === false) {
+    throw new OpenGeniSecureContextRequiredError("insecure_context");
+  }
+  if (
+    typeof globalThis.crypto === "undefined" ||
+    typeof globalThis.crypto.subtle?.digest !== "function"
+  ) {
+    throw new OpenGeniSecureContextRequiredError("web_crypto_unavailable");
+  }
 }
 
 async function sha256ForUpload(body: Blob | ArrayBuffer | string): Promise<string> {

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -13,9 +13,11 @@ export type {
 export {
   OpenGeniApiContractMismatchError,
   OpenGeniApiError,
+  OpenGeniSecureContextRequiredError,
   OpenGeniSessionListCursorError,
   OpenGeniStreamError,
   isRetryableStreamError,
 } from "./errors";
+export type { OpenGeniSecureContextRequiredReason } from "./errors";
 export { resolveWorkspaceVoiceInputEnabled } from "./transcription";
 export { OPENGENI_API_CONTRACT_HEADER, OPENGENI_API_CONTRACT_REVISION } from "./types";

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -49,6 +49,29 @@ export class OpenGeniApiError extends Error {
   }
 }
 
+export type OpenGeniSecureContextRequiredReason = "insecure_context" | "web_crypto_unavailable";
+
+/**
+ * A browser operation requires secure-context-only platform capabilities.
+ * Callers may key UI behavior on the stable `secure_context_required` code;
+ * `reason` exists only to keep the human guidance truthful.
+ */
+export class OpenGeniSecureContextRequiredError extends Error {
+  readonly code = "secure_context_required" as const;
+  readonly retryable = false;
+  readonly reason: OpenGeniSecureContextRequiredReason;
+
+  constructor(reason: OpenGeniSecureContextRequiredReason) {
+    super(
+      reason === "insecure_context"
+        ? "Couldn’t attach this file because OpenGeni is open over HTTP. Attachments require a secure HTTPS connection. Open the secure site or configure HTTPS for this deployment."
+        : "Couldn’t attach this file because secure browser cryptography is unavailable. Attachments require HTTPS and Web Crypto support. Open a secure site in a supported browser or configure HTTPS for this deployment.",
+    );
+    this.name = "OpenGeniSecureContextRequiredError";
+    this.reason = reason;
+  }
+}
+
 function decodeApiErrorBody(body: string): {
   code: string | undefined;
   message: string | undefined;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,10 +26,12 @@ export type {
 export {
   OpenGeniApiContractMismatchError,
   OpenGeniApiError,
+  OpenGeniSecureContextRequiredError,
   OpenGeniSessionListCursorError,
   OpenGeniStreamError,
   isRetryableStreamError,
 } from "./errors";
+export type { OpenGeniSecureContextRequiredReason } from "./errors";
 export {
   AUTOMATIC_SESSION_TITLE_FALLBACK,
   deriveSessionDisplayTitle,

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { OpenGeniClient } from "../src/artifact-client";
-import { OpenGeniApiError } from "../src/errors";
+import { OpenGeniApiError, OpenGeniSecureContextRequiredError } from "../src/errors";
 import {
   OPENGENI_API_CONTRACT_REVISION,
   OPENGENI_CORRELATION_HEADER,
@@ -981,6 +981,85 @@ describe("OpenGeniClient variable sets", () => {
 });
 
 describe("OpenGeniClient files", () => {
+  test("uploadFile fails before any request when the browser context is insecure", async () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { isSecureContext: false },
+    });
+    const { client, requests } = makeClient(() => {
+      throw new Error("fetch must not run from an insecure browser context");
+    });
+
+    try {
+      const error = await client
+        .uploadFile(WORKSPACE_ID, {
+          filename: "insecure.txt",
+          contentType: "text/plain",
+          data: "x",
+          sha256: "a".repeat(64),
+        })
+        .then(
+          () => null,
+          (caught: unknown) => caught,
+        );
+
+      expect(error).toBeInstanceOf(OpenGeniSecureContextRequiredError);
+      expect(error).toMatchObject({
+        code: "secure_context_required",
+        reason: "insecure_context",
+        retryable: false,
+      });
+      expect((error as Error).message).toContain("OpenGeni is open over HTTP");
+      expect(requests).toHaveLength(0);
+    } finally {
+      if (windowDescriptor) {
+        Object.defineProperty(globalThis, "window", windowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
+    }
+  });
+
+  test("uploadFile returns the typed secure-context error when Web Crypto is unavailable", async () => {
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { getRandomValues: cryptoDescriptor?.value?.getRandomValues },
+    });
+    const { client, requests } = makeClient(() => {
+      throw new Error("fetch must not run without Web Crypto");
+    });
+
+    try {
+      const error = await client
+        .uploadFile(WORKSPACE_ID, {
+          filename: "unsupported.txt",
+          contentType: "text/plain",
+          data: "x",
+          sha256: "a".repeat(64),
+        })
+        .then(
+          () => null,
+          (caught: unknown) => caught,
+        );
+
+      expect(error).toBeInstanceOf(OpenGeniSecureContextRequiredError);
+      expect(error).toMatchObject({
+        code: "secure_context_required",
+        reason: "web_crypto_unavailable",
+        retryable: false,
+      });
+      expect(requests).toHaveLength(0);
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "crypto");
+      }
+    }
+  });
+
   test("uploadFile runs begin -> signed PUT -> complete and returns the ready file", async () => {
     const begin = {
       fileId: FILE_ID,

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -1022,7 +1022,12 @@ describe("OpenGeniClient files", () => {
   });
 
   test("uploadFile returns the typed secure-context error when Web Crypto is unavailable", async () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
     const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { isSecureContext: true },
+    });
     Object.defineProperty(globalThis, "crypto", {
       configurable: true,
       value: { getRandomValues: cryptoDescriptor?.value?.getRandomValues },
@@ -1052,6 +1057,63 @@ describe("OpenGeniClient files", () => {
       });
       expect(requests).toHaveLength(0);
     } finally {
+      if (windowDescriptor) {
+        Object.defineProperty(globalThis, "window", windowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "crypto");
+      }
+    }
+  });
+
+  test("uploadFile preserves a supplied checksum in a non-browser runtime without Web Crypto", async () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    Reflect.deleteProperty(globalThis, "window");
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { randomUUID: () => "00000000-0000-4000-8000-000000000001" },
+    });
+    const suppliedSha256 = "A".repeat(64);
+    const { client, requests } = makeClient((request) => {
+      if (request.url.endsWith("/files/uploads")) {
+        return jsonResponse(
+          {
+            fileId: FILE_ID,
+            uploadId: UPLOAD_ID,
+            putUrl: "https://storage.example.test/put/non-browser",
+            requiredHeaders: {},
+            expiresAt: "",
+            maxSizeBytes: 1,
+          },
+          201,
+        );
+      }
+      if (request.url.startsWith("https://storage.example.test/")) {
+        return new Response(null, { status: 200 });
+      }
+      return jsonResponse({ file: { id: FILE_ID, status: "ready" } });
+    });
+
+    try {
+      await client.uploadFile(WORKSPACE_ID, {
+        filename: "server.txt",
+        contentType: "text/plain",
+        data: "x",
+        sha256: suppliedSha256,
+      });
+
+      expect(JSON.parse(requests[0]!.body!).sha256).toBe(suppliedSha256);
+    } finally {
+      if (windowDescriptor) {
+        Object.defineProperty(globalThis, "window", windowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
       if (cryptoDescriptor) {
         Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
       } else {


### PR DESCRIPTION
## Summary

- fail browser attachment uploads before hashing or network I/O when the page is insecure or Web Crypto is unavailable, using a typed, non-retryable `secure_context_required` SDK error
- preserve that stable error code through React attachment state so the composer shows the complete HTTPS guidance, suppresses futile retries, keeps removal available, and blocks send while the failed file remains
- add a persistent self-hosted console warning for insecure origins, document the HTTPS contract, and publish SDK/React patch changesets

## Testing

- [ ] `bun run typecheck` — impacted SDK, React, and web package typechecks passed; the monorepo-wide command was also exercised separately
- [ ] `bun test` — not run monorepo-wide
- [x] `bun run test:react:clean` (1,567 passed, 0 failed)
- [x] focused SDK, React attachment/composer, web warning, session-control, API, and app tests
- [x] SDK and React package builds
- [x] web production build, precompression, and bundle budgets
- [x] compiled CSS consistency, formatting, lint, and diff checks
- [x] desktop Chromium smoke test on a non-loopback HTTP origin (`window.isSecureContext === false`)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] `main` had not advanced; the branch was created from and verified against the current `origin/main`.

## Notes

- No upload hashing fallback is introduced: insecure browser deployments receive actionable HTTPS guidance instead of making uploads appear healthy while voice and artifact capabilities remain unavailable.

## Summary by Sourcery

Require secure browser contexts for file uploads and provide actionable HTTPS guidance across the SDK, React composer, and self-hosted web UI.

New Features:
- Add typed, non-retryable secure-context errors for browser uploads when HTTPS or Web Crypto support is unavailable.
- Surface persistent HTTPS guidance in self-hosted web deployments and on failed attachment cards.

Bug Fixes:
- Prevent insecure browser uploads from proceeding to hashing or network requests.
- Preserve secure-context failures through attachment state so sending remains blocked until the file is removed.

Enhancements:
- Improve attachment failure handling by suppressing futile retries while retaining removal and actionable guidance.
- Adjust settings shells to fit within the application canvas instead of reclaiming the viewport.

Documentation:
- Document HTTPS as required for non-loopback browser deployments and clarify that no upload hashing fallback is provided.

Tests:
- Add coverage for secure-context detection, preflight upload failures, attachment error propagation, composer behavior, and non-browser upload compatibility.

Chores:
- Publish SDK and React patch changesets for the secure-context upload behavior.