### PR TITLE
fix(codex): recover untyped capacity cooldowns

### DIFF
--- a/.changeset/calm-codex-cooldowns.md
+++ b/.changeset/calm-codex-cooldowns.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker": patch
+---
+
+Recover capacity from revision-fenced untyped Codex cooldowns when a live usage read confirms allowance is available.

--- a/.changeset/calm-codex-cooldowns.md
+++ b/.changeset/calm-codex-cooldowns.md
@@ -1,6 +1,6 @@
 ---
 "@opengeni/db": patch
-"@opengeni/worker": patch
+"@opengeni/worker-bundle": patch
 ---
 
 Recover capacity from revision-fenced untyped Codex cooldowns when a live usage read confirms allowance is available.

--- a/apps/worker/src/activities/codex-capacity.ts
+++ b/apps/worker/src/activities/codex-capacity.ts
@@ -123,7 +123,7 @@ export function codexCapacityDecision(
     (account) =>
       account.status === "active" &&
       account.allocatorEnabled &&
-      account.exhaustedKind === "quota" &&
+      (account.exhaustedKind === "quota" || account.exhaustedKind === null) &&
       account.exhaustedUntil !== null &&
       account.exhaustedUntil > now,
   );

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -26,7 +26,7 @@ export function codexAccountNeedsLiveCapacityRefresh(
   return (
     (account.primaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT ||
     (account.secondaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT ||
-    (account.exhaustedKind === "quota" &&
+    ((account.exhaustedKind === "quota" || account.exhaustedKind === null) &&
       account.exhaustedUntil !== null &&
       account.exhaustedUntil > now)
   );

--- a/apps/worker/test/codex-capacity.test.ts
+++ b/apps/worker/test/codex-capacity.test.ts
@@ -74,7 +74,7 @@ describe("Codex capacity availability diagnostics", () => {
     });
   });
 
-  test("typed quota cooldowns use bounded live reconciliation", () => {
+  test("quota and untyped cooldowns use bounded live reconciliation", () => {
     const resetAt = new Date("2100-01-01T00:00:00.000Z");
     const base: CodexCapacitySelectionContext = {
       accounts: [
@@ -98,6 +98,19 @@ describe("Codex capacity availability diagnostics", () => {
     };
 
     expect(codexCapacityDecision(base, testSettings())).toMatchObject({
+      kind: "unavailable",
+      earliestResetAt: resetAt,
+      resetKind: "bounded_refresh",
+    });
+    expect(
+      codexCapacityDecision(
+        {
+          ...base,
+          accounts: [account("cooling", { exhaustedUntil: resetAt, exhaustedKind: null })],
+        },
+        testSettings(),
+      ),
+    ).toMatchObject({
       kind: "unavailable",
       earliestResetAt: resetAt,
       resetKind: "bounded_refresh",

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -27,7 +27,7 @@ import {
 const NOW = new Date("2026-06-30T12:00:00.000Z");
 const HOUR = 3_600_000;
 
-test("live refresh targets quota cooldowns but not generic or legacy cooldowns", () => {
+test("live refresh targets quota and untyped cooldowns but not rate-limit cooldowns", () => {
   const until = new Date(NOW.getTime() + HOUR);
   expect(
     codexAccountNeedsLiveCapacityRefresh(
@@ -42,7 +42,7 @@ test("live refresh targets quota cooldowns but not generic or legacy cooldowns",
     ),
   ).toBe(false);
   expect(codexAccountNeedsLiveCapacityRefresh(acct("legacy", { exhaustedUntil: until }), NOW)).toBe(
-    false,
+    true,
   );
 });
 

--- a/packages/db/src/codex-token-resolver.ts
+++ b/packages/db/src/codex-token-resolver.ts
@@ -73,9 +73,10 @@ export type CodexAccountUsageSnapshot = {
   resetCreditAvailableCount?: number | null;
   resetCreditsCheckedAt?: Date | null;
   /**
-   * Clear only a quota cooldown with this exact revision. Set solely after a
-   * live provider response proves allowance is open; a concurrent refusal
-   * advances the revision and makes this observation stale.
+   * Clear only a quota or untyped rolling-upgrade cooldown with this exact
+   * revision. Set solely after a live provider response proves allowance is
+   * open; a concurrent refusal advances the revision and makes this observation
+   * stale. Typed rate-limit cooldowns remain authoritative.
    */
   clearQuotaCooldownRevision?: number;
 };
@@ -388,7 +389,7 @@ function errorUsagePayload(reason?: "needs_relogin"): CodexUsagePayload {
  *   2. fetch GET /wham/usage with that bearer.
  *   3. normalize (§3) into the P2/P3 contract.
  *   4. on any windows present, write the usage cache and conditionally reconcile
- *      the exact older typed quota cooldown observed before provider I/O.
+ *      the exact older quota/untyped cooldown observed before provider I/O.
  *
  * A refresh that stamps needs_relogin returns { status:"error", reason } and never
  * hits the provider; a transient refresh error returns a plain error payload.
@@ -459,7 +460,8 @@ export async function fetchCodexUsageForAccount(
             }
           : {}),
         ...(observedCredential?.exhaustedUntil &&
-        observedCredential.exhaustedKind === "quota" &&
+        (observedCredential.exhaustedKind === "quota" ||
+          observedCredential.exhaustedKind === null) &&
         codexUsageConfirmsQuotaAvailable(normalized)
           ? { clearQuotaCooldownRevision: observedCredential.exhaustedRevision }
           : {}),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27475,7 +27475,7 @@ export async function completeCodexResetRedemption(
 /** The P2 usage-cache snapshot written by the refreshing usage wrapper. */
 
 /**
- * Cache-write for P2 quota bars and revision-fenced quota cooldown repair on a
+ * Cache-write for P2 quota bars and revision-fenced quota/untyped cooldown repair on a
  * SPECIFIC credential row. NEVER touches credential_encrypted. RLS-scoped, guarded
  * by (id, workspace_id) so it can only write a row the workspace owns. Returns true
  * iff a row was updated (false ⇒ the credential was disconnected under us — the
@@ -27525,7 +27525,7 @@ export async function recordCodexAccountUsageWithWakeTargets(
         snapshot.checkedAt !== undefined &&
         Number.isSafeInteger(snapshot.clearQuotaCooldownRevision) &&
         snapshot.clearQuotaCooldownRevision === previous.exhaustedRevision &&
-        previous.exhaustedKind === "quota" &&
+        (previous.exhaustedKind === "quota" || previous.exhaustedKind === null) &&
         previous.exhaustedUntil !== null;
       const updated = await tx
         .update(schema.codexSubscriptionCredentials)

--- a/packages/db/test/codex-usage.test.ts
+++ b/packages/db/test/codex-usage.test.ts
@@ -406,6 +406,41 @@ describe("fetchCodexUsageForAccount under RLS", () => {
     expect(Number(after?.exhausted_revision)).toBe(Number(before?.exhausted_revision ?? 0) + 1);
   });
 
+  test("a fresh open allowance clears an exact older untyped cooldown", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const id = await connect(
+      ws,
+      "acct_untyped_recovery",
+      { access_token: "AC", refresh_token: "RF", id_token: "ID" },
+      new Date(Date.now() + 3_600_000),
+    );
+    const until = new Date(Date.now() + 5 * 24 * 60 * 60_000);
+    await admin`
+      update codex_subscription_credentials
+      set exhausted_until = ${until}
+      where id = ${id}
+    `;
+    const [before] = await admin<
+      { exhausted_revision: number; exhausted_kind: string | null }[]
+    >`select exhausted_revision, exhausted_kind from codex_subscription_credentials where id = ${id}`;
+    expect(before?.exhausted_kind).toBeNull();
+
+    mockFetch({ wham: () => json(whamBody(0, 0)) });
+    await fetchCodexUsageForAccount(db, settings, ws.workspaceId, id);
+
+    const [after] = await admin<
+      {
+        exhausted_until: Date | null;
+        exhausted_kind: string | null;
+        exhausted_revision: number;
+      }[]
+    >`select exhausted_until, exhausted_kind, exhausted_revision from codex_subscription_credentials where id = ${id}`;
+    expect(after?.exhausted_until).toBeNull();
+    expect(after?.exhausted_kind).toBeNull();
+    expect(Number(after?.exhausted_revision)).toBe(Number(before?.exhausted_revision ?? 0) + 1);
+  });
+
   test("a fresh-token account: no refresh, normalizes the 200, and writes the cache", async () => {
     if (!available) return;
     const ws = await freshWorkspace();


### PR DESCRIPTION
## Summary
- live-refresh untyped cooldowns left by rolling upgrades
- clear only the exact observed cooldown revision after allowance is confirmed
- preserve typed rate-limit cooldowns

## Verification
- `bun run test apps/worker/test/codex-rotation.test.ts apps/worker/test/codex-capacity.test.ts`
- `bun run test packages/db/test/codex-usage.test.ts`
- `bun run typecheck`

## Summary by Sourcery

Recover untyped Codex capacity cooldowns through live usage reconciliation without clearing authoritative typed rate-limit cooldowns.

Bug Fixes:
- Recover capacity from untyped cooldowns left by rolling upgrades when live usage confirms allowance is available.

Enhancements:
- Continue preserving typed rate-limit cooldowns while applying revision-fenced recovery to quota and untyped cooldowns.
- Treat untyped cooldowns as eligible for live capacity refresh and bounded availability reconciliation.

Tests:
- Add coverage for untyped cooldown recovery and live refresh eligibility.