### PR TITLE
fix(config): preserve bare registry turn ownership

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4643,12 +4643,15 @@ export function configuredModels(
   // (opaque DeploymentNotFound 404). A `<provider>/<model>`-namespaced id (it
   // contains "/") that a registry actually owns is never a valid Azure/OpenAI
   // deployment name, and a `codex/`-prefixed id never is either — exclude both
-  // from the built-in list. A BARE id a registry merely redeclares (e.g.
-  // "gpt-5.6-sol") is left in place so the built-in still wins it via the first-wins
-  // de-dup below (preserving the documented built-in-precedence contract). When
-  // a codex/ id has NO codex provider injected (no active subscription) it then
-  // resolves to nothing and getModel fails loud with
-  // CodexSubscriptionUnavailableError instead of mis-routing to Azure.
+  // from the built-in list. A BARE registry id is also excluded when it appears
+  // only as the run-scoped `openaiModel` override and is absent from the
+  // deployment's built-in allow-list. That is an unambiguous per-turn provider
+  // selection, not a deployment ownership claim. A bare id that is present in
+  // the built-in allow-list remains a hard duplicate error so configuration can
+  // never silently change provider or billing ownership. When a codex/ id has
+  // NO codex provider injected (no active subscription) it resolves to nothing
+  // and getModel fails loud with CodexSubscriptionUnavailableError instead of
+  // mis-routing to Azure.
   const parsedRegistry = configuredRegistryProviders(settings);
   const registryOwnedIds = new Set(
     parsedRegistry.flatMap((provider) => provider.models.map((model) => model.id)),
@@ -4656,11 +4659,15 @@ export function configuredModels(
   const registryAliases = new Set(
     parsedRegistry.flatMap((provider) => provider.models.flatMap((model) => model.aliases ?? [])),
   );
-  const isRegistryNamespaced = (id: string): boolean =>
+  const builtinAllowedIds = new Set(splitCsv(settings.openaiAllowedModels));
+  const isUnambiguousRunScopedRegistryModel = (id: string): boolean =>
+    id === settings.openaiModel && registryOwnedIds.has(id) && !builtinAllowedIds.has(id);
+  const isRegistryOwnedForRun = (id: string): boolean =>
     id.startsWith(CODEX_MODEL_ID_PREFIX) ||
     id.startsWith(XAI_SUBSCRIPTION_MODEL_ID_PREFIX) ||
     registryAliases.has(id) ||
-    (id.includes("/") && registryOwnedIds.has(id));
+    (id.includes("/") && registryOwnedIds.has(id)) ||
+    isUnambiguousRunScopedRegistryModel(id);
   const builtinProvider = providerById.get(builtinId);
   if (!builtinProvider) {
     throw new Error(`Built-in model provider ${builtinId} is not configured`);
@@ -4669,7 +4676,7 @@ export function configuredModels(
     settings.openaiModel,
     ...splitCsv(settings.openaiAllowedModels),
   ])
-    .filter((id) => !isRegistryNamespaced(id))
+    .filter((id) => !isRegistryOwnedForRun(id))
     .map((id) => {
       const capabilities = {
         ...legacyModelCapabilities(settings, {

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -1252,6 +1252,36 @@ describe("configuredModels", () => {
     ).toBe(false);
   });
 
+  test("a bare registry id used only by the turn resolves to its registry provider", () => {
+    const base = withEnv(
+      {
+        OPENGENI_OPENAI_PROVIDER: "azure",
+        OPENGENI_AZURE_OPENAI_BASE_URL: "https://res.openai.azure.com/openai/v1",
+        OPENGENI_AZURE_OPENAI_API_KEY: "az-key",
+        OPENGENI_OPENAI_MODEL: "gpt-5.6-terra",
+        OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.6-terra",
+        OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+          {
+            id: "managed-gateway",
+            baseUrl: "https://gateway.example.test/v1",
+            apiKey: "gateway-key",
+            models: [{ id: "deepseek-v4-flash-0731", label: "DeepSeek V4 Flash 0731" }],
+          },
+        ]),
+      },
+      () => getSettings(),
+    );
+    const runSettings = { ...base, openaiModel: "deepseek-v4-flash-0731" };
+    const entries = configuredModels(runSettings).filter(
+      (model) => model.id === "deepseek-v4-flash-0731",
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.providerId).toBe("managed-gateway");
+    expect(resolveModelProvider(runSettings, "deepseek-v4-flash-0731")!.provider.builtin).toBe(
+      false,
+    );
+  });
+
   test("fails boot instead of silently shadowing a duplicate canonical product id", () => {
     expect(() =>
       withEnv(


### PR DESCRIPTION
## What
- treat a bare registry model as registry-owned when it is only the per-turn model override and is absent from the deployment built-in allow-list
- retain the hard duplicate failure for actual deployment ownership conflicts
- add regression coverage for the staging DeepSeek/Gateway failure

## Incident
Staging provider acceptance run 33477655460 failed before model I/O because run-scoped `deepseek-v4-flash-0731` was incorrectly materialized as both Azure and `opengeni-gateway`. The deployment default/allow-list remains `gpt-5.6-terra`; this patch makes that distinction generic at the config boundary.

## Validation
- `bun test packages/config/test/model-providers.test.ts packages/runtime/test/model-providers.test.ts` (166 pass)
- `bun run typecheck`
- `bun x oxfmt --check packages/config/src/index.ts packages/config/test/model-providers.test.ts`
- `bun x oxlint --deny-warnings packages/config/src/index.ts packages/config/test/model-providers.test.ts`
- `git diff --check`

## Summary by Sourcery

Correct model ownership resolution for bare registry IDs used as run-scoped overrides while continuing to reject genuine deployment ownership conflicts.

Bug Fixes:
- Preserve registry ownership for bare models used exclusively as per-turn overrides when they are not in the deployment’s built-in allow-list.
- Retain hard failures for bare model IDs that conflict with deployment-owned models.

Tests:
- Add regression coverage for resolving a bare per-turn registry model to its registry provider.