### PR TITLE
test(runtime): prove gateway turn ownership

### DIFF
--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -40,6 +40,7 @@ import {
   HUMAN_INPUT_TOOL_NAME,
   modelRequestPolicyForProvider,
   MultiProviderModelProvider,
+  OpenGeniResponsesModel,
   resolveTurnModel,
   summarizeForCompaction,
   UNKNOWN_MODEL_FINISH_REASON_CODE,
@@ -2496,9 +2497,11 @@ describe("registry model shadowing is closed — the built-in never claims a nam
     expect(resolved?.provider.id).toBe("opengeni-gateway");
 
     const runSettings = { ...deploymentSettings, openaiModel: gatewayModelId };
-    expect(
-      await new MultiProviderModelProvider(runSettings).getModel(gatewayModelId),
-    ).toBeDefined();
+    const model = await new MultiProviderModelProvider(runSettings).getModel(gatewayModelId);
+    expect(model).toBeInstanceOf(OpenGeniResponsesModel);
+    expect((model as unknown as { provider: ResolvedModelProvider }).provider.id).toBe(
+      "opengeni-gateway",
+    );
   });
 
   test("fails loud when a registry redeclares a bare built-in product id", () => {


### PR DESCRIPTION
## Summary

- strengthen the database-catalog bare-model regression merged in #2113
- assert the actual run-scoped model is bound to `opengeni-gateway`, not the built-in fallback

## Validation

- `bun test packages/config/test/model-catalog-source.test.ts packages/runtime/test/model-providers.test.ts` — 93 pass, 0 fail
- `bun x oxfmt --check ...` — clean
- `bun x oxlint --deny-warnings ...` — clean
- `bun run typecheck` — all 31 projects clean

Follow-up to the valid Sourcery review on #2113.

## Summary by Sourcery

Verify that runtime model resolution preserves gateway ownership for shadowed model identifiers.

Enhancements:
- Strengthen runtime model-provider regression coverage to verify gateway-owned run-scoped models are returned instead of the built-in fallback.

Tests:
- Assert that the resolved model is an OpenGeni responses model bound to the opengeni-gateway provider.