### PR TITLE
Fix stuck new-session draft conflicts

### DIFF
--- a/apps/web/src/lib/use-new-session-draft.test.tsx
+++ b/apps/web/src/lib/use-new-session-draft.test.tsx
@@ -361,6 +361,36 @@ describe("useNewSessionDraft", () => {
     await hook.unmount();
   });
 
+  test("a create-time conflict enters recovery instead of reusing the stale flushed revision", async () => {
+    let authoritative = remote(2, { text: "initial" });
+    const requests: SaveNewSessionDraftRequest[] = [];
+    const hook = await renderDraftHook(
+      client({
+        getNewSessionDraft: async () => authoritative,
+        saveNewSessionDraft: async (_workspaceId, request) => {
+          requests.push(request);
+          authoritative = remote(request.expectedRevision + 1, request);
+          return authoritative;
+        },
+      }),
+    );
+    await flush();
+    await actRun(() => hook.result.current.setValue(editable({ text: "mine" })));
+    const flushed = await actRun(() => hook.result.current.draft.flush());
+    expect(flushed?.revision).toBe(3);
+
+    authoritative = remote(4, { text: "sibling" });
+    expect(await actRun(() => hook.result.current.draft.captureConflict(conflict()))).toBe(true);
+    expect(hook.result.current.draft.conflict?.message).toContain("draft changed");
+    expect(await actRun(() => hook.result.current.draft.flush())).toBeNull();
+
+    await actRun(() => hook.result.current.draft.resolveConflict("keep_mine"));
+    expect(requests.at(-1)).toMatchObject({ expectedRevision: 4, text: "mine" });
+    expect(hook.result.current.draft.revision).toBe(5);
+    expect(hook.result.current.draft.conflict).toBeNull();
+    await hook.unmount();
+  });
+
   test("use remote replaces local state and revalidates its files", async () => {
     let reads = 0;
     const fileId = "00000000-0000-4000-8000-000000000055";

--- a/apps/web/src/lib/use-new-session-draft.ts
+++ b/apps/web/src/lib/use-new-session-draft.ts
@@ -57,6 +57,8 @@ export type UseNewSessionDraftResult = {
     flushed: FlushedNewSessionDraft,
   ) => Promise<AcknowledgeConsumedNewSessionDraftResult | null>;
   reload: () => Promise<void>;
+  /** Surface a create-time OCC rejection through the ordinary draft recovery UI. */
+  captureConflict: (cause: unknown) => boolean;
   resolveConflict: (choice: "keep_mine" | "use_remote") => Promise<void>;
   clearError: () => void;
 };
@@ -104,6 +106,17 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
     conflictRef.current = next;
     setConflict(next);
   }, []);
+
+  const captureConflict = useCallback(
+    (cause: unknown): boolean => {
+      if (!isNewSessionDraftConflict(cause)) return false;
+      const problem = asError(cause);
+      setCurrentConflict(problem);
+      setError(problem);
+      return true;
+    },
+    [setCurrentConflict],
+  );
 
   const abortActiveRemoteReads = useCallback(() => {
     for (const controller of activeRemoteReads.current) controller.abort();
@@ -508,6 +521,7 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
     isCurrentSignature,
     acknowledgeConsumed,
     reload,
+    captureConflict,
     resolveConflict,
     clearError: useCallback(() => {
       setError(null);

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -866,8 +866,10 @@ function SessionsIndexRouteContent({
                     personalWorkspace,
                     submission.options.visibility ?? "workspace",
                   ),
-                  onFailure: ({ error, request }) =>
-                    recoverPersonalResourceAttachment(error, request),
+                  onFailure: ({ error, request }) => {
+                    newSessionDraft.captureConflict(error);
+                    recoverPersonalResourceAttachment(error, request);
+                  },
                 },
               );
               if (!created) return null;
@@ -914,8 +916,10 @@ function SessionsIndexRouteContent({
                   personalWorkspace,
                   submission.options.visibility ?? "workspace",
                 ),
-                onFailure: ({ error, request }) =>
-                  recoverPersonalResourceAttachment(error, request),
+                onFailure: ({ error, request }) => {
+                  newSessionDraft.captureConflict(error);
+                  recoverPersonalResourceAttachment(error, request);
+                },
               },
             );
             if (!created) return null;

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -135,6 +135,7 @@ describe("session control surface architecture", () => {
     expect(route).toContain("fixedResourceSelection.selectionResolved");
     expect(route).toContain("personalResourceSelectionIdentityKey");
     expect(route).toContain("recoverPersonalResourceAttachment(error, request)");
+    expect(route.match(/newSessionDraft\.captureConflict\(error\)/g)).toHaveLength(2);
     expect(route).toContain("recoverNewSessionPersonalResourceAttachment");
     expect(route).toContain("refreshPersonalResourceCatalogs");
     expect(route).toContain("canLoadVariableSetCatalog");


### PR DESCRIPTION
## What changed
- route create-time NEW_SESSION_DRAFT_CONFLICT responses into the existing draft conflict UI
- preserve the local draft and require Keep mine or Use other draft before another create
- cover the stale-revision recovery and both create entry points

## Staging evidence
Reference 014329d0-0ba5-43a2-99cd-81832136b17a showed a sibling client advancing the draft immediately before create. The API correctly returned 409, but the web client kept reusing its stale acknowledged revision on every retry.

## Verification
- 37 focused web tests
- all 31 TypeScript projects
- production web build and bundle budgets
- formatting and focused lint

Linear: OPE-419

## Summary by Sourcery

Handle create-time new-session draft conflicts through the existing recovery flow so users can resolve stale drafts before retrying creation.

New Features:
- Route create-time new-session draft conflicts into the existing draft conflict recovery UI.

Bug Fixes:
- Prevent retries from reusing a stale acknowledged revision after a create-time conflict.
- Require users to choose Keep mine or Use other draft before another create attempt.

Tests:
- Add coverage for stale-revision recovery and both new-session creation entry points.