### PR TITLE
Surface organization invitations for existing users

### DIFF
--- a/.changeset/bright-organization-invitations.md
+++ b/.changeset/bright-organization-invitations.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Direct existing OpenGeni users to the global Organization invitations control in invitation emails while preserving account setup for new users.

--- a/apps/api/src/auth/organization-user-setup.ts
+++ b/apps/api/src/auth/organization-user-setup.ts
@@ -108,8 +108,8 @@ export function renderOrganizationUserSetupEmail(input: OrganizationUserSetupEma
     from: input.senderEmail,
     to: input.recipientEmail,
     subject: `Join ${input.organizationName} on OpenGeni`,
-    text: `${greeting}\n\nYou have been invited to ${input.organizationName} as ${role}.\n\n${workspaceSummary}\n\nThis invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.\n\nSet up your account: ${input.setupUrl}\n\nIf you already have an OpenGeni account, sign in and accept the invitation instead.`,
-    html: `<p>${escapeHtml(greeting)}</p><p>You have been invited to <strong>${escapeHtml(input.organizationName)}</strong> as ${escapeHtml(role)}.</p>${workspaceHtml}<p>This invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.</p><p><a href="${escapeHtml(input.setupUrl)}">Set up your account</a></p><p>If you already have an OpenGeni account, sign in and accept the invitation instead.</p>`,
+    text: `${greeting}\n\nYou have been invited to ${input.organizationName} as ${role}.\n\n${workspaceSummary}\n\nThis invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.\n\nReview invitation: ${input.setupUrl}\n\nAlready use OpenGeni? Sign in, then open Organization invitations from the account menu at the bottom of the sidebar.`,
+    html: `<p>${escapeHtml(greeting)}</p><p>You have been invited to <strong>${escapeHtml(input.organizationName)}</strong> as ${escapeHtml(role)}.</p>${workspaceHtml}<p>This invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.</p><p><a href="${escapeHtml(input.setupUrl)}">Review invitation</a></p><p>Already use OpenGeni? Sign in, then open <strong>Organization invitations</strong> from the account menu at the bottom of the sidebar.</p>`,
   };
 }
 

--- a/apps/api/src/auth/organization-user-setup.ts
+++ b/apps/api/src/auth/organization-user-setup.ts
@@ -107,9 +107,9 @@ export function renderOrganizationUserSetupEmail(input: OrganizationUserSetupEma
   return {
     from: input.senderEmail,
     to: input.recipientEmail,
-    subject: `Join ${input.organizationName} on OpenGeni`,
-    text: `${greeting}\n\nYou have been invited to ${input.organizationName} as ${role}.\n\n${workspaceSummary}\n\nThis invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.\n\nReview invitation: ${input.setupUrl}\n\nAlready use OpenGeni? Sign in, then open Organization invitations from the account menu at the bottom of the sidebar.`,
-    html: `<p>${escapeHtml(greeting)}</p><p>You have been invited to <strong>${escapeHtml(input.organizationName)}</strong> as ${escapeHtml(role)}.</p>${workspaceHtml}<p>This invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.</p><p><a href="${escapeHtml(input.setupUrl)}">Review invitation</a></p><p>Already use OpenGeni? Sign in, then open <strong>Organization invitations</strong> from the account menu at the bottom of the sidebar.</p>`,
+    subject: `You're invited to join ${input.organizationName} on OpenGeni`,
+    text: `${greeting}\n\nYou've been invited to join ${input.organizationName} on OpenGeni as ${role}.\n\n${workspaceSummary}\n\nThis invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.\n\nAccept invitation to ${input.organizationName}: ${input.setupUrl}\n\nYou'll sign in or create an account before joining. Already use OpenGeni? You can also sign in directly, open Organization invitations from the account menu at the bottom of the sidebar, and choose Join organization.`,
+    html: `<p>${escapeHtml(greeting)}</p><p>You've been invited to join <strong>${escapeHtml(input.organizationName)}</strong> on OpenGeni as ${escapeHtml(role)}.</p>${workspaceHtml}<p>This invitation grants only the organization role and shared workspace access listed above. It never shares anyone's Personal workspace.</p><p><a href="${escapeHtml(input.setupUrl)}">Accept invitation to ${escapeHtml(input.organizationName)}</a></p><p>You'll sign in or create an account before joining. Already use OpenGeni? You can also sign in directly, open <strong>Organization invitations</strong> from the account menu at the bottom of the sidebar, and choose <strong>Join organization</strong>.</p>`,
   };
 }
 

--- a/apps/api/test/managed-email.test.ts
+++ b/apps/api/test/managed-email.test.ts
@@ -78,9 +78,13 @@ describe("managed email transport", () => {
     expect(rendered.text).toContain("Ada <Admin>");
     expect(rendered.text).toContain("Launch <Ops>: Viewer");
     expect(rendered.text).toContain("never shares anyone's Personal workspace");
+    expect(rendered.text).toContain("Review invitation:");
+    expect(rendered.text).toContain("Organization invitations");
     expect(rendered.html).toContain("Ada &lt;Admin&gt;");
     expect(rendered.html).toContain("R&amp;D &lt;Labs&gt;");
     expect(rendered.html).toContain("Launch &lt;Ops&gt;");
+    expect(rendered.html).toContain(">Review invitation</a>");
+    expect(rendered.html).toContain("<strong>Organization invitations</strong>");
     expect(rendered.html).not.toContain("Ada <Admin>");
     const digestInput = {
       ...rendered,

--- a/apps/api/test/managed-email.test.ts
+++ b/apps/api/test/managed-email.test.ts
@@ -75,16 +75,19 @@ describe("managed email transport", () => {
       ],
       setupUrl: "https://opengeni.test/setup-account#token=secret-bearer",
     });
+    expect(rendered.subject).toBe("You're invited to join R&D <Labs> on OpenGeni");
     expect(rendered.text).toContain("Ada <Admin>");
     expect(rendered.text).toContain("Launch <Ops>: Viewer");
     expect(rendered.text).toContain("never shares anyone's Personal workspace");
-    expect(rendered.text).toContain("Review invitation:");
+    expect(rendered.text).toContain("Accept invitation to R&D <Labs>:");
+    expect(rendered.text).toContain("You'll sign in or create an account before joining.");
     expect(rendered.text).toContain("Organization invitations");
     expect(rendered.html).toContain("Ada &lt;Admin&gt;");
     expect(rendered.html).toContain("R&amp;D &lt;Labs&gt;");
     expect(rendered.html).toContain("Launch &lt;Ops&gt;");
-    expect(rendered.html).toContain(">Review invitation</a>");
+    expect(rendered.html).toContain(">Accept invitation to R&amp;D &lt;Labs&gt;</a>");
     expect(rendered.html).toContain("<strong>Organization invitations</strong>");
+    expect(rendered.html).toContain("<strong>Join organization</strong>");
     expect(rendered.html).not.toContain("Ada <Admin>");
     const digestInput = {
       ...rendered,

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -661,7 +661,7 @@ describe("organization membership routes", () => {
       expect(failedMessage.text).toContain("never shares anyone's Personal workspace");
       expect(failedMessage.idempotencyKey).toBeTruthy();
 
-      const setupUrl = failedMessage.text.match(/Set up your account: (\S+)/)?.[1];
+      const setupUrl = failedMessage.text.match(/Review invitation: (\S+)/)?.[1];
       expect(setupUrl).toBeTruthy();
       const token = new URL(setupUrl!).hash.slice("#token=".length);
       const previewApp = new Hono();

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -661,7 +661,7 @@ describe("organization membership routes", () => {
       expect(failedMessage.text).toContain("never shares anyone's Personal workspace");
       expect(failedMessage.idempotencyKey).toBeTruthy();
 
-      const setupUrl = failedMessage.text.match(/Review invitation: (\S+)/)?.[1];
+      const setupUrl = failedMessage.text.match(/Accept invitation to .*: (https?:\/\/\S+)/)?.[1];
       expect(setupUrl).toBeTruthy();
       const token = new URL(setupUrl!).hash.slice("#token=".length);
       const previewApp = new Hono();

--- a/apps/web/src/components/browser-account-menu.tsx
+++ b/apps/web/src/components/browser-account-menu.tsx
@@ -34,6 +34,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useRail } from "@/components/rail/rail-context";
+import {
+  OrganizationInvitationsDialog,
+  OrganizationInvitationsMenuItem,
+  useOrganizationInvitations,
+} from "@/components/organization-invitations";
 import { useBrowserAccountPopup } from "@/components/use-browser-account-popup";
 import { useAppContext } from "@/context";
 import { analyticsPreferencesAvailable, openAnalyticsPreferences } from "@/lib/analytics-consent";
@@ -74,6 +79,11 @@ export function BrowserAccountMenu() {
     context.authSession?.user.email ??
     context.accessContext.subjectId;
   const image = context.authSession?.user.image ?? undefined;
+  const organizationInvitations = useOrganizationInvitations({
+    client: context.client,
+    enabled: true,
+    onAccepted: context.revalidatePrincipalAccess,
+  });
   const replacementSlots = useMemo(
     () =>
       projection?.slots.filter((slot) => slot.id !== logoutTarget?.id && slot.state === "active") ??
@@ -274,6 +284,11 @@ export function BrowserAccountMenu() {
             <UserRoundPlusIcon className="size-4" />
             Add another account
           </DropdownMenuItem>
+          <OrganizationInvitationsMenuItem
+            controller={organizationInvitations}
+            className="min-h-11 forced-colors:text-[CanvasText]!"
+            disabled={busy}
+          />
           {showAnalyticsPreferences ? (
             <DropdownMenuItem className="min-h-11" onSelect={() => openAnalyticsPreferences()}>
               <ChartColumnIcon className="size-4" />
@@ -312,6 +327,8 @@ export function BrowserAccountMenu() {
           ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <OrganizationInvitationsDialog controller={organizationInvitations} />
 
       <Dialog open={logoutTarget !== null} onOpenChange={(open) => !open && setLogoutTarget(null)}>
         <DialogContent className="motion-reduce:duration-0">

--- a/apps/web/src/components/organization-invitations.test.tsx
+++ b/apps/web/src/components/organization-invitations.test.tsx
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+const toastSuccess = mock(() => undefined);
+const toastError = mock(() => undefined);
+
+mock.module("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+mock.module("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+mock.module("@/components/ui/dropdown-menu", () => ({
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...props
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+    [key: string]: unknown;
+  }) => (
+    <button type="button" {...props} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+}));
+
+const {
+  OrganizationInvitationsDialog,
+  OrganizationInvitationsMenuItem,
+  useOrganizationInvitations,
+} = await import("./organization-invitations");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+}
+
+function invitation(input: {
+  id: string;
+  organizationId: string;
+  organizationName: string;
+  status: "pending" | "accepted";
+  revision: number;
+}) {
+  const timestamp = "2026-09-08T12:00:00.000Z";
+  return {
+    ...input,
+    targetEmail: "member@example.test",
+    targetName: "Member",
+    initialWorkspaceIds: [crypto.randomUUID()],
+    role: "member" as const,
+    expiresAt: timestamp,
+    acceptedMembershipId: input.status === "accepted" ? crypto.randomUUID() : null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    delivery: null,
+  };
+}
+
+describe("global organization invitations", () => {
+  test("lists only pending invitations and accepts the chosen organization", async () => {
+    const pending = invitation({
+      id: crypto.randomUUID(),
+      organizationId: crypto.randomUUID(),
+      organizationName: "Northwind Research",
+      status: "pending",
+      revision: 3,
+    });
+    const historical = invitation({
+      id: crypto.randomUUID(),
+      organizationId: crypto.randomUUID(),
+      organizationName: "Historical Organization",
+      status: "accepted",
+      revision: 4,
+    });
+    const listOrganizationInvitations = mock(async () => ({
+      invitations: [pending, historical],
+      nextCursor: null,
+    }));
+    const acceptOrganizationInvitation = mock(async () => ({ status: "complete" as const }));
+    const onAccepted = mock(() => undefined);
+    const client = {
+      listOrganizationInvitations,
+      acceptOrganizationInvitation,
+    } as unknown as OpenGeniBrowserClient;
+
+    function Harness() {
+      const controller = useOrganizationInvitations({
+        client,
+        enabled: true,
+        onAccepted,
+      });
+      return (
+        <>
+          <OrganizationInvitationsMenuItem controller={controller} />
+          <OrganizationInvitationsDialog controller={controller} />
+        </>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => root.render(<Harness />));
+      await flush();
+      expect(listOrganizationInvitations).toHaveBeenCalled();
+      expect(
+        container.querySelector<HTMLButtonElement>(
+          'button[aria-label="Organization invitations, 1 pending"]',
+        ),
+      ).not.toBeNull();
+
+      await act(async () =>
+        container
+          .querySelector<HTMLButtonElement>(
+            'button[aria-label="Organization invitations, 1 pending"]',
+          )!
+          .click(),
+      );
+      await flush();
+      expect(container.textContent).toContain("Northwind Research");
+      expect(container.textContent).not.toContain("Historical Organization");
+
+      await act(async () =>
+        container
+          .querySelector<HTMLButtonElement>('button[aria-label="Join Northwind Research"]')!
+          .click(),
+      );
+      await flush();
+      expect(acceptOrganizationInvitation).toHaveBeenCalledWith(pending.id, {
+        expectedRevision: 3,
+        operationId: expect.any(String),
+      });
+      expect(onAccepted).toHaveBeenCalledTimes(1);
+      expect(toastSuccess).toHaveBeenCalledWith("Joined Northwind Research");
+      expect(container.textContent).toContain("No pending invitations");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/components/organization-invitations.test.tsx
+++ b/apps/web/src/components/organization-invitations.test.tsx
@@ -79,6 +79,65 @@ function invitation(input: {
 }
 
 describe("global organization invitations", () => {
+  test("continues through historical pages to find every pending invitation", async () => {
+    const pending = invitation({
+      id: crypto.randomUUID(),
+      organizationId: crypto.randomUUID(),
+      organizationName: "Later Pending Organization",
+      status: "pending",
+      revision: 2,
+    });
+    const nextCursor = crypto.randomUUID();
+    const historical = Array.from({ length: 100 }, (_, index) =>
+      invitation({
+        id: crypto.randomUUID(),
+        organizationId: crypto.randomUUID(),
+        organizationName: `Historical Organization ${index}`,
+        status: "accepted",
+        revision: 1,
+      }),
+    );
+    const listOrganizationInvitations = mock(async (options: { cursor?: string; limit?: number }) =>
+      options.cursor === nextCursor
+        ? { invitations: [pending], nextCursor: null }
+        : { invitations: historical, nextCursor },
+    );
+    const client = {
+      listOrganizationInvitations,
+      acceptOrganizationInvitation: mock(async () => ({ status: "complete" as const })),
+    } as unknown as OpenGeniBrowserClient;
+
+    function Harness() {
+      const controller = useOrganizationInvitations({
+        client,
+        enabled: true,
+        onAccepted: () => undefined,
+      });
+      return <OrganizationInvitationsMenuItem controller={controller} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => root.render(<Harness />));
+      await flush();
+      expect(listOrganizationInvitations).toHaveBeenCalledTimes(2);
+      expect(listOrganizationInvitations.mock.calls).toEqual([
+        [{ limit: 100 }],
+        [{ cursor: nextCursor, limit: 100 }],
+      ]);
+      expect(
+        container.querySelector<HTMLButtonElement>(
+          'button[aria-label="Organization invitations, 1 pending"]',
+        ),
+      ).not.toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
   test("lists only pending invitations and accepts the chosen organization", async () => {
     const pending = invitation({
       id: crypto.randomUUID(),

--- a/apps/web/src/components/organization-invitations.tsx
+++ b/apps/web/src/components/organization-invitations.tsx
@@ -58,9 +58,24 @@ export function useOrganizationInvitations(input: {
     setLoading(true);
     setError(null);
     try {
-      const result = await acceptedClient.listOrganizationInvitations({ limit: 100 });
-      if (activeClient.current !== acceptedClient || readSequence.current !== sequence) return;
-      setInvitations(result.invitations.filter((invitation) => invitation.status === "pending"));
+      const listedInvitations: OrganizationInvitation[] = [];
+      const seenCursors = new Set<string>();
+      let cursor: string | undefined;
+      do {
+        const result = await acceptedClient.listOrganizationInvitations({
+          ...(cursor === undefined ? {} : { cursor }),
+          limit: 100,
+        });
+        if (activeClient.current !== acceptedClient || readSequence.current !== sequence) return;
+        listedInvitations.push(...result.invitations);
+        const nextCursor = result.nextCursor ?? undefined;
+        if (nextCursor !== undefined && seenCursors.has(nextCursor)) {
+          throw new Error("Organization invitation pagination did not advance");
+        }
+        if (nextCursor !== undefined) seenCursors.add(nextCursor);
+        cursor = nextCursor;
+      } while (cursor !== undefined);
+      setInvitations(listedInvitations.filter((invitation) => invitation.status === "pending"));
       setLoaded(true);
     } catch (caught) {
       if (activeClient.current !== acceptedClient || readSequence.current !== sequence) return;

--- a/apps/web/src/components/organization-invitations.tsx
+++ b/apps/web/src/components/organization-invitations.tsx
@@ -1,0 +1,293 @@
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import { Loader2Icon, MailIcon, RefreshCwIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Notice } from "@/components/ui/notice";
+import { isOrganizationConflict } from "@/lib/organization-admin";
+import { cn } from "@/lib/utils";
+import type { OrganizationInvitation } from "@/types";
+
+export type OrganizationInvitationsController = {
+  open: boolean;
+  invitations: OrganizationInvitation[];
+  pendingCount: number;
+  loaded: boolean;
+  loading: boolean;
+  error: Error | null;
+  acceptingInvitationId: string | null;
+  announcement: string;
+  openDialog: () => void;
+  setOpen: (open: boolean) => void;
+  reload: () => Promise<void>;
+  accept: (invitation: OrganizationInvitation) => Promise<void>;
+};
+
+export function useOrganizationInvitations(input: {
+  client: OpenGeniBrowserClient;
+  enabled: boolean;
+  onAccepted: () => void;
+}): OrganizationInvitationsController {
+  const { client, enabled, onAccepted } = input;
+  const [open, setOpen] = useState(false);
+  const [invitations, setInvitations] = useState<OrganizationInvitation[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [acceptingInvitationId, setAcceptingInvitationId] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const readSequence = useRef(0);
+  const activeClient = useRef(client);
+  const operationIds = useRef(new Map<string, string>());
+  activeClient.current = client;
+
+  const reload = useCallback(async () => {
+    if (!enabled) return;
+    const acceptedClient = client;
+    const sequence = ++readSequence.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await acceptedClient.listOrganizationInvitations({ limit: 100 });
+      if (activeClient.current !== acceptedClient || readSequence.current !== sequence) return;
+      setInvitations(result.invitations.filter((invitation) => invitation.status === "pending"));
+      setLoaded(true);
+    } catch (caught) {
+      if (activeClient.current !== acceptedClient || readSequence.current !== sequence) return;
+      setError(caught instanceof Error ? caught : new Error(String(caught)));
+      setLoaded(true);
+    } finally {
+      if (activeClient.current === acceptedClient && readSequence.current === sequence) {
+        setLoading(false);
+      }
+    }
+  }, [client, enabled]);
+
+  useEffect(() => {
+    operationIds.current.clear();
+    setOpen(false);
+    setInvitations([]);
+    setLoaded(false);
+    setLoading(false);
+    setError(null);
+    setAcceptingInvitationId(null);
+    setAnnouncement("");
+    if (enabled) void reload();
+    return () => {
+      readSequence.current += 1;
+    };
+  }, [client, enabled, reload]);
+
+  const openDialog = useCallback(() => {
+    setOpen(true);
+    void reload();
+  }, [reload]);
+
+  const accept = useCallback(
+    async (invitation: OrganizationInvitation) => {
+      if (!enabled || acceptingInvitationId !== null) return;
+      const acceptedClient = client;
+      const operationId = operationIds.current.get(invitation.id) ?? crypto.randomUUID();
+      operationIds.current.set(invitation.id, operationId);
+      setAcceptingInvitationId(invitation.id);
+      setError(null);
+      try {
+        await acceptedClient.acceptOrganizationInvitation(invitation.id, {
+          expectedRevision: invitation.revision,
+          operationId,
+        });
+        if (activeClient.current !== acceptedClient) return;
+        operationIds.current.delete(invitation.id);
+        setInvitations((current) => current.filter((candidate) => candidate.id !== invitation.id));
+        const organizationName = invitation.organizationName ?? "the organization";
+        setAnnouncement(`Joined ${organizationName}.`);
+        toast.success(`Joined ${organizationName}`);
+        onAccepted();
+      } catch (caught) {
+        if (activeClient.current !== acceptedClient) return;
+        if (isOrganizationConflict(caught)) {
+          operationIds.current.delete(invitation.id);
+          toast.error("Invitation state changed", {
+            description: "Your invitations were refreshed. Review them before trying again.",
+          });
+          await reload();
+          return;
+        }
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+      } finally {
+        if (activeClient.current === acceptedClient) setAcceptingInvitationId(null);
+      }
+    },
+    [acceptingInvitationId, client, enabled, onAccepted, reload],
+  );
+
+  return {
+    open,
+    invitations,
+    pendingCount: invitations.length,
+    loaded,
+    loading,
+    error,
+    acceptingInvitationId,
+    announcement,
+    openDialog,
+    setOpen,
+    reload,
+    accept,
+  };
+}
+
+export function OrganizationInvitationsMenuItem(props: {
+  controller: OrganizationInvitationsController;
+  className?: string;
+  disabled?: boolean;
+}) {
+  const { controller } = props;
+  const accessibleLabel =
+    controller.pendingCount > 0
+      ? `Organization invitations, ${controller.pendingCount} pending`
+      : "Organization invitations";
+  return (
+    <DropdownMenuItem
+      className={props.className}
+      aria-label={accessibleLabel}
+      disabled={props.disabled}
+      onSelect={controller.openDialog}
+    >
+      <MailIcon
+        className={cn("size-4", controller.pendingCount > 0 && "text-brand!")}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1">Organization invitations</span>
+      {controller.loading && !controller.loaded ? (
+        <Loader2Icon
+          className="size-3.5 animate-spin text-fg-subtle motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+      ) : controller.pendingCount > 0 ? (
+        <Badge variant="secondary" className="min-w-5 px-1.5 py-0 text-2xs tabular-nums">
+          {controller.pendingCount}
+        </Badge>
+      ) : null}
+    </DropdownMenuItem>
+  );
+}
+
+export function OrganizationInvitationsDialog(props: {
+  controller: OrganizationInvitationsController;
+}) {
+  const { controller } = props;
+  return (
+    <Dialog open={controller.open} onOpenChange={controller.setOpen}>
+      <DialogContent className="max-h-[90dvh] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Organization invitations</DialogTitle>
+          <DialogDescription>
+            Review invitations for this signed-in account. Joining adds the listed organization and
+            shared workspace access; it never shares anyone&apos;s Personal workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {controller.announcement}
+        </span>
+        <div className="min-h-0 overflow-y-auto pr-1">
+          {controller.error ? (
+            <Notice
+              tone="failed"
+              title="Could not update invitations"
+              action={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={controller.loading || controller.acceptingInvitationId !== null}
+                  onClick={() => void controller.reload()}
+                >
+                  <RefreshCwIcon className="size-4" />
+                  Try again
+                </Button>
+              }
+            >
+              No invitation was accepted. Check your connection and try again.
+            </Notice>
+          ) : null}
+
+          {controller.loading && !controller.loaded ? (
+            <p role="status" className="flex items-center gap-2 py-6 text-sm text-fg-muted">
+              <Loader2Icon className="size-4 animate-spin motion-reduce:animate-none" />
+              Loading invitations…
+            </p>
+          ) : controller.loaded && controller.invitations.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center">
+              <p className="text-sm font-medium text-fg">No pending invitations</p>
+              <p className="mt-1 text-xs text-fg-muted">
+                New organization invitations will appear here for the selected account.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-2">
+              {controller.invitations.map((invitation) => {
+                const organizationName = invitation.organizationName ?? "Inviting organization";
+                const sharedWorkspaceCount = invitation.initialWorkspaceIds.length;
+                return (
+                  <article
+                    key={invitation.id}
+                    className="grid gap-3 rounded-lg border border-border bg-surface/40 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-fg">{organizationName}</p>
+                      <p className="mt-1 text-xs text-fg-muted">
+                        {invitation.targetEmail} · {titleCase(invitation.role)}
+                      </p>
+                      <p className="mt-1 text-xs text-fg-subtle">
+                        {sharedWorkspaceCount === 0
+                          ? "No shared workspaces assigned yet"
+                          : `${sharedWorkspaceCount} shared workspace${sharedWorkspaceCount === 1 ? "" : "s"} included`}
+                        {" · Expires "}
+                        <time dateTime={invitation.expiresAt}>
+                          {formatInvitationDate(invitation.expiresAt)}
+                        </time>
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="w-full sm:w-auto"
+                      aria-label={`Join ${organizationName}`}
+                      disabled={controller.acceptingInvitationId !== null || controller.loading}
+                      onClick={() => void controller.accept(invitation)}
+                    >
+                      {controller.acceptingInvitationId === invitation.id ? (
+                        <Loader2Icon className="size-4 animate-spin motion-reduce:animate-none" />
+                      ) : null}
+                      Join organization
+                    </Button>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function titleCase(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}
+
+function formatInvitationDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(value));
+}

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -12,6 +12,11 @@ import {
 import { lazy, Suspense } from "react";
 import { toast } from "sonner";
 
+import {
+  OrganizationInvitationsDialog,
+  OrganizationInvitationsMenuItem,
+  useOrganizationInvitations,
+} from "@/components/organization-invitations";
 import { useRail } from "@/components/rail/rail-context";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -50,6 +55,11 @@ export function RailFooter() {
     context.accessContext.subjectId;
   const secondary = context.authSession?.user.email ?? context.accessContext.subjectId;
   const image = context.authSession?.user.image ?? undefined;
+  const organizationInvitations = useOrganizationInvitations({
+    client: context.client,
+    enabled: managed && !browserAccounts,
+    onAccepted: context.revalidatePrincipalAccess,
+  });
 
   return (
     <div className="mt-auto border-t border-border p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
@@ -107,6 +117,9 @@ export function RailFooter() {
                 ) : null}
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
+              {managed ? (
+                <OrganizationInvitationsMenuItem controller={organizationInvitations} />
+              ) : null}
               {showAnalyticsPreferences ? (
                 <DropdownMenuItem onSelect={() => openAnalyticsPreferences()}>
                   <ChartColumnIcon className="size-4" />
@@ -166,6 +179,9 @@ export function RailFooter() {
           </Tooltip>
         ) : null}
       </div>
+      {managed && !browserAccounts ? (
+        <OrganizationInvitationsDialog controller={organizationInvitations} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/routes/onboarding.test.tsx
+++ b/apps/web/src/routes/onboarding.test.tsx
@@ -380,7 +380,9 @@ describe("organization onboarding UI", () => {
     const root = createRoot(container);
     try {
       await act(async () => root.render(<SetupAccountRoute token="setup-token" />));
-      expect(container.textContent).toContain("Use your existing OpenGeni account");
+      await flush();
+      expect(container.textContent).toContain("Join Test Organization");
+      expect(container.textContent).toContain("create an account to accept this invitation");
       expect(container.textContent).toContain("Organization invitations");
       expect(container.textContent).toContain("Sign in to accept invitation");
       await enter(container.querySelector("#setup-account-name")!, "Grace Hopper");

--- a/apps/web/src/routes/onboarding.test.tsx
+++ b/apps/web/src/routes/onboarding.test.tsx
@@ -380,13 +380,15 @@ describe("organization onboarding UI", () => {
     const root = createRoot(container);
     try {
       await act(async () => root.render(<SetupAccountRoute token="setup-token" />));
-      expect(container.textContent).toContain("Create your login for the organization");
+      expect(container.textContent).toContain("Use your existing OpenGeni account");
+      expect(container.textContent).toContain("Organization invitations");
+      expect(container.textContent).toContain("Sign in to accept invitation");
       await enter(container.querySelector("#setup-account-name")!, "Grace Hopper");
       await enter(container.querySelector("#setup-account-password")!, "password1234");
       await enter(container.querySelector("#setup-account-confirm")!, "password1234");
       await act(async () =>
         Array.from(container.querySelectorAll("button"))
-          .find((button) => button.textContent?.trim() === "Create account")!
+          .find((button) => button.textContent?.trim() === "Create account and join")!
           .click(),
       );
       await flush();

--- a/apps/web/src/routes/setup-account.tsx
+++ b/apps/web/src/routes/setup-account.tsx
@@ -106,9 +106,15 @@ export function SetupAccountRoute({ token }: { token?: string | undefined }) {
             <KeyRoundIcon className="size-4" />
           </span>
           <div>
-            <h1 className="text-base font-semibold">Join an organization</h1>
+            <h1 className="text-base font-semibold">
+              {preview?.state === "pending"
+                ? `Join ${preview.organizationName}`
+                : "Join an organization"}
+            </h1>
             <p className="text-sm text-fg-subtle">
-              Use your existing OpenGeni account or create a new one.
+              {preview?.state === "pending"
+                ? "Sign in or create an account to accept this invitation."
+                : "Use your existing OpenGeni account or create a new one."}
             </p>
           </div>
         </div>

--- a/apps/web/src/routes/setup-account.tsx
+++ b/apps/web/src/routes/setup-account.tsx
@@ -99,16 +99,16 @@ export function SetupAccountRoute({ token }: { token?: string | undefined }) {
   }
 
   return (
-    <section className="flex flex-1 items-center justify-center px-4">
+    <section className="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-4 py-4 sm:items-center">
       <div className="w-full max-w-sm rounded-lg border border-border bg-surface p-5 shadow-sm">
         <div className="mb-4 flex items-center gap-3">
           <span className="flex size-9 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
             <KeyRoundIcon className="size-4" />
           </span>
           <div>
-            <h1 className="text-base font-semibold">Set up your account</h1>
+            <h1 className="text-base font-semibold">Join an organization</h1>
             <p className="text-sm text-fg-subtle">
-              Create your login for the organization that invited you.
+              Use your existing OpenGeni account or create a new one.
             </p>
           </div>
         </div>
@@ -173,6 +173,21 @@ export function SetupAccountRoute({ token }: { token?: string | undefined }) {
                 This does not share anyone&apos;s Personal workspace.
               </p>
             </div>
+            <div className="mb-4 rounded-md border border-border bg-surface-subtle p-3">
+              <p className="text-sm font-medium">Already have an OpenGeni account?</p>
+              <p className="mt-1 text-xs leading-5 text-fg-subtle">
+                Sign in, then open Organization invitations from the account menu at the bottom of
+                the sidebar.
+              </p>
+              <Button asChild variant="secondary" size="sm" className="mt-3 w-full">
+                <Link to="/">Sign in to accept invitation</Link>
+              </Button>
+            </div>
+            <div className="mb-4 flex items-center gap-3 text-xs text-fg-subtle">
+              <span className="h-px flex-1 bg-border" />
+              New to OpenGeni?
+              <span className="h-px flex-1 bg-border" />
+            </div>
             <div className="mb-3">
               <Label htmlFor="setup-account-name">Your name</Label>
               <Input
@@ -217,10 +232,7 @@ export function SetupAccountRoute({ token }: { token?: string | undefined }) {
               ) : (
                 <CheckIcon className="size-4" />
               )}
-              Create account
-            </Button>
-            <Button asChild variant="ghost" className="mt-2 w-full">
-              <Link to="/">I already have an account</Link>
+              Create account and join
             </Button>
           </form>
         )}

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -729,9 +729,15 @@ a skipped green result.
 
 The managed web console exposes this lifecycle as a bounded organization
 administration surface with separate Overview, People & invitations, Retention,
-and Billing sections. Overview projects the canonical organization name plus
-every shared workspace and its direct human/service access roster; the database
-excludes all Personal workspaces before JSON projection. Owners and
+and Billing sections. The global account menu at the bottom of the sidebar also
+lists incoming Organization invitations with a pending count and an acceptance
+dialog, so a human who already belongs to one or more organizations never has
+to discover an invitation through the inviting organization first. Invitation
+emails and the signed-out setup page direct existing users to that same control
+before presenting new-account setup. Overview projects the canonical
+organization name plus every shared workspace and its direct human/service
+access roster; the database excludes all Personal workspaces before JSON
+projection. Owners and
 administrators can rename the organization through a revision- and
 operation-fenced lifecycle function, and managed-access bootstrap never
 overwrites that deliberate name from the user's profile. It lists the

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -630,7 +630,7 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     await setupPage.goto(firstUrl(setupEmail), {
       waitUntil: "domcontentloaded",
     });
-    await setupPage.getByRole("heading", { name: "Join an organization" }).waitFor();
+    await setupPage.getByRole("heading", { name: "Join Onboarding Greenfield Org" }).waitFor();
     let observedSetupCopy = "";
     await waitFor(
       async () => {

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -202,7 +202,8 @@ function isExpectedNavigationReadCancellation(problem: string): boolean {
   return (
     pathname === "/v1/config/client" ||
     pathname === "/v1/auth/get-session" ||
-    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:realtime-)?model-catalog$/u.test(pathname)
+    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:realtime-)?model-catalog$/u.test(pathname) ||
+    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:sessions|machines|new-session-draft)$/u.test(pathname)
   );
 }
 
@@ -629,7 +630,7 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     await setupPage.goto(firstUrl(setupEmail), {
       waitUntil: "domcontentloaded",
     });
-    await setupPage.getByRole("heading", { name: "Set up your account" }).waitFor();
+    await setupPage.getByRole("heading", { name: "Join an organization" }).waitFor();
     let observedSetupCopy = "";
     await waitFor(
       async () => {
@@ -671,7 +672,7 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     await setupPage.getByLabel("Your name").fill("Onboarding Invited");
     await setupPage.getByLabel("Password", { exact: true }).fill(PASSWORD);
     await setupPage.getByLabel("Confirm password").fill(PASSWORD);
-    await setupPage.getByRole("button", { name: "Create account" }).click();
+    await setupPage.getByRole("button", { name: "Create account and join" }).click();
     await setupPage
       .getByText("Your email is verified and your organization access is ready.")
       .waitFor();
@@ -1045,6 +1046,34 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
       organizationId: alternateOrganizationId,
       status: "pending",
     });
+    await registeredPage.setViewportSize({ width: 1024, height: 768 });
+    await registeredPage.getByRole("button", { name: "Account menu" }).click();
+    await registeredPage.getByRole("menuitem", { name: /Organization invitations/ }).click();
+    await registeredPage.getByRole("heading", { name: "Organization invitations" }).waitFor();
+    await registeredPage.getByText("Onboarding Alternate Org").waitFor();
+    await expectNoAxeViolations(registeredPage, "body");
+    await registeredPage.screenshot({
+      path: `${EVIDENCE_DIR}/onboarding-existing-account-invitations-desktop-1024.png`,
+      fullPage: true,
+    });
+    await registeredPage.getByRole("button", { name: "Join Onboarding Alternate Org" }).click();
+    await registeredPage.getByRole("button", { name: "Account menu" }).waitFor();
+    const joinedMemberships = await sdk(registeredCookie).listOrganizationMemberships();
+    expect(joinedMemberships.memberships).toHaveLength(2);
+    expect(joinedMemberships.memberships.map((membership) => membership.organizationId)).toEqual(
+      expect.arrayContaining([organizationId, alternateOrganizationId]),
+    );
+    const acceptedInvitationHistory = await sdk(registeredCookie).listOrganizationInvitations({
+      limit: 20,
+    });
+    expect(
+      acceptedInvitationHistory.invitations.find(
+        (invitation) => invitation.id === alternateInvite.id,
+      ),
+    ).toMatchObject({
+      organizationId: alternateOrganizationId,
+      status: "accepted",
+    });
     expectNoBrowserProblems(alternateProblems);
     await alternateContext.close();
 
@@ -1194,6 +1223,7 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
             "onboarding-owner-desktop-1440.png",
             "onboarding-setup-mobile-390.png",
             "onboarding-registered-mobile-320.png",
+            "onboarding-existing-account-invitations-desktop-1024.png",
           ],
         },
         null,


### PR DESCRIPTION
## Summary

- add a global Organization invitations entry to both managed account menus, with a pending count, invitation details, and revision/operation-fenced acceptance
- revalidate principal access after joining so the newly accepted organization is immediately available
- reword invitation email and setup-page guidance so existing users sign in and use the account menu instead of creating another account
- cover the multi-organization regression with component, API, and real browser/PostgreSQL acceptance tests

## Testing

- [x] `cd apps/web && bun run typecheck`
- [x] `cd apps/api && bun run typecheck`
- [x] `bun test --timeout 30000 apps/web/src/organization-admin-surface.test.ts apps/web/src/components/organization-invitations.test.tsx apps/web/src/routes/onboarding.test.tsx apps/api/test/managed-email.test.ts` (22 passed)
- [x] `bun test --timeout 120000 apps/api/test/organization-memberships-routes.test.ts -t 'journals failed delivery'` (1 passed, 12 filtered)
- [x] `OPENGENI_REQUIRE_REAL_DB=1 OPENGENI_ONBOARDING_EVIDENCE_DIR=... bun --no-env-file test --max-concurrency=1 ./test/e2e/organization-onboarding-acceptance.e2e.ts` (3 passed; production web build, real PostgreSQL, axe checks, 1024x768 invitation-dialog capture)
- [x] targeted `oxfmt --check`, `oxlint`, and `git diff --check`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] This is a focused source fix from current `main`; hotfix freeze-head admission does not apply.

## Notes

- Root cause: invitation acceptance was reachable only during first-time onboarding or inside the inviting organization's settings. Existing users could not enter an organization they had not accepted yet, leaving the invitation unreachable.
- Acceptance never grants access to another user's Personal workspace; the dialog shows only the invited organization role and shared-workspace scope.

## Summary by Sourcery

Enable existing OpenGeni users to discover and accept organization invitations from their account menu.

New Features:
- Add a global Organization invitations control to managed account menus, including pending counts, invitation details, and organization acceptance.

Bug Fixes:
- Allow existing users to accept invitations to additional organizations and immediately access the newly joined organization.

Enhancements:
- Clarify invitation and setup guidance for existing users while preserving new-account onboarding.
- Protect invitation acceptance and refresh behavior against stale or conflicting invitation state.

Documentation:
- Document the global account-menu invitation workflow for existing organization members.

Tests:
- Add component, API, and real-browser PostgreSQL coverage for paginated invitations, acceptance, onboarding, and multi-organization access.