### PR TITLE
Prevent broken generated-file links outside the workspace

### DIFF
--- a/.changeset/clean-sandbox-file-links.md
+++ b/.changeset/clean-sandbox-file-links.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Require agents to copy user-facing screenshots and artifacts into the workspace before emitting sandbox file links, preventing inaccessible links to temporary or host paths.

--- a/packages/runtime/src/operational-instructions.ts
+++ b/packages/runtime/src/operational-instructions.ts
@@ -63,7 +63,7 @@ Your answer is being rendered by an application for the user. Follow these guide
 - When referencing a real local file, prefer a clickable markdown link.
   * Clickable file links should look like [app.py](sandbox:/workspace/app.py:12): plain label, sandbox:/workspace/... target, with optional line number after the path.
   * If a file path has spaces, wrap the target in angle brackets: [My Report.md](<sandbox:/workspace/My Project/My Report.md:3>).
-  * Never link to /tmp, a host path, or any path outside /workspace. If a generated screenshot or artifact lives elsewhere, copy it into /workspace before responding and link the workspace copy.
+  * Never link to /tmp, a host path, or any file outside the current workspace. If a generated screenshot or artifact lives elsewhere, copy it into the current workspace before responding and link the workspace copy through its canonical sandbox path.
   * Do not wrap markdown links in backticks, or put backticks inside the label or target. This confuses the markdown renderer.
   * Do not use URIs like file://, vscode://, or https:// for file links, and do not use host-absolute paths.
   * Do not provide ranges of lines.

--- a/packages/runtime/src/operational-instructions.ts
+++ b/packages/runtime/src/operational-instructions.ts
@@ -63,9 +63,11 @@ Your answer is being rendered by an application for the user. Follow these guide
 - When referencing a real local file, prefer a clickable markdown link.
   * Clickable file links should look like [app.py](sandbox:/workspace/app.py:12): plain label, sandbox:/workspace/... target, with optional line number after the path.
   * If a file path has spaces, wrap the target in angle brackets: [My Report.md](<sandbox:/workspace/My Project/My Report.md:3>).
-  * Never link to /tmp, a host path, or any file outside the current workspace. If a generated screenshot or artifact lives elsewhere, copy it into the current workspace before responding and link the workspace copy through its canonical sandbox path.
+  * Use the active workspace path exactly as exposed to you. Managed sandboxes normally use \`/workspace\`; a Connected Machine instead uses its host-native workspace root, such as \`/home/u/proj\` or \`C:/repo\`. Both are valid inside a \`sandbox:\` link when they are the active workspace.
+  * Connected Machine examples are [app.py](sandbox:/home/u/proj/app.py:12) on POSIX and [app.ts](<sandbox:C:/repo/app.ts:12>) on Windows.
+  * Never link directly to \`/tmp\` or any file outside the current workspace. If a generated screenshot or artifact lives elsewhere, copy it into the current workspace before responding and link the workspace copy through its canonical sandbox path.
   * Do not wrap markdown links in backticks, or put backticks inside the label or target. This confuses the markdown renderer.
-  * Do not use URIs like file://, vscode://, or https:// for file links, and do not use host-absolute paths.
+  * Do not use URIs like file://, vscode://, or https:// for local file links, and do not invent or translate the active workspace root.
   * Do not provide ranges of lines.
   * Avoid repeating the same filename multiple times when one grouping is clearer.
 

--- a/packages/runtime/src/operational-instructions.ts
+++ b/packages/runtime/src/operational-instructions.ts
@@ -63,6 +63,7 @@ Your answer is being rendered by an application for the user. Follow these guide
 - When referencing a real local file, prefer a clickable markdown link.
   * Clickable file links should look like [app.py](sandbox:/workspace/app.py:12): plain label, sandbox:/workspace/... target, with optional line number after the path.
   * If a file path has spaces, wrap the target in angle brackets: [My Report.md](<sandbox:/workspace/My Project/My Report.md:3>).
+  * Never link to /tmp, a host path, or any path outside /workspace. If a generated screenshot or artifact lives elsewhere, copy it into /workspace before responding and link the workspace copy.
   * Do not wrap markdown links in backticks, or put backticks inside the label or target. This confuses the markdown renderer.
   * Do not use URIs like file://, vscode://, or https:// for file links, and do not use host-absolute paths.
   * Do not provide ranges of lines.

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -31,6 +31,9 @@ describe("provider-neutral operational instructions", () => {
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.ts](<sandbox:C:/repo/app.ts:12>)");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link directly to `/tmp`");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "or any file outside the current workspace",
+    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "copy it into the current workspace before responding",
     );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("canonical sandbox path");

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -22,8 +22,9 @@ describe("provider-neutral operational instructions", () => {
     );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link to /tmp");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
-      "copy it into /workspace before responding",
+      "copy it into the current workspace before responding",
     );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("canonical sandbox path");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Do not provide ranges of lines.");
   });
 

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -20,6 +20,10 @@ describe("provider-neutral operational instructions", () => {
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "[My Report.md](<sandbox:/workspace/My Project/My Report.md:3>)",
     );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link to /tmp");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "copy it into /workspace before responding",
+    );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Do not provide ranges of lines.");
   });
 

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -20,11 +20,22 @@ describe("provider-neutral operational instructions", () => {
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "[My Report.md](<sandbox:/workspace/My Project/My Report.md:3>)",
     );
-    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link to /tmp");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "a Connected Machine instead uses its host-native workspace root",
+    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("`/home/u/proj` or `C:/repo`");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "Both are valid inside a `sandbox:` link when they are the active workspace.",
+    );
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.py](sandbox:/home/u/proj/app.py:12)");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.ts](<sandbox:C:/repo/app.ts:12>)");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link directly to `/tmp`");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "copy it into the current workspace before responding",
     );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("canonical sandbox path");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("a host path");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("host-absolute paths");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Do not provide ranges of lines.");
   });
 


### PR DESCRIPTION
## Summary

- require agents to copy user-facing screenshots and generated artifacts into `/workspace` before emitting `sandbox:` links
- explicitly forbid links to `/tmp`, host paths, and other locations outside the workspace authority
- pin the rule with an operational-instruction regression test and a runtime patch changeset

## Testing

- [x] `bun test packages/runtime/test/operational-instructions.test.ts --timeout 30000` (4 passed)
- [x] `cd packages/runtime && bun run typecheck`
- [x] changed-file `oxfmt --check`, `oxlint`, and `git diff --check`
- [ ] full `bun test` (not required for this three-file instruction-only change; exact-head CI is authoritative)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] This branch was created from current `main`; hotfix freeze-head admission does not apply.

## Notes

The reported failure linked a generated screenshot as `sandbox:/tmp/...`. The Files API correctly rejected that absolute path because it was outside the selected workspace root. Relaxing that boundary would expose host/private temporary files and is not appropriate.

Recent adjacent work does not cover this case: merged #2077 corrected attachment materialization under native workspace roots, while open #2118 addresses valid generated-file links failing to wake a cold workspace. This PR closes the remaining agent-handoff gap for generated files that start outside `/workspace`.

## Summary by Sourcery

Ensure user-facing generated files are copied into the active workspace before emitting canonical sandbox links.

Bug Fixes:
- Prevent generated screenshots and artifacts from producing inaccessible sandbox links to temporary files or paths outside the active workspace.

Enhancements:
- Clarify valid sandbox link roots for managed sandboxes and Connected Machines while requiring generated files to be copied into the workspace first.

Tests:
- Add regression coverage for workspace-root guidance, Connected Machine examples, and rejection of out-of-workspace links.