### PR TITLE
docs: map every turn-inference route for operators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -405,14 +405,14 @@ OPENGENI_SUPERGROK_SUBSCRIPTION_ENABLED=true
 # OPENGENI_AZURE_OPENAI_API_VERSION=2025-04-01-preview
 # OPENGENI_AZURE_OPENAI_AD_TOKEN=...
 
-# Extra (non-built-in) model providers. The built-in provider above (OpenAI or
-# Azure) is always present; this JSON registry exposes ADDITIONAL providers and
-# their models. Each entry has its own baseUrl, wire api ("responses" | "chat",
-# default "chat"), and the models it serves. The default kind is "api-key" and
-# requires an inline apiKey OR an apiKeyEnv naming the env var that holds the key
-# (preferred). Explicit kind "anonymous" sends no credential and is externally
-# metered. The models a client can pick are the union of
-# OPENGENI_OPENAI_ALLOWED_MODELS and every registry model.
+# Extra (non-built-in) model providers. See docs/model-providers.md § Configuring
+# inference. The built-in provider above (OpenAI or Azure) is always present; this
+# JSON registry exposes ADDITIONAL providers and their models. Each entry has its
+# own baseUrl, wire api ("responses" | "chat", default "chat"), and the models it
+# serves. The default kind is "api-key" and requires an inline apiKey OR an
+# apiKeyEnv naming the env var that holds the key (preferred). Explicit kind
+# "anonymous" sends no credential and is externally metered. The models a client
+# can pick are the union of OPENGENI_OPENAI_ALLOWED_MODELS and every registry model.
 # Example: add Fireworks AI serving GLM 5.2 (keep the key in its own env var).
 # OPENGENI_FIREWORKS_API_KEY=fw_...
 # OPENGENI_MODEL_PROVIDERS_JSON='[{"id":"fireworks","label":"Fireworks AI","api":"chat","baseUrl":"https://api.fireworks.ai/inference/v1","apiKeyEnv":"OPENGENI_FIREWORKS_API_KEY","models":[{"id":"accounts/fireworks/models/glm-5p2","label":"GLM 5.2","contextWindowTokens":1048576,"reasoningEffort":true,"hostedWebSearch":false}]}]'

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Copy `.env.example` to `.env` and configure at least:
 - `OPENGENI_DEV_BACKEND` when automatic Docker/native selection is not desired
 - `OPENGENI_OPENAI_PROVIDER`
 - OpenAI or Azure OpenAI credentials
+- Extra OpenAI-compatible servers, AI Gateway, OpenRouter, Codex, and SuperGrok: see
+  [Configuring inference](docs/model-providers.md#configuring-inference)
 - `OPENGENI_SANDBOX_BACKEND`
 - `OPENGENI_SANDBOX_PREPARATION_PROFILES` when sandbox credentials or lifecycle hooks are needed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Codemode programmatic tool access | `docs/mcp-surfaces.md`, `docs/architecture.md`; record design in `docs/design/codemode.md` | Runtime/API/worker comments should link instead of restating security invariants. |
 | Client/server compatibility policy | `docs/architecture.md` §3.10 | `packages/sdk/README.md` links; release notes should link. |
 | Typecheck/lint/format toolchain | `docs/toolchain.md` | `CONTRIBUTING.md` links; other docs should not restate tool choice or version. |
+| Model providers and OpenAI-compatible inference routes | `docs/model-providers.md` (start at § Configuring inference) | `README.md` Configuration and `.env.example` should link instead of restating `OPENGENI_MODEL_PROVIDERS_JSON`. |
 | Model catalog pricing audit | `docs/model-providers.md` § Price audit (`bun run check:model-pricing`) | Debit authority stays in `packages/config` `defaultModelPricing`; llm-prices is a canary only. |
 | Provider-aware image generation | `docs/image-generation.md` | Runtime, worker, artifact, SDK, and React summaries should link instead of restating provider and recovery semantics. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1267,7 +1267,7 @@ This index intentionally routes at subsystem granularity. Use
 
 | Change area | Canonical source | Read first |
 | --- | --- | --- |
-| Model registry, routing, pricing, or provider identity | `packages/config/src/index.ts`, `packages/runtime/src/model-provider*.ts` | [`model-providers.md`](model-providers.md) |
+| Model registry, routing, pricing, provider identity, or OpenAI-compatible inference routes | `packages/config/src/index.ts`, `packages/runtime/src/model-provider*.ts` | [`model-providers.md`](model-providers.md) (start at Configuring inference) |
 | Codex subscription authority or capacity | `packages/codex/`, `apps/worker/src/activities/codex-rotation.ts` | [`codex-subscription-rotation.md`](codex-subscription-rotation.md) |
 | SuperGrok/xAI subscription authority or capacity | `packages/xai-subscription/`, `packages/db/src/xai-subscription.ts` | [`supergrok-subscription.md`](supergrok-subscription.md) |
 | First-party MCP, Codemode, or tool selection | `apps/api/src/mcp/`, `packages/codemode/`, `packages/runtime/src/` | [`mcp-surfaces.md`](mcp-surfaces.md) |

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -8,6 +8,85 @@ and per-turn execution identity.
 The point-in-time decision record and evidence are in
 [`design/model-provider-architecture-2026-07-18.md`](design/model-provider-architecture-2026-07-18.md).
 
+## Configuring inference
+
+Turn inference uses two OpenAI-shaped HTTP APIs: **Responses**
+(`POST …/responses`) and **Chat Completions** (`POST …/chat/completions`).
+Configure `.env` (from `.env.example`) and restart the API and both workers.
+OpenGeni does not scrape `GET /models`. Membership is the reviewed catalog
+(`OPENGENI_MODEL_CATALOG_SOURCE=code` by default, or the operator singleton in
+`database` mode). See [Deployment catalog source and cost policy](#deployment-catalog-source-and-cost-policy).
+
+### Built-in OpenAI or Azure — always Responses
+
+Exactly one built-in provider. `OPENGENI_OPENAI_PROVIDER` is `openai` (default)
+or `azure`. In code mode its catalog is `OPENGENI_OPENAI_MODEL` (default
+`gpt-5.6-sol`) and `OPENGENI_OPENAI_ALLOWED_MODELS` (default
+`gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna`). A custom base URL still speaks
+Responses; it does not become Chat Completions.
+
+| | OpenAI | Azure |
+| --- | --- | --- |
+| Credential | `OPENGENI_OPENAI_API_KEY` (`OPENAI_API_KEY`) | `OPENGENI_AZURE_OPENAI_API_KEY` or `OPENGENI_AZURE_OPENAI_AD_TOKEN` |
+| URL | optional `OPENGENI_OPENAI_BASE_URL` (`OPENAI_BASE_URL`); unset is `https://api.openai.com/v1` | `OPENGENI_AZURE_OPENAI_BASE_URL` (`…/openai/v1`), or `OPENGENI_AZURE_OPENAI_ENDPOINT` + `DEPLOYMENT` + `API_VERSION` |
+
+Hosted GPT image generation is attached only for built-in GPT-5.6 ids on
+`https://api.openai.com/v1`. Built-in Responses knobs:
+`OPENGENI_OPENAI_RESPONSES_TRANSPORT` (`http` default, or `websocket`),
+`OPENGENI_OPENAI_PROVIDER_ITEM_IDS`, `OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT`,
+`OPENGENI_WEB_SEARCH_ENABLED`.
+
+### Extra OpenAI-compatible servers — `OPENGENI_MODEL_PROVIDERS_JSON`
+
+A JSON array of additional providers. The built-in stays. Each entry has one
+`baseUrl`, one `api` (`chat` default, or `responses`), and one `wireProfile`
+(`openai` default). Set `wireProfile: "azure-openai"` with `api: "responses"`
+for a second Azure resource (Azure computer-call normalization). Provider `id`
+matches `[A-Za-z0-9_-]+` and must not collide with the built-in (`openai` /
+`azure`) or another registry provider. List every model; a bare model `id`
+already on the built-in allowlist keeps the built-in route.
+
+Operator-writable `kind`:
+
+- `api-key` (default) — `apiKeyEnv` (preferred) or inline `apiKey`. Missing key
+  is a boot error.
+- `anonymous` — no credential and no `defaultHeaders` / `defaultQuery`.
+  Externally metered.
+
+JSON must not declare overlay kinds (`vercel-gateway-managed`,
+`vercel-gateway-workspace`, `openrouter-workspace`, `xai-subscription`) or
+reserved provider ids (`openai`, `azure`, `codex-subscription`,
+`xai-subscription`, `opengeni-gateway`, `workspace-gateway`, `openrouter`,
+`workspace-openrouter`). `baseUrl` is origin + path (no userinfo, query,
+fragment). Put extra query/headers in `defaultQuery` / `defaultHeaders`;
+`Authorization` is SDK-managed. `publicDefaultQueryNames` /
+`publicDefaultHeaderNames` mark which of those appear in public definition
+digests; credential-like names are refused. Model fields, billing derivation,
+and examples are in [Registry configuration](#registry-configuration). In
+database catalog mode the host JSON still owns transport and credentials; the
+singleton owns membership.
+
+### Reviewed overlays — not generic JSON
+
+| Route | Enable | Wire | Catalog |
+| --- | --- | --- | --- |
+| OpenGeni-managed AI Gateway | `OPENGENI_VERCEL_AI_GATEWAY_API_KEY` | Responses | Curated DeepSeek / Kimi, OpenGeni credits |
+| Workspace AI Gateway | member connects a Gateway key in Settings | Responses | Same curated models plus optional workspace slugs, workspace-paid |
+| Deployment OpenRouter | `OPENGENI_OPENROUTER_API_KEY` | Chat Completions | Curated `openrouter/…` (v1 ships one `:free` starter) |
+| Workspace OpenRouter | member connects an OpenRouter key in Settings | Chat Completions | `workspace-openrouter/…`, workspace-paid |
+| Codex ChatGPT subscription | `OPENGENI_CODEX_SUBSCRIPTION_ENABLED` | Responses | `codex/…` after the workspace connection is ready |
+| SuperGrok / xAI subscription | `OPENGENI_SUPERGROK_SUBSCRIPTION_ENABLED` | Responses | `supergrok/…` after the workspace connection is ready |
+
+Workspace BYOK for an arbitrary OpenAI-compatible server is not a registry
+switch. Voice input, image, and video use separate provider settings.
+
+### Compatibility
+
+The chosen wire API, SSE streaming, and ordinary function calling are required.
+Hosted tools, Codex Apps, and Codex `remote_v2` compaction are not implied.
+Non-Codex and Codex-portable sessions compact locally; a session frozen
+`remote_v2` admits only Codex models.
+
 ## Identity layers
 
 A configured model has four distinct identities:


### PR DESCRIPTION
## Summary
- Add a `Configuring inference` operator map at the front of `docs/model-providers.md` covering built-in OpenAI/Azure, extra OpenAI-compatible servers, Gateway, OpenRouter, Codex, and SuperGrok.
- Point README, the docs map, architecture routing, and `.env.example` at that section instead of restating the JSON schema.

## Testing
- [x] `bun run check:docs-refs`
- [ ] `bun run typecheck` (docs-only)
- [ ] `bun test` (docs-only)

## Delivery integrity
- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advanced, I kept the candidate head frozen and verified mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change. Freeze-head source admission is required only for `hotfix/*` into `production`.

## Notes
Docs-only. No runtime change.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Document every supported inference route and direct operators to a single canonical configuration guide.

New Features:
- Add an operator-facing inference configuration map covering built-in providers, OpenAI-compatible servers, Gateway, OpenRouter, Codex, and SuperGrok routes.

Enhancements:
- Centralize inference-route guidance and configuration ownership in the model providers documentation.
- Update documentation indexes and architecture routing to direct operators to the canonical inference configuration section.

Documentation:
- Link the README and documentation map to the new inference configuration guidance instead of duplicating provider configuration details.