### PR TITLE
fix(api): allow external workspace provisioning

### DIFF
--- a/.changeset/bright-external-workspaces.md
+++ b/.changeset/bright-external-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Keep account-scoped external workspace provisioning out of workspace UUID actor middleware so organization API keys can idempotently provision tenant workspaces.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1130,6 +1130,10 @@ const publicWorkspaceBrowserRoutePatterns = [
 ] as const;
 
 export function workspaceActorContextExempt(method: string, pathname: string): boolean {
+  // The account-scoped provisioning route shares the workspace collection prefix.
+  // Hono's trailing wildcard also matches it, but "external" is not a workspace UUID;
+  // the route performs its own organization API-key authorization.
+  if (method === "PUT" && pathname === "/v1/workspaces/external") return true;
   if (/^\/v1\/workspaces\/[^/]+\/mcp$/.test(pathname)) return true;
   if (
     method === "GET" &&

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -83,6 +83,8 @@ describe("API helpers", () => {
 
   test("leaves only route-specific workspace protocols outside ordinary actor middleware", () => {
     const workspace = "00000000-0000-4000-8000-000000000001";
+    expect(workspaceActorContextExempt("PUT", "/v1/workspaces/external")).toBe(true);
+    expect(workspaceActorContextExempt("GET", "/v1/workspaces/external")).toBe(false);
     expect(workspaceActorContextExempt("POST", `/v1/workspaces/${workspace}/mcp`)).toBe(true);
     expect(workspaceActorContextExempt("GET", `/v1/workspaces/${workspace}/github/connect`)).toBe(
       true,


### PR DESCRIPTION
## Summary

- exempt the account-scoped `PUT /v1/workspaces/external` route from workspace UUID actor middleware
- preserve the route’s own organization API-key authorization
- add a regression assertion and API router patch changeset

## Incident evidence

The staging middleware matched `/v1/workspaces/external` as `workspaceId=external` and queried UUID columns with that literal value, causing PostgreSQL `22P02` before the provisioning handler ran. The handler succeeds with the same staging key, settings, and database when invoked without that middleware.

## Verification

- `bun test apps/api/test/app.test.ts --timeout 30000` (72 passed)
- `bun test apps/api/test/personal-workspace-access.test.ts --timeout 30000` (6 passed)
- `cd apps/api && bun run typecheck`
- `bunx oxlint --deny-warnings apps/api/src/app.ts apps/api/test/app.test.ts`
- `bunx oxfmt --check apps/api/src/app.ts apps/api/test/app.test.ts .changeset/bright-external-workspaces.md`
- `git diff --check`

## Summary by Sourcery

Fix external workspace provisioning by preventing the account-scoped route from being interpreted as a workspace UUID.

Bug Fixes:
- Allow account-scoped external workspace provisioning to bypass workspace UUID actor middleware while retaining organization API-key authorization.

Tests:
- Add regression coverage confirming the external provisioning route is exempt only for PUT requests.