### PR TITLE
Prevent ghost sessions on draft conflicts

### DIFF
--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -63,6 +63,7 @@ import {
   type XaiProviderAccountAuthoritySnapshotV1,
 } from "@opengeni/contracts";
 import {
+  assertExactNewSessionDraftInTransaction,
   createSession,
   createSessionWithIdempotencyKeyResult,
   canonicalSessionCommandHash,
@@ -94,6 +95,7 @@ import {
   lockActiveWorkspaceGatewayCustomModelForAdmission,
   lockActiveWorkspaceOpenRouterCustomModelForAdmission,
   requireSession,
+  setSubjectRlsContext,
   replaySubmittedHumanPromptFromBoundaryReceipt,
   submitHumanPromptInTransaction,
   appendSessionEventsWithLockedSessionUpdate,
@@ -817,7 +819,7 @@ export async function createAndStartSessionWithOutcome(input: {
     input.retainWorkspaceCustomModel !== true &&
     input.retainWorkspaceGatewayModel !== true;
   const beforeCreateCommit =
-    requiresActiveWorkspaceCustomModel || input.beforeCreateCommit
+    requiresActiveWorkspaceCustomModel || input.consumeNewSessionDraft || input.beforeCreateCommit
       ? async (tx: Database, sessionId: string, context?: { created: boolean }): Promise<void> => {
           // A committed keyed replay already crossed this fence when its shell
           // was first accepted. Revalidate only the transaction inserting a new
@@ -845,6 +847,18 @@ export async function createAndStartSessionWithOutcome(input: {
                 message: `model is not available: ${input.model}`,
               });
             }
+          }
+          // Reject an already-stale browser draft before the newly inserted
+          // shell can commit. The initializer repeats this exact check while
+          // consuming the draft after it installs the first runnable unit.
+          if (input.consumeNewSessionDraft && context?.created !== false) {
+            await setSubjectRlsContext(tx, input.consumeNewSessionDraft.subjectId);
+            await assertExactNewSessionDraftInTransaction(tx, {
+              workspaceId: input.workspaceId,
+              subjectId: input.consumeNewSessionDraft.subjectId,
+              expectedRevision: input.consumeNewSessionDraft.expectedRevision,
+              expectedSnapshot: input.consumeNewSessionDraft.expectedSnapshot,
+            });
           }
           await input.beforeCreateCommit?.(tx, sessionId);
         }

--- a/packages/core/test/new-session-drafts.test.ts
+++ b/packages/core/test/new-session-drafts.test.ts
@@ -139,6 +139,83 @@ describe("core new-session draft hydration", () => {
     expect(session.titleSource).toBe("agent");
   }, 180_000);
 
+  test("rejects a stale create before committing a visible session shell", async () => {
+    if (!available) return;
+    const { grant } = await fixture();
+    const first = await saveActorNewSessionDraft(
+      { db, settings, objectStorage: null },
+      grant,
+      grant.workspaceId!,
+      {
+        expectedRevision: 0,
+        text: "stale browser prompt",
+        resources: [],
+        tools: [],
+        toolsProvided: true,
+        model: settings.openaiModel,
+        reasoningEffort: settings.openaiReasoningEffort,
+        latencyMode: "standard",
+        options: { visibility: "workspace" },
+      },
+    );
+    await saveActorNewSessionDraft(
+      { db, settings, objectStorage: null },
+      grant,
+      grant.workspaceId!,
+      {
+        expectedRevision: first.revision,
+        text: "newer sibling-tab prompt",
+        resources: [],
+        tools: [],
+        toolsProvided: true,
+        model: settings.openaiModel,
+        reasoningEffort: settings.openaiReasoningEffort,
+        latencyMode: "standard",
+        options: { visibility: "workspace" },
+      },
+    );
+    const noop = async () => undefined;
+    const deps = {
+      settings,
+      db,
+      bus: new MemoryEventBus(),
+      workflowClient: {
+        signalUserMessage: noop,
+        wakeSessionWorkflow: noop,
+        requestSessionWorkflowWakeDispatch: noop,
+        signalApprovalDecision: noop,
+        signalSessionControl: noop,
+        syncScheduledTask: noop,
+        deleteScheduledTaskSchedule: noop,
+        triggerScheduledTask: noop,
+      } as unknown as SessionWorkflowClient,
+      objectStorage: null,
+      githubStateSecret: "test",
+      documentIndexer: { indexDocument: noop },
+      getDocumentServices: () => ({}) as never,
+    } as unknown as ApiRouteDeps;
+
+    await expect(
+      createSessionForRequest(deps, grant, grant.workspaceId!, {
+        initialMessage: first.text,
+        visibility: "workspace",
+        resources: [],
+        tools: [],
+        model: first.model,
+        reasoningEffort: first.reasoningEffort,
+        latencyMode: first.latencyMode,
+        expectedNewSessionDraftRevision: first.revision,
+        idempotencyKey: crypto.randomUUID(),
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+
+    const [stored] = await shared!.admin<Array<{ count: number }>>`
+      select count(*)::int as count
+      from sessions
+      where workspace_id = ${grant.workspaceId!}`;
+    expect(stored).toEqual({ count: 0 });
+  }, 180_000);
+
   test("treats a markerless old-client save, including [], as explicit tools", async () => {
     if (!available) return;
     const { grant } = await fixture();

--- a/packages/db/src/new-session-drafts.ts
+++ b/packages/db/src/new-session-drafts.ts
@@ -357,6 +357,73 @@ export async function rememberNewSessionSelectionInTransaction(
   return Boolean(updated);
 }
 
+async function lockCurrentNewSessionDraft(
+  db: Database,
+  input: { workspaceId: string; subjectId: string },
+): Promise<NewSessionDraftRow | undefined> {
+  await lockNewSessionDraftIdentity(db, input.workspaceId, input.subjectId);
+  const [current] = await db
+    .select()
+    .from(schema.newSessionDrafts)
+    .where(
+      and(
+        eq(schema.newSessionDrafts.workspaceId, input.workspaceId),
+        eq(schema.newSessionDrafts.subjectId, input.subjectId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  return current;
+}
+
+async function lockExactNewSessionDraft(
+  db: Database,
+  input: {
+    workspaceId: string;
+    subjectId: string;
+    expectedRevision: number;
+    expectedSnapshot: NewSessionDraftSnapshot;
+  },
+): Promise<NewSessionDraftRow> {
+  const current = await lockCurrentNewSessionDraft(db, input);
+  if (!current || current.revision !== input.expectedRevision) {
+    throw new NewSessionDraftConflictError(current?.revision ?? 0);
+  }
+  if (
+    stableJson({
+      text: current.text,
+      resources: current.resources,
+      tools: newSessionDraftToolsProvided(current) ? current.tools : [],
+      toolsProvided: newSessionDraftToolsProvided(current),
+      model: current.model,
+      reasoningEffort: current.reasoningEffort,
+      latencyMode: current.latencyMode,
+      options: publicNewSessionDraftOptions(current),
+    }) !== stableJson(input.expectedSnapshot)
+  ) {
+    throw new NewSessionDraftConflictError(current.revision);
+  }
+  return current;
+}
+
+/**
+ * Fence a fresh session shell on the exact actor-private draft it represents.
+ * The caller keeps this row lock through its create transaction, so a draft
+ * that was already stale cannot leave a committed, uninitialized session.
+ * The later atomic initializer still performs the authoritative consume.
+ */
+export async function assertExactNewSessionDraftInTransaction(
+  db: Database,
+  input: {
+    workspaceId: string;
+    subjectId: string;
+    expectedRevision: number;
+    expectedSnapshot: NewSessionDraftSnapshot;
+  },
+): Promise<void> {
+  await lockExactNewSessionDraft(db, input);
+}
+
 /**
  * Replace one exact accepted draft with the next-create safe seed. The row is
  * identity-serialized before the revision check so even the absent-row
@@ -374,38 +441,16 @@ export async function seedNewSessionDraftInTransaction(
     acceptedSelection?: AcceptedNewSessionSelection;
   },
 ): Promise<boolean> {
-  await lockNewSessionDraftIdentity(db, input.workspaceId, input.subjectId);
-  const [current] = await db
-    .select()
-    .from(schema.newSessionDrafts)
-    .where(
-      and(
-        eq(schema.newSessionDrafts.workspaceId, input.workspaceId),
-        eq(schema.newSessionDrafts.subjectId, input.subjectId),
-      ),
-    )
-    .for("update")
-    .limit(1);
+  const current = input.expectedSnapshot
+    ? await lockExactNewSessionDraft(db, {
+        workspaceId: input.workspaceId,
+        subjectId: input.subjectId,
+        expectedRevision: input.expectedRevision,
+        expectedSnapshot: input.expectedSnapshot,
+      })
+    : await lockCurrentNewSessionDraft(db, input);
   if (!current || current.revision !== input.expectedRevision) {
-    if (input.expectedSnapshot) {
-      throw new NewSessionDraftConflictError(current?.revision ?? 0);
-    }
     return false;
-  }
-  if (
-    input.expectedSnapshot &&
-    stableJson({
-      text: current.text,
-      resources: current.resources,
-      tools: newSessionDraftToolsProvided(current) ? current.tools : [],
-      toolsProvided: newSessionDraftToolsProvided(current),
-      model: current.model,
-      reasoningEffort: current.reasoningEffort,
-      latencyMode: current.latencyMode,
-      options: publicNewSessionDraftOptions(current),
-    }) !== stableJson(input.expectedSnapshot)
-  ) {
-    throw new NewSessionDraftConflictError(current.revision);
   }
 
   const parsedOptions = NewSessionDraftOptions.safeParse(publicNewSessionDraftOptions(current));


### PR DESCRIPTION
## Summary

- validate the exact new-session draft inside the session-shell create transaction
- roll an already-stale create back before the shell becomes visible
- keep the later atomic initializer as the authoritative draft-consume boundary
- add a PostgreSQL regression proving the 409 leaves zero sessions

## Verification

- bun test packages/core/test/new-session-drafts.test.ts
- bun test packages/db/test/new-session-drafts.test.ts
- bun run typecheck
- bun run lint
- git diff --check

Linear: OPE-419

## Summary by Sourcery

Reject stale new-session creates before committing session shells while preserving atomic draft consumption.

Bug Fixes:
- Prevent stale new-session draft conflicts from leaving behind committed, visible session shells.

Enhancements:
- Keep exact draft validation and draft consumption serialized across session creation and initialization transactions.

Tests:
- Add regression coverage verifying stale creates return a conflict and persist zero sessions.