### PR TITLE
fix(db): scope managed grants to active organizations

### DIFF
--- a/.changeset/fix-managed-access-context.md
+++ b/.changeset/fix-managed-access-context.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Keep managed-human workspace grants scoped to organizations where the subject has an active membership.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1641,6 +1641,7 @@ async function projectManagedOrganizationAccess(
       accountId: organizationMembership.organizationId,
       workspaceId: null,
     });
+    // These authority tables are non-RLS, so the account GUC does not scope this query.
     const persistedMemberships = await db
       .select({
         membership: schema.workspaceMemberships,
@@ -1649,9 +1650,18 @@ async function projectManagedOrganizationAccess(
       .from(schema.workspaceMemberships)
       .innerJoin(
         schema.workspaces,
-        eq(schema.workspaceMemberships.workspaceId, schema.workspaces.id),
+        and(
+          eq(schema.workspaceMemberships.workspaceId, schema.workspaces.id),
+          eq(schema.workspaceMemberships.accountId, schema.workspaces.accountId),
+        ),
       )
-      .where(eq(schema.workspaceMemberships.subjectId, input.subjectId))
+      .where(
+        and(
+          eq(schema.workspaceMemberships.subjectId, input.subjectId),
+          eq(schema.workspaceMemberships.accountId, organizationMembership.organizationId),
+          eq(schema.workspaces.accountId, organizationMembership.organizationId),
+        ),
+      )
       .orderBy(desc(schema.workspaces.createdAt));
     workspaceGrants.push(
       ...persistedMemberships.map((row) => ({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2025,7 +2025,13 @@ export async function ensureManagedAccessForUserWithOrganizationMemberships(
         schema.workspaces,
         eq(schema.workspaceMemberships.workspaceId, schema.workspaces.id),
       )
-      .where(eq(schema.workspaceMemberships.subjectId, subjectId))
+      .where(
+        and(
+          eq(schema.workspaceMemberships.subjectId, subjectId),
+          eq(schema.workspaceMemberships.accountId, account.id),
+          eq(schema.workspaces.accountId, account.id),
+        ),
+      )
       .orderBy(desc(schema.workspaces.createdAt));
     const workspaceGrants: AccessGrant[] = memberships.map((row) => ({
       workspaceId: row.workspace.id,
@@ -2081,7 +2087,13 @@ export async function ensureManagedAccessForUserWithOrganizationMemberships(
           schema.workspaces,
           eq(schema.workspaceMemberships.workspaceId, schema.workspaces.id),
         )
-        .where(eq(schema.workspaceMemberships.subjectId, subjectId))
+        .where(
+          and(
+            eq(schema.workspaceMemberships.subjectId, subjectId),
+            eq(schema.workspaceMemberships.accountId, organizationMembership.organizationId),
+            eq(schema.workspaces.accountId, organizationMembership.organizationId),
+          ),
+        )
         .orderBy(desc(schema.workspaces.createdAt));
       for (const row of persistedOrganizationMemberships) {
         if (workspaceGrants.some((grant) => grant.workspaceId === row.workspace.id)) continue;

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -346,6 +346,50 @@ describe("migration 0219 managed-human organization provisioning", () => {
     expect(grantCount).toEqual({ count: 0 });
   });
 
+  test("excludes orphaned workspace memberships from managed access projection", async () => {
+    if (!shared || !client) return;
+
+    const userId = `orphaned-workspace-${crypto.randomUUID()}`;
+    const subjectId = `user:${userId}`;
+    const input = {
+      userId,
+      email: `${userId}@example.test`,
+      name: "Managed human with legacy membership",
+    };
+    const initial = await ensureManagedAccessForUser(client.db, input);
+    const activeAccountId = initial.accountGrants[0]!.accountId;
+    const orphanedAccountId = crypto.randomUUID();
+    const orphanedWorkspaceId = crypto.randomUUID();
+
+    await shared.admin`
+      insert into managed_accounts (id, name, external_source, external_id)
+      values (
+        ${orphanedAccountId}, 'Orphaned legacy organization', 'test', ${crypto.randomUUID()}
+      )`;
+    await shared.admin`
+      insert into workspaces (id, account_id, name, external_source, external_id)
+      values (
+        ${orphanedWorkspaceId}, ${orphanedAccountId}, 'Orphaned legacy workspace',
+        'test', ${crypto.randomUUID()}
+      )`;
+    await shared.admin`
+      insert into workspace_inference_controls (account_id, workspace_id)
+      values (${orphanedAccountId}, ${orphanedWorkspaceId})`;
+    await shared.admin`
+      insert into workspace_memberships (account_id, workspace_id, subject_id, role)
+      values (${orphanedAccountId}, ${orphanedWorkspaceId}, ${subjectId}, 'member')`;
+
+    const projected = await ensureManagedAccessForUser(client.db, input);
+
+    expect(projected.accountGrants.map((grant) => grant.accountId)).toEqual([activeAccountId]);
+    expect(
+      projected.workspaceGrants.some((grant) => grant.workspaceId === orphanedWorkspaceId),
+    ).toBe(false);
+    expect(projected.workspaceGrants.every((grant) => grant.accountId === activeAccountId)).toBe(
+      true,
+    );
+  });
+
   test("keeps the capability narrow and fails closed for fabricated, foreign, and terminal authority", async () => {
     if (!shared || !client) return;
 

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -387,7 +387,7 @@ describe("migration 0219 managed-human organization provisioning", () => {
 
       expect(projected.accountGrants.map((grant) => grant.accountId)).toEqual([activeAccountId]);
       expect(projected.workspaceGrants).toHaveLength(2);
-      expect(projected.workspaceGrants[0]?.workspaceId).toBe(projected.defaultWorkspaceId);
+      expect(projected.workspaceGrants[0]?.workspaceId).toBe(projected.defaultWorkspaceId!);
       expect(
         projected.workspaceGrants.some((grant) => grant.workspaceId === orphanedWorkspaceId),
       ).toBe(false);

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -8,6 +8,8 @@ import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/te
 import postgres from "postgres";
 import {
   createDb,
+  acceptOrganizationInvitation,
+  createOrganizationInvitation,
   ensureManagedAccessForUser,
   ensureManagedAccessForUserWithOrganizationMemberships,
   getSelfServiceOrganizationOnboardingState,
@@ -346,48 +348,99 @@ describe("migration 0219 managed-human organization provisioning", () => {
     expect(grantCount).toEqual({ count: 0 });
   });
 
-  test("excludes orphaned workspace memberships from managed access projection", async () => {
-    if (!shared || !client) return;
+  test.each([false, true])(
+    "excludes orphaned memberships (already provisioned: %s)",
+    async (alreadyProvisioned) => {
+      if (!shared || !client) return;
 
-    const userId = `orphaned-workspace-${crypto.randomUUID()}`;
-    const subjectId = `user:${userId}`;
-    const input = {
-      userId,
-      email: `${userId}@example.test`,
-      name: "Managed human with legacy membership",
-    };
-    const initial = await ensureManagedAccessForUser(client.db, input);
-    const activeAccountId = initial.accountGrants[0]!.accountId;
-    const orphanedAccountId = crypto.randomUUID();
-    const orphanedWorkspaceId = crypto.randomUUID();
+      const userId = `orphaned-workspace-${crypto.randomUUID()}`;
+      const subjectId = `user:${userId}`;
+      const input = {
+        userId,
+        email: `${userId}@example.test`,
+        name: "Managed human with legacy membership",
+      };
+      if (alreadyProvisioned) await ensureManagedAccessForUser(client.db, input);
+      const orphanedAccountId = crypto.randomUUID();
+      const orphanedWorkspaceId = crypto.randomUUID();
 
-    await shared.admin`
+      await shared.admin`
       insert into managed_accounts (id, name, external_source, external_id)
       values (
         ${orphanedAccountId}, 'Orphaned legacy organization', 'test', ${crypto.randomUUID()}
       )`;
-    await shared.admin`
+      await shared.admin`
       insert into workspaces (id, account_id, name, external_source, external_id)
       values (
         ${orphanedWorkspaceId}, ${orphanedAccountId}, 'Orphaned legacy workspace',
         'test', ${crypto.randomUUID()}
       )`;
-    await shared.admin`
+      await shared.admin`
       insert into workspace_inference_controls (account_id, workspace_id)
       values (${orphanedAccountId}, ${orphanedWorkspaceId})`;
-    await shared.admin`
+      await shared.admin`
       insert into workspace_memberships (account_id, workspace_id, subject_id, role)
       values (${orphanedAccountId}, ${orphanedWorkspaceId}, ${subjectId}, 'member')`;
 
-    const projected = await ensureManagedAccessForUser(client.db, input);
+      const projected = await ensureManagedAccessForUser(client.db, input);
+      const activeAccountId = projected.defaultAccountId!;
 
-    expect(projected.accountGrants.map((grant) => grant.accountId)).toEqual([activeAccountId]);
+      expect(projected.accountGrants.map((grant) => grant.accountId)).toEqual([activeAccountId]);
+      expect(projected.workspaceGrants).toHaveLength(2);
+      expect(projected.workspaceGrants[0]?.workspaceId).toBe(projected.defaultWorkspaceId);
+      expect(
+        projected.workspaceGrants.some((grant) => grant.workspaceId === orphanedWorkspaceId),
+      ).toBe(false);
+      expect(projected.workspaceGrants.every((grant) => grant.accountId === activeAccountId)).toBe(
+        true,
+      );
+      expect(await ensureManagedAccessForUser(client.db, input)).toEqual(projected);
+    },
+  );
+
+  test("projects each shared membership once across multiple active organizations", async () => {
+    if (!shared || !client) return;
+    const userId = `multi-org-${crypto.randomUUID()}`;
+    const input = { userId, email: `${userId}@example.test`, name: userId };
+    const initial = await ensureManagedAccessForUser(client.db, input);
+    const ownerId = `other-owner-${crypto.randomUUID()}`;
+    const other = await ensureManagedAccessForUser(client.db, {
+      userId: ownerId,
+      email: `${ownerId}@example.test`,
+      name: ownerId,
+    });
+    const organizationId = other.defaultAccountId!;
+    const invitation = await createOrganizationInvitation(client.db, {
+      organizationId,
+      actorSubjectId: other.subjectId,
+      operationId: crypto.randomUUID(),
+      targetSubjectId: initial.subjectId,
+      targetEmail: input.email,
+      role: "member",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    await acceptOrganizationInvitation(client.db, {
+      organizationId,
+      actorSubjectId: initial.subjectId,
+      operationId: crypto.randomUUID(),
+      invitationId: invitation.id,
+      expectedRevision: invitation.revision,
+    });
+    await shared.admin`
+      insert into workspace_memberships (account_id, workspace_id, subject_id, role)
+      values (${organizationId}, ${other.defaultWorkspaceId!}, ${initial.subjectId}, 'member')`;
+    const projected = await ensureManagedAccessForUser(client.db, input);
+    expect(projected.accountGrants).toHaveLength(2);
+    expect(projected.workspaceGrants).toHaveLength(4);
+    expect(new Set(projected.workspaceGrants.map((grant) => grant.workspaceId)).size).toBe(4);
     expect(
-      projected.workspaceGrants.some((grant) => grant.workspaceId === orphanedWorkspaceId),
-    ).toBe(false);
-    expect(projected.workspaceGrants.every((grant) => grant.accountId === activeAccountId)).toBe(
-      true,
-    );
+      projected.workspaceGrants.filter((grant) => grant.workspaceId === other.defaultWorkspaceId),
+    ).toHaveLength(1);
+    for (const grant of projected.workspaceGrants) {
+      expect(
+        projected.accountGrants.filter((account) => account.accountId === grant.accountId),
+      ).toHaveLength(1);
+    }
   });
 
   test("keeps the capability narrow and fails closed for fabricated, foreign, and terminal authority", async () => {


### PR DESCRIPTION
Managed browser users can be rejected as non-human when creating personal connectors because an orphaned workspace membership from another organization poisons the entire access context.

Scope all three managed membership queries to the organization on both non-RLS tables, covering first-login fallback provisioning and subsequent access refreshes. Preserve the existing personal-owner integrity guard. PostgreSQL regressions cover orphaned memberships before and after provisioning, stable default selection, and unique grants across two active organizations.

Validation: 8 real PostgreSQL tests / 119 assertions on the candidate; a disposable merge against main 8db607e83 passed 44 provisioning, organization lifecycle, and connection ownership tests / 344 assertions. DB typecheck passed on both trees; lint, formatting, and workspace/billing static guard passed. Fresh CI is tracked below.

Production impact: application-only query constraints; no migration, data rewrite, new configuration, or drain required. Memberships without active organization authority stop being projected; they must be repaired through the membership lifecycle if access is intended.
