### PR TITLE
test: stabilize release admission under load

### DIFF
--- a/.changeset/stable-release-admission.md
+++ b/.changeset/stable-release-admission.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Stabilize release admission checks under loaded CI runners.

--- a/packages/react/test/timeline-failed-status.test.tsx
+++ b/packages/react/test/timeline-failed-status.test.tsx
@@ -272,23 +272,32 @@ function hasFailedAffordance(container: HTMLElement): boolean {
   return container.querySelector(".text-og-status-failed") !== null;
 }
 
+async function waitForFailedAffordance(container: HTMLElement): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!hasFailedAffordance(container) && Date.now() < deadline) {
+    // SandboxRow is loaded through React.lazy. A busy CI worker can need more
+    // than one event-loop turn to resolve the module and leave Suspense.
+    await flush(10);
+  }
+}
+
 describe("Structural guard — every renderer surfaces failure affordance on failed status", () => {
   for (const c of CASES) {
     test(c.label, async () => {
       if (c.kind === "tool") {
         const Renderer = defaultToolRegistry.resolve(c.item);
         const r = await renderComponent(<Renderer item={c.item} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       } else if (c.kind === "rail-worker") {
         const r = await renderComponent(<ActivityRail items={[c.item]} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       } else {
         const r = await renderComponent(<ActivityRail items={[c.item]} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       }

--- a/packages/testing/src/shared-pg.ts
+++ b/packages/testing/src/shared-pg.ts
@@ -192,6 +192,40 @@ async function dockerOk(args: string[]): Promise<boolean> {
   }
 }
 
+async function startSharedContainer(args: string[]): Promise<string | null> {
+  const attempts = process.env.OPENGENI_REQUIRE_REAL_DB === "1" ? 5 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const started = await docker(args).catch(() => null);
+    const startedId = started?.stdout.trim() ?? "";
+    if (/^[a-f0-9]{64}$/u.test(startedId)) {
+      return startedId;
+    }
+
+    // `docker run` is outcome-ambiguous when the daemon briefly stops
+    // answering: the named container may have been created despite the failed
+    // client call. Re-probe that exact name before attempting another create.
+    const probe = await probeContainer();
+    if (probe.available && probe.id) {
+      if (probe.status === "running" || probe.status === "restarting") {
+        return probe.id;
+      }
+      const resumed =
+        probe.status === "paused"
+          ? await dockerOk(["unpause", probe.id])
+          : await dockerOk(["start", probe.id]);
+      if (resumed) {
+        return probe.id;
+      }
+      await dockerOk(["rm", "-f", "-v", probe.id]);
+    }
+
+    if (attempt < attempts) {
+      await Bun.sleep(250 * attempt);
+    }
+  }
+  return null;
+}
+
 async function readLockOwner(): Promise<LockOwner | null> {
   try {
     const parsed = JSON.parse(await readFile(LOCK_OWNER_FILE, "utf8")) as Partial<LockOwner>;
@@ -489,7 +523,7 @@ async function ensureContainerAndAcquire(): Promise<ContainerHandle | null> {
       // visible) rather than a clean error. Give the throwaway test server a
       // generous ceiling so the whole suite fits. `MAX_CONNECTIONS` keeps the
       // per-file pools small as a second line of defence.
-      const started = await docker([
+      generation = await startSharedContainer([
         "run",
         "-d",
         "-e",
@@ -503,9 +537,8 @@ async function ensureContainerAndAcquire(): Promise<ContainerHandle | null> {
         "max_connections=1000",
         "-c",
         "shared_buffers=256MB",
-      ]).catch(() => null);
-      generation = started?.stdout.trim() ?? null;
-      if (!generation || !/^[a-f0-9]{64}$/u.test(generation)) {
+      ]);
+      if (!generation) {
         return null; // Docker unavailable or unable to start the fixture.
       }
     }

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -203,7 +203,8 @@ function isExpectedNavigationReadCancellation(problem: string): boolean {
     pathname === "/v1/config/client" ||
     pathname === "/v1/auth/get-session" ||
     /^\/v1\/workspaces\/[0-9a-f-]+\/(?:realtime-)?model-catalog$/u.test(pathname) ||
-    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:sessions|machines|new-session-draft)$/u.test(pathname)
+    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:sessions|machines|new-session-draft)$/u.test(pathname) ||
+    /^\/v1\/workspaces\/[0-9a-f-]+\/live-events\/stream$/u.test(pathname)
   );
 }
 

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -34,6 +34,7 @@ import postgres from "postgres";
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const ownerHeaders = { "x-opengeni-subject": "sessionpin-owner" };
 const otherMemberHeaders = { "x-opengeni-subject": "sessionpin-other-member" };
+const ACKNOWLEDGEMENT_TIMEOUT_MS = 30_000;
 const workflowClient: SessionWorkflowClient = {
   signalUserMessage: async () => undefined,
   wakeSessionWorkflow: async () => undefined,
@@ -311,7 +312,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
           response.request().method() === "PUT" &&
           new URL(response.url()).pathname === attentionPath &&
           response.status() === 200,
-        { timeout: 10_000 },
+        { timeout: ACKNOWLEDGEMENT_TIMEOUT_MS },
       );
       await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
       await firstAcknowledgementStarted;
@@ -350,7 +351,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         (response) =>
           response.request().method() === "PUT" &&
           new URL(response.url()).pathname === attentionPath,
-        { timeout: 10_000 },
+        { timeout: ACKNOWLEDGEMENT_TIMEOUT_MS },
       );
       const sendResponse = await page.evaluate(
         async ({ browserApiBaseUrl, targetWorkspaceId, targetSessionId }) => {


### PR DESCRIPTION
## Summary

- wait for React.lazy failure affordances to resolve before asserting
- recognize the exact live-event stream cancellation caused by page navigation
- give acknowledgement retries a loaded-runner response window
- retry ambiguous shared PostgreSQL fixture starts when CI requires a real database

## Verification

- `bun test packages/react/test/timeline-failed-status.test.tsx`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test apps/api/test/automations-authorization.test.ts`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test ./test/e2e/organization-onboarding-acceptance.e2e.ts`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --test-name-pattern "acknowledges later output" ./test/e2e/session-pins.browser.e2e.ts`
- `bun run typecheck`
- `bun run lint`

## Summary by Sourcery

Stabilize release admission checks and integration tests under loaded CI conditions.

Bug Fixes:
- Stabilize release admission and end-to-end tests under loaded CI runners by accommodating asynchronous UI loading, navigation-triggered live-event cancellation, delayed acknowledgements, and transient PostgreSQL fixture startup failures.

Tests:
- Increase test resilience for React lazy-rendered failure states, browser acknowledgement flows, expected navigation cancellations, and shared real-database fixture startup.