### PR TITLE
test(web): await lazy organization key effects

### DIFF
--- a/apps/web/src/routes/org-settings-strict-mode.test.tsx
+++ b/apps/web/src/routes/org-settings-strict-mode.test.tsx
@@ -188,6 +188,17 @@ async function flush() {
   });
 }
 
+async function waitForOrganizationApiKeyReads() {
+  const deadline = Date.now() + 1_000;
+  while (listOrganizationApiKeys.mock.calls.length < 2 && Date.now() < deadline) {
+    // The developer section is loaded through React.lazy. On a busy runner,
+    // StrictMode's two effect passes may settle after more than one tick.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+}
+
 beforeAll(() => {
   GlobalRegistrator.register();
   (
@@ -265,7 +276,7 @@ describe("organization billing StrictMode ownership", () => {
         </StrictMode>,
       );
     });
-    await flush();
+    await waitForOrganizationApiKeyReads();
 
     expect(listOrganizationApiKeys.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(


### PR DESCRIPTION
## Summary

- wait for the lazy organization API-key section to mount before asserting its StrictMode effect passes
- retain the existing assertion that both StrictMode reads use the organization account ID

## Verification

- `bun test apps/web/src/routes/org-settings-strict-mode.test.tsx`
- 10 consecutive isolated runs
- `bunx oxlint --deny-warnings apps/web/src/routes/org-settings-strict-mode.test.tsx`
- `bunx oxfmt --check apps/web/src/routes/org-settings-strict-mode.test.tsx`
- `bunx changeset status --output ...`

## Summary by Sourcery

Stabilize organization API-key StrictMode assertions by waiting for the lazy section’s effect reads to complete.

Bug Fixes:
- Make the organization StrictMode test reliably wait for both lazy API-key reads before asserting ownership behavior.

Tests:
- Improve the organization settings StrictMode test to tolerate delayed lazy-section mounting on busy runners.