### PR TITLE
chore: promote OpenGeni 0.23.14 after admission repair

### DIFF
--- a/.changeset/stable-release-admission.md
+++ b/.changeset/stable-release-admission.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Stabilize release admission checks under loaded CI runners.

--- a/.changeset/stable-release-admission.md
+++ b/.changeset/stable-release-admission.md
@@ -1,5 +1,0 @@
----
-"@opengeni/react": patch
----
-
-Stabilize release admission checks under loaded CI runners.

--- a/apps/web/src/routes/org-settings-strict-mode.test.tsx
+++ b/apps/web/src/routes/org-settings-strict-mode.test.tsx
@@ -188,6 +188,17 @@ async function flush() {
   });
 }
 
+async function waitForOrganizationApiKeyReads() {
+  const deadline = Date.now() + 1_000;
+  while (listOrganizationApiKeys.mock.calls.length < 2 && Date.now() < deadline) {
+    // The developer section is loaded through React.lazy. On a busy runner,
+    // StrictMode's two effect passes may settle after more than one tick.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+}
+
 beforeAll(() => {
   GlobalRegistrator.register();
   (
@@ -265,7 +276,7 @@ describe("organization billing StrictMode ownership", () => {
         </StrictMode>,
       );
     });
-    await flush();
+    await waitForOrganizationApiKeyReads();
 
     expect(listOrganizationApiKeys.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(

--- a/examples/northstar-support/CHANGELOG.md
+++ b/examples/northstar-support/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/example-northstar-support
 
+## 0.0.132
+
+### Patch Changes
+
+- Updated dependencies [a8da2c5]
+  - @opengeni/react@3.4.1
+
 ## 0.0.131
 
 ### Patch Changes

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/example-northstar-support",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opengeni/react
 
+## 3.4.1
+
+### Patch Changes
+
+- a8da2c5: Stabilize release admission checks under loaded CI runners.
+
 ## 3.4.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/react",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/react/test/timeline-failed-status.test.tsx
+++ b/packages/react/test/timeline-failed-status.test.tsx
@@ -272,23 +272,32 @@ function hasFailedAffordance(container: HTMLElement): boolean {
   return container.querySelector(".text-og-status-failed") !== null;
 }
 
+async function waitForFailedAffordance(container: HTMLElement): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!hasFailedAffordance(container) && Date.now() < deadline) {
+    // SandboxRow is loaded through React.lazy. A busy CI worker can need more
+    // than one event-loop turn to resolve the module and leave Suspense.
+    await flush(10);
+  }
+}
+
 describe("Structural guard — every renderer surfaces failure affordance on failed status", () => {
   for (const c of CASES) {
     test(c.label, async () => {
       if (c.kind === "tool") {
         const Renderer = defaultToolRegistry.resolve(c.item);
         const r = await renderComponent(<Renderer item={c.item} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       } else if (c.kind === "rail-worker") {
         const r = await renderComponent(<ActivityRail items={[c.item]} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       } else {
         const r = await renderComponent(<ActivityRail items={[c.item]} />);
-        await flush();
+        await waitForFailedAffordance(r.container);
         expect(hasFailedAffordance(r.container)).toBe(true);
         await r.unmount();
       }

--- a/packages/testing/src/shared-pg.ts
+++ b/packages/testing/src/shared-pg.ts
@@ -192,6 +192,40 @@ async function dockerOk(args: string[]): Promise<boolean> {
   }
 }
 
+async function startSharedContainer(args: string[]): Promise<string | null> {
+  const attempts = process.env.OPENGENI_REQUIRE_REAL_DB === "1" ? 5 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const started = await docker(args).catch(() => null);
+    const startedId = started?.stdout.trim() ?? "";
+    if (/^[a-f0-9]{64}$/u.test(startedId)) {
+      return startedId;
+    }
+
+    // `docker run` is outcome-ambiguous when the daemon briefly stops
+    // answering: the named container may have been created despite the failed
+    // client call. Re-probe that exact name before attempting another create.
+    const probe = await probeContainer();
+    if (probe.available && probe.id) {
+      if (probe.status === "running" || probe.status === "restarting") {
+        return probe.id;
+      }
+      const resumed =
+        probe.status === "paused"
+          ? await dockerOk(["unpause", probe.id])
+          : await dockerOk(["start", probe.id]);
+      if (resumed) {
+        return probe.id;
+      }
+      await dockerOk(["rm", "-f", "-v", probe.id]);
+    }
+
+    if (attempt < attempts) {
+      await Bun.sleep(250 * attempt);
+    }
+  }
+  return null;
+}
+
 async function readLockOwner(): Promise<LockOwner | null> {
   try {
     const parsed = JSON.parse(await readFile(LOCK_OWNER_FILE, "utf8")) as Partial<LockOwner>;
@@ -489,7 +523,7 @@ async function ensureContainerAndAcquire(): Promise<ContainerHandle | null> {
       // visible) rather than a clean error. Give the throwaway test server a
       // generous ceiling so the whole suite fits. `MAX_CONNECTIONS` keeps the
       // per-file pools small as a second line of defence.
-      const started = await docker([
+      generation = await startSharedContainer([
         "run",
         "-d",
         "-e",
@@ -503,9 +537,8 @@ async function ensureContainerAndAcquire(): Promise<ContainerHandle | null> {
         "max_connections=1000",
         "-c",
         "shared_buffers=256MB",
-      ]).catch(() => null);
-      generation = started?.stdout.trim() ?? null;
-      if (!generation || !/^[a-f0-9]{64}$/u.test(generation)) {
+      ]);
+      if (!generation) {
         return null; // Docker unavailable or unable to start the fixture.
       }
     }

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -203,7 +203,8 @@ function isExpectedNavigationReadCancellation(problem: string): boolean {
     pathname === "/v1/config/client" ||
     pathname === "/v1/auth/get-session" ||
     /^\/v1\/workspaces\/[0-9a-f-]+\/(?:realtime-)?model-catalog$/u.test(pathname) ||
-    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:sessions|machines|new-session-draft)$/u.test(pathname)
+    /^\/v1\/workspaces\/[0-9a-f-]+\/(?:sessions|machines|new-session-draft)$/u.test(pathname) ||
+    /^\/v1\/workspaces\/[0-9a-f-]+\/live-events\/stream$/u.test(pathname)
   );
 }
 

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -34,6 +34,7 @@ import postgres from "postgres";
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const ownerHeaders = { "x-opengeni-subject": "sessionpin-owner" };
 const otherMemberHeaders = { "x-opengeni-subject": "sessionpin-other-member" };
+const ACKNOWLEDGEMENT_TIMEOUT_MS = 30_000;
 const workflowClient: SessionWorkflowClient = {
   signalUserMessage: async () => undefined,
   wakeSessionWorkflow: async () => undefined,
@@ -311,7 +312,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
           response.request().method() === "PUT" &&
           new URL(response.url()).pathname === attentionPath &&
           response.status() === 200,
-        { timeout: 10_000 },
+        { timeout: ACKNOWLEDGEMENT_TIMEOUT_MS },
       );
       await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
       await firstAcknowledgementStarted;
@@ -350,7 +351,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         (response) =>
           response.request().method() === "PUT" &&
           new URL(response.url()).pathname === attentionPath,
-        { timeout: 10_000 },
+        { timeout: ACKNOWLEDGEMENT_TIMEOUT_MS },
       );
       const sendResponse = await page.evaluate(
         async ({ browserApiBaseUrl, targetWorkspaceId, targetSessionId }) => {


### PR DESCRIPTION
Promote the fully admitted OpenGeni 0.23.14 source after stabilizing the release CI gates.

Release source: `ee2cba318abdbbb7f6a6c97061f076039872341d`
Reviewed Version head: `5d03ea051e9731f0211a4cb0bab21165a1a67e79`
Reviewed base: `53f6592bef4ed043faa4556a792ab3b93cf2c9a0`
Trusted Version CI: https://github.com/Cloudgeni-ai/opengeni/actions/runs/33572855635

Merge method: merge commit only.

## Summary by Sourcery

Stabilize release admission checks and promote the resulting React and example package versions.

Bug Fixes:
- Improve release admission stability by making React and browser tests tolerate delayed lazy-loaded UI and slower CI acknowledgements.
- Harden shared PostgreSQL test-container startup against transient Docker failures and ambiguous container creation states.
- Treat live-event stream cancellations as expected during organization onboarding tests.

Enhancements:
- Promote @opengeni/react to 3.4.1 and update the Northstar support example to 0.0.132.

Tests:
- Make StrictMode, failed-status, Docker-backed testing, onboarding, and session-pin tests more reliable on busy or transiently unavailable CI runners.