### PR TITLE
chore(release): advance product version to 0.23.15

### DIFF
--- a/.changeset/stable-timeline-annotation-tests.md
+++ b/.changeset/stable-timeline-annotation-tests.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Stabilize timeline annotation interactions when lazy UI effects settle under load.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.14
-appVersion: "0.23.14"
+version: 0.23.15
+appVersion: "0.23.15"

--- a/packages/react/test/timeline-annotations.test.tsx
+++ b/packages/react/test/timeline-annotations.test.tsx
@@ -29,9 +29,7 @@ function userItem(id: string, text: string, sequence: number): UserMessageItem {
   };
 }
 
-function annotation(
-  note = "Keep this exact constraint.",
-): DraftTimelineAnnotation {
+function annotation(note = "Keep this exact constraint."): DraftTimelineAnnotation {
   return {
     id: "00000000-0000-4000-8000-000000000502",
     source: {
@@ -79,10 +77,7 @@ function firstTextNode(element: Element): Text {
   return node;
 }
 
-async function waitFor(
-  condition: () => boolean,
-  message: string,
-): Promise<void> {
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
   const deadline = Date.now() + 1_000;
   while (!condition()) {
     if (Date.now() >= deadline) throw new Error(message);
@@ -95,10 +90,7 @@ describe("timeline annotations", () => {
     let captured: DraftTimelineAnnotation | null = null;
     const item = userItem(SOURCE_EVENT_ID, "alpha beta omega", 3);
     const rendered = await renderComponent(
-      <MessageTimeline
-        items={[item]}
-        onAnnotate={(next) => (captured = next)}
-      />,
+      <MessageTimeline items={[item]} onAnnotate={(next) => (captured = next)} />,
     );
     await flush();
     const source = rendered.container.querySelector<HTMLElement>(
@@ -136,11 +128,7 @@ describe("timeline annotations", () => {
 
   test("rejects a selection spanning two timeline messages", async () => {
     const first = userItem("00000000-0000-4000-8000-000000000511", "first", 1);
-    const second = userItem(
-      "00000000-0000-4000-8000-000000000512",
-      "second",
-      2,
-    );
+    const second = userItem("00000000-0000-4000-8000-000000000512", "second", 2);
     const rendered = await renderComponent(
       <MessageTimeline items={[first, second]} onAnnotate={() => undefined} />,
     );
@@ -182,29 +170,23 @@ describe("timeline annotations", () => {
     expect(textarea).not.toBeNull();
     await act(async () => {
       if (textarea) {
-        const setter = Object.getOwnPropertyDescriptor(
-          HTMLTextAreaElement.prototype,
-          "value",
-        )?.set;
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
         setter?.call(textarea, "Use the quoted value.");
         textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
       }
     });
     expect(note).toBe("Use the quoted value.");
-    const sourceButton = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent?.includes("view source"),
+    const sourceButton = [...document.body.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("view source"),
     );
     await act(async () => sourceButton?.click());
     await waitFor(
       () =>
-        document.body.textContent?.includes(
-          "Source is outside the loaded timeline window.",
-        ) === true,
+        document.body.textContent?.includes("Source is outside the loaded timeline window.") ===
+        true,
       "source-unavailable feedback did not appear",
     );
-    expect(document.body.textContent).toContain(
-      "Source is outside the loaded timeline window.",
-    );
+    expect(document.body.textContent).toContain("Source is outside the loaded timeline window.");
     await rendered.unmount();
   });
 });

--- a/packages/react/test/timeline-annotations.test.tsx
+++ b/packages/react/test/timeline-annotations.test.tsx
@@ -29,7 +29,9 @@ function userItem(id: string, text: string, sequence: number): UserMessageItem {
   };
 }
 
-function annotation(note = "Keep this exact constraint."): DraftTimelineAnnotation {
+function annotation(
+  note = "Keep this exact constraint.",
+): DraftTimelineAnnotation {
   return {
     id: "00000000-0000-4000-8000-000000000502",
     source: {
@@ -77,12 +79,26 @@ function firstTextNode(element: Element): Text {
   return node;
 }
 
+async function waitFor(
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await flush(10);
+  }
+}
+
 describe("timeline annotations", () => {
   test("turns one same-message text selection into one exact draft annotation", async () => {
     let captured: DraftTimelineAnnotation | null = null;
     const item = userItem(SOURCE_EVENT_ID, "alpha beta omega", 3);
     const rendered = await renderComponent(
-      <MessageTimeline items={[item]} onAnnotate={(next) => (captured = next)} />,
+      <MessageTimeline
+        items={[item]}
+        onAnnotate={(next) => (captured = next)}
+      />,
     );
     await flush();
     const source = rendered.container.querySelector<HTMLElement>(
@@ -92,7 +108,13 @@ describe("timeline annotations", () => {
     const text = firstTextNode(source!);
     selectText(text, 6, 10);
     source?.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
-    await flush();
+    await waitFor(
+      () =>
+        [...document.body.querySelectorAll("button")].some(
+          (button) => button.textContent?.trim() === "Annotate",
+        ),
+      "annotation action did not appear",
+    );
     const action = [...document.body.querySelectorAll("button")].find(
       (button) => button.textContent?.trim() === "Annotate",
     );
@@ -114,7 +136,11 @@ describe("timeline annotations", () => {
 
   test("rejects a selection spanning two timeline messages", async () => {
     const first = userItem("00000000-0000-4000-8000-000000000511", "first", 1);
-    const second = userItem("00000000-0000-4000-8000-000000000512", "second", 2);
+    const second = userItem(
+      "00000000-0000-4000-8000-000000000512",
+      "second",
+      2,
+    );
     const rendered = await renderComponent(
       <MessageTimeline items={[first, second]} onAnnotate={() => undefined} />,
     );
@@ -156,17 +182,29 @@ describe("timeline annotations", () => {
     expect(textarea).not.toBeNull();
     await act(async () => {
       if (textarea) {
-        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
         setter?.call(textarea, "Use the quoted value.");
         textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
       }
     });
     expect(note).toBe("Use the quoted value.");
-    const sourceButton = [...document.body.querySelectorAll("button")].find((button) =>
-      button.textContent?.includes("view source"),
+    const sourceButton = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("view source"),
     );
     await act(async () => sourceButton?.click());
-    expect(document.body.textContent).toContain("Source is outside the loaded timeline window.");
+    await waitFor(
+      () =>
+        document.body.textContent?.includes(
+          "Source is outside the loaded timeline window.",
+        ) === true,
+      "source-unavailable feedback did not appear",
+    );
+    expect(document.body.textContent).toContain(
+      "Source is outside the loaded timeline window.",
+    );
     await rendered.unmount();
   });
 });


### PR DESCRIPTION
Advance the source-controlled OpenGeni product/chart version from 0.23.14 to 0.23.15.

The repaired 0.23.14 source passed exact-source CI, but immutable candidate admission correctly rejected it because the earlier candidate already occupies the 0.23.14 registry identity. This forward-only bump gives the admitted repaired source a fresh product version without overwriting any existing image or chart.

Validation:
- bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml
- bun test scripts/release-version.test.ts scripts/package-release-chart.test.ts
- bun test scripts/release-image-workflow-contract.test.ts
- bunx prettier --check deploy/helm/opengeni/Chart.yaml
- git diff --check

Failed pre-mutation candidate admission: https://github.com/Cloudgeni-ai/opengeni/actions/runs/33576509895

## Summary by Sourcery

Advance the product version and stabilize timeline annotation interaction coverage under asynchronous UI conditions.

Bug Fixes:
- Stabilize timeline annotation tests by waiting for asynchronous annotation actions and unavailable-source feedback to appear before asserting results.

Tests:
- Add a changeset documenting improved stability for timeline annotation interactions under load.

Chores:
- Advance the OpenGeni Helm chart and application version from 0.23.14 to 0.23.15.