### PR TITLE
fix(core): make machine-targeted session create atomic

### DIFF
--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -20,6 +20,7 @@
 //     machine route + working directory before the child's first turn.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resolveTurnExecutionPolicyV1 } from "@opengeni/config";
 import postgres from "postgres";
 import {
   testSettings,
@@ -38,7 +39,7 @@ import {
 } from "@opengeni/db";
 import { subjectFor } from "@opengeni/runtime";
 import type { AccessGrant } from "@opengeni/contracts";
-import { createSessionForRequest } from "@opengeni/core";
+import { createAndStartSessionWithOutcome, createSessionForRequest } from "@opengeni/core";
 import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
 import { withChannelA } from "../src/sandbox/channel-a";
 
@@ -329,6 +330,65 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     const [after] = await admin<{ count: string }[]>`
       select count(*)::text as count from sessions where workspace_id = ${workspaceId}`;
     expect(after?.count).toBe(before?.count);
+  }, 60_000);
+
+  test("a committed keyed create replays after its machine target is revoked", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, enrollmentId, sandboxId, bus } = await seedMachine();
+    const idempotencyKey = crypto.randomUUID();
+    const createInput = {
+      db,
+      bus,
+      workflowClient: stubWorkflowClient(),
+      accountId,
+      workspaceId,
+      initialMessage: "replay this machine-targeted session",
+      resources: [],
+      tools: [],
+      toolPolicy: { mode: "explicit" as const, inheritedFromSessionId: null },
+      model: settings.openaiModel,
+      reasoningEffort: settings.openaiReasoningEffort,
+      turnExecutionPolicy: resolveTurnExecutionPolicyV1(settings, {
+        modelId: settings.openaiModel,
+        requestedModelId: null,
+        modelSource: "deployment",
+        reasoningEffort: settings.openaiReasoningEffort,
+        reasoningSource: "deployment",
+      }),
+      sandboxBackend: "selfhosted" as const,
+      metadata: {},
+      firstPartyMcpTools: [],
+      createIdempotencyKey: idempotencyKey,
+      seedTargetSandbox: {
+        sandboxId,
+        settings,
+      },
+    };
+    const created = await createAndStartSessionWithOutcome(createInput);
+    expect(created).toMatchObject({
+      outcome: "created",
+      replay: false,
+      session: { activeSandboxId: sandboxId },
+    });
+
+    await admin`update enrollments set status = 'revoked' where id = ${enrollmentId}`;
+
+    const replayed = await createAndStartSessionWithOutcome(createInput);
+    expect(replayed).toMatchObject({
+      outcome: "repaired",
+      replay: false,
+      changed: true,
+      session: {
+        id: created.session.id,
+        activeSandboxId: sandboxId,
+      },
+    });
+    const [stored] = await admin<{ count: number }[]>`
+      select count(*)::int as count
+      from sessions
+      where workspace_id = ${workspaceId}
+        and create_idempotency_key = ${idempotencyKey}`;
+    expect(stored?.count).toBe(1);
   }, 60_000);
 
   test("a direct terminal command without op-stream fails closed without a phantom lease", async () => {

--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -69,18 +69,26 @@ const settings = testSettings({
 /** A MemoryEventBus whose responder answers ping → online for the agent subject
  *  (a stand-in for a real enrolled agent over NATS), so the seed swap's liveness
  *  gate passes without a broker. */
-function busWithAgent(opts: { workspaceId: string; agentId: string }): MemoryEventBus {
+function busWithAgent(opts: {
+  workspaceId: string;
+  agentId: string;
+  onPing?: () => Promise<void>;
+}): MemoryEventBus {
   const bus = new MemoryEventBus();
   bus.subscribeRequests(
     subjectFor(opts.workspaceId, opts.agentId, CONNECTION_INSTANCE_ID),
-    (payload) => {
+    async (payload) => {
       const req = ControlRequest.decode(payload);
       const op = req.op;
+      if (op?.$case === "ping") await opts.onPing?.();
       const res: ControlResponse =
         op?.$case === "ping"
           ? {
               requestId: req.requestId,
-              result: { $case: "ping", ping: { nonce: op.ping.nonce, agentMonotonicMs: "0" } },
+              result: {
+                $case: "ping",
+                ping: { nonce: op.ping.nonce, agentMonotonicMs: "0" },
+              },
             }
           : op?.$case === "exec"
             ? {
@@ -111,7 +119,10 @@ function busWithAgent(opts: { workspaceId: string; agentId: string }): MemoryEve
   return bus;
 }
 
-async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+async function freshWorkspace(): Promise<{
+  accountId: string;
+  workspaceId: string;
+}> {
   const [a] = await admin<
     { id: string }[]
   >`insert into managed_accounts (name) values ('acct') returning id`;
@@ -124,9 +135,13 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 
 /** Seed an enrolled, online selfhosted machine (+ its sandbox record) in a fresh
  *  workspace, and return the id + a bus whose responder makes it probe online. */
-async function seedMachine(
-  os: "linux" | "macos" | "windows" = "linux",
-): Promise<{ accountId: string; workspaceId: string; sandboxId: string; bus: MemoryEventBus }> {
+async function seedMachine(os: "linux" | "macos" | "windows" = "linux"): Promise<{
+  accountId: string;
+  workspaceId: string;
+  enrollmentId: string;
+  sandboxId: string;
+  bus: MemoryEventBus;
+}> {
   const { accountId, workspaceId } = await freshWorkspace();
   const enrollment = await createEnrollment(db, {
     accountId,
@@ -164,6 +179,7 @@ async function seedMachine(
   return {
     accountId,
     workspaceId,
+    enrollmentId: enrollment.id,
     sandboxId: sandbox.id,
     bus: busWithAgent({ workspaceId, agentId: enrollment.id }),
   };
@@ -209,7 +225,12 @@ function grant(accountId: string, workspaceId: string, fromSessionId?: string): 
     subjectId: "subject",
     permissions: ["sessions:create", "sessions:read"],
     ...(fromSessionId
-      ? { metadata: { sessionId: fromSessionId, firstPartyMcpTools: ["session_create"] } }
+      ? {
+          metadata: {
+            sessionId: fromSessionId,
+            firstPartyMcpTools: ["session_create"],
+          },
+        }
       : {}),
   };
 }
@@ -259,6 +280,55 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     const [turnRow] = await admin<{ sandbox_backend: string }[]>`
       select sandbox_backend from session_turns where session_id = ${session.id} limit 1`;
     expect(turnRow?.sandbox_backend).toBe("selfhosted");
+  }, 60_000);
+
+  test("a rejected machine target leaves no queued session shell", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, bus } = await seedMachine();
+    const [before] = await admin<{ count: string }[]>`
+      select count(*)::text as count from sessions where workspace_id = ${workspaceId}`;
+
+    await expect(
+      createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+        initialMessage: "do not persist this rejected worker",
+        targetSandboxId: crypto.randomUUID(),
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: expect.stringContaining("not found in this workspace"),
+    });
+
+    const [after] = await admin<{ count: string }[]>`
+      select count(*)::text as count from sessions where workspace_id = ${workspaceId}`;
+    expect(after?.count).toBe(before?.count);
+  }, 60_000);
+
+  test("a target revoked after liveness preflight rolls the session insert back", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, enrollmentId, sandboxId } = await seedMachine();
+    const bus = busWithAgent({
+      workspaceId,
+      agentId: enrollmentId,
+      onPing: async () => {
+        await admin`update enrollments set status = 'revoked' where id = ${enrollmentId}`;
+      },
+    });
+    const [before] = await admin<{ count: string }[]>`
+      select count(*)::text as count from sessions where workspace_id = ${workspaceId}`;
+
+    await expect(
+      createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+        initialMessage: "do not commit after target authority changes",
+        targetSandboxId: sandboxId,
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: expect.stringContaining("target authority changed during session creation"),
+    });
+
+    const [after] = await admin<{ count: string }[]>`
+      select count(*)::text as count from sessions where workspace_id = ${workspaceId}`;
+    expect(after?.count).toBe(before?.count);
   }, 60_000);
 
   test("a direct terminal command without op-stream fails closed without a phantom lease", async () => {
@@ -508,7 +578,10 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     const [turnRow] = await admin<
       { sandbox_backend: string; sandbox_os: string }[]
     >`select sandbox_backend, sandbox_os from session_turns where session_id = ${child.id} limit 1`;
-    expect(turnRow).toEqual({ sandbox_backend: "selfhosted", sandbox_os: "macos" });
+    expect(turnRow).toEqual({
+      sandbox_backend: "selfhosted",
+      sandbox_os: "macos",
+    });
   }, 60_000);
 
   test("a targetless top-level selfhosted session is rejected before its first turn", async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,6 +347,11 @@ exact workspace- or organization-scoped machine target and seed the session's
 active pointer before its first turn. A targetless generated schedule cannot
 resolve to `selfhosted`; ingress rejects that configuration, and dispatch
 revalidates the frozen target rather than falling back to managed compute.
+Manual and generated creates preflight the target's current liveness and
+workspace root before insertion, then recheck durable target authority and
+commit the active pointer in the same transaction as the session row. A
+rejected target therefore leaves no queued session shell for discovery or
+parent-tree projections to mistake for live work.
 
 Child workers keep the ordinary low-friction rule: omitting placement shares
 the creator's box. Because a Connected Machine pointer is session-local, that

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -198,7 +198,10 @@ seeds the generated session's active pointer before its first turn. A deployment
 whose default backend is `selfhosted` rejects a generated-session schedule that
 does not select a machine instead of creating a session that cannot execute.
 Manual runs also preflight current liveness and the reported workspace root
-before consuming run capacity.
+before consuming run capacity. After that preflight, session creation rechecks
+durable target authority and commits the active pointer in the same transaction
+as the new session row. If the target is invalid, removed, revoked, or otherwise
+no longer attachable, the create fails without leaving a queued session shell.
 
 Unattended schedules currently accept workspace- and organization-scoped
 machines only. User-scoped machines require an owning human's explicit personal

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -95,6 +95,7 @@ import {
   listSessionTurns,
   listSessionMcpServersForChildInheritance,
   requireSession,
+  setActiveSandbox,
   setSubjectRlsContext,
   replaySubmittedHumanPromptFromBoundaryReceipt,
   submitHumanPromptInTransaction,
@@ -137,7 +138,11 @@ import {
   SessionAuthorizationDeniedError,
 } from "../session-authorization";
 import { assertHostMcpAuthoritySourceAdmissionEnabled } from "./host-mcp-authority-source-admission";
-import { swapActiveSandbox, type FleetContext } from "../sandbox/fleet";
+import {
+  preflightCreateTimeSandboxTarget,
+  swapActiveSandbox,
+  type FleetContext,
+} from "../sandbox/fleet";
 import { managedSessionGroupBackend } from "../sandbox/runtime-settings";
 import {
   isWorkspaceCustomModelId,
@@ -719,7 +724,11 @@ export async function createAndStartSessionWithOutcome(input: {
   createdByActor?: Extract<SessionCommandActor, { type: "agent_attempt" }> | null;
   // Ordered low-to-high precedence. Names/ids only; session.created never
   // carries variable values.
-  variableSets?: Array<{ id: string; name: string; scope: VariableSet["scope"] }>;
+  variableSets?: Array<{
+    id: string;
+    name: string;
+    scope: VariableSet["scope"];
+  }>;
   // The rig + frozen active rig version resolved at create (M3). Both null ⇒ a
   // rig-less session (byte-for-byte today's behavior). Frozen here so a later
   // rig promote never moves an existing session's version.
@@ -771,11 +780,11 @@ export async function createAndStartSessionWithOutcome(input: {
   // OS-labeling surfaces honestly reflect the machine.
   sandboxOs?: Session["sandboxOs"];
   // Create-time machine targeting (A-2a, RACE-FREE): the enrolled machine (a
-  // sandbox id) to run this session on. When set, the active-sandbox pointer is
-  // resolved+validated+seeded (epoch-fenced) INSIDE finishStartSession, AFTER the
-  // session row exists but BEFORE the first turn is enqueued/the workflow woken,
-  // so the FIRST turn routes to the chosen machine. An invalid/unowned/offline
-  // target fails the create (422) — never a silent fall-back to the default box.
+  // sandbox id) to run this session on. When set, target liveness is preflighted
+  // before insertion, then the active-sandbox pointer is authority-checked and
+  // seeded (epoch-fenced) in the SAME transaction as the session row. The FIRST
+  // turn therefore routes to the chosen machine, while an invalid/unowned/offline
+  // target fails the create (422) without leaving a queued session shell.
   // `workingDir` (optional) is the path/cwd base the chosen machine runs under,
   // seeded alongside the pointer through the epoch-fenced CAS.
   seedTargetSandbox?: {
@@ -828,8 +837,41 @@ export async function createAndStartSessionWithOutcome(input: {
     (input.workspaceCustomModel === true || input.workspaceGatewayCustomModel === true) &&
     input.retainWorkspaceCustomModel !== true &&
     input.retainWorkspaceGatewayModel !== true;
+  const seedTargetForNewSession = input.seedTargetSandbox ?? null;
+  if (seedTargetForNewSession && input.sandboxBackend === "none") {
+    throw new HTTPException(422, {
+      message: "cannot target a machine for a session with no sandbox (backend: none)",
+    });
+  }
+  const preflightTarget = seedTargetForNewSession
+    ? await preflightCreateTimeSandboxTarget(
+        {
+          db: input.db,
+          settings: seedTargetForNewSession.settings,
+          bus: input.bus,
+        },
+        {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          ...(seedTargetForNewSession.resourceSubjectId
+            ? { subjectId: seedTargetForNewSession.resourceSubjectId }
+            : {}),
+        },
+        seedTargetForNewSession.sandboxId,
+        seedTargetForNewSession.workingDir ?? null,
+      )
+    : null;
+  if (preflightTarget && !preflightTarget.ok) {
+    throw new HTTPException(422, {
+      message: `cannot target sandbox ${seedTargetForNewSession!.sandboxId}: ${preflightTarget.reason}`,
+    });
+  }
+  let targetSeededBeforeCreateCommit = false;
   const beforeCreateCommit =
-    requiresActiveWorkspaceCustomModel || input.consumeNewSessionDraft || input.beforeCreateCommit
+    requiresActiveWorkspaceCustomModel ||
+    input.consumeNewSessionDraft ||
+    input.beforeCreateCommit ||
+    preflightTarget
       ? async (tx: Database, sessionId: string, context?: { created: boolean }): Promise<void> => {
           // A committed keyed replay already crossed this fence when its shell
           // was first accepted. Revalidate only the transaction inserting a new
@@ -866,6 +908,25 @@ export async function createAndStartSessionWithOutcome(input: {
               expectedRevision: input.consumeNewSessionDraft.expectedRevision,
               expectedSnapshot: input.consumeNewSessionDraft.expectedSnapshot,
             });
+          }
+          if (preflightTarget?.ok && context?.created !== false) {
+            const seeded = await setActiveSandbox(tx, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId,
+              targetSandboxId: preflightTarget.targetSandboxId,
+              expectedEpoch: 0,
+              ...(seedTargetForNewSession?.resourceSubjectId
+                ? { subjectId: seedTargetForNewSession.resourceSubjectId }
+                : {}),
+              workingDir: preflightTarget.workingDir,
+            });
+            if (!seeded.swapped) {
+              throw new HTTPException(422, {
+                message: `cannot target sandbox ${seedTargetForNewSession!.sandboxId}: target authority changed during session creation`,
+              });
+            }
+            targetSeededBeforeCreateCommit = true;
           }
           await input.beforeCreateCommit?.(tx, sessionId);
         }
@@ -951,7 +1012,10 @@ export async function createAndStartSessionWithOutcome(input: {
         changed: finished.changed,
       };
     }
-    const finished = await finishStartSession(input, keyed);
+    const finished = await finishStartSession(
+      targetSeededBeforeCreateCommit ? { ...input, seedTargetSandbox: null } : input,
+      keyed,
+    );
     return {
       session: finished.session,
       outcome: "created",
@@ -1012,7 +1076,10 @@ export async function createAndStartSessionWithOutcome(input: {
     }
     throw error;
   }
-  const finished = await finishStartSession(input, session);
+  const finished = await finishStartSession(
+    targetSeededBeforeCreateCommit ? { ...input, seedTargetSandbox: null } : input,
+    session,
+  );
   return {
     session: finished.session,
     outcome: "created",
@@ -1050,7 +1117,11 @@ async function finishStartSession(
     reasoningEffort: Settings["openaiReasoningEffort"];
     turnExecutionPolicy: TurnExecutionPolicyV1;
     sandboxBackend: Settings["sandboxBackend"];
-    variableSets?: Array<{ id: string; name: string; scope: VariableSet["scope"] }>;
+    variableSets?: Array<{
+      id: string;
+      name: string;
+      scope: VariableSet["scope"];
+    }>;
     goal?: GoalSpec | null;
     initialAutomaticTitle?: string | null;
     sessionMcpServers?: SessionMcpServerMetadata[];
@@ -2330,7 +2401,10 @@ export async function createSessionForRequestWithOutcome(
     payload.firstPartyMcpTools,
     parentSession ? parentSession.firstPartyMcpTools : undefined,
     workspaceFirstPartyDefaults && !parentSession
-      ? { ...deploymentFirstPartyMcpToolPolicy, default: workspaceFirstPartyDefaults }
+      ? {
+          ...deploymentFirstPartyMcpToolPolicy,
+          default: workspaceFirstPartyDefaults,
+        }
       : deploymentFirstPartyMcpToolPolicy,
   );
   const googleDrivePublicationEnabled =
@@ -2406,7 +2480,10 @@ export async function createSessionForRequestWithOutcome(
   let sandboxGroupId: string | null = null;
   let inheritedBackend: Session["sandboxBackend"] | undefined;
   let inheritedSandboxOs: Session["sandboxOs"] | undefined;
-  let inheritedActiveTarget: { sandboxId: string; workingDir: string | null } | null = null;
+  let inheritedActiveTarget: {
+    sandboxId: string;
+    workingDir: string | null;
+  } | null = null;
   // ENV-AWARE GROUPING: under the CURRENT mechanics the workspace VariableSet is
   // creation-time box state — the box's manifest env is fixed when it is cold-
   // created, and the SDK's provided-session guard rejects any manifest-env delta
@@ -3166,7 +3243,15 @@ export async function acceptSessionUserMessageWithOutcome(
           ? { schedulePostCommit: deps.schedulePromptPostCommit }
           : {}),
       });
-    return { accepted, turn, draft, receipt, routing, interruptionCount, replay };
+    return {
+      accepted,
+      turn,
+      draft,
+      receipt,
+      routing,
+      interruptionCount,
+      replay,
+    };
   } catch (error) {
     if (input.clientEventId && boundaryRequestHash) {
       const replay = await withWorkspaceSubjectSessionActivityRls(

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -838,44 +838,50 @@ export async function createAndStartSessionWithOutcome(input: {
     input.retainWorkspaceCustomModel !== true &&
     input.retainWorkspaceGatewayModel !== true;
   const seedTargetForNewSession = input.seedTargetSandbox ?? null;
-  if (seedTargetForNewSession && input.sandboxBackend === "none") {
-    throw new HTTPException(422, {
-      message: "cannot target a machine for a session with no sandbox (backend: none)",
-    });
-  }
-  const preflightTarget = seedTargetForNewSession
-    ? await preflightCreateTimeSandboxTarget(
-        {
-          db: input.db,
-          settings: seedTargetForNewSession.settings,
-          bus: input.bus,
-        },
-        {
-          accountId: input.accountId,
-          workspaceId: input.workspaceId,
-          ...(seedTargetForNewSession.resourceSubjectId
-            ? { subjectId: seedTargetForNewSession.resourceSubjectId }
-            : {}),
-        },
-        seedTargetForNewSession.sandboxId,
-        seedTargetForNewSession.workingDir ?? null,
-      )
-    : null;
-  if (preflightTarget && !preflightTarget.ok) {
-    throw new HTTPException(422, {
-      message: `cannot target sandbox ${seedTargetForNewSession!.sandboxId}: ${preflightTarget.reason}`,
-    });
-  }
+  const unsupportedTargetBackendMessage =
+    seedTargetForNewSession && input.sandboxBackend === "none"
+      ? "cannot target a machine for a session with no sandbox (backend: none)"
+      : null;
+  const preflightTarget =
+    seedTargetForNewSession && !unsupportedTargetBackendMessage
+      ? await preflightCreateTimeSandboxTarget(
+          {
+            db: input.db,
+            settings: seedTargetForNewSession.settings,
+            bus: input.bus,
+          },
+          {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            ...(seedTargetForNewSession.resourceSubjectId
+              ? { subjectId: seedTargetForNewSession.resourceSubjectId }
+              : {}),
+          },
+          seedTargetForNewSession.sandboxId,
+          seedTargetForNewSession.workingDir ?? null,
+        )
+      : null;
+  const targetPreflightFailureMessage = unsupportedTargetBackendMessage
+    ? unsupportedTargetBackendMessage
+    : preflightTarget && !preflightTarget.ok
+      ? `cannot target sandbox ${seedTargetForNewSession!.sandboxId}: ${preflightTarget.reason}`
+      : null;
   let targetSeededBeforeCreateCommit = false;
   const beforeCreateCommit =
     requiresActiveWorkspaceCustomModel ||
     input.consumeNewSessionDraft ||
     input.beforeCreateCommit ||
-    preflightTarget
+    preflightTarget ||
+    targetPreflightFailureMessage
       ? async (tx: Database, sessionId: string, context?: { created: boolean }): Promise<void> => {
           // A committed keyed replay already crossed this fence when its shell
           // was first accepted. Revalidate only the transaction inserting a new
           // session, while still running caller linkage on every replay.
+          if (targetPreflightFailureMessage && context?.created !== false) {
+            throw new HTTPException(422, {
+              message: targetPreflightFailureMessage,
+            });
+          }
           if (requiresActiveWorkspaceCustomModel && context?.created !== false) {
             const reference = {
               scope: input.turnExecutionPolicy.providerId.startsWith("organization-")

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -454,31 +454,18 @@ export async function listFleet(
   };
 }
 
-/** Resolve a swap target id → the value `setActiveSandbox` writes. The session's
- *  own group id maps to NULL (the default pointer); a first-class sandbox id is
- *  validated (workspace ownership + liveness) and written verbatim. */
-async function resolveTarget(
+type FleetResourceContext = Pick<FleetContext, "accountId" | "workspaceId" | "subjectId">;
+
+type ResolvedNamedSandboxTarget =
+  | { ok: true; targetSandboxId: string; workspaceRoot?: string }
+  | { ok: false; reason: string; code: BackendUnresolvableCode };
+
+/** Resolve one named sandbox, independent of any existing session pointer. */
+async function resolveNamedSandboxTarget(
   services: FleetServices,
-  ctx: FleetContext,
+  ctx: FleetResourceContext,
   target: string,
-): Promise<
-  | { ok: true; targetSandboxId: string | null; workspaceRoot?: string }
-  | { ok: false; reason: string; code: BackendUnresolvableCode }
-> {
-  // The session's own group box → the default pointer (null).
-  if (target === ctx.sessionGroupId || target === "session" || target === "default") {
-    if (!managedSessionGroupBackend(services.settings.sandboxBackend, ctx.sessionBackend)) {
-      return {
-        ok: false,
-        reason:
-          ctx.sessionBackend === "none"
-            ? "this session has no home sandbox; attach a Connected Machine"
-            : "this deployment has no managed session sandbox; select an enrolled machine",
-        code: "unsupported_backend_context",
-      };
-    }
-    return { ok: true, targetSandboxId: null };
-  }
+): Promise<ResolvedNamedSandboxTarget> {
   const sandbox = await getSandbox(
     services.db,
     ctx.subjectId
@@ -564,6 +551,81 @@ async function resolveTarget(
     targetSandboxId: sandbox.id,
     ...(targetWorkspaceRoot ? { workspaceRoot: targetWorkspaceRoot } : {}),
   };
+}
+
+export type CreateTimeSandboxTargetPreflight =
+  | { ok: true; targetSandboxId: string; workingDir: string | null }
+  | {
+      ok: false;
+      reason: string;
+      code: BackendUnresolvableCode | "invalid_working_directory";
+    };
+
+/**
+ * Validate a named create-time machine target before any session row exists.
+ * The caller still commits the pointer with `setActiveSandbox` inside the
+ * session-create transaction, which rechecks durable ownership/enrollment
+ * authority and closes the remove/revoke race without holding database locks
+ * across the liveness probe.
+ */
+export async function preflightCreateTimeSandboxTarget(
+  services: FleetServices,
+  ctx: FleetResourceContext,
+  target: string,
+  workingDir: string | null,
+): Promise<CreateTimeSandboxTargetPreflight> {
+  const resolved = await resolveNamedSandboxTarget(services, ctx, target);
+  if (!resolved.ok) return resolved;
+  if (!resolved.workspaceRoot) {
+    return {
+      ok: true,
+      targetSandboxId: resolved.targetSandboxId,
+      workingDir,
+    };
+  }
+  try {
+    return {
+      ok: true,
+      targetSandboxId: resolved.targetSandboxId,
+      workingDir:
+        resolveConnectedMachineWorkspaceRoot(resolved.workspaceRoot, workingDir) ??
+        resolved.workspaceRoot,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+      code: "invalid_working_directory",
+    };
+  }
+}
+
+/** Resolve a swap target id → the value `setActiveSandbox` writes. The session's
+ *  own group id maps to NULL (the default pointer); a first-class sandbox id is
+ *  validated (workspace ownership + liveness) and written verbatim. */
+async function resolveTarget(
+  services: FleetServices,
+  ctx: FleetContext,
+  target: string,
+): Promise<
+  | { ok: true; targetSandboxId: string | null; workspaceRoot?: string }
+  | { ok: false; reason: string; code: BackendUnresolvableCode }
+> {
+  // The session's own group box → the default pointer (null).
+  if (target === ctx.sessionGroupId || target === "session" || target === "default") {
+    if (!managedSessionGroupBackend(services.settings.sandboxBackend, ctx.sessionBackend)) {
+      return {
+        ok: false,
+        reason:
+          ctx.sessionBackend === "none"
+            ? "this session has no home sandbox; attach a Connected Machine"
+            : "this deployment has no managed session sandbox; select an enrolled machine",
+        code: "unsupported_backend_context",
+      };
+    }
+    return { ok: true, targetSandboxId: null };
+  }
+  return await resolveNamedSandboxTarget(services, ctx, target);
 }
 
 /**


### PR DESCRIPTION
## Summary

- preflight create-time machine target liveness and workspace-root resolution before inserting a session
- recheck durable target authority and seed the active pointer inside the session-create transaction
- prevent invalid, removed, revoked, or backend-none targets from leaving queued session shells
- document the lifecycle invariant and add invalid-target plus revoke-race regressions

## Testing

- [x] `bun scripts/typecheck.ts --project packages/core --project apps/api`
- [x] `bun test --timeout 60000 apps/api/test/machine-home-backend.test.ts apps/api/test/sandbox-shared-and-viewer.test.ts` (47 passed, 1 opt-in Modal test skipped)
- [x] `oxfmt --check` on changed TypeScript files
- [x] `oxlint` on changed TypeScript files
- [x] `git diff origin/main...HEAD --check`

## Delivery integrity

- [x] Candidate contains substantive source and regression-test changes.
- [x] Candidate was rebased onto the September 2, 2026 `main` head before final validation.

## Notes

- `session_get` parent/tree differences observed during diagnosis are the existing target-only related-access redaction; the durable queued shell was the misleading status source fixed here.
- An independent child review was attempted, but the reviewer did not settle after bounded waits and an explicit wrap-up request. It was paused with a recorded reason to avoid leaving another misleading long-running descendant.

## Summary by Sourcery

Make machine-targeted session creation atomic by validating targets before insertion and committing target authority with the session in one transaction.

Bug Fixes:
- Make machine-targeted session creation fail atomically when the target is invalid, unavailable, revoked, removed, or otherwise loses authority during creation, leaving no queued session shell.
- Preserve and repair idempotent machine-targeted creates without creating duplicate sessions after target authority changes.

Enhancements:
- Validate machine liveness and workspace-root configuration before session insertion, then commit the active machine pointer together with the session row.
- Document the invariant that rejected machine targets must not leave discoverable queued sessions.

Documentation:
- Document create-time machine target preflight, transactional authority checks, and the no-queued-shell lifecycle invariant.

Tests:
- Add regressions covering invalid machine targets, revoke races during creation, and idempotent replay after target revocation.