### PR TITLE
chore(release): advance product version to 0.23.16

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.15
-appVersion: "0.23.15"
+version: 0.23.16
+appVersion: "0.23.16"


### PR DESCRIPTION
Advances the Helm chart and app version to 0.23.16 for today’s forward-compatible production release.

## Summary by Sourcery

Chores:
- Advance the Helm chart and application versions to 0.23.16.