### PR TITLE
Fix skip admission for busy scheduled sessions

### DIFF
--- a/.changeset/scheduled-skip-idle-admission.md
+++ b/.changeset/scheduled-skip-idle-admission.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Enforce idle-boundary admission for skip-overlap scheduled sessions.

--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -1390,15 +1390,16 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
                 xaiProviderAccountAuthoritySnapshot: taskXaiProviderAccountAuthoritySnapshot,
                 scheduledTaskRunId: run.id,
               },
-              async (tx, wakeEventId) => {
+              async (tx, wakeEventId, _updateId, rejectionReason) => {
                 if (!wakeEventId) {
+                  const error = scheduledSessionRejectionError(rejectionReason);
                   await settleScheduledTaskRunInTransaction(tx, {
                     workspaceId: task.workspaceId,
                     runId: scheduledRun.id,
                     sessionId: session.id,
                     triggerEventId: null,
                     status: "skipped",
-                    error: "session_cancelled",
+                    error,
                   });
                   return;
                 }
@@ -1410,26 +1411,33 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
                   status: "dispatched",
                 });
               },
-              incidentPreflightRequired
-                ? {
-                    prepareSource: async (tx, sessionId) =>
-                      await prepareIncidentTelemetrySource({
-                        tx,
-                        settings,
-                        taskId: task.id,
-                        workspaceId: task.workspaceId,
-                        sessionId,
-                        alertOccurrenceLabels: structuredAlertOccurrence?.labels ?? null,
-                        acceptedExecution,
-                      }),
-                  }
-                : undefined,
+              {
+                requireIdleSession: task.overlapPolicy === "skip" && !sessionCreated,
+                ...(incidentPreflightRequired
+                  ? {
+                      prepareSource: async (tx, sessionId) =>
+                        await prepareIncidentTelemetrySource({
+                          tx,
+                          settings,
+                          taskId: task.id,
+                          workspaceId: task.workspaceId,
+                          sessionId,
+                          alertOccurrenceLabels: structuredAlertOccurrence?.labels ?? null,
+                          acceptedExecution,
+                        }),
+                    }
+                  : {}),
+              },
             );
-            if (scheduledUpdate.reason === "session_cancelled") {
+            if (
+              scheduledUpdate.reason === "session_cancelled" ||
+              scheduledUpdate.reason === "session_not_idle"
+            ) {
+              const error = scheduledSessionRejectionError(scheduledUpdate.reason);
               return {
                 kind: "blocked" as const,
                 result: { action: "blocked" as const, reason: "scheduled_run_terminal" as const },
-                run: { ...run, status: "skipped" as const, error: "session_cancelled" },
+                run: { ...run, status: "skipped" as const, error },
               };
             }
             if (scheduledUpdate.added && scheduledUpdate.events.length > 0) {
@@ -1467,39 +1475,14 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
               sessionId: session.id,
             });
             // A user-cancelled (terminal) reusable session must not be revived and
-            // re-billed on the next fire. Early check avoids the pre-lock goal
-            // upsert side-effect; the locked-callback check below is the
-            // authoritative atomic guard. Mirrors apps/api/src/domain/sessions.ts.
+            // re-billed on the next fire. This cheap check gives an early answer;
+            // the locked admission check below remains authoritative. Mirrors
+            // apps/api/src/domain/sessions.ts.
             assertReusableSessionRevivable(session.status);
             // Defensive backstop for the API-level 409: a reusable session keeps
             // its creation-time attachment, so a diverged task attachment must
             // fail the run instead of silently running with the wrong secrets.
             assertReusableSessionBindingMatches(session, task);
-            // A recurring "maintain X" task re-establishes its objective on every
-            // fire: replace the goal text, reactivate it, and reset the counters.
-            const goalEvents =
-              task.runMode === "reusable_session" && goalSpec && run.status === "queued"
-                ? await upsertScheduledSessionGoalForRun(dispatchDb, {
-                    accountId: task.accountId,
-                    workspaceId: task.workspaceId,
-                    sessionId: session.id,
-                    runId: run.id,
-                    text: goalSpec.text,
-                    successCriteria: goalSpec.successCriteria ?? null,
-                    maxAutoContinuations: goalSpec.maxAutoContinuations ?? null,
-                    ...(goalSpec.mutationPolicy ? { mutationPolicy: goalSpec.mutationPolicy } : {}),
-                  })
-                : [];
-            if (goalEvents.length > 0) {
-              if (deferPublications) {
-                deferredEvents.push({
-                  sessionId: session.id,
-                  events: goalEvents,
-                });
-              } else {
-                await publishDurableSessionEvents(bus, task.workspaceId, session.id, goalEvents);
-              }
-            }
             const bundled = await addSessionSystemUpdateWithSourceMutation(
               dispatchDb,
               {
@@ -1534,15 +1517,16 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
                 xaiProviderAccountAuthoritySnapshot: taskXaiProviderAccountAuthoritySnapshot,
                 scheduledTaskRunId: run.id,
               },
-              async (tx, wakeEventId) => {
+              async (tx, wakeEventId, _updateId, rejectionReason) => {
                 if (!wakeEventId) {
+                  const error = scheduledSessionRejectionError(rejectionReason);
                   await settleScheduledTaskRunInTransaction(tx, {
                     workspaceId: task.workspaceId,
                     runId: scheduledRun.id,
                     sessionId: session.id,
                     triggerEventId: null,
                     status: "skipped",
-                    error: "session_cancelled",
+                    error,
                   });
                   return;
                 }
@@ -1554,10 +1538,26 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
                   status: "dispatched",
                 });
               },
-              incidentPreflightRequired
-                ? {
-                    prepareSource: async (tx, sessionId) =>
-                      await prepareIncidentTelemetrySource({
+              {
+                requireIdleSession: task.overlapPolicy === "skip",
+                prepareSource: async (tx, sessionId) => {
+                  const goalEvents =
+                    task.runMode === "reusable_session" && goalSpec && run.status === "queued"
+                      ? await upsertScheduledSessionGoalForRun(tx, {
+                          accountId: task.accountId,
+                          workspaceId: task.workspaceId,
+                          sessionId,
+                          runId: run.id,
+                          text: goalSpec.text,
+                          successCriteria: goalSpec.successCriteria ?? null,
+                          maxAutoContinuations: goalSpec.maxAutoContinuations ?? null,
+                          ...(goalSpec.mutationPolicy
+                            ? { mutationPolicy: goalSpec.mutationPolicy }
+                            : {}),
+                        })
+                      : [];
+                  const incidentSource = incidentPreflightRequired
+                    ? await prepareIncidentTelemetrySource({
                         tx,
                         settings,
                         taskId: task.id,
@@ -1565,15 +1565,21 @@ export function createScheduledTaskActivities(services: () => Promise<ControlAct
                         sessionId,
                         alertOccurrenceLabels: structuredAlertOccurrence?.labels ?? null,
                         acceptedExecution,
-                      }),
-                  }
-                : undefined,
+                      })
+                    : undefined;
+                  return {
+                    ...(incidentSource ?? {}),
+                    ...(goalEvents.length > 0 ? { events: goalEvents } : {}),
+                  };
+                },
+              },
             );
-            if (bundled.reason === "session_cancelled") {
+            if (bundled.reason === "session_cancelled" || bundled.reason === "session_not_idle") {
+              const error = scheduledSessionRejectionError(bundled.reason);
               return {
                 kind: "blocked" as const,
                 result: { action: "blocked" as const, reason: "scheduled_run_terminal" as const },
-                run: { ...run, status: "skipped" as const, error: "session_cancelled" },
+                run: { ...run, status: "skipped" as const, error },
               };
             }
             if (bundled.added && bundled.events.length > 0) {
@@ -1795,6 +1801,14 @@ function scheduledRunTerminalResult(
     return { action: "blocked", reason: "incident_data_source_unsuitable" };
   }
   return { action: "blocked", reason: "scheduled_run_terminal" };
+}
+
+function scheduledSessionRejectionError(
+  rejectionReason: "session_cancelled" | "session_not_idle" | null,
+): "session_cancelled" | "scheduled_session_not_idle" {
+  return rejectionReason === "session_not_idle"
+    ? "scheduled_session_not_idle"
+    : "session_cancelled";
 }
 
 async function prepareIncidentTelemetrySource(input: {
@@ -2304,23 +2318,6 @@ async function recoverBoundScheduledTaskDispatch(input: {
       await publishDurableSessionEvents(input.bus, task.workspaceId, session.id, titleEvents);
     }
   }
-  if (!generatedSession && task.runMode === "reusable_session" && task.agentConfig.goal) {
-    const goalEvents = await upsertScheduledSessionGoalForRun(input.db, {
-      accountId: task.accountId,
-      workspaceId: task.workspaceId,
-      sessionId: session.id,
-      runId: input.run.id,
-      text: task.agentConfig.goal.text,
-      successCriteria: task.agentConfig.goal.successCriteria ?? null,
-      maxAutoContinuations: task.agentConfig.goal.maxAutoContinuations ?? null,
-      ...(task.agentConfig.goal.mutationPolicy
-        ? { mutationPolicy: task.agentConfig.goal.mutationPolicy }
-        : {}),
-    });
-    if (goalEvents.length > 0) {
-      await publishDurableSessionEvents(input.bus, task.workspaceId, session.id, goalEvents);
-    }
-  }
   const scheduledUpdate = await addSessionSystemUpdateWithSourceMutation(
     input.db,
     {
@@ -2359,15 +2356,16 @@ async function recoverBoundScheduledTaskDispatch(input: {
         input.acceptedExecution.xaiProviderAccountAuthoritySnapshot,
       scheduledTaskRunId: input.run.id,
     },
-    async (tx, wakeEventId) => {
+    async (tx, wakeEventId, _updateId, rejectionReason) => {
       if (!wakeEventId) {
+        const error = scheduledSessionRejectionError(rejectionReason);
         await settleScheduledTaskRunInTransaction(tx, {
           workspaceId: task.workspaceId,
           runId: input.run.id,
           sessionId: session.id,
           triggerEventId: null,
           status: "skipped",
-          error: "session_cancelled",
+          error,
         });
         return;
       }
@@ -2379,10 +2377,25 @@ async function recoverBoundScheduledTaskDispatch(input: {
         status: "dispatched",
       });
     },
-    input.acceptedExecution.incidentPreflightRequired
-      ? {
-          prepareSource: async (tx, sessionId) =>
-            await prepareIncidentTelemetrySource({
+    {
+      requireIdleSession: task.overlapPolicy === "skip" && !generatedSession,
+      prepareSource: async (tx, sessionId) => {
+        const goal = task.agentConfig.goal;
+        const goalEvents =
+          !generatedSession && task.runMode === "reusable_session" && goal
+            ? await upsertScheduledSessionGoalForRun(tx, {
+                accountId: task.accountId,
+                workspaceId: task.workspaceId,
+                sessionId,
+                runId: input.run.id,
+                text: goal.text,
+                successCriteria: goal.successCriteria ?? null,
+                maxAutoContinuations: goal.maxAutoContinuations ?? null,
+                ...(goal.mutationPolicy ? { mutationPolicy: goal.mutationPolicy } : {}),
+              })
+            : [];
+        const incidentSource = input.acceptedExecution.incidentPreflightRequired
+          ? await prepareIncidentTelemetrySource({
               tx,
               settings: input.settings,
               taskId: task.id,
@@ -2390,11 +2403,19 @@ async function recoverBoundScheduledTaskDispatch(input: {
               sessionId,
               alertOccurrenceLabels: input.acceptedExecution.alertOccurrenceLabels,
               acceptedExecution: input.acceptedExecution,
-            }),
-        }
-      : undefined,
+            })
+          : undefined;
+        return {
+          ...(incidentSource ?? {}),
+          ...(goalEvents.length > 0 ? { events: goalEvents } : {}),
+        };
+      },
+    },
   );
-  if (scheduledUpdate.reason === "session_cancelled") {
+  if (
+    scheduledUpdate.reason === "session_cancelled" ||
+    scheduledUpdate.reason === "session_not_idle"
+  ) {
     return { action: "blocked", reason: "scheduled_run_terminal" };
   }
   if (scheduledUpdate.added && scheduledUpdate.events.length > 0) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -731,7 +731,9 @@ admitted only when that session's locked status is exactly `idle`. The status
 check, optional reusable-goal reset, run settlement, and pending-update append
 share the ordinary session event transaction, so concurrent occurrences cannot
 both cross the same idle boundary and a skipped occurrence cannot mutate the
-goal. A newly generated session still admits the occurrence that creates it.
+goal. An admitted occurrence persists `queued` to consume that boundary even
+when a pause or active realtime lease withholds its workflow wake. A newly
+generated session still admits the occurrence that creates it.
 
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -726,6 +726,13 @@ snapshots, and remains a scheduled run in audit and settlement. Scheduled
 occurrences attached to an existing human/API turn, and all other machine-input
 batches, keep the internal `system`-role envelope.
 
+For `skip`, a scheduled occurrence targeting an existing or reusable session is
+admitted only when that session's locked status is exactly `idle`. The status
+check, optional reusable-goal reset, run settlement, and pending-update append
+share the ordinary session event transaction, so concurrent occurrences cannot
+both cross the same idle boundary and a skipped occurrence cannot mutate the
+goal. A newly generated session still admits the occurrence that creates it.
+
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage
 boundaries.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -69663,8 +69663,9 @@ export type AddSessionSystemUpdateInput = {
   scheduledTaskRunId?: string | null;
 } & SessionSystemUpdateInputVariant;
 
-export type AddSessionSystemUpdateResult =
+export type AddSessionSystemUpdateResult<RequireIdleSession extends boolean = boolean> =
   | { added: false; reason: "session_cancelled" }
+  | (RequireIdleSession extends true ? { added: false; reason: "session_not_idle" } : never)
   | {
       added: boolean;
       reason: "added" | "duplicate";
@@ -69679,12 +69680,14 @@ export type AddSessionSystemUpdateResult =
 export type PrepareSessionSystemUpdateSourceResult = {
   /** Private, bounded, content-free source authority appended before insert. */
   lineage?: Record<string, unknown>;
+  /** Source-owned events appended before the pending-update event. */
+  events?: SessionEvent[];
 };
 
 export async function addSessionSystemUpdate(
   db: Database,
   input: AddSessionSystemUpdateInput,
-): Promise<AddSessionSystemUpdateResult> {
+): Promise<AddSessionSystemUpdateResult<false>> {
   if (input.payload.type !== input.kind) {
     throw new Error(`Internal update payload discriminator must equal kind ${input.kind}`);
   }
@@ -69695,29 +69698,34 @@ export async function addSessionSystemUpdate(
  * Persist one internal update without fabricating a user prompt or queue row.
  * Dedupe and any producer/outbox mutation commit in the same transaction.
  */
-export async function addSessionSystemUpdateWithSourceMutation(
+export async function addSessionSystemUpdateWithSourceMutation<
+  RequireIdleSession extends boolean = false,
+>(
   db: Database,
   input: AddSessionSystemUpdateInput,
   mutateSource: (
     tx: Database,
     wakeEventId: string | null,
     updateId: string | null,
+    rejectionReason: "session_cancelled" | "session_not_idle" | null,
   ) => Promise<void>,
   options: {
+    /** Admit only when the already-locked session is at its idle boundary. */
+    requireIdleSession?: RequireIdleSession;
     /** Runs under the locked session/source transaction before any update/event insert. */
     prepareSource?: (
       tx: Database,
       sessionId: string,
     ) => Promise<PrepareSessionSystemUpdateSourceResult | void>;
   } = {},
-): Promise<AddSessionSystemUpdateResult> {
+): Promise<AddSessionSystemUpdateResult<RequireIdleSession>> {
   if (Buffer.byteLength(JSON.stringify(input.payload)) > MAX_INTERNAL_UPDATE_BYTES) {
     throw new Error(`Internal update payload exceeds ${MAX_INTERNAL_UPDATE_BYTES} bytes`);
   }
   if (Buffer.byteLength(input.summary) > MAX_INTERNAL_UPDATE_BYTES) {
     throw new Error(`Internal update summary exceeds ${MAX_INTERNAL_UPDATE_BYTES} bytes`);
   }
-  return await withSessionActivityRlsContext(
+  return (await withSessionActivityRlsContext(
     db,
     { accountId: input.accountId, workspaceId: input.workspaceId },
     async (scopedDb) =>
@@ -69727,8 +69735,9 @@ export async function addSessionSystemUpdateWithSourceMutation(
           controlLock: "share",
           sessionIds: [input.sessionId],
         });
-        const session = locks.sessions[0];
+        let session = locks.sessions[0];
         if (!session) throw new Error(`Session not found: ${input.sessionId}`);
+        const temporalWorkflowId = session.temporalWorkflowId;
         const effectiveControl = await evaluateSessionControl(
           tx as unknown as Database,
           input.workspaceId,
@@ -69736,10 +69745,71 @@ export async function addSessionSystemUpdateWithSourceMutation(
           { workspaceControl: locks.control ?? undefined },
         );
         if (session.status === "cancelled") {
-          await mutateSource(tx as unknown as Database, null, null);
+          await mutateSource(tx as unknown as Database, null, null, "session_cancelled");
           return { added: false, reason: "session_cancelled" } as const;
         }
+        const replayExistingUpdate = async (events: SessionEvent[]) => {
+          const [existing] = await tx
+            .select()
+            .from(schema.sessionSystemUpdates)
+            .where(
+              and(
+                eq(schema.sessionSystemUpdates.workspaceId, input.workspaceId),
+                eq(schema.sessionSystemUpdates.sessionId, input.sessionId),
+                eq(schema.sessionSystemUpdates.dedupeKey, input.dedupeKey),
+              ),
+            )
+            .limit(1);
+          if (!existing) return null;
+          const [pendingEvent] = await tx
+            .select({ id: schema.sessionEvents.id })
+            .from(schema.sessionEvents)
+            .where(
+              and(
+                eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                eq(schema.sessionEvents.sessionId, input.sessionId),
+                eq(schema.sessionEvents.type, "system.update.pending"),
+                sql`${schema.sessionEvents.payload} ->> 'updateId' = ${existing.id}`,
+              ),
+            )
+            .limit(1);
+          if (!pendingEvent) throw new Error("System-update pending event disappeared");
+          await mutateSource(tx as unknown as Database, pendingEvent.id, existing.id, null);
+          return {
+            added: false,
+            reason: "duplicate",
+            update: mapSessionSystemUpdate(existing),
+            shouldWake: false,
+            workflowWakeRevision: null,
+            wakeEventId: pendingEvent.id,
+            temporalWorkflowId,
+            events,
+          } as const;
+        };
+
+        if (options.requireIdleSession && session.status !== "idle") {
+          const replayed = await replayExistingUpdate([]);
+          if (replayed) {
+            return replayed;
+          }
+          await mutateSource(tx as unknown as Database, null, null, "session_not_idle");
+          return { added: false, reason: "session_not_idle" } as const;
+        }
         const prepared = await options.prepareSource?.(tx as unknown as Database, input.sessionId);
+        if ((prepared?.events?.length ?? 0) > 0) {
+          const [refreshedSession] = await tx
+            .select()
+            .from(schema.sessions)
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, input.sessionId),
+              ),
+            )
+            .limit(1);
+          if (!refreshedSession) throw new Error(`Session not found: ${input.sessionId}`);
+          session = refreshedSession;
+        }
         const lineage = {
           ...(input.lineage ?? {}),
           ...(prepared?.lineage ?? {}),
@@ -69784,42 +69854,9 @@ export async function addSessionSystemUpdateWithSourceMutation(
           })
           .returning();
         if (!inserted) {
-          const [existing] = await tx
-            .select()
-            .from(schema.sessionSystemUpdates)
-            .where(
-              and(
-                eq(schema.sessionSystemUpdates.workspaceId, input.workspaceId),
-                eq(schema.sessionSystemUpdates.sessionId, input.sessionId),
-                eq(schema.sessionSystemUpdates.dedupeKey, input.dedupeKey),
-              ),
-            )
-            .limit(1);
-          if (!existing) throw new Error("System-update dedupe row disappeared");
-          const [pendingEvent] = await tx
-            .select({ id: schema.sessionEvents.id })
-            .from(schema.sessionEvents)
-            .where(
-              and(
-                eq(schema.sessionEvents.workspaceId, input.workspaceId),
-                eq(schema.sessionEvents.sessionId, input.sessionId),
-                eq(schema.sessionEvents.type, "system.update.pending"),
-                sql`${schema.sessionEvents.payload} ->> 'updateId' = ${existing.id}`,
-              ),
-            )
-            .limit(1);
-          if (!pendingEvent) throw new Error("System-update pending event disappeared");
-          await mutateSource(tx as unknown as Database, pendingEvent.id, existing.id);
-          return {
-            added: false,
-            reason: "duplicate",
-            update: mapSessionSystemUpdate(existing),
-            shouldWake: false,
-            workflowWakeRevision: null,
-            wakeEventId: pendingEvent.id,
-            temporalWorkflowId: session.temporalWorkflowId,
-            events: [],
-          };
+          const replayed = await replayExistingUpdate(prepared?.events ?? []);
+          if (!replayed) throw new Error("System-update dedupe row disappeared");
+          return replayed;
         }
 
         const now = new Date();
@@ -69851,7 +69888,7 @@ export async function addSessionSystemUpdateWithSourceMutation(
           )
           .returning();
         if (!event) throw new Error("Failed to create system-update pending event");
-        await mutateSource(tx as unknown as Database, event.id, inserted.id);
+        await mutateSource(tx as unknown as Database, event.id, inserted.id, null);
         // Producer-side supersession of this child's now-stale pending notices
         // on the parent: a newer child_progress replaces an older one, and a
         // resolution supersedes the child_requires_action of the same exact
@@ -70012,13 +70049,14 @@ export async function addSessionSystemUpdateWithSourceMutation(
           wakeEventId: event.id,
           temporalWorkflowId: session.temporalWorkflowId,
           events: [
+            ...(prepared?.events ?? []),
             mapEvent(event),
             ...(supersededEvent ? [mapEvent(supersededEvent)] : []),
             ...(resumedEvent ? [mapEvent(resumedEvent)] : []),
           ],
         };
       }),
-  );
+  )) as AddSessionSystemUpdateResult<RequireIdleSession>;
 }
 
 /**

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -70032,11 +70032,16 @@ export async function addSessionSystemUpdateWithSourceMutation<
               temporalWorkflowId: session.temporalWorkflowId ?? `session-${session.id}`,
             })
           : null;
+        // An idle-gated admission consumes that boundary even when control or
+        // realtime ownership withholds the workflow wake. Persisting `queued`
+        // reserves the accepted work so a later distinct skip occurrence
+        // cannot cross the same idle boundary while this update is pending.
+        const shouldQueue = shouldWake || options.requireIdleSession === true;
         await tx
           .update(schema.sessions)
           .set({
             lastSequence: session.lastSequence + appendedSequences,
-            ...(shouldWake ? { status: "queued" as const } : {}),
+            ...(shouldQueue ? { status: "queued" as const } : {}),
             updatedAt: now,
           })
           .where(eq(schema.sessions.id, session.id));

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -3676,13 +3676,34 @@ describe("worker activities integration", () => {
     });
     expect(turn.status).toBe("idle");
 
+    await withWorkspaceRls(dbClient.db, grant.workspaceId, (db) =>
+      db.transaction((tx) =>
+        mutateWorkspaceControlInTransaction(tx as typeof db, {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId,
+          actor: { type: "human", subjectId: grant.subjectId },
+          action: "pause",
+          reason: "verify scheduled idle reservation",
+          operationKey: `pause:${crypto.randomUUID()}`,
+          expectedRevision: 0,
+        }),
+      ),
+    );
     const third = await activities.dispatchScheduledTaskRun({
       workspaceId: grant.workspaceId,
       taskId: task.id,
       triggerType: "scheduled",
       producerKey: `worker-activity-${crypto.randomUUID()}`,
     });
-    expect(third).toMatchObject({ action: "signal", sessionId: first.sessionId });
+    expect(third).toMatchObject({
+      action: "signal",
+      sessionId: first.sessionId,
+      workflowWakeRevision: null,
+    });
+    expect(await getSession(dbClient.db, grant.workspaceId, first.sessionId)).toMatchObject({
+      status: "queued",
+      effectiveControl: { state: "paused" },
+    });
     expect(await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId)).toMatchObject({
       id: goalAfterFirst.id,
       status: "active",
@@ -3690,9 +3711,29 @@ describe("worker activities integration", () => {
     });
     const goalAfterThird = await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId);
     expect(goalAfterThird!.version).toBeGreaterThan(goalAfterFirst.version);
+    await expect(
+      activities.dispatchScheduledTaskRun({
+        workspaceId: grant.workspaceId,
+        taskId: task.id,
+        triggerType: "scheduled",
+        producerKey: `worker-activity-${crypto.randomUUID()}`,
+      }),
+    ).resolves.toEqual({ action: "blocked", reason: "scheduled_run_terminal" });
+    expect(await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId)).toMatchObject({
+      id: goalAfterThird!.id,
+      status: goalAfterThird!.status,
+      version: goalAfterThird!.version,
+      objectiveRevision: goalAfterThird!.objectiveRevision,
+      updatedAt: goalAfterThird!.updatedAt,
+    });
     expect(
       await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
     ).toHaveLength(1);
+    expect(
+      (await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).filter(
+        (run) => run.status === "skipped" && run.error === "scheduled_session_not_idle",
+      ),
+    ).toHaveLength(2);
   });
 
   test("dispatches existing-session tasks to the exact target without replacing its goal", async () => {

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -25,6 +25,7 @@ import {
   createSessionGoal,
   createVariableSet,
   dbSql,
+  setSessionGoalStatusWithEvent,
   encryptEnvironmentValue,
   enablePackInstallation,
   loadVariableSetForRun,
@@ -3573,6 +3574,125 @@ describe("worker activities integration", () => {
     const runs = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
     expect(runs).toHaveLength(2);
     expect(runs.every((run) => run.status === "dispatched")).toBe(true);
+  });
+
+  test("skips reusable scheduled occurrences until the session returns idle", async () => {
+    const grant = await testGrant(dbClient.db);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "scheduled-reusable-skip",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "skip",
+      agentConfig: {
+        prompt: "maintain the reusable session",
+        resources: [],
+        tools: [],
+        metadata: {},
+        goal: {
+          text: "Keep the reusable session healthy",
+          successCriteria: "The scheduled maintenance turn completes",
+        },
+      },
+      metadata: {},
+    });
+    const activities = createWorkerActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ outputText: "maintenance complete" }]),
+      }),
+    });
+
+    const producerKey = `worker-activity-${crypto.randomUUID()}`;
+    const first = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey,
+    });
+    if (first.action !== "start") {
+      throw new Error(`first reusable occurrence was not admitted: ${first.action}`);
+    }
+    const goalAfterFirst = await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId);
+    if (!goalAfterFirst) throw new Error("reusable scheduled goal was not created");
+
+    const retry = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey,
+    });
+    expect(retry).toMatchObject({
+      sessionId: first.sessionId,
+      triggerEventId: first.triggerEventId,
+    });
+    await expect(
+      activities.dispatchScheduledTaskRun({
+        workspaceId: grant.workspaceId,
+        taskId: task.id,
+        triggerType: "scheduled",
+        producerKey: `worker-activity-${crypto.randomUUID()}`,
+      }),
+    ).resolves.toEqual({ action: "blocked", reason: "scheduled_run_terminal" });
+
+    expect(
+      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
+    ).toHaveLength(1);
+    expect(await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId)).toMatchObject({
+      id: goalAfterFirst.id,
+      status: goalAfterFirst.status,
+      version: goalAfterFirst.version,
+      objectiveRevision: goalAfterFirst.objectiveRevision,
+      updatedAt: goalAfterFirst.updatedAt,
+    });
+    const runsAfterSkip = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
+    expect(runsAfterSkip).toHaveLength(2);
+    expect(runsAfterSkip).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "dispatched" }),
+        expect.objectContaining({ status: "skipped", error: "scheduled_session_not_idle" }),
+      ]),
+    );
+
+    await setSessionGoalStatusWithEvent(dbClient.db, grant.workspaceId, first.sessionId, {
+      status: "completed",
+      evidence: "scheduled maintenance fixture completed",
+      event: {
+        type: "goal.completed",
+        evidence: "scheduled maintenance fixture completed",
+      },
+    });
+    const turn = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: first.sessionId,
+      trigger: { kind: "next" },
+      workflowId: first.workflowId,
+      workflowRunId: crypto.randomUUID(),
+    });
+    expect(turn.status).toBe("idle");
+
+    const third = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: `worker-activity-${crypto.randomUUID()}`,
+    });
+    expect(third).toMatchObject({ action: "signal", sessionId: first.sessionId });
+    expect(await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId)).toMatchObject({
+      id: goalAfterFirst.id,
+      status: "active",
+      version: expect.any(Number),
+    });
+    const goalAfterThird = await getSessionGoal(dbClient.db, grant.workspaceId, first.sessionId);
+    expect(goalAfterThird!.version).toBeGreaterThan(goalAfterFirst.version);
+    expect(
+      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
+    ).toHaveLength(1);
   });
 
   test("dispatches existing-session tasks to the exact target without replacing its goal", async () => {


### PR DESCRIPTION
## Summary

- admit `skip` scheduled occurrences for existing or reusable sessions only when the locked session status is exactly `idle`
- keep reusable-goal reset, scheduled-run settlement, and pending-update append in the same session transaction
- preserve idempotent retries as duplicates and allow a newly generated session to admit its creating occurrence

## Validation

- `node node_modules/typescript/bin/tsc --noEmit -p packages/db/tsconfig.json --pretty false`
- `node node_modules/typescript/bin/tsc --noEmit -p apps/worker/tsconfig.json --pretty false`
- `bun test --timeout 120000 ./test/integration/worker-activity.integration.ts -t 'skips reusable scheduled occurrences until the session returns idle'`
- `bun test --timeout 30000 packages/db/test/session-event-writer-audit.test.ts packages/db/test/turn-initiator.test.ts`
- `bunx oxfmt --check apps/worker/src/activities/scheduled-tasks.ts packages/db/src/index.ts test/integration/worker-activity.integration.ts`
- `bunx oxlint --deny-warnings apps/worker/src/activities/scheduled-tasks.ts packages/db/src/index.ts test/integration/worker-activity.integration.ts`
- `bun run check:public-hygiene`

## Summary by Sourcery

Enforce idle-boundary admission for skip-overlap scheduled sessions to prevent concurrent work from mutating reusable sessions.

Bug Fixes:
- Prevent `skip` scheduled occurrences from being admitted while an existing or reusable session is busy, while still allowing idempotent retries and newly created sessions to proceed.
- Report idle-boundary rejections distinctly from cancelled-session skips.

Enhancements:
- Keep reusable-goal updates, scheduled-run settlement, source events, and pending updates atomic within the session transaction.
- Reserve the idle boundary for admitted skipped occurrences even when workflow execution is paused or held by another realtime owner.

Documentation:
- Document idle-boundary admission and transactional behavior for skip-overlap scheduled sessions.

Tests:
- Add integration coverage for reusable scheduled occurrences, idempotent retries, busy-session skips, idle re-admission, and paused-session behavior.

Chores:
- Add patch changeset entries for the database and worker bundle packages.