### PR TITLE
Keep pending session titles distinguishable

### DIFF
--- a/.changeset/prompt-first-session-titles.md
+++ b/.changeset/prompt-first-session-titles.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/sdk": patch
+"@opengeni/api-router": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep pending sessions distinguishable with a sensitive-safe opening-prompt preview or short session reference, and let bounded parallel semantic title generation finish after quick responses instead of cancelling it at turn settlement.

--- a/apps/api/src/integrations/slack-app-home.ts
+++ b/apps/api/src/integrations/slack-app-home.ts
@@ -1,4 +1,4 @@
-import { AUTOMATIC_SESSION_TITLE_FALLBACK, type Session } from "@opengeni/contracts";
+import { deriveSessionDisplayTitle, type Session } from "@opengeni/contracts";
 import type { SlackHomeBlock } from "./slack-bot";
 
 const ATTENTION_LIMIT = 5;
@@ -186,7 +186,7 @@ function appendSessionGroup(
   );
   for (const session of sessions) {
     const url = sessionUrl(session.id);
-    const title = (session.title?.trim() || AUTOMATIC_SESSION_TITLE_FALLBACK).slice(0, 180);
+    const title = deriveSessionDisplayTitle(session).slice(0, 180);
     blocks.push({
       type: "section",
       block_id: `opengeni_home_session_${session.id}`,

--- a/apps/api/test/slack-app-home.test.ts
+++ b/apps/api/test/slack-app-home.test.ts
@@ -119,7 +119,7 @@ describe("Slack App Home projection", () => {
         nowMs: Date.parse("2026-08-14T12:00:00.000Z"),
       }),
     );
-    expect(serialized).toContain("Conversation 00000000");
+    expect(serialized).toContain("Conversation 00000000-0000");
     expect(serialized).not.toContain("super-secret-value");
   });
 

--- a/apps/api/test/slack-app-home.test.ts
+++ b/apps/api/test/slack-app-home.test.ts
@@ -105,7 +105,7 @@ describe("Slack App Home projection", () => {
     expect(blocks.at(-1)).toMatchObject({ type: "actions", block_id: "opengeni_home_actions" });
   });
 
-  test("uses a prompt-free fallback when an older session has no durable title", () => {
+  test("uses a prompt-free session reference when an older session has no durable title", () => {
     const untitled = {
       ...session("00000000-0000-4000-8000-000000000005", "running", "ignored"),
       title: null,
@@ -119,8 +119,27 @@ describe("Slack App Home projection", () => {
         nowMs: Date.parse("2026-08-14T12:00:00.000Z"),
       }),
     );
-    expect(serialized).toContain("New conversation");
+    expect(serialized).toContain("Conversation 00000000");
     expect(serialized).not.toContain("super-secret-value");
+  });
+
+  test("skips an unsafe leading URL and shows the next safe prompt line", () => {
+    const untitled = {
+      ...session("123e4567-e89b-42d3-a456-426614174000", "running", "ignored"),
+      title: null,
+      initialMessage:
+        "https://homeserver.example.test/workspaces/one/sessions/two\nFix default session naming behavior",
+    };
+    const serialized = JSON.stringify(
+      buildSlackAppHomeBlocks({
+        sessions: [untitled],
+        workspaceUrl: null,
+        sessionUrl: () => null,
+        nowMs: Date.parse("2026-08-14T12:00:00.000Z"),
+      }),
+    );
+    expect(serialized).toContain("Fix default session naming behavior");
+    expect(serialized).not.toContain("homeserver.example.test");
   });
 
   test("access views contain no stale task content", () => {

--- a/apps/web/src/lib/session-rename.test.ts
+++ b/apps/web/src/lib/session-rename.test.ts
@@ -108,8 +108,24 @@ describe("sessionDisplayTitle", () => {
       ),
     ).toBe("Please investigate automatic session title generation failures");
     expect(
-      sessionDisplayTitle(session({ title: null, initialMessage: "SECRET_TOKEN=hunter2" })),
-    ).toBe("New conversation");
+      sessionDisplayTitle(
+        session({
+          title: "New conversation",
+          titleSource: "agent",
+          initialMessage:
+            "https://homeserver.example.test/workspaces/one/sessions/two\nFix default session naming behavior",
+        }),
+      ),
+    ).toBe("Fix default session naming behavior");
+    expect(
+      sessionDisplayTitle(
+        session({
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          title: null,
+          initialMessage: "SECRET_TOKEN=hunter2",
+        }),
+      ),
+    ).toBe("Conversation 123e4567");
     expect(
       sessionDisplayTitle(
         session({
@@ -120,8 +136,14 @@ describe("sessionDisplayTitle", () => {
       ),
     ).toBe("New conversation");
     expect(
-      sessionDisplayTitle(session({ title: "   ", initialMessage: null as unknown as string })),
-    ).toBe("New conversation");
+      sessionDisplayTitle(
+        session({
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          title: "   ",
+          initialMessage: null as unknown as string,
+        }),
+      ),
+    ).toBe("Conversation 123e4567");
   });
 });
 
@@ -132,9 +154,15 @@ describe("renameSeedValue", () => {
       "Inspect the repo",
     );
     expect(renameSeedValue(session({ title: null }))).toBe("Inspect the repo");
-    expect(renameSeedValue(session({ title: null, initialMessage: "SECRET_TOKEN=hunter2" }))).toBe(
-      "",
-    );
+    expect(
+      renameSeedValue(
+        session({
+          id: "123e4567-e89b-42d3-a456-426614174000",
+          title: null,
+          initialMessage: "SECRET_TOKEN=hunter2",
+        }),
+      ),
+    ).toBe("");
     expect(renameSeedValue(session({ title: "New conversation", titleSource: "user" }))).toBe(
       "New conversation",
     );

--- a/apps/web/src/lib/session-rename.test.ts
+++ b/apps/web/src/lib/session-rename.test.ts
@@ -125,7 +125,7 @@ describe("sessionDisplayTitle", () => {
           initialMessage: "SECRET_TOKEN=hunter2",
         }),
       ),
-    ).toBe("Conversation 123e4567");
+    ).toBe("Conversation 123e4567-e89b");
     expect(
       sessionDisplayTitle(
         session({
@@ -143,7 +143,7 @@ describe("sessionDisplayTitle", () => {
           initialMessage: null as unknown as string,
         }),
       ),
-    ).toBe("Conversation 123e4567");
+    ).toBe("Conversation 123e4567-e89b");
   });
 });
 

--- a/apps/web/src/lib/session-rename.ts
+++ b/apps/web/src/lib/session-rename.ts
@@ -6,7 +6,7 @@
 // lives in exactly one place.
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  AUTOMATIC_SESSION_TITLE_FALLBACK,
+  deriveAutomaticSessionTitlePreview,
   deriveSessionDisplayTitle,
   sessionTitleIsPending,
 } from "@opengeni/sdk";
@@ -28,15 +28,15 @@ export function sessionDisplayTitle(session: Session): string {
 
 /**
  * The value the editor seeds from when entering edit mode. A safe provisional
- * prompt preview is editable because it is also what the user sees; the generic
- * fallback remains an empty draft rather than becoming an accidental rename.
+ * prompt preview is editable because it is also what the user sees; the
+ * UUID-derived reference remains an empty draft rather than becoming an
+ * accidental rename.
  */
 export function renameSeedValue(session: Session): string {
   if (!sessionTitleIsPending(session)) {
     return session.title?.trim() || "";
   }
-  const display = deriveSessionDisplayTitle(session);
-  return display === AUTOMATIC_SESSION_TITLE_FALLBACK ? "" : display;
+  return deriveAutomaticSessionTitlePreview(session.initialMessage) ?? "";
 }
 
 /**

--- a/apps/worker/src/activities/agent-turn/session-title.ts
+++ b/apps/worker/src/activities/agent-turn/session-title.ts
@@ -59,12 +59,15 @@ export const PARALLEL_SESSION_TITLE_TIMEOUT_MS = 15_000;
 
 export type ParallelSessionTitleGeneration = {
   finish: () => Promise<GeneratedSessionTitle | null>;
+  cancel: () => Promise<void>;
 };
 
 /**
  * Start title inference immediately and keep it independent of the main agent
- * stream. finish() aborts any still-pending request and joins its physical
- * settlement, so no provider work escapes the owning runAgentTurn activity.
+ * stream. finish() waits for the already-running bounded request, so a quick
+ * main response does not discard a valid title merely because it completed
+ * first. cancel() aborts and joins exceptional/cancelled exits so no provider
+ * work escapes the owning runAgentTurn activity.
  */
 export function startParallelSessionTitleGeneration(input: {
   generate: (signal: AbortSignal) => Promise<GeneratedSessionTitle>;
@@ -72,9 +75,9 @@ export function startParallelSessionTitleGeneration(input: {
   timeoutMs?: number;
   onError?: (error: unknown) => void;
 }): ParallelSessionTitleGeneration {
-  const finishController = new AbortController();
+  const cancellationController = new AbortController();
   const timeoutSignal = AbortSignal.timeout(input.timeoutMs ?? PARALLEL_SESSION_TITLE_TIMEOUT_MS);
-  const signals = [finishController.signal, timeoutSignal];
+  const signals = [cancellationController.signal, timeoutSignal];
   if (input.signal) signals.push(input.signal);
   const signal = AbortSignal.any(signals);
   const generation = input
@@ -89,9 +92,12 @@ export function startParallelSessionTitleGeneration(input: {
   return {
     finish: () => {
       if (finished) return finished;
-      finishController.abort();
       finished = generation;
       return finished;
+    },
+    cancel: async () => {
+      cancellationController.abort();
+      await generation;
     },
   };
 }

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -409,6 +409,11 @@ export async function runTurnStreamAttempt(
       });
     }
   };
+  const cancelParallelSessionTitle = async (): Promise<void> => {
+    if (parallelSessionTitleFinished) return;
+    parallelSessionTitleFinished = true;
+    await parallelSessionTitle?.cancel();
+  };
   let runInput: Awaited<ReturnType<typeof turnInput>>["input"] | null = null;
   const prepareRunAttemptInput = async () => {
     const historyPreparationStartedAt = performance.now();
@@ -1898,6 +1903,6 @@ export async function runTurnStreamAttempt(
       }
     }
   } finally {
-    await finishParallelSessionTitle();
+    await cancelParallelSessionTitle();
   }
 }

--- a/apps/worker/test/agent-build-session-title.test.ts
+++ b/apps/worker/test/agent-build-session-title.test.ts
@@ -166,7 +166,27 @@ describe("startParallelSessionTitleGeneration", () => {
     });
   });
 
-  test("finish aborts and joins a title request that is still pending", async () => {
+  test("finish waits for a title request that is still pending", async () => {
+    let observedSignal: AbortSignal | null = null;
+    let completeGeneration!: (value: { title: string; usage: null }) => void;
+    const task = startParallelSessionTitleGeneration({
+      generate: async (signal) => {
+        observedSignal = signal;
+        return await new Promise<{ title: string; usage: null }>((resolve) => {
+          completeGeneration = resolve;
+        });
+      },
+    });
+
+    await Promise.resolve();
+    const finished = task.finish();
+    expect(observedSignal?.aborted).toBe(false);
+    completeGeneration({ title: "Quick response title", usage: null });
+    expect(await finished).toEqual({ title: "Quick response title", usage: null });
+    expect(observedSignal?.aborted).toBe(false);
+  });
+
+  test("cancel aborts and joins a title request that is still pending", async () => {
     let observedSignal: AbortSignal | null = null;
     const task = startParallelSessionTitleGeneration({
       generate: async (signal) => {
@@ -177,7 +197,7 @@ describe("startParallelSessionTitleGeneration", () => {
     });
 
     await Promise.resolve();
-    expect(await task.finish()).toBeNull();
+    await task.cancel();
     expect(observedSignal?.aborted).toBe(true);
   });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -619,10 +619,12 @@ Automatic semantic naming is an attempt-owned auxiliary branch, not part of the
 main model/tool loop. When the durable title is still pending and exact session
 tool policy permits naming, the production runtime starts one bounded tool-less
 title request in parallel with the ordinary stream, meters it independently,
-and aborts/joins it before atomic turn settlement. The title write uses the
-generic session-title lifecycle and still loses to a human rename. Custom
-runtimes without the optional auxiliary seam retain the serialized
-`set_session_title` compatibility path.
+and joins it before atomic turn settlement. A normal fast response waits for the
+already-running bounded title request instead of cancelling it; exceptional or
+cancelled exits abort and join it. The title write uses the generic session-title
+lifecycle and still loses to a human rename. Custom runtimes without the
+optional auxiliary seam retain the serialized `set_session_title` compatibility
+path.
 
 ### 5.2 Lifecycle overview
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -31,13 +31,15 @@ OpenAI Agents SDK loop makes as many model calls and tool calls as the work
 needs.
 
 Session display titles are durable session metadata, not a truncation of model
-history. Creation and migration use `New conversation` as the durable marker
-that semantic naming is still pending. Human-facing clients may render a short,
-sensitive-safe opening-prompt preview while that marker (or a legacy null title)
-remains; the preview is display-only, never persisted or searched as title
-metadata, and obvious credential-, URL-, or identifier-shaped prefixes retain
-the generic marker. When the durable title changes, the client naturally yields
-to it.
+history. Creation and migration use `New conversation` only as the durable
+marker that semantic naming is still pending. Human-facing clients render a
+short, sensitive-safe opening-prompt preview while that marker (or a legacy null
+title) remains. Unsafe leading lines are skipped, so a pasted URL followed by a
+normal request still gets a useful immediate label; if no safe prompt line
+exists, a short session reference keeps rows distinguishable without exposing
+prompt bytes. The preview/reference is display-only, never persisted or searched
+as title metadata, and the client naturally yields when `session.title_set`
+arrives.
 
 The first-party `session_create` tool is the bounded exception for an
 agent-created child: the manager may provide a concise semantic title, and an

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -58,13 +58,14 @@ one bounded, tool-less title request beside the ordinary response stream. The
 sidecar uses the same resolved provider and credential authority, receives only
 a bounded conversation opener, and is metered as its own model call. The main
 agent does not wait for a title tool result or make a title follow-up model call.
-When the main stream reaches settlement, the worker aborts any still-pending
-sidecar and joins its physical completion; a completed candidate then uses the
-canonical title mutation, which updates the session row and appends
-`session.title_set`. Generation or persistence failure leaves the safe pending
-marker in place, and a human title remains protected from every later automatic
-write. Historical fallback sessions therefore self-heal on their next eligible
-model turn.
+When the main stream reaches normal settlement, the worker waits for the
+already-running bounded sidecar and joins it without cancelling. Exceptional or
+cancelled exits abort and join any still-pending sidecar. A completed candidate
+then uses the canonical title mutation, which updates the session row and
+appends `session.title_set`. Generation or persistence failure leaves the safe
+pending marker in place, and a human title remains protected from every later
+automatic write. Historical fallback sessions therefore self-heal on their
+next eligible model turn.
 
 `OpenGeniRuntime.generateSessionTitle` is a rolling-compatible optional seam.
 Older or custom runtimes that do not implement it retain the prior attempt-local

--- a/packages/contracts/src/session-titles.ts
+++ b/packages/contracts/src/session-titles.ts
@@ -15,6 +15,14 @@ export const AUTOMATIC_SESSION_TITLE_MAX_GRAPHEMES = 80;
  */
 export const AUTOMATIC_SESSION_TITLE_FALLBACK = "New conversation";
 
+// Session creation accepts a body far larger than a navigation label. Bound
+// the source before any replace/split/normalization so a persisted large prompt
+// cannot amplify memory or CPU on every client render.
+const PROMPT_PREVIEW_SCAN_MAX_CODE_UNITS = 4_096;
+
+const SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
 let titleSegmenter: Intl.Segmenter | null | undefined;
 
 const KNOWN_SENSITIVE_VALUE_PATTERNS = [
@@ -328,4 +336,96 @@ export function normalizeAutomaticSessionTitle(value: string): string | null {
     .trim();
   if (!title || !hasVisibleAutomaticTitleContent(title)) return null;
   return title;
+}
+
+export type SessionDisplayTitleInput = {
+  id?: string | null | undefined;
+  title?: string | null | undefined;
+  titleSource?: "user" | "agent" | null | undefined;
+  initialMessage?: string | null | undefined;
+  metadata?: Readonly<Record<string, unknown>> | undefined;
+};
+
+export type SessionDisplayTitleOptions = {
+  /** Optional metadata fields to try before the opening-prompt preview. */
+  metadataKeys?: readonly string[] | undefined;
+};
+
+/**
+ * Derive a bounded, sensitive-safe preview from the opening prompt.
+ *
+ * Unsafe leading lines are skipped instead of forcing the whole session back
+ * to a generic label. This covers prompts that begin with a pasted URL or
+ * identifier followed by an ordinary natural-language request on the next
+ * line, without putting the rejected value into navigation surfaces.
+ */
+export function deriveAutomaticSessionTitlePreview(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const lines = value
+    .slice(0, PROMPT_PREVIEW_SCAN_MAX_CODE_UNITS)
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/gu, "\n")
+    .split(/\n+/u);
+
+  for (const candidate of lines) {
+    const line = candidate.trim();
+    if (!line || containsSensitiveAutomaticSessionTitleValue(line)) continue;
+
+    const preview = boundAutomaticSessionTitle(line.replace(/\s+/gu, " "))
+      .replace(/[\s.!?,;:\-–—]+$/u, "")
+      .trim();
+    if (preview) return preview;
+  }
+
+  return null;
+}
+
+function automaticSessionReferenceTitle(id: unknown): string {
+  const sessionId = typeof id === "string" ? id.trim() : "";
+  return SESSION_ID_PATTERN.test(sessionId)
+    ? `Conversation ${sessionId.slice(0, 8)}`
+    : AUTOMATIC_SESSION_TITLE_FALLBACK;
+}
+
+/**
+ * Whether the durable title still represents the automatic-title pending state.
+ * A user-authored title always wins, even when its literal value is the marker.
+ */
+export function sessionTitleIsPending(input: SessionDisplayTitleInput): boolean {
+  const title = input.title?.trim() ?? "";
+  return input.titleSource !== "user" && (!title || title === AUTOMATIC_SESSION_TITLE_FALLBACK);
+}
+
+/**
+ * Derive the title a human-facing client should display for a session.
+ *
+ * A semantic agent title or human rename wins. While automatic naming is still
+ * pending, clients show a short, sensitive-safe preview of the opening prompt.
+ * If no safe prompt text exists, a UUID-derived reference keeps real sessions
+ * distinguishable without exposing prompt bytes. The durable pending marker is
+ * therefore an internal lifecycle value rather than the ordinary visible name.
+ */
+export function deriveSessionDisplayTitle(
+  input: SessionDisplayTitleInput,
+  options: SessionDisplayTitleOptions = {},
+): string {
+  const title = input.title?.trim() ?? "";
+  if (input.titleSource === "user") {
+    return title || automaticSessionReferenceTitle(input.id);
+  }
+  if (title && !sessionTitleIsPending(input)) {
+    return title;
+  }
+
+  for (const key of options.metadataKeys ?? []) {
+    const value = input.metadata?.[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return (
+    deriveAutomaticSessionTitlePreview(input.initialMessage) ??
+    automaticSessionReferenceTitle(input.id)
+  );
 }

--- a/packages/contracts/src/session-titles.ts
+++ b/packages/contracts/src/session-titles.ts
@@ -383,7 +383,7 @@ export function deriveAutomaticSessionTitlePreview(value: unknown): string | nul
 function automaticSessionReferenceTitle(id: unknown): string {
   const sessionId = typeof id === "string" ? id.trim() : "";
   return SESSION_ID_PATTERN.test(sessionId)
-    ? `Conversation ${sessionId.slice(0, 8)}`
+    ? `Conversation ${sessionId.slice(0, 13)}`
     : AUTOMATIC_SESSION_TITLE_FALLBACK;
 }
 

--- a/packages/contracts/test/session-titles.test.ts
+++ b/packages/contracts/test/session-titles.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   AUTOMATIC_SESSION_TITLE_FALLBACK,
   AUTOMATIC_SESSION_TITLE_MAX_GRAPHEMES,
+  deriveAutomaticSessionTitlePreview,
+  deriveSessionDisplayTitle,
   normalizeAutomaticSessionTitle,
 } from "../src/session-titles";
 
@@ -230,6 +232,43 @@ describe("automatic session titles", () => {
     expect(unicode).not.toBeNull();
     expect(graphemeCount(unicode!)).toBeLessThanOrEqual(AUTOMATIC_SESSION_TITLE_MAX_GRAPHEMES);
     expect(unicode).not.toContain("�");
+  });
+
+  test("uses the first safe prompt line when an unsafe URL or secret precedes the request", () => {
+    expect(
+      deriveAutomaticSessionTitlePreview(
+        "https://app.example.test/workspaces/one/sessions/two\nFix default session naming behavior",
+      ),
+    ).toBe("Fix default session naming behavior");
+    expect(
+      deriveAutomaticSessionTitlePreview(
+        "API_TOKEN=super-secret-value\nInvestigate the deployment failure",
+      ),
+    ).toBe("Investigate the deployment failure");
+    expect(
+      deriveAutomaticSessionTitlePreview(
+        "https://app.example.test/private?token=super-secret-value",
+      ),
+    ).toBeNull();
+  });
+
+  test("uses a short session reference when no safe prompt preview exists", () => {
+    expect(
+      deriveSessionDisplayTitle({
+        id: "123e4567-e89b-42d3-a456-426614174000",
+        title: AUTOMATIC_SESSION_TITLE_FALLBACK,
+        titleSource: "agent",
+        initialMessage: "API_TOKEN=super-secret-value",
+      }),
+    ).toBe("Conversation 123e4567");
+    expect(
+      deriveSessionDisplayTitle({
+        id: "not-a-session-id",
+        title: AUTOMATIC_SESSION_TITLE_FALLBACK,
+        titleSource: "agent",
+        initialMessage: "API_TOKEN=super-secret-value",
+      }),
+    ).toBe(AUTOMATIC_SESSION_TITLE_FALLBACK);
   });
 
   test("returns null for empty/boilerplate-only candidates so callers retain the safe fallback", () => {

--- a/packages/contracts/test/session-titles.test.ts
+++ b/packages/contracts/test/session-titles.test.ts
@@ -260,7 +260,15 @@ describe("automatic session titles", () => {
         titleSource: "agent",
         initialMessage: "API_TOKEN=super-secret-value",
       }),
-    ).toBe("Conversation 123e4567");
+    ).toBe("Conversation 123e4567-e89b");
+    expect(
+      deriveSessionDisplayTitle({
+        id: "123e4567-f012-42d3-a456-426614174000",
+        title: AUTOMATIC_SESSION_TITLE_FALLBACK,
+        titleSource: "agent",
+        initialMessage: "API_TOKEN=super-secret-value",
+      }),
+    ).toBe("Conversation 123e4567-f012");
     expect(
       deriveSessionDisplayTitle({
         id: "not-a-session-id",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -86,8 +86,10 @@ security boundary, and delivery checklist.
 
 For session lists, `deriveSessionDisplayTitle(session)` returns the durable
 agent/user title when available. While the automatic title is still pending, it
-shows a short, sensitive-safe preview of the opening prompt and automatically
-yields to the later `session.title_set` value.
+shows the first short, sensitive-safe line of the opening prompt, skipping an
+unsafe pasted URL or identifier when later safe text exists. If no safe line is
+available, a short session reference keeps rows distinguishable. The display
+automatically yields to the later `session.title_set` value.
 
 Browser consoles that do not need operator-only surfaces can import
 `OpenGeniBrowserClient` from `@opengeni/sdk/browser`. Document authority migration

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -35,6 +35,7 @@ export {
 export type { OpenGeniSecureContextRequiredReason } from "./errors";
 export {
   AUTOMATIC_SESSION_TITLE_FALLBACK,
+  deriveAutomaticSessionTitlePreview,
   deriveSessionDisplayTitle,
   sessionTitleIsPending,
 } from "./session-titles";

--- a/packages/sdk/src/session-titles.ts
+++ b/packages/sdk/src/session-titles.ts
@@ -1,84 +1,10 @@
-import {
+export {
   AUTOMATIC_SESSION_TITLE_FALLBACK,
-  boundAutomaticSessionTitle,
-  containsSensitiveAutomaticSessionTitleValue,
+  deriveAutomaticSessionTitlePreview,
+  deriveSessionDisplayTitle,
+  sessionTitleIsPending,
 } from "@opengeni/contracts/session-titles";
-import type { Session } from "./types";
-
-export { AUTOMATIC_SESSION_TITLE_FALLBACK };
-
-// Session creation accepts a body far larger than a navigation label. Bound
-// the source before any replace/split/normalization so a persisted large prompt
-// cannot amplify memory or CPU on every browser render.
-const PROMPT_PREVIEW_SCAN_MAX_CODE_UNITS = 4_096;
-
-function deriveOpeningPromptPreview(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-
-  const firstLine = value
-    .slice(0, PROMPT_PREVIEW_SCAN_MAX_CODE_UNITS)
-    .replace(/[\u0000-\u001f\u007f-\u009f]+/gu, "\n")
-    .split(/\n+/u)
-    .map((line) => line.trim())
-    .find(Boolean);
-  if (!firstLine) return null;
-  if (containsSensitiveAutomaticSessionTitleValue(firstLine)) return null;
-
-  const preview = boundAutomaticSessionTitle(firstLine.replace(/\s+/gu, " "))
-    .replace(/[\s.!?,;:\-–—]+$/u, "")
-    .trim();
-  if (!preview) return null;
-  return preview;
-}
-
-export type SessionDisplayTitleInput = {
-  title?: Session["title"] | undefined;
-  titleSource?: Session["titleSource"] | undefined;
-  initialMessage?: Session["initialMessage"] | null | undefined;
-  metadata?: Readonly<Record<string, unknown>> | undefined;
-};
-
-export type SessionDisplayTitleOptions = {
-  /** Optional metadata fields to try before the opening-prompt preview. */
-  metadataKeys?: readonly string[] | undefined;
-};
-
-/**
- * Whether the durable title still represents the automatic-title pending state.
- * A user-authored title always wins, even when its literal value is the fallback.
- */
-export function sessionTitleIsPending(input: SessionDisplayTitleInput): boolean {
-  const title = input.title?.trim() ?? "";
-  return input.titleSource !== "user" && (!title || title === AUTOMATIC_SESSION_TITLE_FALLBACK);
-}
-
-/**
- * Derive the title a client should display for a session.
- *
- * A semantic agent title or human rename wins. While automatic naming is still
- * pending, clients show a short, sensitive-safe preview of the opening prompt;
- * the preview is never persisted as title metadata and is replaced naturally
- * when `session.title_set` arrives. Obvious credential-, URL-, or identifier-
- * shaped prompt prefixes retain the generic fallback.
- */
-export function deriveSessionDisplayTitle(
-  input: SessionDisplayTitleInput,
-  options: SessionDisplayTitleOptions = {},
-): string {
-  const title = input.title?.trim() ?? "";
-  if (input.titleSource === "user") {
-    return title || AUTOMATIC_SESSION_TITLE_FALLBACK;
-  }
-  if (title && !sessionTitleIsPending(input)) {
-    return title;
-  }
-
-  for (const key of options.metadataKeys ?? []) {
-    const value = input.metadata?.[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value.trim();
-    }
-  }
-
-  return deriveOpeningPromptPreview(input.initialMessage) ?? AUTOMATIC_SESSION_TITLE_FALLBACK;
-}
+export type {
+  SessionDisplayTitleInput,
+  SessionDisplayTitleOptions,
+} from "@opengeni/contracts/session-titles";

--- a/packages/sdk/test/session-titles.test.ts
+++ b/packages/sdk/test/session-titles.test.ts
@@ -48,6 +48,15 @@ describe("session display titles", () => {
         initialMessage: "A later prompt preview must not replace durable metadata",
       }),
     ).toBe("Automatic Session Naming");
+
+    expect(
+      deriveSessionDisplayTitle({
+        title: AUTOMATIC_SESSION_TITLE_FALLBACK,
+        titleSource: "agent",
+        initialMessage:
+          "https://homeserver.example.test/workspaces/one/sessions/two\nFix default session naming behavior",
+      }),
+    ).toBe("Fix default session naming behavior");
   });
 
   test("preserves metadata precedence when a host requests it", () => {
@@ -64,7 +73,7 @@ describe("session display titles", () => {
     ).toBe("Nightly drift check");
   });
 
-  test("keeps the generic fallback for sensitive prompt prefixes and honors a user-set fallback", () => {
+  test("uses a session reference for unsafe prompts and honors a user-set fallback", () => {
     for (const initialMessage of [
       "SECRET_TOKEN=hunter2 investigate the failed deployment",
       "Open https://example.com/private?token=hunter2 and inspect the failure",
@@ -76,11 +85,12 @@ describe("session display titles", () => {
     ]) {
       expect(
         deriveSessionDisplayTitle({
+          id: "123e4567-e89b-42d3-a456-426614174000",
           title: AUTOMATIC_SESSION_TITLE_FALLBACK,
           titleSource: "agent",
           initialMessage,
         }),
-      ).toBe(AUTOMATIC_SESSION_TITLE_FALLBACK);
+      ).toBe("Conversation 123e4567");
     }
 
     expect(
@@ -93,9 +103,18 @@ describe("session display titles", () => {
 
     expect(
       deriveSessionDisplayTitle({
+        id: "123e4567-e89b-42d3-a456-426614174000",
         title: "   ",
         titleSource: "user",
         initialMessage: "Inspect the workspace",
+      }),
+    ).toBe("Conversation 123e4567");
+
+    expect(
+      deriveSessionDisplayTitle({
+        title: AUTOMATIC_SESSION_TITLE_FALLBACK,
+        titleSource: "agent",
+        initialMessage: "API_TOKEN=hunter2",
       }),
     ).toBe(AUTOMATIC_SESSION_TITLE_FALLBACK);
   });

--- a/packages/sdk/test/session-titles.test.ts
+++ b/packages/sdk/test/session-titles.test.ts
@@ -90,7 +90,7 @@ describe("session display titles", () => {
           titleSource: "agent",
           initialMessage,
         }),
-      ).toBe("Conversation 123e4567");
+      ).toBe("Conversation 123e4567-e89b");
     }
 
     expect(
@@ -108,7 +108,7 @@ describe("session display titles", () => {
         titleSource: "user",
         initialMessage: "Inspect the workspace",
       }),
-    ).toBe("Conversation 123e4567");
+    ).toBe("Conversation 123e4567-e89b");
 
     expect(
       deriveSessionDisplayTitle({

--- a/test/e2e/session-header.browser.e2e.ts
+++ b/test/e2e/session-header.browser.e2e.ts
@@ -418,6 +418,60 @@ describe("responsive production session header", () => {
       await context.close();
     }
   }, 30_000);
+
+  test("pending titles use safe prompt text or a unique session reference", async () => {
+    const safePromptLine = "Fix default session naming behavior";
+    const urlLeading = await createSession(dbClient.db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      initialMessage: `https://homeserver.example.test/workspaces/one/sessions/two\n${safePromptLine}`,
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    const sensitiveOnly = await createSession(dbClient.db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      initialMessage: "API_TOKEN=super-secret-value",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    const context = await configuredContext(browser, {
+      viewport: { width: 1440, height: 900 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    try {
+      const page = await context.newPage();
+      await page.goto(sessionUrl({ ...fixture, sessionId: urlLeading.id }));
+
+      const titleButton = page.locator("header button[title$='click to rename']");
+      await titleButton.waitFor();
+      expect((await titleButton.textContent())?.trim()).toBe(safePromptLine);
+      expect(await page.getByText(safePromptLine, { exact: true }).count()).toBeGreaterThan(0);
+      expect(await page.getByText("New conversation", { exact: true }).count()).toBe(0);
+
+      await page.goto(sessionUrl({ ...fixture, sessionId: sensitiveOnly.id }));
+      await titleButton.waitFor();
+      expect((await titleButton.textContent())?.trim()).toBe(
+        `Conversation ${sensitiveOnly.id.slice(0, 8)}`,
+      );
+      expect(await page.getByText("New conversation", { exact: true }).count()).toBe(0);
+      const displayedTitles = await page
+        .locator("[data-session-row-title], header button[title$='click to rename']")
+        .allTextContents();
+      expect(displayedTitles.join(" ")).not.toContain("super-secret-value");
+      expect(pageErrors.get(context)).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  }, 30_000);
 });
 
 function sessionUrl(value: HeaderFixture): string {

--- a/test/e2e/session-header.browser.e2e.ts
+++ b/test/e2e/session-header.browser.e2e.ts
@@ -460,7 +460,7 @@ describe("responsive production session header", () => {
       await page.goto(sessionUrl({ ...fixture, sessionId: sensitiveOnly.id }));
       await titleButton.waitFor();
       expect((await titleButton.textContent())?.trim()).toBe(
-        `Conversation ${sensitiveOnly.id.slice(0, 8)}`,
+        `Conversation ${sensitiveOnly.id.slice(0, 13)}`,
       );
       expect(await page.getByText("New conversation", { exact: true }).count()).toBe(0);
       const displayedTitles = await page


### PR DESCRIPTION
## Summary

- Show the first safe, truncated opening-prompt line while automatic session naming is pending, including when a pasted URL or secret occupies an earlier line.
- Use a short UUID-derived conversation reference when no prompt line is safe, so session rows remain distinguishable without exposing prompt bytes.
- Let the bounded parallel semantic-title request finish after a quick normal response; exceptional and cancelled exits still abort and join it.
- Apply the shared display policy consistently in the web UI, SDK, and Slack App Home.

## Testing

- [x] Typechecked packages/contracts, packages/sdk, apps/api, apps/worker, and apps/web.
- [x] 88 focused contract, SDK, API, web, worker, and contract-parity tests.
- [x] Targeted desktop Playwright regression: pending titles use safe prompt text or a unique session reference.
- [x] Formatting, lint, public repository hygiene, and documentation reference checks.
- [ ] Full bun test suite was not run.

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] The branch was created from the then-current main head and kept frozen while verification ran.

## Notes

- The parallel-title change landed on September 1, 2026. Its normal settlement path aborted a title request whenever the main response completed first, leaving quick sessions on the pending marker.
- One full session-header browser-file run also hit the existing ancestry-loading timing race (expected unavailable while still loading). The new title regression passes independently and was visually inspected at 1440 by 900.

## Summary by Sourcery

Make pending sessions distinguishable without exposing sensitive prompt content and preserve semantic titles generated alongside quick responses.

New Features:
- Display safe opening-prompt previews for pending sessions, skipping unsafe leading lines and falling back to short session references when no preview is available.
- Share the pending-session display-title policy across contracts, SDK, web UI, and Slack App Home.

Bug Fixes:
- Preserve valid automatically generated titles by allowing bounded parallel title generation to complete after normal quick responses.

Enhancements:
- Abort and join parallel title generation on exceptional or cancelled turn exits while retaining normal-response results.

Documentation:
- Document the updated pending-title display behavior and parallel title-generation lifecycle.

Tests:
- Add contract, SDK, Slack, worker, web, and end-to-end coverage for safe previews, session references, and parallel title settlement.

Chores:
- Publish patch changesets for the contracts, SDK, API router, and worker bundle.