### PR TITLE
Fix scheduled task unclaimed occurrence lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -738,6 +738,15 @@ goal. An admitted occurrence persists `queued` to consume that boundary even
 when a pause or active realtime lease withholds its workflow wake. A newly
 generated session still admits the occurrence that creates it.
 
+Pausing or soft-deleting a scheduled task is a durable first-claim cutoff. The
+task lifecycle transaction locks each nonterminal agent run and marks it
+skipped only when no scheduler-owned turn exists. A concurrent deposit
+therefore either commits first and is invalidated, or observes the terminal run
+and cannot publish; a concurrent claim either creates its turn first and
+remains recoverable, or observes the skipped run and cancels the pending update
+without starting model, tool, or sandbox work. Resuming the task never revives
+those pre-pause deposits.
+
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage
 boundaries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -745,7 +745,9 @@ therefore either commits first and is invalidated, or observes the terminal run
 and cannot publish; a concurrent claim either creates its turn first and
 remains recoverable, or observes the skipped run and cancels the pending update
 without starting model, tool, or sandbox work. Resuming the task never revives
-those pre-pause deposits.
+those pre-pause deposits. A database delivery fence rejects `pending` to
+`delivered` transitions for terminal scheduled runs, so a rolling old worker
+cannot bypass the cutoff before the new claim logic is fully deployed.
 
 None of them creates a parallel agent engine. They differ in admission and
 provenance, then use the same logical turn, attempt, event, recovery, and usage

--- a/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
+++ b/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
@@ -8,6 +8,46 @@
 SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '5min';
 
+-- Old claimers do not inspect scheduled_task_runs.status after this migration
+-- marks an occurrence terminal. Keep the rolling boundary safe in the database:
+-- every binary must cross this state transition before it can create the
+-- scheduler-owned turn or start provider work.
+CREATE FUNCTION fence_terminal_scheduled_occurrence_delivery()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+DECLARE
+  run_status text;
+BEGIN
+  SELECT run.status INTO run_status
+  FROM scheduled_task_runs run
+  WHERE run.id = OLD.scheduled_task_run_id
+    AND run.account_id = OLD.account_id
+    AND run.workspace_id = OLD.workspace_id
+    AND run.session_id = OLD.session_id
+    AND run.action_kind = 'agent_turn'
+  FOR UPDATE;
+
+  IF run_status IS DISTINCT FROM 'dispatched' THEN
+    RAISE EXCEPTION 'terminal scheduled occurrence cannot be delivered'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END
+$body$;
+
+CREATE TRIGGER scheduled_terminal_occurrence_delivery_fence
+BEFORE UPDATE OF state ON session_system_updates
+FOR EACH ROW
+WHEN (
+  OLD.scheduled_task_run_id IS NOT NULL
+  AND OLD.state = 'pending'
+  AND NEW.state = 'delivered'
+)
+EXECUTE FUNCTION fence_terminal_scheduled_occurrence_delivery();
+
 CREATE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -89,6 +129,7 @@ EXECUTE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive();
 REVOKE ALL ON FUNCTION
   invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()
   FROM PUBLIC;
+REVOKE ALL ON FUNCTION fence_terminal_scheduled_occurrence_delivery() FROM PUBLIC;
 
 DO $pin_scheduled_task_unclaimed_invalidation$
 DECLARE
@@ -96,6 +137,12 @@ DECLARE
 BEGIN
   EXECUTE pg_catalog.format(
     'ALTER FUNCTION %I.invalidate_unclaimed_scheduled_agent_runs_on_task_inactive() '
+      || 'SET search_path = pg_catalog, %I, pg_temp',
+    data_schema,
+    data_schema
+  );
+  EXECUTE pg_catalog.format(
+    'ALTER FUNCTION %I.fence_terminal_scheduled_occurrence_delivery() '
       || 'SET search_path = pg_catalog, %I, pg_temp',
     data_schema,
     data_schema

--- a/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
+++ b/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
@@ -1,0 +1,104 @@
+-- deployment-mode: rolling
+-- Pausing or soft-deleting a scheduled task is a durable first-claim cutoff.
+-- Runs whose scheduler-owned turn already exists remain accepted work and keep
+-- their normal attempt/recovery lifecycle. Every earlier occurrence becomes a
+-- terminal receipt, so a later Resume cannot revive a deposit accepted before
+-- the lifecycle boundary.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+CREATE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+DECLARE
+  run_row record;
+  invalidation_error text := CASE
+    WHEN OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL
+      THEN 'scheduled_task_deleted_before_claim'
+    ELSE 'scheduled_task_paused_before_claim'
+  END;
+BEGIN
+  INSERT INTO opengeni_private.scheduled_personal_resource_capabilities (
+    backend_pid, transaction_id, capability_kind
+  ) VALUES (
+    pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'run_lifecycle'
+  )
+  ON CONFLICT DO NOTHING;
+
+  -- Run admission takes the task row first. Deposit and claim both lock the run
+  -- before they can publish an occurrence or a scheduler-owned turn. Once this
+  -- loop owns a run, a fresh turn lookup therefore decides the race exactly:
+  -- no turn means no claim crossed the lifecycle boundary.
+  FOR run_row IN
+    SELECT run.id
+    FROM scheduled_task_runs run
+    WHERE run.account_id = NEW.account_id
+      AND run.workspace_id = NEW.workspace_id
+      AND run.task_id = NEW.id
+      AND run.action_kind = 'agent_turn'
+      AND run.status IN ('queued', 'dispatched')
+    ORDER BY run.id
+    FOR UPDATE
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM session_turns turn_value
+      WHERE turn_value.account_id = NEW.account_id
+        AND turn_value.workspace_id = NEW.workspace_id
+        AND turn_value.scheduled_task_run_id = run_row.id
+    ) THEN
+      UPDATE scheduled_task_runs run
+      SET status = 'skipped',
+        error = invalidation_error,
+        completed_at = pg_catalog.clock_timestamp(),
+        updated_at = pg_catalog.clock_timestamp()
+      WHERE run.id = run_row.id
+        AND run.account_id = NEW.account_id
+        AND run.workspace_id = NEW.workspace_id
+        AND run.status IN ('queued', 'dispatched');
+    END IF;
+  END LOOP;
+
+  DELETE FROM opengeni_private.scheduled_personal_resource_capabilities
+  WHERE backend_pid = pg_catalog.pg_backend_pid()
+    AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+    AND capability_kind = 'run_lifecycle';
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  DELETE FROM opengeni_private.scheduled_personal_resource_capabilities
+  WHERE backend_pid = pg_catalog.pg_backend_pid()
+    AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+    AND capability_kind = 'run_lifecycle';
+  RAISE;
+END
+$body$;
+
+CREATE TRIGGER scheduled_task_unclaimed_occurrence_invalidation
+AFTER UPDATE OF status, deleted_at ON scheduled_tasks
+FOR EACH ROW
+WHEN (
+  (OLD.status = 'active' AND NEW.status = 'paused')
+  OR (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
+)
+EXECUTE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive();
+
+REVOKE ALL ON FUNCTION
+  invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()
+  FROM PUBLIC;
+
+DO $pin_scheduled_task_unclaimed_invalidation$
+DECLARE
+  data_schema text := pg_catalog.current_schema();
+BEGIN
+  EXECUTE pg_catalog.format(
+    'ALTER FUNCTION %I.invalidate_unclaimed_scheduled_agent_runs_on_task_inactive() '
+      || 'SET search_path = pg_catalog, %I, pg_temp',
+    data_schema,
+    data_schema
+  );
+END
+$pin_scheduled_task_unclaimed_invalidation$;

--- a/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
+++ b/packages/db/drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql
@@ -56,12 +56,18 @@ SET search_path FROM CURRENT
 AS $body$
 DECLARE
   run_row record;
-  invalidation_error text := CASE
-    WHEN OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL
+  invalidation_error text;
+BEGIN
+  invalidation_error := CASE
+    -- 0275 introduced deleted_at. JSON row introspection keeps this rolling
+    -- trigger installable in legacy-upgrade fixtures that intentionally replay
+    -- 0275 after the current tail, while current schemas still classify delete.
+    WHEN pg_catalog.to_jsonb(OLD) ->> 'deleted_at' IS NULL
+      AND pg_catalog.to_jsonb(NEW) ->> 'deleted_at' IS NOT NULL
       THEN 'scheduled_task_deleted_before_claim'
     ELSE 'scheduled_task_paused_before_claim'
   END;
-BEGIN
+
   INSERT INTO opengeni_private.scheduled_personal_resource_capabilities (
     backend_pid, transaction_id, capability_kind
   ) VALUES (
@@ -118,12 +124,9 @@ END
 $body$;
 
 CREATE TRIGGER scheduled_task_unclaimed_occurrence_invalidation
-AFTER UPDATE OF status, deleted_at ON scheduled_tasks
+AFTER UPDATE OF status ON scheduled_tasks
 FOR EACH ROW
-WHEN (
-  (OLD.status = 'active' AND NEW.status = 'paused')
-  OR (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
-)
+WHEN (OLD.status = 'active' AND NEW.status = 'paused')
 EXECUTE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive();
 
 REVOKE ALL ON FUNCTION

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17470,17 +17470,10 @@ async function validateScheduledTargetExecutionAtClaim(
     runId: string;
   },
 ): Promise<string | null> {
-  const [liveAuthority] = await rawRows<{ denial: string | null }>(
-    tx,
-    sql`select validate_scheduled_agent_run_live_authority(
-      ${input.accountId}::uuid,
-      ${input.workspaceId}::uuid,
-      ${input.runId}::uuid
-    ) as denial`,
-  );
-  if (liveAuthority?.denial) return liveAuthority.denial;
   const [run] = await tx
     .select({
+      status: schema.scheduledTaskRuns.status,
+      error: schema.scheduledTaskRuns.error,
       acceptedExecutionSnapshot: schema.scheduledTaskRuns.acceptedExecutionSnapshot,
     })
     .from(schema.scheduledTaskRuns)
@@ -17495,6 +17488,22 @@ async function validateScheduledTargetExecutionAtClaim(
     .limit(1)
     .for("update");
   if (!run?.acceptedExecutionSnapshot) return "scheduled_authority_snapshot_missing";
+  if (run.status !== "dispatched") {
+    return run.status === "skipped" &&
+      (run.error === "scheduled_task_paused_before_claim" ||
+        run.error === "scheduled_task_deleted_before_claim")
+      ? "scheduled_task_inactive_before_claim"
+      : "scheduled_run_terminal_before_claim";
+  }
+  const [liveAuthority] = await rawRows<{ denial: string | null }>(
+    tx,
+    sql`select validate_scheduled_agent_run_live_authority(
+      ${input.accountId}::uuid,
+      ${input.workspaceId}::uuid,
+      ${input.runId}::uuid
+    ) as denial`,
+  );
+  if (liveAuthority?.denial) return liveAuthority.denial;
   const accepted = ScheduledTaskRunAcceptedExecution.parse(run.acceptedExecutionSnapshot);
   const target = accepted.targetSessionExecution;
   if (!target) return null;
@@ -61019,6 +61028,7 @@ export async function claimSessionWorkForAttempt(
           }
           const validUpdates: typeof updates = [];
           const cancelledUpdateIds: string[] = [];
+          const scheduledTaskInactiveUpdateIds: string[] = [];
           const authorityRejectedUpdateIds: string[] = [];
           const unrecognizedUpdateIds: string[] = [];
           // Retained so later consumers of the delivered batch (the child
@@ -61054,17 +61064,28 @@ export async function claimSessionWorkForAttempt(
                 })
               : null;
             if (update.scheduledTaskRunId && scheduledAuthorityDenial) {
-              await markScheduledTaskRunAuthorityRejectedInTransaction(tx as unknown as Database, {
-                workspaceId,
-                sessionId,
-                runId: update.scheduledTaskRunId,
-                error: scheduledAuthorityDenial,
-              });
+              const scheduledTaskInactive =
+                scheduledAuthorityDenial === "scheduled_task_inactive_before_claim";
+              if (!scheduledTaskInactive) {
+                await markScheduledTaskRunAuthorityRejectedInTransaction(
+                  tx as unknown as Database,
+                  {
+                    workspaceId,
+                    sessionId,
+                    runId: update.scheduledTaskRunId,
+                    error: scheduledAuthorityDenial,
+                  },
+                );
+              }
               await tx
                 .update(schema.sessionSystemUpdates)
-                .set({ state: "failed" })
+                .set({ state: scheduledTaskInactive ? "cancelled" : "failed" })
                 .where(eq(schema.sessionSystemUpdates.id, update.id));
-              authorityRejectedUpdateIds.push(update.id);
+              if (scheduledTaskInactive) {
+                scheduledTaskInactiveUpdateIds.push(update.id);
+              } else {
+                authorityRejectedUpdateIds.push(update.id);
+              }
               continue;
             }
             if (input.validatePendingSystemUpdateAuthority) {
@@ -61170,6 +61191,25 @@ export async function claimSessionWorkForAttempt(
                   updateIds: cancelledUpdateIds,
                   count: cancelledUpdateIds.length,
                   reason: "stale_goal_continuation",
+                },
+                occurredAt,
+              });
+            }
+            if (scheduledTaskInactiveUpdateIds.length > 0) {
+              cancellationEvents.push({
+                accountId,
+                workspaceId,
+                sessionId,
+                turnId: null,
+                turnGeneration: null,
+                turnAttemptId: null,
+                turnAssociation: null,
+                sequence: ++sequence,
+                type: "system.update.cancelled" as const,
+                payload: {
+                  updateIds: scheduledTaskInactiveUpdateIds,
+                  count: scheduledTaskInactiveUpdateIds.length,
+                  reason: "scheduled_task_inactive",
                 },
                 occurredAt,
               });
@@ -61308,6 +61348,25 @@ export async function claimSessionWorkForAttempt(
                 updateIds: cancelledUpdateIds,
                 count: cancelledUpdateIds.length,
                 reason: "stale_goal_continuation",
+              },
+              occurredAt,
+            });
+          }
+          if (scheduledTaskInactiveUpdateIds.length > 0) {
+            events.push({
+              accountId,
+              workspaceId,
+              sessionId,
+              turnId,
+              turnGeneration,
+              turnAttemptId: input.attemptId,
+              turnAssociation: "current",
+              sequence: ++sequence,
+              type: "system.update.cancelled",
+              payload: {
+                updateIds: scheduledTaskInactiveUpdateIds,
+                count: scheduledTaskInactiveUpdateIds.length,
+                reason: "scheduled_task_inactive",
               },
               occurredAt,
             });

--- a/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
+++ b/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
@@ -14,6 +14,12 @@ describe("migration 0395 scheduled task unclaimed occurrence invalidation", () =
       "CREATE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()",
     );
     expect(migration).toContain("AFTER UPDATE OF status, deleted_at ON scheduled_tasks");
+    expect(migration).toContain("CREATE FUNCTION fence_terminal_scheduled_occurrence_delivery()");
+    expect(migration).toContain("BEFORE UPDATE OF state ON session_system_updates");
+    expect(migration).toContain("OLD.state = 'pending'");
+    expect(migration).toContain("NEW.state = 'delivered'");
+    expect(migration).toContain("run_status IS DISTINCT FROM 'dispatched'");
+    expect(migration).toContain("terminal scheduled occurrence cannot be delivered");
     expect(migration).toContain("OLD.status = 'active' AND NEW.status = 'paused'");
     expect(migration).toContain("OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL");
     expect(migration).toContain("AND run.status IN ('queued', 'dispatched')");

--- a/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
+++ b/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
@@ -13,7 +13,7 @@ describe("migration 0395 scheduled task unclaimed occurrence invalidation", () =
     expect(migration).toContain(
       "CREATE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()",
     );
-    expect(migration).toContain("AFTER UPDATE OF status, deleted_at ON scheduled_tasks");
+    expect(migration).toContain("AFTER UPDATE OF status ON scheduled_tasks");
     expect(migration).toContain("CREATE FUNCTION fence_terminal_scheduled_occurrence_delivery()");
     expect(migration).toContain("BEFORE UPDATE OF state ON session_system_updates");
     expect(migration).toContain("OLD.state = 'pending'");
@@ -21,7 +21,8 @@ describe("migration 0395 scheduled task unclaimed occurrence invalidation", () =
     expect(migration).toContain("run_status IS DISTINCT FROM 'dispatched'");
     expect(migration).toContain("terminal scheduled occurrence cannot be delivered");
     expect(migration).toContain("OLD.status = 'active' AND NEW.status = 'paused'");
-    expect(migration).toContain("OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL");
+    expect(migration).toContain("pg_catalog.to_jsonb(OLD) ->> 'deleted_at' IS NULL");
+    expect(migration).toContain("pg_catalog.to_jsonb(NEW) ->> 'deleted_at' IS NOT NULL");
     expect(migration).toContain("AND run.status IN ('queued', 'dispatched')");
     expect(migration).toContain("FOR UPDATE");
     expect(migration).toContain("FROM session_turns turn_value");

--- a/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
+++ b/packages/db/test/migration-0395-scheduled-task-unclaimed-occurrence-invalidation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const migrationUrl = new URL(
+  "../drizzle/0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+  import.meta.url,
+);
+
+describe("migration 0395 scheduled task unclaimed occurrence invalidation", () => {
+  test("installs a rolling first-claim cutoff without mutating claimed turns", async () => {
+    const migration = await readFile(migrationUrl, "utf8");
+    expect(migration.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(migration).toContain(
+      "CREATE FUNCTION invalidate_unclaimed_scheduled_agent_runs_on_task_inactive()",
+    );
+    expect(migration).toContain("AFTER UPDATE OF status, deleted_at ON scheduled_tasks");
+    expect(migration).toContain("OLD.status = 'active' AND NEW.status = 'paused'");
+    expect(migration).toContain("OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL");
+    expect(migration).toContain("AND run.status IN ('queued', 'dispatched')");
+    expect(migration).toContain("FOR UPDATE");
+    expect(migration).toContain("FROM session_turns turn_value");
+    expect(migration).toContain("scheduled_task_paused_before_claim");
+    expect(migration).toContain("scheduled_task_deleted_before_claim");
+    expect(migration).not.toContain("UPDATE session_turns");
+    expect(migration).not.toContain("UPDATE session_system_updates");
+  });
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -115,12 +115,17 @@ describe("release schema contract", () => {
       (migration) => migration.path === "0394_session_selected_skill_activation.sql",
     );
     const completeSourceContractWithSessionSelectedSkillActivation = completeSourceContract;
+    const sessionSelectedSkillActivationIndex =
+      completeSourceContractWithSessionSelectedSkillActivation.migrations.findIndex(
+        (migration) => migration.path === "0394_session_selected_skill_activation.sql",
+      );
     completeSourceContract = sessionSelectedSkillActivation
       ? {
           ...completeSourceContractWithSessionSelectedSkillActivation,
           latestMigration:
-            completeSourceContractWithSessionSelectedSkillActivation.migrations.at(-2)?.path ??
-            completeSourceContractWithSessionSelectedSkillActivation.latestMigration,
+            completeSourceContractWithSessionSelectedSkillActivation.migrations[
+              sessionSelectedSkillActivationIndex - 1
+            ]?.path ?? completeSourceContractWithSessionSelectedSkillActivation.latestMigration,
         }
       : completeSourceContractWithSessionSelectedSkillActivation;
     const contextCompactionPendingObservability = completeSourceContract.migrations.some(
@@ -268,6 +273,9 @@ describe("release schema contract", () => {
     const workspaceMemoryAndLearningDefaults = completeSourceContract.migrations.some(
       (migration) => migration.path === "0393_workspace_memory_and_learning_defaults.sql",
     );
+    const scheduledTaskUnclaimedOccurrenceInvalidation = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+    );
     if (workspaceMemoryAndLearningDefaults) {
       completeSourceContract = {
         ...completeSourceContract,
@@ -280,7 +288,14 @@ describe("release schema contract", () => {
         latestMigration: "0394_session_selected_skill_activation.sql",
       };
     }
+    if (scheduledTaskUnclaimedOccurrenceInvalidation) {
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+      };
+    }
     const automaticSessionTitleMigrationPaths = new Set([
+      "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
       "0394_session_selected_skill_activation.sql",
       "0392_context_compaction_pending_observability.sql",
       "0353_automatic_session_title_policy_fence.sql",
@@ -331,6 +346,7 @@ describe("release schema contract", () => {
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (sessionSelectedSkillActivation ? 1 : 0) +
+        (scheduledTaskUnclaimedOccurrenceInvalidation ? 1 : 0) +
         (contextCompactionPendingObservability ? 1 : 0) +
         migrationsBeforeAutomaticSessionTitles.length +
         (automaticSessionTitlePolicyFence ? 1 : 0) +
@@ -462,6 +478,9 @@ describe("release schema contract", () => {
       ...(sessionSelectedSkillActivation
         ? { latestMigration: "0394_session_selected_skill_activation.sql" }
         : {}),
+      ...(scheduledTaskUnclaimedOccurrenceInvalidation
+        ? { latestMigration: "0395_scheduled_task_unclaimed_occurrence_invalidation.sql" }
+        : {}),
     });
     expect(completeSourceContractWithContextCompaction.latestMigration).toBe(
       workspaceMemoryAndLearningDefaults
@@ -471,9 +490,11 @@ describe("release schema contract", () => {
           : completeSourceContract.latestMigration,
     );
     expect(completeSourceContractWithSessionSelectedSkillActivation.latestMigration).toBe(
-      sessionSelectedSkillActivation
-        ? "0394_session_selected_skill_activation.sql"
-        : completeSourceContractWithContextCompaction.latestMigration,
+      scheduledTaskUnclaimedOccurrenceInvalidation
+        ? "0395_scheduled_task_unclaimed_occurrence_invalidation.sql"
+        : sessionSelectedSkillActivation
+          ? "0394_session_selected_skill_activation.sql"
+          : completeSourceContractWithContextCompaction.latestMigration,
     );
   });
 
@@ -493,12 +514,17 @@ describe("release schema contract", () => {
       (migration) => migration.path === "0394_session_selected_skill_activation.sql",
     );
     const completeSourceContractWithSessionSelectedSkillActivation = completeSourceContract;
+    const sessionSelectedSkillActivationIndex =
+      completeSourceContractWithSessionSelectedSkillActivation.migrations.findIndex(
+        (migration) => migration.path === "0394_session_selected_skill_activation.sql",
+      );
     completeSourceContract = sessionSelectedSkillActivation
       ? {
           ...completeSourceContractWithSessionSelectedSkillActivation,
           latestMigration:
-            completeSourceContractWithSessionSelectedSkillActivation.migrations.at(-2)?.path ??
-            completeSourceContractWithSessionSelectedSkillActivation.latestMigration,
+            completeSourceContractWithSessionSelectedSkillActivation.migrations[
+              sessionSelectedSkillActivationIndex - 1
+            ]?.path ?? completeSourceContractWithSessionSelectedSkillActivation.latestMigration,
         }
       : completeSourceContractWithSessionSelectedSkillActivation;
     const contextCompactionPendingObservability = completeSourceContract.migrations.some(
@@ -635,6 +661,7 @@ describe("release schema contract", () => {
       "0390_organization_model_provider_connections.sql",
       "0391_sandbox_provider_deadline_interaction_followup.sql",
       "0393_workspace_memory_and_learning_defaults.sql",
+      "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -797,6 +824,9 @@ describe("release schema contract", () => {
     const workspaceMemoryAndLearningDefaults = completeSourceContract.migrations.some(
       (migration) => migration.path === "0393_workspace_memory_and_learning_defaults.sql",
     );
+    const scheduledTaskUnclaimedOccurrenceInvalidation = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+    );
     if (workspaceMemoryAndLearningDefaults) {
       completeSourceContract = {
         ...completeSourceContract,
@@ -809,9 +839,16 @@ describe("release schema contract", () => {
         latestMigration: "0394_session_selected_skill_activation.sql",
       };
     }
+    if (scheduledTaskUnclaimedOccurrenceInvalidation) {
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+      };
+    }
     expect(completeSourceContract).toMatchObject({
       fileCount:
         (sessionSelectedSkillActivation ? 1 : 0) +
+        (scheduledTaskUnclaimedOccurrenceInvalidation ? 1 : 0) +
         (contextCompactionPendingObservability ? 1 : 0) +
         (atomicConnectedMachineAttachments ? 347 : routedSlackHandles ? 346 : 345) +
         (documentAuthorityReclassification ? 1 : 0) +
@@ -958,6 +995,9 @@ describe("release schema contract", () => {
       ...(sessionSelectedSkillActivation
         ? { latestMigration: "0394_session_selected_skill_activation.sql" }
         : {}),
+      ...(scheduledTaskUnclaimedOccurrenceInvalidation
+        ? { latestMigration: "0395_scheduled_task_unclaimed_occurrence_invalidation.sql" }
+        : {}),
     });
     expect(completeSourceContractWithContextCompaction.latestMigration).toBe(
       workspaceMemoryAndLearningDefaults
@@ -967,9 +1007,11 @@ describe("release schema contract", () => {
           : completeSourceContract.latestMigration,
     );
     expect(completeSourceContractWithSessionSelectedSkillActivation.latestMigration).toBe(
-      sessionSelectedSkillActivation
-        ? "0394_session_selected_skill_activation.sql"
-        : completeSourceContractWithContextCompaction.latestMigration,
+      scheduledTaskUnclaimedOccurrenceInvalidation
+        ? "0395_scheduled_task_unclaimed_occurrence_invalidation.sql"
+        : sessionSelectedSkillActivation
+          ? "0394_session_selected_skill_activation.sql"
+          : completeSourceContractWithContextCompaction.latestMigration,
     );
     expect(
       completeSourceContract.migrations.find(

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -3612,6 +3612,11 @@ describe("worker activities integration", () => {
     if (first.action !== "start") throw new Error("pause fixture did not create its session");
 
     await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { status: "paused" });
+    const [pausedRun] = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
+    expect(pausedRun).toMatchObject({
+      status: "skipped",
+      error: "scheduled_task_paused_before_claim",
+    });
     expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual([
       expect.objectContaining({
         status: "skipped",
@@ -3620,6 +3625,20 @@ describe("worker activities integration", () => {
     ]);
 
     await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { status: "active" });
+    await expect(
+      withWorkspaceRls(
+        dbClient.db,
+        grant.workspaceId,
+        async (scopedDb) =>
+          await scopedDb.execute(dbSql`
+          update session_system_updates
+          set state = 'delivered'
+          where workspace_id = ${grant.workspaceId}
+            and scheduled_task_run_id = ${pausedRun!.id}
+            and state = 'pending'
+        `),
+      ),
+    ).rejects.toMatchObject({ cause: { code: "42501" } });
     const pausedClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
       sessionId: first.sessionId,
       workflowId: first.workflowId,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -21,6 +21,7 @@ import {
   createDb,
   createFileUpload,
   createScheduledTask,
+  deleteScheduledTask,
   createSession,
   createSessionGoal,
   createVariableSet,
@@ -3574,6 +3575,284 @@ describe("worker activities integration", () => {
     const runs = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
     expect(runs).toHaveLength(2);
     expect(runs.every((run) => run.status === "dispatched")).toBe(true);
+  });
+
+  test("invalidates unclaimed scheduled occurrences across pause, resume, and deletion", async () => {
+    const grant = await testGrant(dbClient.db);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "scheduled-unclaimed-lifecycle",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "allow_concurrent",
+      agentConfig: {
+        prompt: "do not claim after lifecycle cutoff",
+        resources: [],
+        tools: [],
+        metadata: {},
+      },
+      metadata: {},
+    });
+    const activities = createWorkerActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ outputText: "must not run" }]),
+      }),
+    });
+
+    const first = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: `worker-activity-${crypto.randomUUID()}`,
+    });
+    if (first.action !== "start") throw new Error("pause fixture did not create its session");
+
+    await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { status: "paused" });
+    expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual([
+      expect.objectContaining({
+        status: "skipped",
+        error: "scheduled_task_paused_before_claim",
+      }),
+    ]);
+
+    await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { status: "active" });
+    const pausedClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: first.sessionId,
+      workflowId: first.workflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: `paused-claim-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    expect(pausedClaim).toEqual({ action: "unclaimed", reason: "no-work" });
+    expect(
+      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
+    ).toHaveLength(0);
+    expect(
+      await listSessionTurns(dbClient.db, grant.workspaceId, first.sessionId, 10),
+    ).toHaveLength(0);
+    expect(
+      (await listSessionEvents(dbClient.db, grant.workspaceId, first.sessionId, 0, 50)).some(
+        (event) =>
+          event.type === "system.update.cancelled" &&
+          event.payload.reason === "scheduled_task_inactive",
+      ),
+    ).toBe(true);
+
+    const second = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: `worker-activity-${crypto.randomUUID()}`,
+    });
+    expect(second).toMatchObject({ action: "signal", sessionId: first.sessionId });
+    await deleteScheduledTask(dbClient.db, grant.workspaceId, task.id);
+    const deletedClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: first.sessionId,
+      workflowId: first.workflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: `deleted-claim-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    expect(deletedClaim).toEqual({ action: "unclaimed", reason: "no-work" });
+    expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "skipped",
+          error: "scheduled_task_paused_before_claim",
+        }),
+        expect.objectContaining({
+          status: "skipped",
+          error: "scheduled_task_deleted_before_claim",
+        }),
+      ]),
+    );
+    expect(
+      await listSessionTurns(dbClient.db, grant.workspaceId, first.sessionId, 10),
+    ).toHaveLength(0);
+  });
+
+  test("preserves a claimed scheduled turn and its recovery after task deletion", async () => {
+    const grant = await testGrant(dbClient.db);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "scheduled-claimed-lifecycle",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "allow_concurrent",
+      agentConfig: {
+        prompt: "preserve claimed recovery",
+        resources: [],
+        tools: [],
+        metadata: {},
+      },
+      metadata: {},
+    });
+    const activities = createWorkerActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ outputText: "recovered" }]),
+      }),
+    });
+    const dispatched = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: `worker-activity-${crypto.randomUUID()}`,
+    });
+    if (dispatched.action !== "start") throw new Error("claim fixture did not create its session");
+    const attemptId = crypto.randomUUID();
+    const claimed = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: dispatched.sessionId,
+      workflowId: dispatched.workflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: `claimed-before-delete-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    if (claimed.action !== "claimed") throw new Error(`scheduled turn was not claimed`);
+
+    await deleteScheduledTask(dbClient.db, grant.workspaceId, task.id);
+    expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual([
+      expect.objectContaining({ status: "dispatched", error: null }),
+    ]);
+    expect(
+      await requestSessionTurnRecovery(dbClient.db, grant.workspaceId, {
+        sessionId: dispatched.sessionId,
+        turnId: claimed.turn.id,
+        triggerEventId: claimed.turn.triggerEventId,
+        attemptId,
+        reason: "worker_shutdown",
+      }),
+    ).toMatchObject({ action: "recovering" });
+    const recoveredAttemptId = crypto.randomUUID();
+    const recovered = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: dispatched.sessionId,
+      workflowId: dispatched.workflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: recoveredAttemptId,
+      dispatchId: `recovered-after-delete-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    expect(recovered).toMatchObject({
+      action: "claimed",
+      turn: {
+        id: claimed.turn.id,
+        activeAttemptId: recoveredAttemptId,
+        executionGeneration: claimed.turn.executionGeneration + 1,
+      },
+    });
+    expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual([
+      expect.objectContaining({ status: "dispatched", error: null }),
+    ]);
+  });
+
+  test("linearizes a concurrent scheduled claim ahead of task pause", async () => {
+    const grant = await testGrant(dbClient.db);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "scheduled-claim-pause-race",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "allow_concurrent",
+      agentConfig: {
+        prompt: "claim before pause",
+        resources: [],
+        tools: [],
+        metadata: {},
+      },
+      metadata: {},
+    });
+    const activities = createWorkerActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ outputText: "claimed" }]),
+      }),
+    });
+    const dispatched = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: `worker-activity-${crypto.randomUUID()}`,
+    });
+    if (dispatched.action !== "start") throw new Error("race fixture did not create its session");
+    const [run] = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
+    if (!run) throw new Error("race fixture did not create its run");
+
+    const blockerDb = createDb(services.databaseUrl);
+    let releaseRunLock = () => undefined;
+    const runLockReleased = new Promise<void>((resolve) => {
+      releaseRunLock = resolve;
+    });
+    let announceRunLock = () => undefined;
+    const runLocked = new Promise<void>((resolve) => {
+      announceRunLock = resolve;
+    });
+    const blocker = withWorkspaceRls(
+      blockerDb.db,
+      grant.workspaceId,
+      async (scopedDb) =>
+        await scopedDb.transaction(async (tx) => {
+          await tx.execute(dbSql`
+          select id from scheduled_task_runs
+          where workspace_id = ${grant.workspaceId} and id = ${run.id}
+          for update
+        `);
+          announceRunLock();
+          await runLockReleased;
+        }),
+    );
+    await runLocked;
+
+    const attemptId = crypto.randomUUID();
+    const claim = claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: dispatched.sessionId,
+      workflowId: dispatched.workflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: `claim-pause-race-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    let pause: ReturnType<typeof updateScheduledTask> | null = null;
+    try {
+      expect(
+        await Promise.race([
+          claim.then(() => "settled" as const),
+          Bun.sleep(100).then(() => "waiting" as const),
+        ]),
+      ).toBe("waiting");
+      pause = updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { status: "paused" });
+      expect(
+        await Promise.race([
+          pause.then(() => "settled" as const),
+          Bun.sleep(100).then(() => "waiting" as const),
+        ]),
+      ).toBe("waiting");
+    } finally {
+      releaseRunLock();
+      await blocker;
+      await blockerDb.close();
+    }
+    const [claimed, paused] = await Promise.all([claim, pause!]);
+    expect(claimed).toMatchObject({
+      action: "claimed",
+      turn: { activeAttemptId: attemptId },
+    });
+    expect(paused.status).toBe("paused");
+    expect(await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id)).toEqual([
+      expect.objectContaining({ status: "dispatched", error: null }),
+    ]);
   });
 
   test("skips reusable scheduled occurrences until the session returns idle", async () => {


### PR DESCRIPTION
## Summary
- make pause and soft-delete a durable first-claim cutoff for scheduled agent occurrences
- cancel terminalized pending occurrences at claim without relabeling them as authority failures
- preserve already-claimed scheduled turns and same-turn recovery
- cover pause/resume, deletion, recovery, and claim-versus-pause contention

## Verification
- targeted database and worker TypeScript projects
- migration schema contract, ordinal, RLS-backfill, and test-budget guards
- release schema contract and migration source tests
- worker activity integration tests for lifecycle invalidation and concurrency
- focused formatting and lint checks

## Deployment note
This rolling migration intentionally has no historical backlog backfill. Existing stale deposits should be reconciled through the deployment-specific operational cleanup path.

## Summary by Sourcery

Enforce a durable pause and deletion cutoff for unclaimed scheduled occurrences while preserving already-claimed turns and recovery.

Bug Fixes:
- Prevent paused or deleted scheduled tasks from allowing unclaimed occurrences to be delivered or claimed after the lifecycle cutoff.
- Cancel invalidated pending scheduled updates without treating them as scheduled-authority failures.
- Preserve scheduled turns that were already claimed, including their normal recovery behavior after task deletion.

Enhancements:
- Add database lifecycle fencing and locking to linearize scheduled claims against task pause or deletion.
- Document the durable first-claim cutoff semantics for scheduled task occurrences.

Deployment:
- Add a rolling migration that enforces the cutoff at the database boundary without backfilling historical stale deposits.

Documentation:
- Document pause and soft-delete behavior for unclaimed scheduled occurrences, including claim contention and recovery semantics.

Tests:
- Add migration and worker integration coverage for pause/resume, deletion, delivery fencing, claimed-turn recovery, and claim-versus-pause concurrency.
- Update release schema contracts for the new migration.