### PR TITLE
Fix workspace administration deletion follow-up

### DIFF
--- a/apps/web/src/components/settings/organization-workspace-administration.test.ts
+++ b/apps/web/src/components/settings/organization-workspace-administration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AccessContext } from "@/types";
+import { organizationAdministrationAccountIds } from "./organization-workspace-administration";
+
+function accessContext(): AccessContext {
+  return {
+    mode: "managed",
+    subjectId: "user:administrator",
+    accountGrants: [
+      {
+        accountId: "33333333-3333-4333-8333-333333333333",
+        subjectId: "user:administrator",
+        role: "member",
+        permissions: ["account:read"],
+      },
+      {
+        accountId: "22222222-2222-4222-8222-222222222222",
+        subjectId: "user:administrator",
+        role: "admin",
+        permissions: ["account:read", "members:manage", "workspace:create", "billing:read"],
+      },
+      {
+        accountId: "11111111-1111-4111-8111-111111111111",
+        subjectId: "user:administrator",
+        role: "owner",
+        permissions: ["account:admin"],
+      },
+      {
+        accountId: "44444444-4444-4444-8444-444444444444",
+        subjectId: "user:someone-else",
+        role: "owner",
+        permissions: ["account:admin"],
+      },
+    ],
+    workspaceGrants: [],
+    defaultAccountId: null,
+    defaultWorkspaceId: null,
+  };
+}
+
+describe("organization workspace administration authority", () => {
+  test("admits exact same-subject owner and admin roles without requiring account:admin", () => {
+    expect(organizationAdministrationAccountIds(accessContext())).toEqual([
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/organization-workspace-administration.tsx
+++ b/apps/web/src/components/settings/organization-workspace-administration.tsx
@@ -30,6 +30,17 @@ export function useOrganizationWorkspaceAdministration(): OrganizationWorkspaceA
   return useContext(OrganizationWorkspaceAdministrationContext);
 }
 
+export function organizationAdministrationAccountIds(accessContext: AccessContext): string[] {
+  return accessContext.accountGrants
+    .filter(
+      (grant) =>
+        grant.subjectId === accessContext.subjectId &&
+        (grant.role === "owner" || grant.role === "admin"),
+    )
+    .map((grant) => grant.accountId)
+    .sort();
+}
+
 export function OrganizationWorkspaceAdministrationBoundary(props: {
   client: OpenGeniBrowserClient;
   accessContext: AccessContext;
@@ -39,15 +50,7 @@ export function OrganizationWorkspaceAdministrationBoundary(props: {
   children: (administration: OrganizationWorkspaceAdministration) => ReactNode;
 }) {
   const organizationIds = useMemo(
-    () =>
-      props.accessContext.accountGrants
-        .filter(
-          (grant) =>
-            grant.subjectId === props.accessContext.subjectId &&
-            grant.permissions.includes("account:admin"),
-        )
-        .map((grant) => grant.accountId)
-        .sort(),
+    () => organizationAdministrationAccountIds(props.accessContext),
     [props.accessContext],
   );
   const authorityKey = `${props.accessKeyVersion}:${props.workspaceId}:${organizationIds.join(",")}`;

--- a/apps/web/src/lib/workspace-deletion.test.ts
+++ b/apps/web/src/lib/workspace-deletion.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { OpenGeniApiError } from "@opengeni/sdk/browser";
 
-import { deleteWorkspaceWithReconciliation } from "./workspace-deletion";
+import {
+  deleteOrganizationWorkspaceWithReconciliation,
+  deleteWorkspaceWithReconciliation,
+} from "./workspace-deletion";
 
 describe("workspace deletion reconciliation", () => {
   test("accepts direct success without a point read", async () => {
@@ -105,6 +108,95 @@ describe("workspace deletion reconciliation", () => {
         readWorkspace: async () => {
           throw new OpenGeniApiError(503, "unavailable");
         },
+      }),
+    ).rejects.toBe(mutationError);
+  });
+
+  test("accepts an authoritative null point read", async () => {
+    await expect(
+      deleteWorkspaceWithReconciliation({
+        deleteWorkspace: async () => {
+          throw new TypeError("network failed");
+        },
+        readWorkspace: async () => null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("reconciles organization-admin deletion through the administration overview", async () => {
+    const mutationError = new OpenGeniApiError(503, "unavailable", {
+      mutation: true,
+      outcomeUnknown: true,
+    });
+    let reads = 0;
+
+    await expect(
+      deleteOrganizationWorkspaceWithReconciliation({
+        client: {
+          deleteOrganizationWorkspace: async () => {
+            throw mutationError;
+          },
+          getOrganizationAdministrationOverview: async () => {
+            reads += 1;
+            return { workspaces: [{ id: "remaining-workspace" }] };
+          },
+        },
+        organizationId: "organization",
+        workspaceId: "deleted-workspace",
+      }),
+    ).resolves.toEqual({ workspaces: [{ id: "remaining-workspace" }] });
+    expect(reads).toBe(1);
+  });
+
+  test("returns a fresh organization overview after direct deletion success", async () => {
+    let reads = 0;
+
+    await expect(
+      deleteOrganizationWorkspaceWithReconciliation({
+        client: {
+          deleteOrganizationWorkspace: async () => {},
+          getOrganizationAdministrationOverview: async () => {
+            reads += 1;
+            return { workspaces: [{ id: "current-workspace" }] };
+          },
+        },
+        organizationId: "organization",
+        workspaceId: "deleted-workspace",
+      }),
+    ).resolves.toEqual({ workspaces: [{ id: "current-workspace" }] });
+    expect(reads).toBe(1);
+  });
+
+  test("keeps deletion successful when the post-delete overview refresh is unavailable", async () => {
+    await expect(
+      deleteOrganizationWorkspaceWithReconciliation({
+        client: {
+          deleteOrganizationWorkspace: async () => {},
+          getOrganizationAdministrationOverview: async () => {
+            throw new TypeError("network failed");
+          },
+        },
+        organizationId: "organization",
+        workspaceId: "deleted-workspace",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("preserves an unknown organization-admin outcome while the workspace still exists", async () => {
+    const mutationError = new TypeError("network failed");
+
+    await expect(
+      deleteOrganizationWorkspaceWithReconciliation({
+        client: {
+          deleteOrganizationWorkspace: async () => {
+            throw mutationError;
+          },
+          getOrganizationAdministrationOverview: async () => ({
+            workspaces: [{ id: "target-workspace" }],
+          }),
+        },
+        organizationId: "organization",
+        workspaceId: "target-workspace",
       }),
     ).rejects.toBe(mutationError);
   });

--- a/apps/web/src/lib/workspace-deletion.test.ts
+++ b/apps/web/src/lib/workspace-deletion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OpenGeniApiError } from "@opengeni/sdk/browser";
 
 import {
+  completeWorkspaceDeletionFollowUp,
   deleteOrganizationWorkspaceWithReconciliation,
   deleteWorkspaceWithReconciliation,
 } from "./workspace-deletion";
@@ -199,5 +200,35 @@ describe("workspace deletion reconciliation", () => {
         workspaceId: "target-workspace",
       }),
     ).rejects.toBe(mutationError);
+  });
+
+  test("keeps committed deletion successful when refresh fails and still attempts navigation", async () => {
+    const refreshError = new TypeError("refresh failed");
+    let navigated = false;
+
+    await expect(
+      completeWorkspaceDeletionFollowUp({
+        refreshAccess: async () => {
+          throw refreshError;
+        },
+        navigate: async () => {
+          navigated = true;
+        },
+      }),
+    ).resolves.toEqual({ status: "failed", error: refreshError });
+    expect(navigated).toBe(true);
+  });
+
+  test("reports a navigation failure without rejecting committed deletion", async () => {
+    const navigationError = new Error("navigation failed");
+
+    await expect(
+      completeWorkspaceDeletionFollowUp({
+        refreshAccess: async () => {},
+        navigate: async () => {
+          throw navigationError;
+        },
+      }),
+    ).resolves.toEqual({ status: "failed", error: navigationError });
   });
 });

--- a/apps/web/src/lib/workspace-deletion.ts
+++ b/apps/web/src/lib/workspace-deletion.ts
@@ -70,3 +70,29 @@ export async function deleteOrganizationWorkspaceWithReconciliation(input: {
     return null;
   }
 }
+
+/**
+ * Once deletion is authoritative, refresh and navigation are best-effort
+ * follow-up work. Attempt both, but never turn their failure into a mutation
+ * failure that invites the user to retry an already-committed deletion.
+ */
+export async function completeWorkspaceDeletionFollowUp(input: {
+  refreshAccess: () => Promise<void>;
+  navigate: () => Promise<void>;
+}): Promise<{ status: "completed" } | { status: "failed"; error: unknown }> {
+  let firstError: unknown;
+  let failed = false;
+  try {
+    await input.refreshAccess();
+  } catch (error) {
+    firstError = error;
+    failed = true;
+  }
+  try {
+    await input.navigate();
+  } catch (error) {
+    if (!failed) firstError = error;
+    failed = true;
+  }
+  return failed ? { status: "failed", error: firstError } : { status: "completed" };
+}

--- a/apps/web/src/lib/workspace-deletion.ts
+++ b/apps/web/src/lib/workspace-deletion.ts
@@ -11,7 +11,7 @@ function shouldReconcile(error: unknown): boolean {
  */
 export async function deleteWorkspaceWithReconciliation(input: {
   deleteWorkspace: () => Promise<void>;
-  readWorkspace: () => Promise<unknown>;
+  readWorkspace: () => Promise<unknown | null>;
 }): Promise<void> {
   try {
     await input.deleteWorkspace();
@@ -23,12 +23,50 @@ export async function deleteWorkspaceWithReconciliation(input: {
       throw mutationError;
     }
     try {
-      await input.readWorkspace();
+      const workspace = await input.readWorkspace();
+      if (workspace === null) {
+        return;
+      }
     } catch (readError) {
       if (readError instanceof OpenGeniApiError && readError.status === 404) {
         return;
       }
     }
     throw mutationError;
+  }
+}
+
+/** Reconcile organization-admin deletion through its content-blind overview. */
+export async function deleteOrganizationWorkspaceWithReconciliation(input: {
+  client: {
+    deleteOrganizationWorkspace: (organizationId: string, workspaceId: string) => Promise<void>;
+    getOrganizationAdministrationOverview: (
+      organizationId: string,
+    ) => Promise<{ workspaces: readonly { id: string }[] }>;
+  };
+  organizationId: string;
+  workspaceId: string;
+}): Promise<{ workspaces: readonly { id: string }[] } | null> {
+  let reconciledOverview: { workspaces: readonly { id: string }[] } | null = null;
+  await deleteWorkspaceWithReconciliation({
+    deleteWorkspace: async () =>
+      await input.client.deleteOrganizationWorkspace(input.organizationId, input.workspaceId),
+    readWorkspace: async () => {
+      const overview = await input.client.getOrganizationAdministrationOverview(
+        input.organizationId,
+      );
+      reconciledOverview = overview;
+      return overview.workspaces.find((workspace) => workspace.id === input.workspaceId) ?? null;
+    },
+  });
+  if (reconciledOverview) {
+    return reconciledOverview;
+  }
+  try {
+    return await input.client.getOrganizationAdministrationOverview(input.organizationId);
+  } catch {
+    // Deletion already succeeded (or was authoritatively absent). A failed
+    // navigation refresh must not turn that irreversible result into an error.
+    return null;
   }
 }

--- a/apps/web/src/routes/workspace-settings-deletion.test.tsx
+++ b/apps/web/src/routes/workspace-settings-deletion.test.tsx
@@ -46,6 +46,7 @@ async function setInputValue(input: HTMLInputElement, value: string): Promise<vo
 describe("workspace deletion confirmation", () => {
   test("reconciles organization-admin deletion and stays in its manageable workspace roster", () => {
     expect(workspaceSettingsSource).toContain("deleteOrganizationWorkspaceWithReconciliation({");
+    expect(workspaceSettingsSource).toContain("completeWorkspaceDeletionFollowUp({");
     expect(workspaceSettingsSource).toContain(
       "currentOverview?.workspaces.find((candidate) => candidate.id !== workspace.id) ?? null;",
     );
@@ -96,6 +97,42 @@ describe("workspace deletion confirmation", () => {
       expect(form.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(false);
     } finally {
       pending.resolve(false);
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("closes the confirmation after committed deletion even when the route stays mounted", async () => {
+    const onDelete = mock(async () => true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <DangerZone
+            workspaceName="Workspace A"
+            canDelete
+            isOnlyWorkspaceInAccount={false}
+            onDelete={onDelete}
+          />,
+        );
+      });
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>("button")!.click();
+      });
+      const input = document.body.querySelector<HTMLInputElement>("#confirm-workspace-name")!;
+      await setInputValue(input, "Workspace A");
+      await act(async () => {
+        input.closest("form")!.requestSubmit();
+        await Promise.resolve();
+      });
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+      expect(document.body.querySelector("#confirm-workspace-name")).toBeNull();
+      expect(container.querySelector<HTMLButtonElement>("button")?.disabled).toBe(false);
+    } finally {
       await act(async () => root.unmount());
       container.remove();
     }

--- a/apps/web/src/routes/workspace-settings-deletion.test.tsx
+++ b/apps/web/src/routes/workspace-settings-deletion.test.tsx
@@ -13,6 +13,9 @@ afterAll(() => {
 });
 
 const { DangerZone } = await import("./workspace-settings");
+const workspaceSettingsSource = await Bun.file(
+  new URL("./workspace-settings.tsx", import.meta.url),
+).text();
 
 function deferred<Value>() {
   let resolve!: (value: Value | PromiseLike<Value>) => void;
@@ -41,6 +44,16 @@ async function setInputValue(input: HTMLInputElement, value: string): Promise<vo
 }
 
 describe("workspace deletion confirmation", () => {
+  test("reconciles organization-admin deletion and stays in its manageable workspace roster", () => {
+    expect(workspaceSettingsSource).toContain("deleteOrganizationWorkspaceWithReconciliation({");
+    expect(workspaceSettingsSource).toContain(
+      "currentOverview?.workspaces.find((candidate) => candidate.id !== workspace.id) ?? null;",
+    );
+    expect(workspaceSettingsSource).not.toContain(
+      "context.workspaces.find((candidate) => candidate.accountId === organizationId)",
+    );
+  });
+
   test("submits only once while a deletion request is pending", async () => {
     const pending = deferred<boolean>();
     const onDelete = mock(() => pending.promise);

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -65,6 +65,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAppContext } from "@/context";
 import { orgLabel } from "@/lib/org";
 import { isPersonalWorkspace } from "@/lib/managed-self-context";
+import { deleteOrganizationWorkspaceWithReconciliation } from "@/lib/workspace-deletion";
 import {
   apiKeyPermissionGroups,
   defaultApiKeyPermissions,
@@ -977,9 +978,14 @@ function OrganizationManagedWorkspaceSettings({
   async function deleteWorkspace(): Promise<boolean> {
     setBusy(true);
     try {
-      await context.client.deleteOrganizationWorkspace(organizationId, workspace.id);
+      const currentOverview = await deleteOrganizationWorkspaceWithReconciliation({
+        client: context.client,
+        organizationId,
+        workspaceId: workspace.id,
+      });
       await context.revalidatePrincipalAccess();
-      const next = context.workspaces.find((candidate) => candidate.accountId === organizationId);
+      const next =
+        currentOverview?.workspaces.find((candidate) => candidate.id !== workspace.id) ?? null;
       if (next) {
         await navigate({
           to: "/workspaces/$workspaceId/organization",

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -65,7 +65,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAppContext } from "@/context";
 import { orgLabel } from "@/lib/org";
 import { isPersonalWorkspace } from "@/lib/managed-self-context";
-import { deleteOrganizationWorkspaceWithReconciliation } from "@/lib/workspace-deletion";
+import {
+  completeWorkspaceDeletionFollowUp,
+  deleteOrganizationWorkspaceWithReconciliation,
+} from "@/lib/workspace-deletion";
 import {
   apiKeyPermissionGroups,
   defaultApiKeyPermissions,
@@ -983,18 +986,29 @@ function OrganizationManagedWorkspaceSettings({
         organizationId,
         workspaceId: workspace.id,
       });
-      await context.revalidatePrincipalAccess();
       const next =
         currentOverview?.workspaces.find((candidate) => candidate.id !== workspace.id) ?? null;
-      if (next) {
-        await navigate({
-          to: "/workspaces/$workspaceId/organization",
-          params: { workspaceId: next.id },
-          search: { section: "overview" },
-          replace: true,
+      const followUp = await completeWorkspaceDeletionFollowUp({
+        refreshAccess: async () => await context.revalidatePrincipalAccess(),
+        navigate: async () => {
+          if (next) {
+            await navigate({
+              to: "/workspaces/$workspaceId/organization",
+              params: { workspaceId: next.id },
+              search: { section: "overview" },
+              replace: true,
+            });
+          } else {
+            await navigate({ to: "/", replace: true });
+          }
+        },
+      });
+      if (followUp.status === "failed") {
+        toast.warning("Workspace deleted, but the page may be out of date", {
+          description: `${
+            followUp.error instanceof Error ? followUp.error.message : String(followUp.error)
+          }. Reload to refresh your workspace access.`,
         });
-      } else {
-        await navigate({ to: "/", replace: true });
       }
       return true;
     } catch (error) {
@@ -1348,12 +1362,25 @@ export function DangerZone(props: {
     }
     deleteInFlight.current = true;
     setBusy(true);
-    // onDelete (context.deleteWorkspace) surfaces its own error toast; on
-    // success it navigates away, unmounting this dialog.
-    const ok = await props.onDelete();
-    if (ok) {
-      toast.success("Workspace deleted");
-    } else {
+    // onDelete surfaces expected mutation errors. Close explicitly on success
+    // because a best-effort post-delete navigation can leave this route mounted.
+    try {
+      const ok = await props.onDelete();
+      if (ok) {
+        toast.success("Workspace deleted");
+        deleteInFlight.current = false;
+        setBusy(false);
+        setOpen(false);
+        setConfirmName("");
+      }
+      if (!ok) {
+        deleteInFlight.current = false;
+        setBusy(false);
+      }
+    } catch (error) {
+      toast.error("Couldn't finish workspace deletion", {
+        description: error instanceof Error ? error.message : String(error),
+      });
       deleteInFlight.current = false;
       setBusy(false);
     }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3156,6 +3156,24 @@ async function lockBackgroundCommandWorkspaceLifecycle(
   }
 }
 
+async function authorizeOrganizationWorkspaceDeletion(
+  tx: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    subjectId: string;
+  },
+): Promise<void> {
+  await setSubjectRlsContext(tx, input.subjectId);
+  await tx.execute(sql`
+    select authorize_organization_shared_workspace_administration(
+      ${input.accountId}::uuid,
+      ${input.workspaceId}::uuid,
+      ${input.subjectId}
+    )
+  `);
+}
+
 /**
  * Atomically prove a workspace has no live runtime ownership and delete it.
  *
@@ -3176,6 +3194,24 @@ export async function deleteWorkspaceIfQuiescent(
 ): Promise<DeleteWorkspaceIfQuiescentResult> {
   const transactionStartedAt = performance.now();
   try {
+    if (input.organizationAdministratorSubjectId) {
+      // Reject a clearly unauthorized caller before it can acquire or wait on
+      // the exclusive workspace lifecycle lock. This preflight is deliberately
+      // not the mutation authority: the deletion transaction repeats the same
+      // check after taking the lifecycle lock so a concurrent demotion still
+      // fails closed without reintroducing the account/lifecycle lock cycle.
+      await withRlsContext(
+        db,
+        { accountId: input.accountId, workspaceId: input.workspaceId },
+        async (scopedDb) =>
+          await authorizeOrganizationWorkspaceDeletion(scopedDb, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            subjectId: input.organizationAdministratorSubjectId!,
+          }),
+      );
+    }
+
     const result = await withRlsContext(
       db,
       { accountId: input.accountId, workspaceId: input.workspaceId },
@@ -3198,14 +3234,11 @@ export async function deleteWorkspaceIfQuiescent(
           });
 
           if (input.organizationAdministratorSubjectId) {
-            await setSubjectRlsContext(tx, input.organizationAdministratorSubjectId);
-            await tx.execute(sql`
-              select authorize_organization_shared_workspace_administration(
-                ${input.accountId}::uuid,
-                ${input.workspaceId}::uuid,
-                ${input.organizationAdministratorSubjectId}
-              )
-            `);
+            await authorizeOrganizationWorkspaceDeletion(tx, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              subjectId: input.organizationAdministratorSubjectId,
+            });
           }
 
           const accountWorkspaceLockStartedAt = performance.now();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3182,6 +3182,21 @@ export async function deleteWorkspaceIfQuiescent(
       async (scopedDb) =>
         await scopedDb.transaction(async (txRaw) => {
           const tx = txRaw as unknown as Database;
+          // Adoption takes the matching shared prefix before its canonical
+          // session/attempt or retained-process locks. Taking the exclusive
+          // prefix first prevents parent-FK deletion from deadlocking with an
+          // already-started cross-workspace adoption. It must also precede the
+          // organization-administration seam: that seam takes the account row
+          // FOR KEY SHARE, while ordinary deletion takes this lifecycle lock
+          // before upgrading the account row to FOR UPDATE.
+          const lifecycleLockStartedAt = performance.now();
+          await lockBackgroundCommandWorkspaceLifecycle(tx, [input.workspaceId], "update");
+          observeWorkspaceDeletePhase(input.observer, {
+            phase: "lifecycle_lock",
+            outcome: "ok",
+            durationSeconds: workspaceDeletePhaseDuration(lifecycleLockStartedAt),
+          });
+
           if (input.organizationAdministratorSubjectId) {
             await setSubjectRlsContext(tx, input.organizationAdministratorSubjectId);
             await tx.execute(sql`
@@ -3192,17 +3207,6 @@ export async function deleteWorkspaceIfQuiescent(
               )
             `);
           }
-          // Adoption takes the matching shared prefix before its canonical
-          // session/attempt or retained-process locks. Taking the exclusive
-          // prefix first prevents parent-FK deletion from deadlocking with an
-          // already-started cross-workspace adoption.
-          const lifecycleLockStartedAt = performance.now();
-          await lockBackgroundCommandWorkspaceLifecycle(tx, [input.workspaceId], "update");
-          observeWorkspaceDeletePhase(input.observer, {
-            phase: "lifecycle_lock",
-            outcome: "ok",
-            durationSeconds: workspaceDeletePhaseDuration(lifecycleLockStartedAt),
-          });
 
           const accountWorkspaceLockStartedAt = performance.now();
           const [account] = await tx

--- a/packages/db/test/workspace-deletion-lock-order.test.ts
+++ b/packages/db/test/workspace-deletion-lock-order.test.ts
@@ -5,15 +5,17 @@ const functionStart = source.indexOf("export async function deleteWorkspaceIfQui
 const functionEnd = source.indexOf("\nexport async function ", functionStart + 1);
 const deletionSource = source.slice(functionStart, functionEnd);
 
-test("takes the deletion lifecycle lock before organization authorization", () => {
+test("preauthorizes before the lifecycle lock and reauthorizes after it", () => {
   expect(functionStart).toBeGreaterThanOrEqual(0);
-  expect(deletionSource.indexOf("await lockBackgroundCommandWorkspaceLifecycle(")).toBeGreaterThan(
-    -1,
+  const preflightAuthorization = deletionSource.indexOf(
+    "await authorizeOrganizationWorkspaceDeletion(",
   );
-  expect(
-    deletionSource.indexOf("authorize_organization_shared_workspace_administration("),
-  ).toBeGreaterThan(-1);
-  expect(deletionSource.indexOf("await lockBackgroundCommandWorkspaceLifecycle(")).toBeLessThan(
-    deletionSource.indexOf("authorize_organization_shared_workspace_administration("),
+  const lifecycleLock = deletionSource.indexOf("await lockBackgroundCommandWorkspaceLifecycle(");
+  const authoritativeAuthorization = deletionSource.indexOf(
+    "await authorizeOrganizationWorkspaceDeletion(",
+    preflightAuthorization + 1,
   );
+  expect(preflightAuthorization).toBeGreaterThan(-1);
+  expect(lifecycleLock).toBeGreaterThan(preflightAuthorization);
+  expect(authoritativeAuthorization).toBeGreaterThan(lifecycleLock);
 });

--- a/packages/db/test/workspace-deletion-lock-order.test.ts
+++ b/packages/db/test/workspace-deletion-lock-order.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("../src/index.ts", import.meta.url)).text();
+const functionStart = source.indexOf("export async function deleteWorkspaceIfQuiescent(");
+const functionEnd = source.indexOf("\nexport async function ", functionStart + 1);
+const deletionSource = source.slice(functionStart, functionEnd);
+
+test("takes the deletion lifecycle lock before organization authorization", () => {
+  expect(functionStart).toBeGreaterThanOrEqual(0);
+  expect(deletionSource.indexOf("await lockBackgroundCommandWorkspaceLifecycle(")).toBeGreaterThan(
+    -1,
+  );
+  expect(
+    deletionSource.indexOf("authorize_organization_shared_workspace_administration("),
+  ).toBeGreaterThan(-1);
+  expect(deletionSource.indexOf("await lockBackgroundCommandWorkspaceLifecycle(")).toBeLessThan(
+    deletionSource.indexOf("authorize_organization_shared_workspace_administration("),
+  );
+});


### PR DESCRIPTION
## Summary

- prevent mixed ordinary and organization-admin workspace deletion requests from acquiring the account and lifecycle locks in opposite order
- reconcile outcome-unknown organization-admin deletions through the content-blind organization overview
- keep post-delete navigation inside the remaining organization-managed workspace roster
- admit exact same-subject organization owners and administrators to the management-only workspace boundary without requiring the owner-only `account:admin` permission

## Testing

- web, database, API, and SDK typechecks
- 117 focused API, SDK, web, release-contract, authority, and deletion tests
- real-PostgreSQL migration 0350 and 0398 tests
- migration ordinal and schema-contract checks
- full formatter and lint checks

## Review provenance

This follow-up resulted from the `Bendik PR review and merge` scheduled task after PR #2163 was merged while its independent review was still running.

## Remaining design follow-up

Organization-admin workspace deletion still has no caller-supplied operation ID or durable actor-attributed deletion receipt. This PR intentionally does not invent that broader schema/rollout design; it should be resolved before treating the destructive path as fully audited and replayable.

## Summary by Sourcery

Make organization-admin workspace deletion safe to reconcile, resilient after commit, and consistent with workspace administration authority and lock ordering.

Bug Fixes:
- Prevent deadlocks between ordinary and organization-admin workspace deletion requests by enforcing a consistent lock order while retaining authoritative authorization checks.
- Reconcile uncertain organization-admin deletions through the organization workspace overview and preserve committed deletions when refresh or navigation fails.
- Keep post-deletion navigation within the remaining organization-managed workspaces and close the confirmation dialog after successful deletion.

Enhancements:
- Allow exact-subject organization owners and administrators to access workspace administration without requiring the owner-only account:admin permission.

Tests:
- Add coverage for deletion reconciliation, post-delete follow-up behavior, administration authority, navigation behavior, and database lock ordering.