### PR TITLE
Let managed users create additional organizations

### DIFF
--- a/.changeset/clean-multi-organization-creation.md
+++ b/.changeset/clean-multi-organization-creation.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/sdk": patch
+---
+
+Add the managed-human API, SDK, and atomic tenant lifecycle for creating additional organizations with an isolated Personal workspace and a first shared team workspace.

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Core endpoints:
 - `GET /v1/config/client`
 - `GET /v1/access/me`
 - `GET /v1/organization-memberships` (managed-human self membership and personal-workspace identity)
+- `POST /v1/organizations/additional` (managed-human creation of another isolated organization with its first shared workspace)
 - bounded/keyset `GET /v1/organization-invitations` and exact subject-bound
   `POST /v1/organization-invitations/:id/accept`
 - `GET|POST /v1/organizations/:id/invitations` for bounded admin listing and

--- a/apps/api/src/routes/organization-memberships.ts
+++ b/apps/api/src/routes/organization-memberships.ts
@@ -142,8 +142,14 @@ function parseId(schema: z.ZodString, value: string, label: string): string {
   return parsed.data;
 }
 
-function rethrowMembershipError(error: unknown): never {
-  const status = organizationMembershipHttpStatus(nestedPostgresSqlState(error));
+function rethrowMembershipError(error: unknown, resourceLimitMessage?: string): never {
+  const sqlState = nestedPostgresSqlState(error);
+  if (sqlState === "54000" && resourceLimitMessage) {
+    throw new HTTPException(409, {
+      message: resourceLimitMessage,
+    });
+  }
+  const status = organizationMembershipHttpStatus(sqlState);
   if (status !== null) {
     throw new HTTPException(status, {
       message:
@@ -194,7 +200,7 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
         201,
       );
     } catch (error) {
-      rethrowMembershipError(error);
+      rethrowMembershipError(error, "additional organization limit reached");
     }
   });
 

--- a/apps/api/src/routes/organization-memberships.ts
+++ b/apps/api/src/routes/organization-memberships.ts
@@ -1,5 +1,7 @@
 import {
   AcceptOrganizationInvitationRequest,
+  CreateAdditionalOrganizationRequest,
+  CreateAdditionalOrganizationResponse,
   CreateOrganizationRequest,
   CreateOrganizationResponse,
   CreateOrganizationWorkspaceRequest,
@@ -40,6 +42,7 @@ import {
   acceptOrganizationInvitation,
   bindPendingOrganizationInvitationsForVerifiedEmail,
   claimOrganizationUserSetupDelivery,
+  createAdditionalManagedOrganization,
   createManagedOrganization,
   createOrganizationWorkspace,
   createOrganizationInvitation,
@@ -118,7 +121,9 @@ async function requireOrganizationAdministrator(
     );
     return { subjectId };
   }
-  throw new HTTPException(401, { message: "organization administrator session required" });
+  throw new HTTPException(401, {
+    message: "organization administrator session required",
+  });
 }
 
 async function parseBody<S extends z.ZodType>(context: Context, schema: S): Promise<z.infer<S>> {
@@ -162,6 +167,25 @@ export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDe
       return context.json(
         CreateOrganizationResponse.parse(
           await createManagedOrganization(deps.db, {
+            subjectId,
+            subjectLabel: session.user.email || session.user.name,
+            ...payload,
+          }),
+        ),
+        201,
+      );
+    } catch (error) {
+      rethrowMembershipError(error);
+    }
+  });
+
+  app.post("/v1/organizations/additional", async (context) => {
+    const { session, subjectId } = await requireManagedHuman(context, deps);
+    const payload = await parseBody(context, CreateAdditionalOrganizationRequest);
+    try {
+      return context.json(
+        CreateAdditionalOrganizationResponse.parse(
+          await createAdditionalManagedOrganization(deps.db, {
             subjectId,
             subjectLabel: session.user.email || session.user.name,
             ...payload,

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -3,6 +3,7 @@ import type { ApiRouteDeps, ManagedEmailDeliveryResult, ManagedEmailMessage } fr
 import {
   bootstrapWorkspace,
   claimOrganizationUserSetupDelivery,
+  completeSelfServiceOrganizationSetup,
   createDb,
   createOrganizationInvitation,
   ensureManagedAccessForUserWithOrganizationMemberships,
@@ -218,6 +219,13 @@ describe("organization membership routes", () => {
       managedAuth: null,
     } as ApiRouteDeps);
     expect((await configured.request("http://x/v1/organization-memberships")).status).toBe(401);
+    expect(
+      (
+        await configured.request("http://x/v1/organizations/additional", {
+          method: "POST",
+        })
+      ).status,
+    ).toBe(401);
 
     const delegated = new Hono();
     registerOrganizationMembershipRoutes(delegated, {
@@ -228,6 +236,17 @@ describe("organization membership routes", () => {
     expect(
       (
         await delegated.request("http://x/v1/organization-memberships", {
+          headers: {
+            authorization: "Bearer delegated",
+            cookie: "session=present",
+          },
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await delegated.request("http://x/v1/organizations/additional", {
+          method: "POST",
           headers: {
             authorization: "Bearer delegated",
             cookie: "session=present",
@@ -1386,6 +1405,110 @@ describe("organization membership routes", () => {
       select count(*)::int as count from organization_membership_invitations
       where target_email = ${targetEmail}`;
     expect(committed?.count).toBe(0);
+  });
+
+  test("creates another organization for the same authenticated human", async () => {
+    if (!shared || !client) return;
+    const additionalUserId = `additional-organization-${crypto.randomUUID()}`;
+    const additionalSubjectId = `user:${additionalUserId}`;
+    const additionalSessionId = `session-${crypto.randomUUID()}`;
+    const additionalEmail = `${additionalUserId}@example.test`;
+    await shared.admin`
+      insert into auth_users (id, name, email, email_verified)
+      values (${additionalUserId}, 'Additional owner', ${additionalEmail}, true)`;
+    await completeSelfServiceOrganizationSetup(client.db, {
+      authUserId: additionalUserId,
+      actorSubjectId: additionalSubjectId,
+      organizationName: "Original organization",
+      operationId: crypto.randomUUID(),
+      requestFingerprint: "b".repeat(64),
+    });
+    await shared.admin`
+      insert into auth_identities (id, user_id, provider_id, account_id)
+      values (${crypto.randomUUID()}, ${additionalUserId}, 'credential', ${additionalUserId})`;
+    const identity = await synchronizeCanonicalHumanLoginBindings(client.db, additionalUserId);
+    await shared.admin`
+      insert into auth_sessions (
+        id, user_id, token, expires_at,
+        identity_id, identity_revision, auth_revision
+      ) values (
+        ${additionalSessionId}, ${additionalUserId}, ${crypto.randomUUID()}, now() + interval '1 hour',
+        ${identity.identityId}, ${identity.identityRevision}, ${identity.authRevision}
+      )`;
+
+    const additionalApp = new Hono();
+    registerOrganizationMembershipRoutes(additionalApp, {
+      db: client.db,
+      settings: managedSettings,
+      managedAuth: {
+        api: {
+          getSession: async () => ({
+            headers: new Headers(),
+            response: {
+              session: { id: additionalSessionId },
+              user: {
+                id: additionalUserId,
+                email: additionalEmail,
+                name: "Additional owner",
+                emailVerified: true,
+              },
+            },
+          }),
+        },
+      } as never,
+      managedEmailTransport,
+    } as ApiRouteDeps);
+
+    const request = {
+      name: "New team",
+      workspaceName: "General",
+      operationId: crypto.randomUUID(),
+    };
+    const response = await additionalApp.request("http://x/v1/organizations/additional", {
+      method: "POST",
+      headers: { cookie: "session=present", "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    expect(response.status).toBe(201);
+    const created = (await response.json()) as {
+      organization: { id: string; name: string };
+      workspaceId: string;
+      personalWorkspaceId: string;
+    };
+    expect(created).toMatchObject({ organization: { name: "New team" } });
+    expect(created.workspaceId).not.toBe(created.personalWorkspaceId);
+
+    const replay = await additionalApp.request("http://x/v1/organizations/additional", {
+      method: "POST",
+      headers: { cookie: "session=present", "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    expect(replay.status).toBe(201);
+    expect(await replay.json()).toEqual(created);
+
+    const malformed = await additionalApp.request("http://x/v1/organizations/additional", {
+      method: "POST",
+      headers: { cookie: "session=present", "content-type": "application/json" },
+      body: JSON.stringify({ ...request, operationId: crypto.randomUUID(), unexpected: true }),
+    });
+    expect(malformed.status).toBe(422);
+
+    const [graph] = await shared.admin<
+      Array<{ memberships: number; workspaces: number; access: number }>
+    >`
+      select
+        (select count(*)::int from organization_memberships
+          where account_id = ${created.organization.id}
+            and subject_id = ${additionalSubjectId}
+            and role = 'owner' and status = 'active') as memberships,
+        (select count(*)::int from workspaces
+          where account_id = ${created.organization.id}) as workspaces,
+        (select count(*)::int from workspace_memberships
+          where account_id = ${created.organization.id}
+            and workspace_id = ${created.workspaceId}
+            and subject_id = ${additionalSubjectId}
+            and role = 'admin') as access`;
+    expect(graph).toEqual({ memberships: 1, workspaces: 2, access: 1 });
   });
 
   test("returns only the current active membership and reports terminal state as empty", async () => {

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -1493,6 +1493,30 @@ describe("organization membership routes", () => {
     });
     expect(malformed.status).toBe(422);
 
+    for (let index = 2; index <= 10; index += 1) {
+      const withinLimit = await additionalApp.request("http://x/v1/organizations/additional", {
+        method: "POST",
+        headers: { cookie: "session=present", "content-type": "application/json" },
+        body: JSON.stringify({
+          name: `Additional team ${index}`,
+          workspaceName: `Workspace ${index}`,
+          operationId: crypto.randomUUID(),
+        }),
+      });
+      expect(withinLimit.status).toBe(201);
+    }
+    const overLimit = await additionalApp.request("http://x/v1/organizations/additional", {
+      method: "POST",
+      headers: { cookie: "session=present", "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "One too many",
+        workspaceName: "Overflow",
+        operationId: crypto.randomUUID(),
+      }),
+    });
+    expect(overLimit.status).toBe(409);
+    expect(await overLimit.text()).toBe("additional organization limit reached");
+
     const [graph] = await shared.admin<
       Array<{ memberships: number; workspaces: number; access: number }>
     >`

--- a/apps/web/src/components/rail/create-organization-dialog.tsx
+++ b/apps/web/src/components/rail/create-organization-dialog.tsx
@@ -24,6 +24,7 @@ type CreateOrganizationFormProps = {
   organizationName: string;
   workspaceName: string;
   busy: boolean;
+  committed?: boolean;
   onOrganizationNameChange: (name: string) => void;
   onWorkspaceNameChange: (name: string) => void;
   onCancel: () => void;
@@ -60,6 +61,7 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
             onChange={(event) => props.onOrganizationNameChange(event.target.value)}
             placeholder="Acme"
             maxLength={120}
+            disabled={props.committed}
             autoFocus
           />
         </div>
@@ -71,6 +73,7 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
             onChange={(event) => props.onWorkspaceNameChange(event.target.value)}
             placeholder="General"
             maxLength={120}
+            disabled={props.committed}
           />
           <p className="text-xs text-fg-subtle">
             Your team can start working here. You can add more workspaces later.
@@ -101,18 +104,21 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
 
       <DialogFooter className="mt-5">
         <Button type="button" variant="ghost" disabled={props.busy} onClick={props.onCancel}>
-          Cancel
+          {props.committed ? "Close" : "Cancel"}
         </Button>
         <Button
           type="submit"
-          disabled={props.busy || !props.organizationName.trim() || !props.workspaceName.trim()}
+          disabled={
+            props.busy ||
+            (!props.committed && (!props.organizationName.trim() || !props.workspaceName.trim()))
+          }
         >
           {props.busy ? (
             <Loader2Icon aria-hidden="true" className="size-4 animate-spin" />
           ) : (
             <CheckIcon aria-hidden="true" className="size-4" />
           )}
-          Create organization
+          {props.committed ? "Try opening again" : "Create organization"}
         </Button>
       </DialogFooter>
     </form>
@@ -132,9 +138,13 @@ export function CreateOrganizationDialog(
           {...props}
           header={
             <DialogHeader>
-              <DialogTitle>New organization</DialogTitle>
+              <DialogTitle>
+                {props.committed ? `${props.organizationName} was created` : "New organization"}
+              </DialogTitle>
               <DialogDescription>
-                Create a separate home for another team, with its own members, workspaces, and data.
+                {props.committed
+                  ? "Try again to refresh your access and open the new organization. This will not create another one."
+                  : "Create a separate home for another team, with its own members, workspaces, and data."}
               </DialogDescription>
             </DialogHeader>
           }

--- a/apps/web/src/components/rail/create-organization-dialog.tsx
+++ b/apps/web/src/components/rail/create-organization-dialog.tsx
@@ -24,7 +24,7 @@ type CreateOrganizationFormProps = {
   organizationName: string;
   workspaceName: string;
   busy: boolean;
-  committed?: boolean;
+  creationState?: "draft" | "uncertain" | "committed";
   onOrganizationNameChange: (name: string) => void;
   onWorkspaceNameChange: (name: string) => void;
   onCancel: () => void;
@@ -35,6 +35,8 @@ type CreateOrganizationFormProps = {
 export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
   const organizationName = props.organizationName.trim() || "Your organization";
   const workspaceName = props.workspaceName.trim() || "First shared workspace";
+  const creationState = props.creationState ?? "draft";
+  const requestLocked = creationState !== "draft";
 
   return (
     <form
@@ -61,7 +63,7 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
             onChange={(event) => props.onOrganizationNameChange(event.target.value)}
             placeholder="Acme"
             maxLength={120}
-            disabled={props.committed}
+            disabled={requestLocked}
             autoFocus
           />
         </div>
@@ -73,7 +75,7 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
             onChange={(event) => props.onWorkspaceNameChange(event.target.value)}
             placeholder="General"
             maxLength={120}
-            disabled={props.committed}
+            disabled={requestLocked}
           />
           <p className="text-xs text-fg-subtle">
             Your team can start working here. You can add more workspaces later.
@@ -104,13 +106,13 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
 
       <DialogFooter className="mt-5">
         <Button type="button" variant="ghost" disabled={props.busy} onClick={props.onCancel}>
-          {props.committed ? "Close" : "Cancel"}
+          {requestLocked ? "Close" : "Cancel"}
         </Button>
         <Button
           type="submit"
           disabled={
             props.busy ||
-            (!props.committed && (!props.organizationName.trim() || !props.workspaceName.trim()))
+            (!requestLocked && (!props.organizationName.trim() || !props.workspaceName.trim()))
           }
         >
           {props.busy ? (
@@ -118,7 +120,11 @@ export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
           ) : (
             <CheckIcon aria-hidden="true" className="size-4" />
           )}
-          {props.committed ? "Try opening again" : "Create organization"}
+          {creationState === "committed"
+            ? "Try opening again"
+            : creationState === "uncertain"
+              ? "Check creation again"
+              : "Create organization"}
         </Button>
       </DialogFooter>
     </form>
@@ -131,6 +137,7 @@ export function CreateOrganizationDialog(
     onOpenChange: (open: boolean) => void;
   },
 ) {
+  const creationState = props.creationState ?? "draft";
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -139,12 +146,18 @@ export function CreateOrganizationDialog(
           header={
             <DialogHeader>
               <DialogTitle>
-                {props.committed ? `${props.organizationName} was created` : "New organization"}
+                {creationState === "committed"
+                  ? `${props.organizationName} was created`
+                  : creationState === "uncertain"
+                    ? "Confirm organization creation"
+                    : "New organization"}
               </DialogTitle>
               <DialogDescription>
-                {props.committed
+                {creationState === "committed"
                   ? "Try again to refresh your access and open the new organization. This will not create another one."
-                  : "Create a separate home for another team, with its own members, workspaces, and data."}
+                  : creationState === "uncertain"
+                    ? "OpenGeni could not confirm the result. Try again to safely replay this exact request without creating a duplicate."
+                    : "Create a separate home for another team, with its own members, workspaces, and data."}
               </DialogDescription>
             </DialogHeader>
           }

--- a/apps/web/src/components/rail/create-organization-dialog.tsx
+++ b/apps/web/src/components/rail/create-organization-dialog.tsx
@@ -1,0 +1,146 @@
+import {
+  ArrowRightIcon,
+  Building2Icon,
+  CheckIcon,
+  Loader2Icon,
+  PanelsTopLeftIcon,
+  ShieldCheckIcon,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type CreateOrganizationFormProps = {
+  organizationName: string;
+  workspaceName: string;
+  busy: boolean;
+  onOrganizationNameChange: (name: string) => void;
+  onWorkspaceNameChange: (name: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  header?: ReactNode;
+};
+
+export function CreateOrganizationForm(props: CreateOrganizationFormProps) {
+  const organizationName = props.organizationName.trim() || "Your organization";
+  const workspaceName = props.workspaceName.trim() || "First shared workspace";
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        props.onSubmit();
+      }}
+    >
+      {props.header ?? (
+        <DialogHeader>
+          <h2 className="text-lg leading-none font-semibold">New organization</h2>
+          <p className="text-sm text-muted-foreground">
+            Create a separate home for another team, with its own members, workspaces, and data.
+          </p>
+        </DialogHeader>
+      )}
+
+      <div className="mt-5 grid gap-4">
+        <div className="grid gap-1.5">
+          <Label htmlFor="new-organization-name">Organization name</Label>
+          <Input
+            id="new-organization-name"
+            value={props.organizationName}
+            onChange={(event) => props.onOrganizationNameChange(event.target.value)}
+            placeholder="Acme"
+            maxLength={120}
+            autoFocus
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="new-organization-workspace-name">First shared workspace</Label>
+          <Input
+            id="new-organization-workspace-name"
+            value={props.workspaceName}
+            onChange={(event) => props.onWorkspaceNameChange(event.target.value)}
+            placeholder="General"
+            maxLength={120}
+          />
+          <p className="text-xs text-fg-subtle">
+            Your team can start working here. You can add more workspaces later.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface-2/45 p-3.5">
+          <div className="flex items-center gap-2.5 text-sm">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-bg text-fg-muted">
+              <Building2Icon aria-hidden="true" className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1 truncate font-medium">{organizationName}</span>
+            <ArrowRightIcon aria-hidden="true" className="size-3.5 shrink-0 text-fg-subtle" />
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
+              <PanelsTopLeftIcon aria-hidden="true" className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1 truncate font-medium">{workspaceName}</span>
+          </div>
+          <div className="mt-3 flex items-start gap-2 border-t border-border pt-3 text-xs leading-relaxed text-fg-subtle">
+            <ShieldCheckIcon aria-hidden="true" className="mt-0.5 size-3.5 shrink-0 text-success" />
+            <span>
+              You become the owner. Your login stays the same, and nothing is copied from your
+              current organization.
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter className="mt-5">
+        <Button type="button" variant="ghost" disabled={props.busy} onClick={props.onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={props.busy || !props.organizationName.trim() || !props.workspaceName.trim()}
+        >
+          {props.busy ? (
+            <Loader2Icon aria-hidden="true" className="size-4 animate-spin" />
+          ) : (
+            <CheckIcon aria-hidden="true" className="size-4" />
+          )}
+          Create organization
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export function CreateOrganizationDialog(
+  props: Omit<CreateOrganizationFormProps, "header" | "onCancel"> & {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  },
+) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <CreateOrganizationForm
+          {...props}
+          header={
+            <DialogHeader>
+              <DialogTitle>New organization</DialogTitle>
+              <DialogDescription>
+                Create a separate home for another team, with its own members, workspaces, and data.
+              </DialogDescription>
+            </DialogHeader>
+          }
+          onCancel={() => props.onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -5,7 +5,10 @@ import { createRoot } from "react-dom/client";
 import { OpenGeniApiError } from "@opengeni/sdk";
 
 import { CreateOrganizationForm } from "@/components/rail/create-organization-dialog";
-import { additionalOrganizationCreationOutcomeUnknown } from "@/components/rail/switcher-block";
+import {
+  additionalOrganizationCreationAttemptIsCurrent,
+  additionalOrganizationCreationOutcomeUnknown,
+} from "@/components/rail/switcher-block";
 import { WorkspaceSwitcherTrigger } from "@/components/rail/workspace-switcher";
 import type { Workspace } from "@/types";
 
@@ -51,6 +54,27 @@ describe("WorkspaceSwitcherTrigger", () => {
 });
 
 describe("CreateOrganizationForm", () => {
+  test("rejects a stale creation completion after the managed identity changes", () => {
+    expect(
+      additionalOrganizationCreationAttemptIsCurrent({
+        acceptedRevision: 4,
+        currentRevision: 4,
+        ownerUserId: "user-a",
+        currentManagedUserId: "user-a",
+        operationOwnerUserId: "user-a",
+      }),
+    ).toBe(true);
+    expect(
+      additionalOrganizationCreationAttemptIsCurrent({
+        acceptedRevision: 4,
+        currentRevision: 5,
+        ownerUserId: "user-a",
+        currentManagedUserId: "user-b",
+        operationOwnerUserId: null,
+      }),
+    ).toBe(false);
+  });
+
   test("classifies only ambiguous mutation failures as outcome unknown", () => {
     expect(
       additionalOrganizationCreationOutcomeUnknown(

--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -88,4 +88,42 @@ describe("CreateOrganizationForm", () => {
     await act(async () => root.unmount());
     host.remove();
   });
+
+  test("keeps a committed organization immutable while offering a safe open retry", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    let submitted = 0;
+    await act(async () => {
+      root.render(
+        <CreateOrganizationForm
+          organizationName="Product team"
+          workspaceName="Launch room"
+          busy={false}
+          committed
+          onOrganizationNameChange={() => undefined}
+          onWorkspaceNameChange={() => undefined}
+          onCancel={() => undefined}
+          onSubmit={() => {
+            submitted += 1;
+          }}
+        />,
+      );
+    });
+
+    const inputs = Array.from(document.querySelectorAll("input"));
+    expect(inputs).toHaveLength(2);
+    expect(inputs.every((input) => input.disabled)).toBe(true);
+    const retry = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Try opening again"),
+    );
+    expect(retry).toBeInstanceOf(HTMLButtonElement);
+    await act(async () => {
+      retry?.click();
+    });
+    expect(submitted).toBe(1);
+
+    await act(async () => root.unmount());
+    host.remove();
+  });
 });

--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -3,6 +3,7 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, createRef, type RefObject } from "react";
 import { createRoot } from "react-dom/client";
 
+import { CreateOrganizationForm } from "@/components/rail/create-organization-dialog";
 import { WorkspaceSwitcherTrigger } from "@/components/rail/workspace-switcher";
 import type { Workspace } from "@/types";
 
@@ -43,6 +44,48 @@ describe("WorkspaceSwitcherTrigger", () => {
     await act(async () => {
       root.unmount();
     });
+    host.remove();
+  });
+});
+
+describe("CreateOrganizationForm", () => {
+  test("explains the isolated organization graph and submits both names", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    let submitted = 0;
+    await act(async () => {
+      root.render(
+        <CreateOrganizationForm
+          organizationName="Product team"
+          workspaceName="Launch room"
+          busy={false}
+          onOrganizationNameChange={() => undefined}
+          onWorkspaceNameChange={() => undefined}
+          onCancel={() => undefined}
+          onSubmit={() => {
+            submitted += 1;
+          }}
+        />,
+      );
+    });
+
+    expect(document.body.textContent).toContain("New organization");
+    expect(document.body.textContent).toContain("Product team");
+    expect(document.body.textContent).toContain("Launch room");
+    expect(document.body.textContent).toContain("Your login stays the same");
+    expect(document.body.textContent).toContain("nothing is copied");
+
+    const submit = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Create organization"),
+    );
+    expect(submit).toBeInstanceOf(HTMLButtonElement);
+    await act(async () => {
+      submit?.click();
+    });
+    expect(submitted).toBe(1);
+
+    await act(async () => root.unmount());
     host.remove();
   });
 });

--- a/apps/web/src/components/rail/switcher-block.test.tsx
+++ b/apps/web/src/components/rail/switcher-block.test.tsx
@@ -2,8 +2,10 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, createRef, type RefObject } from "react";
 import { createRoot } from "react-dom/client";
+import { OpenGeniApiError } from "@opengeni/sdk";
 
 import { CreateOrganizationForm } from "@/components/rail/create-organization-dialog";
+import { additionalOrganizationCreationOutcomeUnknown } from "@/components/rail/switcher-block";
 import { WorkspaceSwitcherTrigger } from "@/components/rail/workspace-switcher";
 import type { Workspace } from "@/types";
 
@@ -49,6 +51,19 @@ describe("WorkspaceSwitcherTrigger", () => {
 });
 
 describe("CreateOrganizationForm", () => {
+  test("classifies only ambiguous mutation failures as outcome unknown", () => {
+    expect(
+      additionalOrganizationCreationOutcomeUnknown(
+        new OpenGeniApiError(0, "", { mutation: true, outcomeUnknown: true }),
+      ),
+    ).toBe(true);
+    expect(
+      additionalOrganizationCreationOutcomeUnknown(
+        new OpenGeniApiError(409, "limit reached", { mutation: true }),
+      ),
+    ).toBe(false);
+  });
+
   test("explains the isolated organization graph and submits both names", async () => {
     const host = document.createElement("div");
     document.body.append(host);
@@ -100,7 +115,7 @@ describe("CreateOrganizationForm", () => {
           organizationName="Product team"
           workspaceName="Launch room"
           busy={false}
-          committed
+          creationState="committed"
           onOrganizationNameChange={() => undefined}
           onWorkspaceNameChange={() => undefined}
           onCancel={() => undefined}
@@ -122,6 +137,34 @@ describe("CreateOrganizationForm", () => {
       retry?.click();
     });
     expect(submitted).toBe(1);
+
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  test("freezes an outcome-unknown request and offers exact replay", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(
+        <CreateOrganizationForm
+          organizationName="Product team"
+          workspaceName="Launch room"
+          busy={false}
+          creationState="uncertain"
+          onOrganizationNameChange={() => undefined}
+          onWorkspaceNameChange={() => undefined}
+          onCancel={() => undefined}
+          onSubmit={() => undefined}
+        />,
+      );
+    });
+
+    expect(Array.from(document.querySelectorAll("input")).every((input) => input.disabled)).toBe(
+      true,
+    );
+    expect(document.body.textContent).toContain("Check creation again");
 
     await act(async () => root.unmount());
     host.remove();

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -23,6 +23,7 @@ import {
   WorkspaceSwitcherMenu,
 } from "@/components/rail/workspace-switcher";
 import { organizationsForSubject, type OrgOption } from "@/lib/org";
+import { canCreateAdditionalOrganization } from "@/lib/managed-self-context";
 
 const LazyCreateOrganizationDialog = lazy(() =>
   import("@/components/rail/create-organization-dialog").then((module) => ({
@@ -43,7 +44,13 @@ export function SwitcherBlock() {
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
   const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
-  const canCreateOrganization = context.clientConfig.auth.mode === "managedSession";
+  const canCreateOrganization =
+    context.clientConfig.auth.mode === "managedSession" &&
+    canCreateAdditionalOrganization({
+      managedUserId: context.authSession?.user.id ?? null,
+      emailVerified: context.authSession?.user.emailVerified === true,
+      selfContext: context.managedSelfContext,
+    });
   const [createOpen, setCreateOpen] = useState(false);
   const [organizationName, setOrganizationName] = useState("");
   const [workspaceName, setWorkspaceName] = useState("General");

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -5,7 +5,7 @@
 // the same workspace menu.
 import { Link } from "@tanstack/react-router";
 import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon, SettingsIcon } from "lucide-react";
-import { lazy, Suspense, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -55,30 +55,53 @@ export function SwitcherBlock() {
   const [organizationName, setOrganizationName] = useState("");
   const [workspaceName, setWorkspaceName] = useState("General");
   const [createBusy, setCreateBusy] = useState(false);
+  const [createCommitted, setCreateCommitted] = useState(false);
   const operationId = useRef<string | null>(null);
+  const operationOwnerUserId = useRef<string | null>(null);
+
+  function resetCreateOrganizationDraft() {
+    setOrganizationName("");
+    setWorkspaceName("General");
+    setCreateCommitted(false);
+    operationId.current = null;
+    operationOwnerUserId.current = null;
+  }
+
+  useEffect(() => {
+    const managedUserId = context.authSession?.user.id ?? null;
+    if (operationOwnerUserId.current !== null && operationOwnerUserId.current !== managedUserId) {
+      setCreateOpen(false);
+      resetCreateOrganizationDraft();
+    }
+  }, [context.authSession?.user.id]);
 
   function updateCreateOpen(open: boolean) {
     if (createBusy && !open) return;
     setCreateOpen(open);
-    if (!open) {
-      setOrganizationName("");
-      setWorkspaceName("General");
-      operationId.current = null;
+    if (!open && !createCommitted) {
+      resetCreateOrganizationDraft();
     }
   }
 
   async function submitCreateOrganization() {
     const name = organizationName.trim();
     const initialWorkspaceName = workspaceName.trim();
-    if (!name || !initialWorkspaceName || createBusy) return;
-    operationId.current ??= crypto.randomUUID();
+    const managedUserId = context.authSession?.user.id ?? null;
+    if (!name || !initialWorkspaceName || !managedUserId || createBusy) return;
+    if (!operationId.current) {
+      operationId.current = crypto.randomUUID();
+      operationOwnerUserId.current = managedUserId;
+    }
     setCreateBusy(true);
+    let committed = createCommitted;
     try {
       const created = await context.client.createAdditionalOrganization({
         name,
         workspaceName: initialWorkspaceName,
         operationId: operationId.current,
       });
+      committed = true;
+      setCreateCommitted(true);
       const refreshed = await context.refreshPrincipalAccess();
       if (!refreshed) {
         throw new Error("Your access changed before the new organization could be opened");
@@ -88,14 +111,18 @@ export function SwitcherBlock() {
       });
       setCreateBusy(false);
       setCreateOpen(false);
-      setOrganizationName("");
-      setWorkspaceName("General");
-      operationId.current = null;
+      resetCreateOrganizationDraft();
       rail.openWorkspace(created.workspaceId);
     } catch (error) {
-      toast.error("Failed to create organization", {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(
+        committed ? "Organization created, but not opened" : "Failed to create organization",
+        {
+          description: committed
+            ? `${message}. Try again to refresh access and open the same organization.`
+            : message,
+        },
+      );
       setCreateBusy(false);
     }
   }
@@ -117,6 +144,7 @@ export function SwitcherBlock() {
               organizationName={organizationName}
               workspaceName={workspaceName}
               busy={createBusy}
+              committed={createCommitted}
               onOrganizationNameChange={setOrganizationName}
               onWorkspaceNameChange={setWorkspaceName}
               onOpenChange={updateCreateOpen}
@@ -145,6 +173,7 @@ export function SwitcherBlock() {
             organizationName={organizationName}
             workspaceName={workspaceName}
             busy={createBusy}
+            committed={createCommitted}
             onOrganizationNameChange={setOrganizationName}
             onWorkspaceNameChange={setWorkspaceName}
             onOpenChange={updateCreateOpen}

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -4,6 +4,7 @@
 // Collapsed, the whole block reduces to a workspace-initial avatar that opens
 // the same workspace menu.
 import { Link } from "@tanstack/react-router";
+import { OpenGeniApiError } from "@opengeni/sdk";
 import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon, SettingsIcon } from "lucide-react";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -31,6 +32,12 @@ const LazyCreateOrganizationDialog = lazy(() =>
   })),
 );
 
+type AdditionalOrganizationCreationState = "draft" | "uncertain" | "committed";
+
+export function additionalOrganizationCreationOutcomeUnknown(error: unknown): boolean {
+  return error instanceof OpenGeniApiError ? error.outcomeUnknown : error instanceof TypeError;
+}
+
 export const WORKSPACE_SWITCHER_GRID_CLASS =
   "grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-3 pt-1";
 
@@ -55,14 +62,14 @@ export function SwitcherBlock() {
   const [organizationName, setOrganizationName] = useState("");
   const [workspaceName, setWorkspaceName] = useState("General");
   const [createBusy, setCreateBusy] = useState(false);
-  const [createCommitted, setCreateCommitted] = useState(false);
+  const [creationState, setCreationState] = useState<AdditionalOrganizationCreationState>("draft");
   const operationId = useRef<string | null>(null);
   const operationOwnerUserId = useRef<string | null>(null);
 
   function resetCreateOrganizationDraft() {
     setOrganizationName("");
     setWorkspaceName("General");
-    setCreateCommitted(false);
+    setCreationState("draft");
     operationId.current = null;
     operationOwnerUserId.current = null;
   }
@@ -78,7 +85,7 @@ export function SwitcherBlock() {
   function updateCreateOpen(open: boolean) {
     if (createBusy && !open) return;
     setCreateOpen(open);
-    if (!open && !createCommitted) {
+    if (!open && creationState === "draft") {
       resetCreateOrganizationDraft();
     }
   }
@@ -93,15 +100,19 @@ export function SwitcherBlock() {
       operationOwnerUserId.current = managedUserId;
     }
     setCreateBusy(true);
-    let committed = createCommitted;
+    let attemptedState: AdditionalOrganizationCreationState = creationState;
+    if (attemptedState === "draft") {
+      attemptedState = "uncertain";
+      setCreationState("uncertain");
+    }
     try {
       const created = await context.client.createAdditionalOrganization({
         name,
         workspaceName: initialWorkspaceName,
         operationId: operationId.current,
       });
-      committed = true;
-      setCreateCommitted(true);
+      attemptedState = "committed";
+      setCreationState("committed");
       const refreshed = await context.refreshPrincipalAccess();
       if (!refreshed) {
         throw new Error("Your access changed before the new organization could be opened");
@@ -115,12 +126,26 @@ export function SwitcherBlock() {
       rail.openWorkspace(created.workspaceId);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const outcomeUnknown = additionalOrganizationCreationOutcomeUnknown(error);
+      if (attemptedState !== "committed" && !outcomeUnknown) {
+        attemptedState = "draft";
+        setCreationState("draft");
+        operationId.current = null;
+        operationOwnerUserId.current = null;
+      }
       toast.error(
-        committed ? "Organization created, but not opened" : "Failed to create organization",
+        attemptedState === "committed"
+          ? "Organization created, but not opened"
+          : attemptedState === "uncertain"
+            ? "Creation could not be confirmed"
+            : "Failed to create organization",
         {
-          description: committed
-            ? `${message}. Try again to refresh access and open the same organization.`
-            : message,
+          description:
+            attemptedState === "committed"
+              ? `${message}. Try again to refresh access and open the same organization.`
+              : attemptedState === "uncertain"
+                ? `${message}. Try again to safely replay this exact request and confirm the result.`
+                : message,
         },
       );
       setCreateBusy(false);
@@ -144,7 +169,7 @@ export function SwitcherBlock() {
               organizationName={organizationName}
               workspaceName={workspaceName}
               busy={createBusy}
-              committed={createCommitted}
+              creationState={creationState}
               onOrganizationNameChange={setOrganizationName}
               onWorkspaceNameChange={setWorkspaceName}
               onOpenChange={updateCreateOpen}
@@ -173,7 +198,7 @@ export function SwitcherBlock() {
             organizationName={organizationName}
             workspaceName={workspaceName}
             busy={createBusy}
-            committed={createCommitted}
+            creationState={creationState}
             onOrganizationNameChange={setOrganizationName}
             onWorkspaceNameChange={setWorkspaceName}
             onOpenChange={updateCreateOpen}

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -38,6 +38,20 @@ export function additionalOrganizationCreationOutcomeUnknown(error: unknown): bo
   return error instanceof OpenGeniApiError ? error.outcomeUnknown : error instanceof TypeError;
 }
 
+export function additionalOrganizationCreationAttemptIsCurrent(input: {
+  acceptedRevision: number;
+  currentRevision: number;
+  ownerUserId: string;
+  currentManagedUserId: string | null;
+  operationOwnerUserId: string | null;
+}): boolean {
+  return (
+    input.acceptedRevision === input.currentRevision &&
+    input.ownerUserId === input.currentManagedUserId &&
+    input.ownerUserId === input.operationOwnerUserId
+  );
+}
+
 export const WORKSPACE_SWITCHER_GRID_CLASS =
   "grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-3 pt-1";
 
@@ -51,10 +65,11 @@ export function SwitcherBlock() {
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
   const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
+  const managedUserId = context.authSession?.user.id ?? null;
   const canCreateOrganization =
     context.clientConfig.auth.mode === "managedSession" &&
     canCreateAdditionalOrganization({
-      managedUserId: context.authSession?.user.id ?? null,
+      managedUserId,
       emailVerified: context.authSession?.user.emailVerified === true,
       selfContext: context.managedSelfContext,
     });
@@ -65,6 +80,9 @@ export function SwitcherBlock() {
   const [creationState, setCreationState] = useState<AdditionalOrganizationCreationState>("draft");
   const operationId = useRef<string | null>(null);
   const operationOwnerUserId = useRef<string | null>(null);
+  const currentManagedUserId = useRef(managedUserId);
+  const creationAttemptRevision = useRef(0);
+  currentManagedUserId.current = managedUserId;
 
   function resetCreateOrganizationDraft() {
     setOrganizationName("");
@@ -75,12 +93,20 @@ export function SwitcherBlock() {
   }
 
   useEffect(() => {
-    const managedUserId = context.authSession?.user.id ?? null;
     if (operationOwnerUserId.current !== null && operationOwnerUserId.current !== managedUserId) {
+      creationAttemptRevision.current += 1;
+      setCreateBusy(false);
       setCreateOpen(false);
       resetCreateOrganizationDraft();
     }
-  }, [context.authSession?.user.id]);
+  }, [managedUserId]);
+
+  useEffect(
+    () => () => {
+      creationAttemptRevision.current += 1;
+    },
+    [],
+  );
 
   function updateCreateOpen(open: boolean) {
     if (createBusy && !open) return;
@@ -93,12 +119,23 @@ export function SwitcherBlock() {
   async function submitCreateOrganization() {
     const name = organizationName.trim();
     const initialWorkspaceName = workspaceName.trim();
-    const managedUserId = context.authSession?.user.id ?? null;
     if (!name || !initialWorkspaceName || !managedUserId || createBusy) return;
+    if (operationOwnerUserId.current !== null && operationOwnerUserId.current !== managedUserId) {
+      return;
+    }
     if (!operationId.current) {
       operationId.current = crypto.randomUUID();
       operationOwnerUserId.current = managedUserId;
     }
+    const acceptedAttemptRevision = ++creationAttemptRevision.current;
+    const attemptIsCurrent = () =>
+      additionalOrganizationCreationAttemptIsCurrent({
+        acceptedRevision: acceptedAttemptRevision,
+        currentRevision: creationAttemptRevision.current,
+        ownerUserId: managedUserId,
+        currentManagedUserId: currentManagedUserId.current,
+        operationOwnerUserId: operationOwnerUserId.current,
+      });
     setCreateBusy(true);
     let attemptedState: AdditionalOrganizationCreationState = creationState;
     if (attemptedState === "draft") {
@@ -111,20 +148,23 @@ export function SwitcherBlock() {
         workspaceName: initialWorkspaceName,
         operationId: operationId.current,
       });
+      if (!attemptIsCurrent()) return;
       attemptedState = "committed";
       setCreationState("committed");
       const refreshed = await context.refreshPrincipalAccess();
+      if (!attemptIsCurrent()) return;
       if (!refreshed) {
         throw new Error("Your access changed before the new organization could be opened");
       }
+      rail.openWorkspace(created.workspaceId);
       toast.success(`${created.organization.name} created`, {
         description: `${initialWorkspaceName} is ready for your team.`,
       });
       setCreateBusy(false);
       setCreateOpen(false);
       resetCreateOrganizationDraft();
-      rail.openWorkspace(created.workspaceId);
     } catch (error) {
+      if (!attemptIsCurrent()) return;
       const message = error instanceof Error ? error.message : String(error);
       const outcomeUnknown = additionalOrganizationCreationOutcomeUnknown(error);
       if (attemptedState !== "committed" && !outcomeUnknown) {
@@ -148,7 +188,8 @@ export function SwitcherBlock() {
                 : message,
         },
       );
-      setCreateBusy(false);
+    } finally {
+      if (attemptIsCurrent()) setCreateBusy(false);
     }
   }
 

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -1,10 +1,12 @@
 // The rail's top switcher: a muted Organization line over a prominent Workspace
-// line. The org line is a menu only when the subject belongs to >1 org (a plain
-// label otherwise); the workspace line is always a menu listing the current
-// org's workspaces plus create / settings actions. Collapsed, the whole block
-// reduces to a workspace-initial avatar that opens the same workspace menu.
+// line. The org line opens organization switching, creation, and settings; the
+// workspace line lists the current org's workspaces plus workspace actions.
+// Collapsed, the whole block reduces to a workspace-initial avatar that opens
+// the same workspace menu.
 import { Link } from "@tanstack/react-router";
-import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, SettingsIcon } from "lucide-react";
+import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon, SettingsIcon } from "lucide-react";
+import { lazy, Suspense, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import {
   DropdownMenu,
@@ -22,6 +24,12 @@ import {
 } from "@/components/rail/workspace-switcher";
 import { organizationsForSubject, type OrgOption } from "@/lib/org";
 
+const LazyCreateOrganizationDialog = lazy(() =>
+  import("@/components/rail/create-organization-dialog").then((module) => ({
+    default: module.CreateOrganizationDialog,
+  })),
+);
+
 export const WORKSPACE_SWITCHER_GRID_CLASS =
   "grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-3 pt-1";
 
@@ -35,15 +43,81 @@ export function SwitcherBlock() {
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
   const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
+  const canCreateOrganization = context.clientConfig.auth.mode === "managedSession";
+  const [createOpen, setCreateOpen] = useState(false);
+  const [organizationName, setOrganizationName] = useState("");
+  const [workspaceName, setWorkspaceName] = useState("General");
+  const [createBusy, setCreateBusy] = useState(false);
+  const operationId = useRef<string | null>(null);
+
+  function updateCreateOpen(open: boolean) {
+    if (createBusy && !open) return;
+    setCreateOpen(open);
+    if (!open) {
+      setOrganizationName("");
+      setWorkspaceName("General");
+      operationId.current = null;
+    }
+  }
+
+  async function submitCreateOrganization() {
+    const name = organizationName.trim();
+    const initialWorkspaceName = workspaceName.trim();
+    if (!name || !initialWorkspaceName || createBusy) return;
+    operationId.current ??= crypto.randomUUID();
+    setCreateBusy(true);
+    try {
+      const created = await context.client.createAdditionalOrganization({
+        name,
+        workspaceName: initialWorkspaceName,
+        operationId: operationId.current,
+      });
+      const refreshed = await context.refreshPrincipalAccess();
+      if (!refreshed) {
+        throw new Error("Your access changed before the new organization could be opened");
+      }
+      toast.success(`${created.organization.name} created`, {
+        description: `${initialWorkspaceName} is ready for your team.`,
+      });
+      setCreateBusy(false);
+      setCreateOpen(false);
+      setOrganizationName("");
+      setWorkspaceName("General");
+      operationId.current = null;
+      rail.openWorkspace(created.workspaceId);
+    } catch (error) {
+      toast.error("Failed to create organization", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+      setCreateBusy(false);
+    }
+  }
 
   if (rail.collapsed) {
     return (
-      <WorkspaceSwitcherMenu
-        workspaceId={rail.workspaceId}
-        collapsed
-        align="start"
-        onSelect={rail.openWorkspace}
-      />
+      <>
+        <WorkspaceSwitcherMenu
+          workspaceId={rail.workspaceId}
+          collapsed
+          align="start"
+          onSelect={rail.openWorkspace}
+          onCreateOrganization={canCreateOrganization ? () => setCreateOpen(true) : undefined}
+        />
+        {createOpen ? (
+          <Suspense fallback={null}>
+            <LazyCreateOrganizationDialog
+              open
+              organizationName={organizationName}
+              workspaceName={workspaceName}
+              busy={createBusy}
+              onOrganizationNameChange={setOrganizationName}
+              onWorkspaceNameChange={setWorkspaceName}
+              onOpenChange={updateCreateOpen}
+              onSubmit={() => void submitCreateOrganization()}
+            />
+          </Suspense>
+        ) : null}
+      </>
     );
   }
 
@@ -54,8 +128,23 @@ export function SwitcherBlock() {
         currentLabel={currentOrgLabel}
         activeAccountId={activeAccountId}
         onSelect={rail.openOrg}
+        onCreate={canCreateOrganization ? () => setCreateOpen(true) : undefined}
         workspaceId={rail.workspaceId}
       />
+      {createOpen ? (
+        <Suspense fallback={null}>
+          <LazyCreateOrganizationDialog
+            open
+            organizationName={organizationName}
+            workspaceName={workspaceName}
+            busy={createBusy}
+            onOrganizationNameChange={setOrganizationName}
+            onWorkspaceNameChange={setWorkspaceName}
+            onOpenChange={updateCreateOpen}
+            onSubmit={() => void submitCreateOrganization()}
+          />
+        </Suspense>
+      ) : null}
 
       <WorkspaceSwitcherMenu
         workspaceId={rail.workspaceId}
@@ -72,6 +161,7 @@ export function OrganizationSwitcherLine(props: {
   currentLabel: string;
   activeAccountId: string | null;
   onSelect: (accountId: string) => void;
+  onCreate?: () => void;
   workspaceId: string | null;
 }) {
   return (
@@ -120,6 +210,20 @@ export function OrganizationSwitcherLine(props: {
         ) : (
           <DropdownMenuLabel className="text-fg-subtle">{props.currentLabel}</DropdownMenuLabel>
         )}
+        {props.onCreate ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                props.onCreate?.();
+              }}
+            >
+              <PlusIcon className="size-4" />
+              New organization…
+            </DropdownMenuItem>
+          </>
+        ) : null}
         {props.workspaceId ? (
           <>
             <DropdownMenuSeparator />

--- a/apps/web/src/components/rail/workspace-switcher.tsx
+++ b/apps/web/src/components/rail/workspace-switcher.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ChevronsUpDownIcon, PauseIcon, PlusIcon } from "lucide-react";
+import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PauseIcon, PlusIcon } from "lucide-react";
 import { forwardRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { toast } from "sonner";
 
@@ -49,6 +49,7 @@ export function WorkspaceSwitcherMenu(props: {
   collapsed: boolean;
   align: "start" | "end";
   onSelect: (workspaceId: string) => void;
+  onCreateOrganization?: () => void;
   className?: string;
 }) {
   const context = useAppContext();
@@ -99,6 +100,7 @@ export function WorkspaceSwitcherMenu(props: {
         canCreate={createAccountId !== null}
         onSelect={props.onSelect}
         onCreate={() => setCreateOpen(true)}
+        onCreateOrganization={props.onCreateOrganization}
         managedSelfContext={context.managedSelfContext}
         align={props.align}
       >
@@ -201,6 +203,7 @@ export function WorkspaceMenu(props: {
   canCreate: boolean;
   onSelect: (workspaceId: string) => void;
   onCreate: () => void;
+  onCreateOrganization?: () => void;
   managedSelfContext: ManagedSelfContext | null;
   align: "start" | "end";
   children: ReactNode;
@@ -258,6 +261,17 @@ export function WorkspaceMenu(props: {
           >
             <PlusIcon className="size-4" />
             New workspace…
+          </DropdownMenuItem>
+        ) : null}
+        {props.onCreateOrganization ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              props.onCreateOrganization?.();
+            }}
+          >
+            <BuildingIcon className="size-4" />
+            New organization…
           </DropdownMenuItem>
         ) : null}
       </DropdownMenuContent>

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -297,6 +297,8 @@ export type AppContextValue = {
   handleManagedSignOut: () => Promise<void>;
   /** Reload grants, workspaces, and managed self-membership from the cookie. */
   revalidatePrincipalAccess: () => void;
+  /** Refreshes the current principal's organization and workspace grants in place. */
+  refreshPrincipalAccess: () => Promise<boolean>;
   createWorkspace: (request: CreateWorkspaceRequest) => Promise<Workspace | null>;
   renameWorkspace: (workspaceId: string, name: string) => Promise<Workspace | null>;
   setWorkspaceInferenceControl: (
@@ -2385,6 +2387,57 @@ export function RootRouteComponent() {
     () => setAccessKeyVersion((version) => version + 1),
     [],
   );
+  async function refreshPrincipalAccess(): Promise<boolean> {
+    if (!clientConfig || !authReady) return false;
+    let acceptedPrincipal = principalTransitionIdentity.current;
+    const acceptedManagedIdentity =
+      clientConfig.auth.mode === "managedSession" && authSession
+        ? managedSelfContextIdentity({
+            credentialGeneration: accessKeyVersion,
+            managedUserId: authSession.user.id,
+          })
+        : null;
+    managedSelfContextIdentityRef.current = acceptedManagedIdentity;
+    const selfContextPromise = acceptedManagedIdentity
+      ? loadCurrentManagedSelfContext({
+          identity: acceptedManagedIdentity,
+          currentIdentity: () => managedSelfContextIdentityRef.current,
+          request: () => client.listOrganizationMemberships(),
+        })
+      : Promise.resolve(null);
+    const [nextAccessContext, nextWorkspaces, nextManagedSelfContext] = await Promise.all([
+      client.getAccessContext(),
+      client.listWorkspaces(),
+      selfContextPromise,
+    ]);
+    if (!ownsPrincipalTransition(principalTransitionIdentity.current, acceptedPrincipal)) {
+      return false;
+    }
+    if (acceptedManagedIdentity && nextManagedSelfContext === null) return false;
+    if (
+      nextManagedSelfContext &&
+      nextAccessContext.subjectId !== nextManagedSelfContext.identity.subjectId
+    ) {
+      throw new Error("managed self context did not match the authenticated subject");
+    }
+    if (
+      accessPrincipalIdRef.current !== null &&
+      accessPrincipalIdRef.current !== nextAccessContext.subjectId
+    ) {
+      invalidatePrincipalWorkspaceState();
+      acceptedPrincipal = principalTransitionIdentity.current;
+      managedSelfContextIdentityRef.current = acceptedManagedIdentity;
+    }
+    if (!ownsPrincipalTransition(principalTransitionIdentity.current, acceptedPrincipal)) {
+      return false;
+    }
+    accessPrincipalIdRef.current = nextAccessContext.subjectId;
+    setAccessContext(nextAccessContext);
+    setWorkspaces(nextWorkspaces);
+    setManagedSelfContext(nextManagedSelfContext);
+    return true;
+  }
+  const contextRefreshPrincipalAccess = useLatestCallback(refreshPrincipalAccess);
   const contextCreateWorkspace = useLatestCallback(createWorkspace);
   const contextRenameWorkspace = useLatestCallback(renameWorkspace);
   const contextSetWorkspaceInferenceControl = useLatestCallback(setWorkspaceInferenceControl);
@@ -2500,6 +2553,7 @@ export function RootRouteComponent() {
           forgetAccessKey: contextForgetAccessKey,
           handleManagedSignOut: contextHandleManagedSignOut,
           revalidatePrincipalAccess,
+          refreshPrincipalAccess: contextRefreshPrincipalAccess,
           createWorkspace: contextCreateWorkspace,
           renameWorkspace: contextRenameWorkspace,
           setWorkspaceInferenceControl: contextSetWorkspaceInferenceControl,
@@ -2588,6 +2642,7 @@ export function RootRouteComponent() {
     latencyMode,
     reasoningEffort,
     revalidatePrincipalAccess,
+    contextRefreshPrincipalAccess,
     refreshGitHub,
     refreshPersonalGitHub,
     refreshWorkspace,

--- a/apps/web/src/lib/managed-self-context.test.ts
+++ b/apps/web/src/lib/managed-self-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  canCreateAdditionalOrganization,
   isPersonalWorkspace,
   loadCurrentManagedSelfContext,
   managedSelfContextIdentity,
@@ -29,6 +30,43 @@ function deferred<Value>() {
 }
 
 describe("managed self context", () => {
+  test("permits additional organization creation only for the verified onboarded identity", () => {
+    const identity = managedSelfContextIdentity({
+      credentialGeneration: 4,
+      managedUserId: "user-id",
+    });
+    const selfContext = { identity, memberships: [membership] };
+
+    expect(
+      canCreateAdditionalOrganization({
+        managedUserId: "user-id",
+        emailVerified: true,
+        selfContext,
+      }),
+    ).toBe(true);
+    expect(
+      canCreateAdditionalOrganization({
+        managedUserId: "user-id",
+        emailVerified: false,
+        selfContext,
+      }),
+    ).toBe(false);
+    expect(
+      canCreateAdditionalOrganization({
+        managedUserId: "user-id",
+        emailVerified: true,
+        selfContext: { identity, memberships: [] },
+      }),
+    ).toBe(false);
+    expect(
+      canCreateAdditionalOrganization({
+        managedUserId: "different-user",
+        emailVerified: true,
+        selfContext,
+      }),
+    ).toBe(false);
+  });
+
   test("uses canonical workspace kind for display while owner linkage uses the exact tuple", () => {
     const identity = managedSelfContextIdentity({
       credentialGeneration: 4,

--- a/apps/web/src/lib/managed-self-context.ts
+++ b/apps/web/src/lib/managed-self-context.ts
@@ -33,6 +33,25 @@ export function sameManagedSelfContextIdentity(
 }
 
 /**
+ * Additional organization creation is available only after the exact current
+ * managed identity is verified and its server-issued membership projection
+ * proves that initial onboarding has completed.
+ */
+export function canCreateAdditionalOrganization(input: {
+  managedUserId: string | null;
+  emailVerified: boolean;
+  selfContext: ManagedSelfContext | null;
+}): boolean {
+  const { managedUserId, selfContext } = input;
+  if (!managedUserId || !input.emailVerified || !selfContext) return false;
+  return (
+    selfContext.identity.managedUserId === managedUserId &&
+    selfContext.identity.subjectId === `user:${managedUserId}` &&
+    selfContext.memberships.some((membership) => membership.status === "active")
+  );
+}
+
+/**
  * Resolve managed-human membership facts only for the credential/principal
  * identity that started the request. A late response from a replaced cookie
  * session is discarded instead of becoming the next principal's UI truth.

--- a/apps/web/src/routes/onboarding-preview.tsx
+++ b/apps/web/src/routes/onboarding-preview.tsx
@@ -1,10 +1,80 @@
+import { ChevronsUpDownIcon } from "lucide-react";
+import { useState } from "react";
+
 import { ManagedAuthPanel } from "@/components/managed-auth-panel";
 import { OrganizationOnboardingPanel } from "@/components/organization-onboarding-panel";
+import { CreateOrganizationDialog } from "@/components/rail/create-organization-dialog";
+import { OrganizationSwitcherLine } from "@/components/rail/switcher-block";
 import { SetupAccountRoute } from "@/routes/setup-account";
+
+function AdditionalOrganizationPreview() {
+  const [open, setOpen] = useState(true);
+  const [organizationName, setOrganizationName] = useState("Product team");
+  const [workspaceName, setWorkspaceName] = useState("General");
+
+  return (
+    <main className="min-h-screen bg-bg p-5 text-fg">
+      <div className="mx-auto flex min-h-[calc(100vh-2.5rem)] max-w-6xl overflow-hidden rounded-xl border border-border bg-surface-1 shadow-2xl">
+        <aside className="w-64 shrink-0 border-r border-border bg-surface-2/35 p-3">
+          <div className="mb-6 flex items-center gap-2 px-1 py-2 text-sm font-semibold">
+            <span className="flex size-7 items-center justify-center rounded-md bg-brand text-xs font-bold text-white">
+              O
+            </span>
+            OpenGeni
+          </div>
+          <div className="grid gap-1.5">
+            <OrganizationSwitcherLine
+              orgs={[{ accountId: "preview-account", label: "OpenGeni", canManage: true }]}
+              currentLabel="OpenGeni"
+              activeAccountId="preview-account"
+              onSelect={() => undefined}
+              onCreate={() => setOpen(true)}
+              workspaceId="preview-workspace"
+            />
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left"
+            >
+              <span className="flex size-7 items-center justify-center rounded-md bg-brand-strong/25 text-xs font-semibold text-brand">
+                A
+              </span>
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">Analytics</span>
+              <ChevronsUpDownIcon className="size-3.5 text-fg-subtle" />
+            </button>
+          </div>
+        </aside>
+        <section className="flex flex-1 items-center justify-center bg-bg/55 p-8">
+          <div className="max-w-sm text-center">
+            <p className="text-xs font-medium tracking-wide text-fg-subtle uppercase">
+              Development preview
+            </p>
+            <h1 className="mt-2 text-xl font-semibold">Organization creation</h1>
+            <p className="mt-2 text-sm text-fg-muted">
+              Open the organization menu in the upper-left corner to create another organization.
+            </p>
+          </div>
+        </section>
+      </div>
+      <CreateOrganizationDialog
+        open={open}
+        organizationName={organizationName}
+        workspaceName={workspaceName}
+        busy={false}
+        onOrganizationNameChange={setOrganizationName}
+        onWorkspaceNameChange={setWorkspaceName}
+        onOpenChange={setOpen}
+        onSubmit={() => setOpen(false)}
+      />
+    </main>
+  );
+}
 
 /** Public development-only harness rendering the production onboarding components. */
 export function OnboardingPreviewRoute() {
   const view = new URLSearchParams(window.location.search).get("view");
+  if (view === "additional-organization") {
+    return <AdditionalOrganizationPreview />;
+  }
   if (view === "setup") {
     return <SetupAccountRoute token="approval-preview-token-not-submitted" />;
   }

--- a/apps/worker/test/embedded-lifecycle.test.ts
+++ b/apps/worker/test/embedded-lifecycle.test.ts
@@ -495,6 +495,7 @@ describe("embedded worker lifecycle contract", () => {
           can_trigger: false,
         })),
         ...[
+          "additional_organization_creation_receipts",
           "canonical_human_identities",
           "canonical_human_identity_subjects",
           "canonical_human_login_bindings",
@@ -503,6 +504,7 @@ describe("embedded worker lifecycle contract", () => {
           ...organizationRecoveryTables,
           "organization_user_setup_deliveries",
           "organization_user_setup_delivery_attempts",
+          "session_tenancy_additional_organization_activation_evidence",
         ].map((name) => ({
           name,
           owner: "opengeni_migrator",
@@ -648,6 +650,7 @@ describe("embedded worker lifecycle contract", () => {
       expectedRole: "opengeni_app",
       targetSchema: "public",
       protectedTables: [
+        "additional_organization_creation_receipts",
         "canonical_human_identities",
         "canonical_human_identity_subjects",
         "canonical_human_login_bindings",
@@ -656,9 +659,11 @@ describe("embedded worker lifecycle contract", () => {
         ...organizationRecoveryTables,
         "organization_user_setup_deliveries",
         "organization_user_setup_delivery_attempts",
+        "session_tenancy_additional_organization_activation_evidence",
       ],
       tablePrivileges: {},
       protectedNoDirectDmlTables: [
+        "additional_organization_creation_receipts",
         "canonical_human_identities",
         "canonical_human_identity_subjects",
         "canonical_human_login_bindings",
@@ -667,6 +672,7 @@ describe("embedded worker lifecycle contract", () => {
         ...organizationRecoveryTables,
         "organization_user_setup_deliveries",
         "organization_user_setup_delivery_attempts",
+        "session_tenancy_additional_organization_activation_evidence",
       ],
     })();
     expect((catalogResults[9] as Array<{ name: string }>).map((routine) => routine.name)).toEqual([

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,7 +301,9 @@ organizations from the organization switcher. The login and canonical human
 identity remain global; each organization gets a separate owner membership and
 Personal workspace. The creation lifecycle also creates one first shared
 workspace with an explicit administrator grant, refreshes authoritative access
-before navigation, and copies no tenant data from the current organization.
+before navigation, and copies no tenant data from the current organization. A
+subject-scoped database fence limits this self-service lifecycle to ten
+additional organizations per human; invitation memberships do not consume it.
 First-sign-in onboarding and invitation precedence remain a separate one-shot
 path.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -296,6 +296,15 @@ that includes `capabilities:manage`, so they can configure their own Plugins,
 Integrations, and Codex subscription without receiving the `workspace:admin`
 wildcard, member management, or API-key delegation.
 
+An already-onboarded verified managed human may create additional independent
+organizations from the organization switcher. The login and canonical human
+identity remain global; each organization gets a separate owner membership and
+Personal workspace. The creation lifecycle also creates one first shared
+workspace with an explicit administrator grant, refreshes authoritative access
+before navigation, and copies no tenant data from the current organization.
+First-sign-in onboarding and invitation precedence remain a separate one-shot
+path.
+
 Canonical: `packages/core/src/access/index.ts`,
 `packages/core/src/session-authorization.ts`, `packages/db/src/runtime-posture.ts`,
 [`organization-tenancy.md`](organization-tenancy.md),

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -493,6 +493,10 @@ The managed-human API surface is:
   organization-name-only setup. It creates exactly the owning human's active
   organization membership and canonical Personal workspace/control row—no
   shared workspace and no Personal `workspace_memberships` row;
+- `POST /v1/organizations/additional` lets an already-onboarded verified human
+  create another independent organization. It atomically creates that
+  organization's owner membership, canonical Personal workspace, and a named
+  first shared workspace with an explicit administrator grant for the creator;
 - `POST /v1/organizations/:organizationId/workspaces` idempotently creates a
   shared workspace and atomically gives that exact creator an explicit named
   workspace-admin grant; unrelated organization administrators receive no
@@ -603,6 +607,33 @@ deadlock migration 0299 fences. Adoption requires the account to carry **no**
 organization membership at all; one that already has memberships is refused,
 because granting owner there would be a privilege event rather than a repair.
 No migration-time backfill over a FORCE-RLS table is needed.
+
+### Additional organization creation (0398)
+
+Migration `0399_additional_managed_organization_creation.sql` adds a separate
+managed-cookie-only lifecycle for a verified human who already has at least one
+active organization membership. It does not weaken or reuse first-sign-in
+setup: a human with no active membership must still pass through the 0348
+onboarding or invitation path, so invitation precedence and legacy-account
+adoption remain unchanged during a rolling deployment.
+
+One authentication account still represents one canonical human. Creating an
+additional organization does **not** create another Better Auth user or another
+canonical identity. It creates a distinct active owner membership for the same
+`user:<auth-user-id>`, with a new Personal workspace scoped to that membership.
+The organization also starts with one named shared workspace, where the creator
+receives an explicit `admin` workspace membership. No settings, sessions,
+credentials, connections, files, or other data are copied from the current
+organization.
+
+The database function creates the complete graph and an immutable,
+input-bound operation receipt in one transaction. Exact concurrent retries
+converge; changed operation-id reuse fails closed. Once the deployment has a
+session-tenancy activation witness, the same transaction validates the exact
+fresh graph and writes its activation, enabled private-session setting, event,
+and immutable evidence. The application role can execute only the public
+creation capability and has no direct DML on either receipt table or access to
+the owner-only activation helper.
 
 Pre-registration invitation creation now claims a matching durable
 `organization_user_setup_deliveries` row and append-only attempt before calling

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -608,7 +608,7 @@ organization membership at all; one that already has memberships is refused,
 because granting owner there would be a privilege event rather than a repair.
 No migration-time backfill over a FORCE-RLS table is needed.
 
-### Additional organization creation (0398)
+### Additional organization creation (0399)
 
 Migration `0399_additional_managed_organization_creation.sql` adds a separate
 managed-cookie-only lifecycle for a verified human who already has at least one
@@ -628,12 +628,15 @@ organization.
 
 The database function creates the complete graph and an immutable,
 input-bound operation receipt in one transaction. Exact concurrent retries
-converge; changed operation-id reuse fails closed. Once the deployment has a
-session-tenancy activation witness, the same transaction validates the exact
-fresh graph and writes its activation, enabled private-session setting, event,
-and immutable evidence. The application role can execute only the public
-creation capability and has no direct DML on either receipt table or access to
-the owner-only activation helper.
+converge; changed operation-id reuse fails closed. A subject-scoped transaction
+lock atomically enforces a lifetime allowance of ten organizations created
+through this self-service lifecycle. Organizations joined by invitation do not
+consume that allowance, and exact retries still replay after it is full. Once
+the deployment has a session-tenancy activation witness, the same transaction
+validates the exact fresh graph and writes its activation, enabled
+private-session setting, event, and immutable evidence. The application role
+can execute only the public creation capability and has no direct DML on either
+receipt table or access to the owner-only activation helper.
 
 Pre-registration invitation creation now claims a matching durable
 `organization_user_setup_deliveries` row and append-only attempt before calling

--- a/packages/contracts/src/organization-membership-lifecycle.ts
+++ b/packages/contracts/src/organization-membership-lifecycle.ts
@@ -239,6 +239,26 @@ export const CreateOrganizationResponse = z.object({
 });
 export type CreateOrganizationResponse = z.infer<typeof CreateOrganizationResponse>;
 
+export const CreateAdditionalOrganizationRequest = z
+  .object({
+    name: z.string().trim().min(1).max(120),
+    workspaceName: z.string().trim().min(1).max(120),
+    operationId: z.string().uuid(),
+  })
+  .strict();
+export type CreateAdditionalOrganizationRequest = z.infer<
+  typeof CreateAdditionalOrganizationRequest
+>;
+
+export const CreateAdditionalOrganizationResponse = z.object({
+  organization: OrganizationSummary,
+  workspaceId: z.string().uuid(),
+  personalWorkspaceId: z.string().uuid(),
+});
+export type CreateAdditionalOrganizationResponse = z.infer<
+  typeof CreateAdditionalOrganizationResponse
+>;
+
 export const UpdateOrganizationNameRequest = z.object({
   name: z.string().trim().min(1).max(120),
   expectedUpdatedAt: z.string().datetime({ offset: true }),

--- a/packages/db/drizzle/0399_additional_managed_organization_creation.sql
+++ b/packages/db/drizzle/0399_additional_managed_organization_creation.sql
@@ -1,0 +1,671 @@
+-- deployment-mode: rolling
+-- Migration 0399 follows organization workspace management activation.
+-- Lets an already-onboarded, verified managed human create another independent
+-- organization. One transaction creates the organization, its Personal
+-- workspace, its first shared workspace, and both access anchors. The original
+-- first-sign-in setup remains a separate one-shot lifecycle so invitations and
+-- legacy-account adoption keep their existing precedence and semantics.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+CREATE TABLE additional_organization_creation_receipts (
+  operation_id uuid PRIMARY KEY,
+  actor_subject_id text NOT NULL,
+  account_id uuid NOT NULL UNIQUE
+    REFERENCES managed_accounts(id) ON DELETE RESTRICT,
+  organization_membership_id uuid NOT NULL UNIQUE
+    REFERENCES organization_memberships(id) ON DELETE RESTRICT,
+  personal_workspace_id uuid NOT NULL UNIQUE
+    REFERENCES workspaces(id) ON DELETE RESTRICT,
+  shared_workspace_id uuid NOT NULL UNIQUE
+    REFERENCES workspaces(id) ON DELETE RESTRICT,
+  organization_name text NOT NULL,
+  workspace_name text NOT NULL,
+  result jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT additional_organization_creation_actor_check CHECK (
+    actor_subject_id LIKE 'user:%'
+    AND octet_length(convert_to(actor_subject_id, 'UTF8')) BETWEEN 6 AND 1024
+  ),
+  CONSTRAINT additional_organization_creation_names_check CHECK (
+    organization_name = btrim(organization_name)
+    AND char_length(organization_name) BETWEEN 1 AND 120
+    AND octet_length(convert_to(organization_name, 'UTF8')) BETWEEN 1 AND 480
+    AND workspace_name = btrim(workspace_name)
+    AND char_length(workspace_name) BETWEEN 1 AND 120
+    AND octet_length(convert_to(workspace_name, 'UTF8')) BETWEEN 1 AND 480
+  ),
+  CONSTRAINT additional_organization_creation_distinct_workspaces_check CHECK (
+    personal_workspace_id <> shared_workspace_id
+  ),
+  CONSTRAINT additional_organization_creation_result_check CHECK (
+    jsonb_typeof(result) = 'object'
+  )
+);
+ALTER TABLE additional_organization_creation_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE additional_organization_creation_receipts FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE additional_organization_creation_receipts FROM PUBLIC;
+CREATE POLICY additional_organization_creation_lifecycle
+  ON additional_organization_creation_receipts
+  USING (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    = 'additional_organization_creation')
+  WITH CHECK (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    = 'additional_organization_creation');
+
+CREATE TRIGGER additional_organization_creation_receipts_immutable
+  BEFORE UPDATE OR DELETE ON additional_organization_creation_receipts
+  FOR EACH ROW EXECUTE FUNCTION opengeni_private.organization_membership_history_immutable();
+
+CREATE TABLE session_tenancy_additional_organization_activation_evidence (
+  account_id uuid PRIMARY KEY
+    REFERENCES session_tenancy_activations(account_id) ON DELETE RESTRICT,
+  eligibility_version integer NOT NULL,
+  creation_operation_id uuid NOT NULL UNIQUE
+    REFERENCES additional_organization_creation_receipts(operation_id) ON DELETE RESTRICT,
+  actor_subject_id text NOT NULL,
+  personal_workspace_id uuid NOT NULL UNIQUE,
+  shared_workspace_id uuid NOT NULL UNIQUE,
+  organization_membership_id uuid NOT NULL UNIQUE,
+  boundary_witness_account_id uuid NOT NULL
+    REFERENCES session_tenancy_activations(account_id) ON DELETE RESTRICT,
+  boundary_witness_activated_at timestamptz NOT NULL,
+  graph_evidence jsonb NOT NULL,
+  graph_digest text NOT NULL,
+  activation_parity_digest text NOT NULL,
+  private_setting_version bigint NOT NULL,
+  private_setting_event_id uuid NOT NULL UNIQUE
+    REFERENCES organization_private_session_setting_events(id) ON DELETE RESTRICT,
+  activated_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT session_tenancy_additional_organization_eligibility_check CHECK (
+    eligibility_version = 1
+  ),
+  CONSTRAINT session_tenancy_additional_organization_actor_check CHECK (
+    actor_subject_id LIKE 'user:%'
+  ),
+  CONSTRAINT session_tenancy_additional_organization_workspaces_check CHECK (
+    personal_workspace_id <> shared_workspace_id
+  ),
+  CONSTRAINT session_tenancy_additional_organization_digests_check CHECK (
+    graph_digest ~ '^[0-9a-f]{64}$'
+    AND activation_parity_digest ~ '^[0-9a-f]{64}$'
+  ),
+  CONSTRAINT session_tenancy_additional_organization_witness_check CHECK (
+    boundary_witness_account_id <> account_id
+  ),
+  CONSTRAINT session_tenancy_additional_organization_graph_check CHECK (
+    jsonb_typeof(graph_evidence) = 'object'
+  ),
+  CONSTRAINT session_tenancy_additional_organization_setting_version_check CHECK (
+    private_setting_version > 0
+  ),
+  CONSTRAINT session_tenancy_additional_organization_personal_workspace_fk
+    FOREIGN KEY (personal_workspace_id)
+    REFERENCES additional_organization_creation_receipts(personal_workspace_id)
+      ON DELETE RESTRICT,
+  CONSTRAINT session_tenancy_additional_organization_shared_workspace_fk
+    FOREIGN KEY (shared_workspace_id)
+    REFERENCES additional_organization_creation_receipts(shared_workspace_id)
+      ON DELETE RESTRICT,
+  CONSTRAINT session_tenancy_additional_organization_membership_fk
+    FOREIGN KEY (organization_membership_id)
+    REFERENCES additional_organization_creation_receipts(organization_membership_id)
+      ON DELETE RESTRICT
+);
+ALTER TABLE session_tenancy_additional_organization_activation_evidence
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE session_tenancy_additional_organization_activation_evidence
+  FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE session_tenancy_additional_organization_activation_evidence FROM PUBLIC;
+CREATE POLICY session_tenancy_additional_organization_activation_lifecycle
+  ON session_tenancy_additional_organization_activation_evidence
+  USING (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    = 'session_tenancy_greenfield_activation')
+  WITH CHECK (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    = 'session_tenancy_greenfield_activation');
+
+CREATE FUNCTION activate_session_tenancy_from_additional_organization(
+  p_operation_id uuid
+) RETURNS boolean
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $activation$
+DECLARE
+  previous_lifecycle text := pg_catalog.current_setting(
+    'opengeni.organization_tenancy_lifecycle', true
+  );
+  creation additional_organization_creation_receipts%ROWTYPE;
+  account_row managed_accounts%ROWTYPE;
+  organization_membership organization_memberships%ROWTYPE;
+  personal_workspace workspaces%ROWTYPE;
+  shared_workspace workspaces%ROWTYPE;
+  shared_access workspace_memberships%ROWTYPE;
+  witness session_tenancy_activations%ROWTYPE;
+  inserted_activation session_tenancy_activations%ROWTYPE;
+  existing_evidence session_tenancy_additional_organization_activation_evidence%ROWTYPE;
+  account_inserted_in_current_transaction boolean;
+  account_never_updated boolean;
+  organization_membership_count integer;
+  workspace_count integer;
+  workspace_control_count integer;
+  personal_workspace_control_count integer;
+  shared_workspace_control_count integer;
+  workspace_membership_count integer;
+  graph_evidence_value jsonb;
+  graph_digest_value text;
+  parity_digest_value text;
+  private_setting_event_id_value uuid := pg_catalog.gen_random_uuid();
+BEGIN
+  IF p_operation_id IS NULL THEN
+    RAISE EXCEPTION 'additional organization activation operation is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO creation
+  FROM additional_organization_creation_receipts receipt
+  WHERE receipt.operation_id = p_operation_id
+  FOR KEY SHARE;
+  IF NOT FOUND
+    OR creation.actor_subject_id IS DISTINCT FROM opengeni_private.current_subject_id()
+    OR creation.account_id IS DISTINCT FROM opengeni_private.current_account_id()
+    OR creation.result ->> 'organizationId' IS DISTINCT FROM creation.account_id::text
+    OR creation.result ->> 'personalWorkspaceId'
+      IS DISTINCT FROM creation.personal_workspace_id::text
+    OR creation.result ->> 'workspaceId' IS DISTINCT FROM creation.shared_workspace_id::text
+  THEN
+    RAISE EXCEPTION 'additional organization activation receipt is invalid'
+      USING ERRCODE = '55000';
+  END IF;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'organization_membership_lifecycle', true
+  );
+
+  SELECT * INTO account_row
+  FROM managed_accounts account
+  WHERE account.id = creation.account_id
+  FOR KEY SHARE;
+  IF NOT FOUND
+    OR account_row.external_source IS DISTINCT FROM 'opengeni:additional-organization'
+    OR account_row.external_id IS DISTINCT FROM creation.operation_id::text
+    OR account_row.name IS DISTINCT FROM creation.organization_name
+  THEN
+    RAISE EXCEPTION 'additional organization activation requires its exact new account'
+      USING ERRCODE = '55000';
+  END IF;
+  SELECT
+    account.xmin::text::bigint = pg_catalog.pg_current_xact_id()::text::bigint,
+    account.created_at = account.updated_at
+  INTO account_inserted_in_current_transaction, account_never_updated
+  FROM managed_accounts account
+  WHERE account.id = creation.account_id;
+  IF account_inserted_in_current_transaction IS NOT TRUE
+    OR account_never_updated IS NOT TRUE
+  THEN
+    RAISE EXCEPTION 'additional organization activation requires a newly inserted account'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT * INTO organization_membership
+  FROM organization_memberships membership
+  WHERE membership.id = creation.organization_membership_id
+    AND membership.account_id = creation.account_id
+  FOR KEY SHARE;
+  SELECT count(*)::integer INTO organization_membership_count
+  FROM organization_memberships membership
+  WHERE membership.account_id = creation.account_id;
+  IF organization_membership.id IS NULL
+    OR organization_membership_count <> 1
+    OR organization_membership.subject_id IS DISTINCT FROM creation.actor_subject_id
+    OR organization_membership.role IS DISTINCT FROM 'owner'
+    OR organization_membership.status IS DISTINCT FROM 'active'
+    OR organization_membership.personal_workspace_id
+      IS DISTINCT FROM creation.personal_workspace_id
+  THEN
+    RAISE EXCEPTION 'additional organization membership graph is invalid'
+      USING ERRCODE = '55000';
+  END IF;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', creation.personal_workspace_id::text, true
+  );
+  SELECT * INTO personal_workspace
+  FROM workspaces workspace
+  WHERE workspace.id = creation.personal_workspace_id
+    AND workspace.account_id = creation.account_id
+  FOR KEY SHARE;
+  SELECT count(*)::integer INTO personal_workspace_control_count
+  FROM workspace_inference_controls control
+  WHERE control.account_id = creation.account_id
+    AND control.workspace_id = creation.personal_workspace_id;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', creation.shared_workspace_id::text, true
+  );
+  SELECT * INTO shared_workspace
+  FROM workspaces workspace
+  WHERE workspace.id = creation.shared_workspace_id
+    AND workspace.account_id = creation.account_id
+  FOR KEY SHARE;
+  SELECT count(*)::integer INTO workspace_count
+  FROM workspaces workspace WHERE workspace.account_id = creation.account_id;
+  SELECT count(*)::integer INTO shared_workspace_control_count
+  FROM workspace_inference_controls control
+  WHERE control.account_id = creation.account_id
+    AND control.workspace_id = creation.shared_workspace_id;
+  workspace_control_count :=
+    personal_workspace_control_count + shared_workspace_control_count;
+  SELECT count(*)::integer INTO workspace_membership_count
+  FROM workspace_memberships membership
+  WHERE membership.account_id = creation.account_id;
+  SELECT * INTO shared_access
+  FROM workspace_memberships membership
+  WHERE membership.account_id = creation.account_id
+    AND membership.workspace_id = creation.shared_workspace_id
+    AND membership.subject_id = creation.actor_subject_id
+  FOR KEY SHARE;
+  IF personal_workspace.id IS NULL
+    OR shared_workspace.id IS NULL
+    OR shared_access.id IS NULL
+    OR workspace_count <> 2
+    OR workspace_control_count <> 2
+    OR workspace_membership_count <> 1
+    OR personal_workspace.name IS DISTINCT FROM 'Personal workspace'
+    OR personal_workspace.slug IS NOT NULL
+    OR personal_workspace.external_source IS DISTINCT FROM
+      'opengeni:organization-membership'
+    OR personal_workspace.external_id IS DISTINCT FROM
+      creation.account_id::text || ':' || creation.actor_subject_id
+    OR shared_workspace.name IS DISTINCT FROM creation.workspace_name
+    OR shared_workspace.slug IS NOT NULL
+    OR shared_workspace.external_source IS DISTINCT FROM
+      'opengeni:additional-organization-default'
+    OR shared_workspace.external_id IS DISTINCT FROM creation.account_id::text
+    OR shared_access.role IS DISTINCT FROM 'admin'
+    OR shared_access.permissions IS DISTINCT FROM
+      opengeni_private.workspace_member_role_permissions('admin')
+  THEN
+    RAISE EXCEPTION 'additional organization workspace graph is invalid'
+      USING ERRCODE = '55000';
+  END IF;
+
+  graph_evidence_value := pg_catalog.jsonb_build_object(
+    'schemaVersion', 1,
+    'kind', 'additional_organization_with_first_shared_workspace',
+    'accountId', creation.account_id,
+    'operationId', creation.operation_id,
+    'actorSubjectId', creation.actor_subject_id,
+    'organizationMembershipId', creation.organization_membership_id,
+    'personalWorkspaceId', creation.personal_workspace_id,
+    'sharedWorkspaceId', creation.shared_workspace_id,
+    'organizationMembershipCount', organization_membership_count,
+    'workspaceCount', workspace_count,
+    'workspaceControlCount', workspace_control_count,
+    'workspaceMembershipCount', workspace_membership_count
+  );
+  graph_digest_value := pg_catalog.encode(pg_catalog.sha256(pg_catalog.convert_to(
+    graph_evidence_value::text, 'UTF8'
+  )), 'hex');
+
+  -- The exact graph is locked before the same deployment-wide fence used by
+  -- operator and first-signup activation. A creation that wins the fence stays
+  -- operator-managed; one after the first product witness activates atomically.
+  PERFORM lock_session_tenancy_activation_boundary();
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'session_tenancy_greenfield_activation', true
+  );
+
+  SELECT * INTO existing_evidence
+  FROM session_tenancy_additional_organization_activation_evidence evidence
+  WHERE evidence.account_id = creation.account_id;
+  IF FOUND THEN
+    IF existing_evidence.creation_operation_id IS DISTINCT FROM creation.operation_id
+      OR existing_evidence.actor_subject_id IS DISTINCT FROM creation.actor_subject_id
+      OR existing_evidence.personal_workspace_id IS DISTINCT FROM creation.personal_workspace_id
+      OR existing_evidence.shared_workspace_id IS DISTINCT FROM creation.shared_workspace_id
+      OR existing_evidence.organization_membership_id
+        IS DISTINCT FROM creation.organization_membership_id
+      OR existing_evidence.graph_digest IS DISTINCT FROM graph_digest_value
+    THEN
+      RAISE EXCEPTION 'additional organization activation evidence conflicts with creation'
+        USING ERRCODE = '23505';
+    END IF;
+    PERFORM pg_catalog.set_config(
+      'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+    );
+    RETURN true;
+  END IF;
+
+  SELECT * INTO witness
+  FROM session_tenancy_activations activation
+  WHERE activation.account_id <> creation.account_id
+  ORDER BY activation.activated_at, activation.account_id
+  LIMIT 1;
+  IF NOT FOUND THEN
+    PERFORM pg_catalog.set_config(
+      'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+    );
+    RETURN false;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM session_tenancy_activations activation
+    WHERE activation.account_id = creation.account_id
+  ) OR EXISTS (
+    SELECT 1 FROM organization_private_session_settings setting
+    WHERE setting.account_id = creation.account_id
+  ) THEN
+    RAISE EXCEPTION 'additional organization session tenancy already exists without evidence'
+      USING ERRCODE = '55000';
+  END IF;
+
+  parity_digest_value := pg_catalog.encode(pg_catalog.sha256(pg_catalog.convert_to(
+    pg_catalog.jsonb_build_object(
+      'schemaVersion', 1,
+      'graphDigest', graph_digest_value,
+      'boundaryWitnessAccountId', witness.account_id,
+      'boundaryWitnessActivatedAt', witness.activated_at
+    )::text,
+    'UTF8'
+  )), 'hex');
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle', 'session_tenancy_activation', true
+  );
+  INSERT INTO session_tenancy_activations (
+    account_id, activation_version, inventory_digest, parity_digest,
+    activated_by, backfill_receipt_ids
+  ) VALUES (
+    creation.account_id, 1, graph_digest_value, parity_digest_value,
+    'opengeni:additional-organization-creation:v1', ARRAY[]::uuid[]
+  ) RETURNING * INTO inserted_activation;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'organization_private_session_settings', true
+  );
+  INSERT INTO organization_private_session_settings (
+    account_id, enabled, version, updated_by_membership_id, updated_at
+  ) VALUES (
+    creation.account_id, true, 1, creation.organization_membership_id,
+    inserted_activation.activated_at
+  );
+  INSERT INTO organization_private_session_setting_events (
+    id, account_id, actor_membership_id, requested_enabled,
+    expected_version, result_enabled, result_version, result_updated_at, changed
+  ) VALUES (
+    private_setting_event_id_value, creation.account_id,
+    creation.organization_membership_id, true, 0, true, 1,
+    inserted_activation.activated_at, true
+  );
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'session_tenancy_greenfield_activation', true
+  );
+  INSERT INTO session_tenancy_additional_organization_activation_evidence (
+    account_id, eligibility_version, creation_operation_id, actor_subject_id,
+    personal_workspace_id, shared_workspace_id, organization_membership_id,
+    boundary_witness_account_id, boundary_witness_activated_at,
+    graph_evidence, graph_digest, activation_parity_digest,
+    private_setting_version, private_setting_event_id, activated_at
+  ) VALUES (
+    creation.account_id, 1, creation.operation_id, creation.actor_subject_id,
+    creation.personal_workspace_id, creation.shared_workspace_id,
+    creation.organization_membership_id, witness.account_id, witness.activated_at,
+    graph_evidence_value, graph_digest_value, parity_digest_value,
+    1, private_setting_event_id_value, inserted_activation.activated_at
+  );
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+  );
+  RETURN true;
+EXCEPTION WHEN OTHERS THEN
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle', coalesce(previous_lifecycle, ''), true
+  );
+  RAISE;
+END
+$activation$;
+REVOKE ALL ON FUNCTION activate_session_tenancy_from_additional_organization(uuid)
+  FROM PUBLIC;
+
+CREATE FUNCTION create_additional_managed_organization(
+  p_subject_id text,
+  p_subject_label text,
+  p_organization_name text,
+  p_workspace_name text,
+  p_operation_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $creation$
+DECLARE
+  auth_user_id_value text := substring(p_subject_id from length('user:') + 1);
+  organization_name_value text := nullif(pg_catalog.btrim(p_organization_name), '');
+  workspace_name_value text := nullif(pg_catalog.btrim(p_workspace_name), '');
+  subject_label_value text := nullif(pg_catalog.btrim(p_subject_label), '');
+  auth_user auth_users%ROWTYPE;
+  prior additional_organization_creation_receipts%ROWTYPE;
+  account_row managed_accounts%ROWTYPE;
+  organization_membership organization_memberships%ROWTYPE;
+  personal_workspace workspaces%ROWTYPE;
+  shared_workspace workspaces%ROWTYPE;
+  public_result jsonb;
+BEGIN
+  IF p_subject_id IS NULL
+    OR p_subject_id NOT LIKE 'user:%'
+    OR p_subject_id IS DISTINCT FROM opengeni_private.current_subject_id()
+    OR pg_catalog.octet_length(pg_catalog.convert_to(p_subject_id, 'UTF8'))
+      NOT BETWEEN 6 AND 1024
+    OR organization_name_value IS NULL
+    OR pg_catalog.char_length(organization_name_value) > 120
+    OR pg_catalog.octet_length(pg_catalog.convert_to(organization_name_value, 'UTF8')) > 480
+    OR workspace_name_value IS NULL
+    OR pg_catalog.char_length(workspace_name_value) > 120
+    OR pg_catalog.octet_length(pg_catalog.convert_to(workspace_name_value, 'UTF8')) > 480
+    OR (subject_label_value IS NOT NULL AND
+      pg_catalog.octet_length(pg_catalog.convert_to(subject_label_value, 'UTF8')) > 1024)
+    OR p_operation_id IS NULL
+  THEN
+    RAISE EXCEPTION 'additional organization creation input is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO auth_user
+  FROM auth_users candidate
+  WHERE candidate.id = auth_user_id_value
+  FOR KEY SHARE;
+  IF NOT FOUND OR auth_user.email_verified IS NOT TRUE THEN
+    RAISE EXCEPTION 'verified managed user required' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'organization_membership_lifecycle', true
+  );
+  IF NOT EXISTS (
+    SELECT 1 FROM organization_memberships membership
+    WHERE membership.subject_id = p_subject_id
+      AND membership.status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'initial organization setup must be completed first'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
+    'additional-organization-creation:' || p_operation_id::text, 0
+  ));
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'additional_organization_creation', true
+  );
+  SELECT * INTO prior
+  FROM additional_organization_creation_receipts receipt
+  WHERE receipt.operation_id = p_operation_id
+  FOR UPDATE;
+  IF FOUND THEN
+    IF prior.actor_subject_id IS DISTINCT FROM p_subject_id
+      OR prior.organization_name IS DISTINCT FROM organization_name_value
+      OR prior.workspace_name IS DISTINCT FROM workspace_name_value
+    THEN
+      RAISE EXCEPTION 'additional organization operation key was reused'
+        USING ERRCODE = '23505';
+    END IF;
+    RETURN prior.result;
+  END IF;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'organization_membership_lifecycle', true
+  );
+
+  INSERT INTO managed_accounts (name, external_source, external_id)
+  VALUES (
+    organization_name_value,
+    'opengeni:additional-organization',
+    p_operation_id::text
+  ) RETURNING * INTO account_row;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'organization-membership:' || account_row.id::text, 0
+    )
+  );
+  PERFORM pg_catalog.set_config('opengeni.account_id', account_row.id::text, true);
+
+  personal_workspace.id := pg_catalog.gen_random_uuid();
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', personal_workspace.id::text, true
+  );
+  INSERT INTO workspaces (
+    id, account_id, name, slug, external_source, external_id
+  ) VALUES (
+    personal_workspace.id, account_row.id, 'Personal workspace', NULL,
+    'opengeni:organization-membership',
+    account_row.id::text || ':' || p_subject_id
+  ) RETURNING * INTO personal_workspace;
+  INSERT INTO workspace_inference_controls (workspace_id, account_id)
+  VALUES (personal_workspace.id, account_row.id);
+
+  INSERT INTO organization_memberships (
+    account_id, subject_id, role, status, personal_workspace_id
+  ) VALUES (
+    account_row.id, p_subject_id, 'owner', 'active', personal_workspace.id
+  ) RETURNING * INTO organization_membership;
+
+  shared_workspace.id := pg_catalog.gen_random_uuid();
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', shared_workspace.id::text, true
+  );
+  INSERT INTO workspaces (
+    id, account_id, name, slug, external_source, external_id
+  ) VALUES (
+    shared_workspace.id, account_row.id, workspace_name_value, NULL,
+    'opengeni:additional-organization-default', account_row.id::text
+  ) RETURNING * INTO shared_workspace;
+  INSERT INTO workspace_inference_controls (workspace_id, account_id)
+  VALUES (shared_workspace.id, account_row.id);
+  INSERT INTO workspace_memberships (
+    account_id, workspace_id, subject_id, subject_label, role, permissions
+  ) VALUES (
+    account_row.id, shared_workspace.id, p_subject_id, subject_label_value,
+    'admin', opengeni_private.workspace_member_role_permissions('admin')
+  );
+
+  public_result := pg_catalog.jsonb_build_object(
+    'organizationId', account_row.id,
+    'organization', pg_catalog.jsonb_build_object(
+      'id', account_row.id,
+      'name', account_row.name,
+      'createdAt', account_row.created_at,
+      'updatedAt', account_row.updated_at
+    ),
+    'workspaceId', shared_workspace.id,
+    'personalWorkspaceId', personal_workspace.id
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.organization_tenancy_lifecycle',
+    'additional_organization_creation', true
+  );
+  INSERT INTO additional_organization_creation_receipts (
+    operation_id, actor_subject_id, account_id, organization_membership_id,
+    personal_workspace_id, shared_workspace_id, organization_name,
+    workspace_name, result
+  ) VALUES (
+    p_operation_id, p_subject_id, account_row.id, organization_membership.id,
+    personal_workspace.id, shared_workspace.id, organization_name_value,
+    workspace_name_value, public_result
+  );
+
+  PERFORM activate_session_tenancy_from_additional_organization(p_operation_id);
+  RETURN public_result;
+END
+$creation$;
+
+REVOKE ALL ON FUNCTION create_additional_managed_organization(
+  text, text, text, text, uuid
+) FROM PUBLIC;
+
+DO $posture$
+DECLARE
+  data_schema text := pg_catalog.current_schema();
+BEGIN
+  EXECUTE pg_catalog.format(
+    'ALTER FUNCTION %I.activate_session_tenancy_from_additional_organization(uuid) '
+      || 'SET search_path = pg_catalog, %I, opengeni_private, pg_temp',
+    data_schema, data_schema
+  );
+  EXECUTE pg_catalog.format(
+    'ALTER FUNCTION %I.create_additional_managed_organization(text,text,text,text,uuid) '
+      || 'SET search_path = pg_catalog, %I, opengeni_private, pg_temp',
+    data_schema, data_schema
+  );
+END
+$posture$;
+
+DO $application_grants$
+DECLARE
+  data_schema text := pg_catalog.current_schema();
+  application_role text;
+BEGIN
+  FOR application_role IN
+    SELECT role_value.rolname
+    FROM pg_catalog.jsonb_array_elements_text(
+      coalesce(nullif(current_setting('opengeni.migration_application_roles', true), ''), '[]')::jsonb
+    ) configured(value)
+    JOIN pg_catalog.pg_roles role_value ON role_value.rolname = configured.value
+    UNION SELECT 'opengeni_app'
+      WHERE EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'opengeni_app')
+  LOOP
+    EXECUTE pg_catalog.format(
+      'GRANT EXECUTE ON FUNCTION %1$I.create_additional_managed_organization(text,text,text,text,uuid) TO %2$I',
+      data_schema, application_role
+    );
+    EXECUTE pg_catalog.format(
+      'REVOKE ALL ON TABLE %1$I.additional_organization_creation_receipts, %1$I.session_tenancy_additional_organization_activation_evidence FROM %2$I',
+      data_schema, application_role
+    );
+    EXECUTE pg_catalog.format(
+      'REVOKE ALL ON FUNCTION %1$I.activate_session_tenancy_from_additional_organization(uuid) FROM %2$I',
+      data_schema, application_role
+    );
+  END LOOP;
+END
+$application_grants$;
+
+COMMENT ON TABLE additional_organization_creation_receipts IS
+  'Immutable exact-command receipts for additional organization creation by an already-onboarded managed human.';
+COMMENT ON TABLE session_tenancy_additional_organization_activation_evidence IS
+  'Immutable graph, boundary-witness, private-setting, and activation evidence for a newly created additional organization.';
+COMMENT ON FUNCTION create_additional_managed_organization(text, text, text, text, uuid) IS
+  'Creates an additional organization, Personal workspace, first shared workspace, owner membership, and creator access atomically.';
+COMMENT ON FUNCTION activate_session_tenancy_from_additional_organization(uuid) IS
+  'Owner-only atomic activation for the exact fresh graph created by create_additional_managed_organization.';
+
+RESET statement_timeout;
+RESET lock_timeout;

--- a/packages/db/drizzle/0399_additional_managed_organization_creation.sql
+++ b/packages/db/drizzle/0399_additional_managed_organization_creation.sql
@@ -43,6 +43,8 @@ CREATE TABLE additional_organization_creation_receipts (
     jsonb_typeof(result) = 'object'
   )
 );
+CREATE INDEX additional_organization_creation_receipts_actor_subject_idx
+  ON additional_organization_creation_receipts (actor_subject_id);
 ALTER TABLE additional_organization_creation_receipts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE additional_organization_creation_receipts FORCE ROW LEVEL SECURITY;
 REVOKE ALL ON TABLE additional_organization_creation_receipts FROM PUBLIC;

--- a/packages/db/drizzle/0399_additional_managed_organization_creation.sql
+++ b/packages/db/drizzle/0399_additional_managed_organization_creation.sql
@@ -445,6 +445,7 @@ LANGUAGE plpgsql VOLATILE SECURITY DEFINER
 SET search_path FROM CURRENT
 AS $creation$
 DECLARE
+  additional_organization_limit constant integer := 10;
   auth_user_id_value text := substring(p_subject_id from length('user:') + 1);
   organization_name_value text := nullif(pg_catalog.btrim(p_organization_name), '');
   workspace_name_value text := nullif(pg_catalog.btrim(p_workspace_name), '');
@@ -455,6 +456,7 @@ DECLARE
   organization_membership organization_memberships%ROWTYPE;
   personal_workspace workspaces%ROWTYPE;
   shared_workspace workspaces%ROWTYPE;
+  created_organization_count integer;
   public_result jsonb;
 BEGIN
   IF p_subject_id IS NULL
@@ -517,6 +519,22 @@ BEGIN
         USING ERRCODE = '23505';
     END IF;
     RETURN prior.result;
+  END IF;
+
+  -- Fresh operation ids must not turn one verified login into an unbounded
+  -- tenant allocator. Serialize every create for the canonical subject, then
+  -- count only organizations allocated through this lifecycle. Invitations do
+  -- not consume the self-service allowance, and an exact committed retry above
+  -- continues to replay after the allowance is full.
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
+    'additional-organization-creation-subject:' || p_subject_id, 0
+  ));
+  SELECT count(*)::integer INTO created_organization_count
+  FROM additional_organization_creation_receipts receipt
+  WHERE receipt.actor_subject_id = p_subject_id;
+  IF created_organization_count >= additional_organization_limit THEN
+    RAISE EXCEPTION 'additional organization limit reached'
+      USING ERRCODE = '54000';
   END IF;
 
   PERFORM pg_catalog.set_config(

--- a/packages/db/src/organization-membership-lifecycle.ts
+++ b/packages/db/src/organization-membership-lifecycle.ts
@@ -1,4 +1,5 @@
 import {
+  CreateAdditionalOrganizationResponse,
   CreateOrganizationResponse,
   ListOrganizationAdministrationMembersResponse,
   ListOrganizationInvitationsResponse,
@@ -18,6 +19,7 @@ import {
   OrganizationRetentionPolicy,
   OrganizationSummary,
   RevokeOrganizationWorkspaceMemberResponse,
+  type CreateAdditionalOrganizationResponse as CreateAdditionalOrganizationResponseType,
   type CreateOrganizationResponse as CreateOrganizationResponseType,
   type OrganizationAdministrationMember as OrganizationAdministrationMemberType,
   type OrganizationAdministrationOverview as OrganizationAdministrationOverviewType,
@@ -71,6 +73,32 @@ export async function createManagedOrganization(
       ) as result`,
     );
     return CreateOrganizationResponse.parse(row?.result);
+  });
+}
+
+export async function createAdditionalManagedOrganization(
+  db: Database,
+  input: {
+    subjectId: string;
+    subjectLabel: string;
+    name: string;
+    workspaceName: string;
+    operationId: string;
+  },
+): Promise<CreateAdditionalOrganizationResponseType> {
+  return await db.transaction(async (tx) => {
+    await setSubjectRlsContext(tx as unknown as Database, input.subjectId);
+    const [row] = await rawRows<{ result: unknown }>(
+      tx,
+      sql`select create_additional_managed_organization(
+        ${input.subjectId},
+        ${input.subjectLabel},
+        ${input.name},
+        ${input.workspaceName},
+        ${input.operationId}::uuid
+      ) as result`,
+    );
+    return CreateAdditionalOrganizationResponse.parse(row?.result);
   });
 }
 
@@ -208,7 +236,10 @@ async function settleOrganizationMembershipProtocols(
   db: Database,
   settlements: OrganizationMembershipProtocolSettlement[],
 ): Promise<void> {
-  const [prior] = await rawRows<{ subject_id: string; initiating_human_subject_id: string }>(
+  const [prior] = await rawRows<{
+    subject_id: string;
+    initiating_human_subject_id: string;
+  }>(
     db,
     sql`select
       coalesce(current_setting('opengeni.subject_id', true), '') as subject_id,
@@ -436,7 +467,9 @@ async function runOrganizationWorkspaceCommand(
     { accountId: command.organizationId, workspaceId: null },
     async (scopedDb) => {
       await setSubjectRlsContext(scopedDb, command.actorSubjectId);
-      const [row] = await rawRows<{ result: OrganizationWorkspaceCommandResult }>(
+      const [row] = await rawRows<{
+        result: OrganizationWorkspaceCommandResult;
+      }>(
         scopedDb,
         sql`select organization_workspace_command(${JSON.stringify(command)}::jsonb) as result`,
       );
@@ -455,7 +488,10 @@ export async function createOrganizationWorkspace(
     operationId: string;
   },
 ): Promise<OrganizationWorkspaceAccessType> {
-  const command = await runOrganizationWorkspaceCommand(db, { action: "create", ...input });
+  const command = await runOrganizationWorkspaceCommand(db, {
+    action: "create",
+    ...input,
+  });
   const overview = await getOrganizationAdministrationOverview(db, input);
   const workspace = overview.workspaces.find((candidate) => candidate.id === command.workspaceId);
   if (!workspace) throw new Error("Created organization workspace is missing from its overview");
@@ -615,7 +651,9 @@ export async function assertActiveManagedHumanOrganizationMembership(
   db: Database,
   input: { accountId: string; subjectId: string },
 ): Promise<number | null> {
-  const [row] = await rawRows<{ authorization_revision: number | string | null }>(
+  const [row] = await rawRows<{
+    authorization_revision: number | string | null;
+  }>(
     db,
     sql`select assert_active_managed_human_organization_membership(
       ${input.accountId}::uuid,
@@ -1098,7 +1136,11 @@ export async function previewOrganizationRetentionDeletions(
 
 export async function claimOrganizationRetentionDeletion(
   db: Database,
-  input: { organizationId: string; operationId: string; excludedMembershipIds?: string[] },
+  input: {
+    organizationId: string;
+    operationId: string;
+    excludedMembershipIds?: string[];
+  },
 ): Promise<OrganizationRetentionDeletionClaimType | null> {
   return await runRetentionCapability(db, input.organizationId, async (scopedDb) => {
     const excludedMembershipIds = input.excludedMembershipIds ?? [];

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -540,6 +540,7 @@ async function grantAppRoleIfSchemaExists(
     "resolve_organization_workspace_removal_subject(uuid,text,uuid)",
     "prepare_organization_workspace_member_removal(jsonb)",
     "record_organization_workspace_member_removal(jsonb,uuid,uuid)",
+    "create_additional_managed_organization(text,text,text,text,uuid)",
     "create_managed_organization(text,text,text,uuid)",
     "assert_organization_shared_workspace_administrator(uuid,uuid,text)",
     "open_organization_shared_workspace_administration_capability(uuid,uuid,text)",

--- a/packages/db/src/runtime-posture.ts
+++ b/packages/db/src/runtime-posture.ts
@@ -81,6 +81,8 @@ const KNOWLEDGE_SOURCE_SYNC_LOCK_AUTHORITY_TABLES = [
 ] as const;
 const MANAGED_HUMAN_PERSONAL_WORKSPACE_ROUTINE =
   "ensure_managed_human_personal_workspace(uuid, text, uuid)";
+const ADDITIONAL_ORGANIZATION_CREATION_ROUTINE =
+  "create_additional_managed_organization(text, text, text, text, uuid)";
 const ORGANIZATION_MEMBERSHIP_LIFECYCLE_ROUTINES = [
   "list_self_organization_memberships(text)",
   "list_self_organization_invitations(text)",
@@ -98,6 +100,7 @@ const ORGANIZATION_MEMBERSHIP_LIFECYCLE_ROUTINES = [
   "resolve_organization_workspace_removal_subject(uuid, text, uuid)",
   "prepare_organization_workspace_member_removal(jsonb)",
   "record_organization_workspace_member_removal(jsonb, uuid, uuid)",
+  ADDITIONAL_ORGANIZATION_CREATION_ROUTINE,
   "create_managed_organization(text, text, text, uuid)",
   "assert_organization_shared_workspace_administrator(uuid, uuid, text)",
   "open_organization_shared_workspace_administration_capability(uuid, uuid, text)",
@@ -154,6 +157,10 @@ const ORGANIZATION_MEMBERSHIP_LIFECYCLE_AUTHORITY_TABLES = [
   "organization_workspace_lifecycle_events",
   "organization_workspace_operation_receipts",
   "self_service_organization_setup_receipts",
+] as const;
+const ADDITIONAL_ORGANIZATION_CREATION_AUTHORITY_TABLES = [
+  ...ORGANIZATION_MEMBERSHIP_LIFECYCLE_AUTHORITY_TABLES,
+  "additional_organization_creation_receipts",
 ] as const;
 const PRIVATE_SESSION_CREATE_POLICY_ROUTINE = "get_private_session_create_policy(uuid, uuid, text)";
 const ORGANIZATION_PRIVATE_SESSION_SETTINGS_READ_ROUTINE =
@@ -490,6 +497,8 @@ const TENANCY_BACKFILL_ACTIVATION_EVIDENCE_ROUTINE =
   "check_tenancy_backfill_activation_evidence(uuid)";
 const GREENFIELD_SESSION_TENANCY_ACTIVATION_ROUTINE =
   "activate_greenfield_session_tenancy_from_setup(text)";
+const ADDITIONAL_ORGANIZATION_SESSION_TENANCY_ACTIVATION_ROUTINE =
+  "activate_session_tenancy_from_additional_organization(uuid)";
 const SESSION_VISIBILITY_LIFECYCLE_CAPABILITY_ROUTINE =
   "session_visibility_lifecycle_capability_held()";
 const PRIVATE_SESSION_CREATE_CAPABILITY_ROUTINES = [
@@ -598,6 +607,7 @@ const RUNTIME_TARGET_SCHEMA_PUBLIC_POLICY_PREDICATE_ROUTINE_SET = new Set<string
 
 /** Owner-internal helpers that must exist but must never be callable by the runtime role. */
 export const RUNTIME_TARGET_SCHEMA_FORBIDDEN_ROUTINES = [
+  ADDITIONAL_ORGANIZATION_SESSION_TENANCY_ACTIVATION_ROUTINE,
   AUTOMATIC_SESSION_TITLE_QUARANTINE_FENCE_ROUTINE,
   ORGANIZATION_PRIVATE_SESSIONS_ENABLED_ROUTINE,
   GREENFIELD_SESSION_TENANCY_ACTIVATION_ROUTINE,
@@ -621,6 +631,7 @@ const RUNTIME_TARGET_SCHEMA_INVOKER_ROUTINE_SET = new Set<string>(
  * commit as the migration so startup cannot silently accept an unreviewed gap.
  */
 export const FORCE_RLS_TABLES = [
+  "additional_organization_creation_receipts",
   "agent_run_states",
   "api_keys",
   "attached_browser_devices",
@@ -887,6 +898,7 @@ export const FORCE_RLS_TABLES = [
   "session_system_update_outbox",
   "session_system_updates",
   "session_tenancy_activations",
+  "session_tenancy_additional_organization_activation_evidence",
   "session_tenancy_greenfield_activation_evidence",
   "session_turn_attempts",
   "session_turn_startup_milestones",
@@ -1281,6 +1293,7 @@ export const RUNTIME_READ_INSERT_UPDATE_TABLES = [
  * The ordinary application role must have no direct table privileges on them.
  */
 export const PROTECTED_NO_DIRECT_DML_TABLES = [
+  "additional_organization_creation_receipts",
   "canonical_human_identities",
   "canonical_human_identity_operations",
   "canonical_human_identity_subjects",
@@ -1370,6 +1383,7 @@ export const PROTECTED_NO_DIRECT_DML_TABLES = [
   "session_attempt_personal_document_snapshots",
   "session_attempt_personal_resource_admissions",
   "session_attempt_personal_resource_snapshots",
+  "session_tenancy_additional_organization_activation_evidence",
   "session_tenancy_greenfield_activation_evidence",
   "session_variable_set_attachments",
   "session_visibility_write_capabilities",
@@ -2293,6 +2307,29 @@ export function evaluateRuntimeDatabasePosture(
         );
       } else {
         const authorityTables = COMPANY_PROFILE_AGENT_ADMIN_AUTHORITY_TABLES.map(
+          (tableName) => tableByName.get(tableName)!,
+        );
+        const authorityOwners = new Set(authorityTables.map((table) => table.owner));
+        if (authorityOwners.size !== 1) {
+          violations.push(
+            `target-schema runtime capability ${routine.name} authority table owners do not match: ${authorityTables.map((table) => `${table.name}=${table.owner}`).join(", ")}`,
+          );
+        } else if (routine.owner !== authorityTables[0]!.owner) {
+          violations.push(
+            `target-schema runtime capability ${routine.name} owner ${routine.owner} does not match authority table owner ${authorityTables[0]!.owner}`,
+          );
+        }
+      }
+    } else if (routine.name === ADDITIONAL_ORGANIZATION_CREATION_ROUTINE) {
+      const missingAuthorityTables = ADDITIONAL_ORGANIZATION_CREATION_AUTHORITY_TABLES.filter(
+        (tableName) => !tableByName.has(tableName),
+      );
+      if (missingAuthorityTables.length > 0) {
+        violations.push(
+          `target-schema runtime capability ${routine.name} authority tables are missing: ${missingAuthorityTables.join(", ")}`,
+        );
+      } else {
+        const authorityTables = ADDITIONAL_ORGANIZATION_CREATION_AUTHORITY_TABLES.map(
           (tableName) => tableByName.get(tableName)!,
         );
         const authorityOwners = new Set(authorityTables.map((table) => table.owner));

--- a/packages/db/test/migration-0353-automatic-session-title-policy-fence.test.ts
+++ b/packages/db/test/migration-0353-automatic-session-title-policy-fence.test.ts
@@ -947,6 +947,7 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
     // today's evaluator strict for every table that existed at that boundary,
     // while explicitly removing tables introduced by later migrations.
     const post0353RuntimeTables = new Set([
+      "additional_organization_creation_receipts",
       "company_profile_agent_automatic_activation_receipts",
       "deployment_model_catalog",
       "organization_company_profile_agent_policies",
@@ -968,6 +969,7 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
       "pr_review_managed_github_authority_nonces",
       "pr_review_managed_github_routes",
       "remember_knowledge_memory_materializations",
+      "session_tenancy_additional_organization_activation_evidence",
       "session_event_cursors",
       "session_work_claim_revisions",
       "session_work_claim_write_capabilities",
@@ -1028,8 +1030,12 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
     ]);
     const post0353CapabilityRoutines = new Set([
       ...sessionSetRoutines,
+      "create_additional_managed_organization(text, text, text, text, uuid)",
       "issue_self_local_connection_use_grant(uuid, uuid, uuid, text, boolean)",
       "resolve_workspace_codex_subscription_source(uuid, uuid)",
+    ]);
+    const post0353ForbiddenRoutines = new Set([
+      "activate_session_tenancy_from_additional_organization(uuid)",
     ]);
     const post0353ProtectedTables = new Set([...post0353RuntimeTables, ...sessionSetTables]);
     const preSessionSetProtectedTables = FORCE_RLS_TABLES.filter(
@@ -1054,7 +1060,9 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
       protectedNoDirectDmlTables: preSessionSetNoDirectDmlTables,
       tablePrivileges: preSessionSetTablePrivileges,
       targetSchemaCapabilityRoutines: preSessionSetCapabilityRoutines,
-      targetSchemaForbiddenRoutines: RUNTIME_TARGET_SCHEMA_FORBIDDEN_ROUTINES,
+      targetSchemaForbiddenRoutines: RUNTIME_TARGET_SCHEMA_FORBIDDEN_ROUTINES.filter(
+        (routine) => !post0353ForbiddenRoutines.has(routine),
+      ),
     });
 
     try {

--- a/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
+++ b/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
@@ -77,6 +77,8 @@ describe("migration 0399 additional managed organization creation", () => {
     );
     expect(source).toContain("account.xmin::text::bigint = pg_catalog.pg_current_xact_id()");
     expect(source).toContain("workspace_membership_count <> 1");
+    expect(source).toContain("'additional-organization-creation-subject:' || p_subject_id");
+    expect(source).toContain("created_organization_count >= additional_organization_limit");
     expect(FORCE_RLS_TABLES).toContain("additional_organization_creation_receipts");
     expect(FORCE_RLS_TABLES).toContain(
       "session_tenancy_additional_organization_activation_evidence",
@@ -211,6 +213,43 @@ describe("migration 0399 additional managed organization creation", () => {
       select count(*)::int as count from organization_memberships
       where subject_id = ${subjectId} and status = 'active'`;
     expect(membershipCount?.count).toBe(3);
+
+    for (let index = 3; index <= 9; index += 1) {
+      await createAdditionalManagedOrganization(appClient.db, {
+        ...input,
+        name: `Team ${index}`,
+        workspaceName: `Workspace ${index}`,
+        operationId: crypto.randomUUID(),
+      });
+    }
+    const competing = await Promise.allSettled(
+      ["Ten A", "Ten B"].map((name) =>
+        createAdditionalManagedOrganization(appClient!.db, {
+          ...input,
+          name,
+          workspaceName: name,
+          operationId: crypto.randomUUID(),
+        }),
+      ),
+    );
+    expect(competing.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = competing.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    expect(nestedPostgresSqlState(rejected?.reason)).toBe("54000");
+
+    const [quota] = await owned.admin<Array<{ receipts: number; accounts: number }>>`
+      select
+        (select count(*)::int from additional_organization_creation_receipts
+          where actor_subject_id = ${subjectId}) as receipts,
+        (select count(*)::int from managed_accounts
+          where external_source = 'opengeni:additional-organization'
+            and id in (
+              select account_id from additional_organization_creation_receipts
+              where actor_subject_id = ${subjectId}
+            )) as accounts`;
+    expect(quota).toEqual({ receipts: 10, accounts: 10 });
+    expect(await createAdditionalManagedOrganization(appClient.db, input)).toEqual(left);
 
     const outsiderId = crypto.randomUUID();
     await owned.admin`

--- a/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
+++ b/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
@@ -79,6 +79,9 @@ describe("migration 0399 additional managed organization creation", () => {
     expect(source).toContain("workspace_membership_count <> 1");
     expect(source).toContain("'additional-organization-creation-subject:' || p_subject_id");
     expect(source).toContain("created_organization_count >= additional_organization_limit");
+    expect(source).toContain(
+      "CREATE INDEX additional_organization_creation_receipts_actor_subject_idx",
+    );
     expect(FORCE_RLS_TABLES).toContain("additional_organization_creation_receipts");
     expect(FORCE_RLS_TABLES).toContain(
       "session_tenancy_additional_organization_activation_evidence",

--- a/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
+++ b/packages/db/test/migration-0399-additional-managed-organization-creation.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { readFileSync } from "node:fs";
+import postgres from "postgres";
+
+import {
+  completeSelfServiceOrganizationSetup,
+  createAdditionalManagedOrganization,
+  createDb,
+  nestedPostgresSqlState,
+  type DbClient,
+} from "../src";
+import { FORCE_RLS_TABLES, PROTECTED_NO_DIRECT_DML_TABLES } from "../src/runtime-posture";
+import { migrate } from "../src/migrate";
+import { provisionRoles } from "../src/provision-roles";
+
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+let owned: OwnerMigratedTestDatabase | null = null;
+let appClient: DbClient | null = null;
+let app: postgres.Sql | null = null;
+
+async function expectSqlState(action: () => Promise<unknown>, state: string): Promise<void> {
+  let failure: unknown;
+  try {
+    await action();
+  } catch (error) {
+    failure = error;
+  }
+  expect(nestedPostgresSqlState(failure)).toBe(state);
+}
+
+beforeAll(async () => {
+  owned = await acquireOwnerMigratedTestDatabase("migration-0398-additional-organization");
+  if (!owned) {
+    if (requireRealDatabase) throw new Error("additional organization PostgreSQL unavailable");
+    return;
+  }
+  await migrate(owned.ownerUrl);
+  await provisionRoles(owned.adminUrl, {
+    appPassword: owned.appPassword,
+    rlsStrategy: "force",
+  });
+  const appUrl = new URL(owned.ownerUrl);
+  appUrl.username = "opengeni_app";
+  appUrl.password = owned.appPassword;
+  appClient = createDb(appUrl.toString(), { max: 4, rlsStrategy: "force" });
+  app = postgres(appUrl.toString(), {
+    max: 2,
+    prepare: false,
+    onnotice: () => undefined,
+  });
+}, 900_000);
+
+afterAll(async () => {
+  await appClient?.close().catch(() => undefined);
+  await app?.end({ timeout: 5 }).catch(() => undefined);
+  await owned?.release();
+}, 180_000);
+
+describe("migration 0399 additional managed organization creation", () => {
+  test("keeps the new lifecycle separate, owner-mediated, and FORCE-RLS protected", async () => {
+    const source = readFileSync(
+      new URL("../drizzle/0399_additional_managed_organization_creation.sql", import.meta.url),
+      "utf8",
+    );
+    expect(source.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+    expect(source).toContain("CREATE FUNCTION create_additional_managed_organization");
+    expect(source).toContain(
+      "CREATE FUNCTION activate_session_tenancy_from_additional_organization",
+    );
+    expect(source).not.toContain("CREATE OR REPLACE FUNCTION create_managed_organization");
+    expect(source).not.toContain(
+      "CREATE OR REPLACE FUNCTION complete_self_service_organization_setup",
+    );
+    expect(source).toContain("account.xmin::text::bigint = pg_catalog.pg_current_xact_id()");
+    expect(source).toContain("workspace_membership_count <> 1");
+    expect(FORCE_RLS_TABLES).toContain("additional_organization_creation_receipts");
+    expect(FORCE_RLS_TABLES).toContain(
+      "session_tenancy_additional_organization_activation_evidence",
+    );
+    expect(PROTECTED_NO_DIRECT_DML_TABLES).toContain("additional_organization_creation_receipts");
+    expect(PROTECTED_NO_DIRECT_DML_TABLES).toContain(
+      "session_tenancy_additional_organization_activation_evidence",
+    );
+  });
+
+  test("creates two isolated organizations for one login with exact replay and activation", async () => {
+    if (!owned || !appClient || !app) return;
+    const userId = crypto.randomUUID();
+    const subjectId = `user:${userId}`;
+    await owned.admin`
+      insert into auth_users (id, name, email, email_verified)
+      values (${userId}, 'Multi-org owner', ${`${userId}@example.test`}, true)`;
+
+    await completeSelfServiceOrganizationSetup(appClient.db, {
+      authUserId: userId,
+      actorSubjectId: subjectId,
+      organizationName: "Original organization",
+      operationId: crypto.randomUUID(),
+      requestFingerprint: "a".repeat(64),
+    });
+
+    const witnessAccountId = crypto.randomUUID();
+    await owned.admin`
+      insert into managed_accounts (id, name)
+      values (${witnessAccountId}, 'Committed activation witness')`;
+    await owned.admin`
+      insert into session_tenancy_activations (
+        account_id, activation_version, inventory_digest, parity_digest,
+        activated_by, backfill_receipt_ids
+      ) values (
+        ${witnessAccountId}, 1, ${"0".repeat(64)}, ${"1".repeat(64)},
+        'test:additional-organization-witness', array[]::uuid[]
+      )`;
+
+    const input = {
+      subjectId,
+      subjectLabel: "Multi-org owner",
+      name: "Product team",
+      workspaceName: "Launch room",
+      operationId: crypto.randomUUID(),
+    };
+    const [left, right] = await Promise.all([
+      createAdditionalManagedOrganization(appClient.db, input),
+      createAdditionalManagedOrganization(appClient.db, input),
+    ]);
+    expect(right).toEqual(left);
+    expect(left.organization.name).toBe("Product team");
+    expect(left.workspaceId).not.toBe(left.personalWorkspaceId);
+
+    const [graph] = await owned.admin<
+      Array<{
+        memberships: number;
+        workspaces: number;
+        controls: number;
+        workspaceMemberships: number;
+        ownerRole: string;
+        sharedRole: string;
+        sharedName: string;
+        personalName: string;
+        activation: number;
+        evidence: number;
+        settingEnabled: boolean;
+        receiptResult: unknown;
+      }>
+    >`
+      select
+        (select count(*)::int from organization_memberships where account_id = ${left.organization.id}) as memberships,
+        (select count(*)::int from workspaces where account_id = ${left.organization.id}) as workspaces,
+        (select count(*)::int from workspace_inference_controls where account_id = ${left.organization.id}) as controls,
+        (select count(*)::int from workspace_memberships where account_id = ${left.organization.id}) as "workspaceMemberships",
+        owner_membership.role as "ownerRole",
+        shared_membership.role as "sharedRole",
+        shared_workspace.name as "sharedName",
+        personal_workspace.name as "personalName",
+        (select count(*)::int from session_tenancy_activations where account_id = ${left.organization.id}) as activation,
+        (select count(*)::int from session_tenancy_additional_organization_activation_evidence where account_id = ${left.organization.id}) as evidence,
+        private_setting.enabled as "settingEnabled",
+        receipt.result as "receiptResult"
+      from additional_organization_creation_receipts receipt
+      join organization_memberships owner_membership
+        on owner_membership.id = receipt.organization_membership_id
+      join workspaces shared_workspace on shared_workspace.id = receipt.shared_workspace_id
+      join workspaces personal_workspace on personal_workspace.id = receipt.personal_workspace_id
+      join workspace_memberships shared_membership
+        on shared_membership.account_id = receipt.account_id
+        and shared_membership.workspace_id = receipt.shared_workspace_id
+        and shared_membership.subject_id = receipt.actor_subject_id
+      join organization_private_session_settings private_setting
+        on private_setting.account_id = receipt.account_id
+      where receipt.operation_id = ${input.operationId}`;
+    expect(graph).toMatchObject({
+      memberships: 1,
+      workspaces: 2,
+      controls: 2,
+      workspaceMemberships: 1,
+      ownerRole: "owner",
+      sharedRole: "admin",
+      sharedName: "Launch room",
+      personalName: "Personal workspace",
+      activation: 1,
+      evidence: 1,
+      settingEnabled: true,
+    });
+    expect(graph?.receiptResult).toMatchObject({
+      organizationId: left.organization.id,
+      workspaceId: left.workspaceId,
+      personalWorkspaceId: left.personalWorkspaceId,
+    });
+
+    await expectSqlState(
+      () =>
+        createAdditionalManagedOrganization(appClient!.db, {
+          ...input,
+          workspaceName: "Different input",
+        }),
+      "23505",
+    );
+
+    const second = await createAdditionalManagedOrganization(appClient.db, {
+      ...input,
+      name: "Research team",
+      workspaceName: "Research",
+      operationId: crypto.randomUUID(),
+    });
+    expect(second.organization.id).not.toBe(left.organization.id);
+    const [membershipCount] = await owned.admin<Array<{ count: number }>>`
+      select count(*)::int as count from organization_memberships
+      where subject_id = ${subjectId} and status = 'active'`;
+    expect(membershipCount?.count).toBe(3);
+
+    const outsiderId = crypto.randomUUID();
+    await owned.admin`
+      insert into auth_users (id, name, email, email_verified)
+      values (${outsiderId}, 'Not onboarded', ${`${outsiderId}@example.test`}, true)`;
+    await expectSqlState(
+      () =>
+        createAdditionalManagedOrganization(appClient!.db, {
+          subjectId: `user:${outsiderId}`,
+          subjectLabel: "Not onboarded",
+          name: "Bypass attempt",
+          workspaceName: "General",
+          operationId: crypto.randomUUID(),
+        }),
+      "42501",
+    );
+  }, 300_000);
+});

--- a/packages/db/test/runtime-posture.test.ts
+++ b/packages/db/test/runtime-posture.test.ts
@@ -236,6 +236,7 @@ function companyProfileAgentAdminAuthorityTables(): RuntimeTablePosture[] {
 
 function organizationMembershipLifecycleAuthorityTables(): RuntimeTablePosture[] {
   return [
+    "additional_organization_creation_receipts",
     "organization_invitation_binding_events",
     "organization_membership_invitations",
     "organization_membership_lifecycle_events",
@@ -557,14 +558,14 @@ describe("runtime database posture evaluator", () => {
         ).length;
       const contracts = hasCurrentMainActivityLedger
         ? ([
-            [FORCE_RLS_TABLES, 313],
+            [FORCE_RLS_TABLES, 315],
             [NON_RLS_RUNTIME_TABLES, 14],
             [RUNTIME_FULL_DML_TABLES, 157],
             [RUNTIME_READ_ONLY_TABLES, 22],
             [readUpdateTables, 1],
             [RUNTIME_READ_INSERT_TABLES, 46],
             [RUNTIME_READ_INSERT_UPDATE_TABLES, 32],
-            [PROTECTED_NO_DIRECT_DML_TABLES, 69],
+            [PROTECTED_NO_DIRECT_DML_TABLES, 71],
             [RUNTIME_DML_TABLES, 258],
           ] as const)
         : ([
@@ -592,7 +593,7 @@ describe("runtime database posture evaluator", () => {
       }
 
       expect(Object.keys(RUNTIME_TABLE_PRIVILEGES).sort()).toEqual([...RUNTIME_DML_TABLES]);
-      const tableCount = hasCurrentMainActivityLedger ? 327 : 218;
+      const tableCount = hasCurrentMainActivityLedger ? 329 : 218;
       expect(new Set([...RUNTIME_DML_TABLES, ...PROTECTED_NO_DIRECT_DML_TABLES]).size).toBe(
         tableCount +
           personalResourceProtectedTableCount +

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -760,6 +760,7 @@ Every public endpoint group has typed methods:
 | Group | Methods |
 | --- | --- |
 | Access + workspaces | `getAccessContext`, `listWorkspaces`, `createWorkspace`, `ensureWorkspace`, `getWorkspace`, `updateWorkspace` |
+| Managed organizations | `createOrganization` for first-time compatibility; `createAdditionalOrganization` for an already-onboarded human; `listOrganizationMemberships`, `listOrganizationInvitations`, `acceptOrganizationInvitation` |
 | Sessions + events | `createSession`, `listSessions`, `listSessionPage`, `listAgentTopology`, `getSession`, `getSessionLineage`, `updateSession`, `listEvents`, `sendEvent`, `sendMessage`, `steerMessage`, `pauseSession`, `resumeSession`, `cancelSession`, `sendApprovalDecision`, `streamEvents`, `openEventStream` |
 | Machines (bring-your-own-compute) | `listMachines`, `machineMetricsSeries`, `swapActiveSandbox`, `mintEnrollToken`, `lookupDeviceEnrollment`, `approveDeviceEnrollment`, `denyDeviceEnrollment` |
 | Turn queue | `getQueue`, `moveQueueItem`, `editQueueItem`, `steerQueueItem`, `deleteQueueItem` |

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -278,6 +278,8 @@ import type {
   AcceptOrganizationRecoveryCustodyRequest,
   ConfigureOrganizationRecoveryPolicyRequest,
   CreateOrganizationInvitationRequest,
+  CreateAdditionalOrganizationRequest,
+  CreateAdditionalOrganizationResponse,
   CreateOrganizationRequest,
   CreateOrganizationResponse,
   CreateOrganizationWorkspaceRequest,
@@ -4340,6 +4342,17 @@ export class OpenGeniClient {
     request: CreateOrganizationRequest,
   ): Promise<CreateOrganizationResponse> {
     return await this.requestJson<CreateOrganizationResponse>("POST", "/v1/organizations", request);
+  }
+
+  /** Create another organization owned by the current managed human. */
+  async createAdditionalOrganization(
+    request: CreateAdditionalOrganizationRequest,
+  ): Promise<CreateAdditionalOrganizationResponse> {
+    return await this.requestJson<CreateAdditionalOrganizationResponse>(
+      "POST",
+      "/v1/organizations/additional",
+      request,
+    );
   }
 
   /** Pending and historical invitations addressed to the current managed human. */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -4023,6 +4023,16 @@ export type CreateOrganizationResponse = {
   organization: OrganizationSummary;
   workspaceId: string;
 };
+export type CreateAdditionalOrganizationRequest = {
+  name: string;
+  workspaceName: string;
+  operationId: string;
+};
+export type CreateAdditionalOrganizationResponse = {
+  organization: OrganizationSummary;
+  workspaceId: string;
+  personalWorkspaceId: string;
+};
 export type UpdateOrganizationNameRequest = {
   name: string;
   expectedUpdatedAt: string;

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -382,6 +382,11 @@ describe("OpenGeniClient access + workspaces", () => {
     const invitationId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const membershipId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
     const operationId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    await client.createAdditionalOrganization({
+      name: "Product team",
+      workspaceName: "General",
+      operationId,
+    });
     await client.listOrganizationInvitations({
       cursor: invitationId,
       limit: 25,
@@ -419,6 +424,7 @@ describe("OpenGeniClient access + workspaces", () => {
     });
     expect(requests.map((request) => `${request.method} ${new URL(request.url).pathname}`)).toEqual(
       [
+        "POST /v1/organizations/additional",
         "GET /v1/organization-invitations",
         `GET /v1/organizations/${organizationId}/invitations`,
         `POST /v1/organizations/${organizationId}/invitations`,
@@ -430,11 +436,16 @@ describe("OpenGeniClient access + workspaces", () => {
         `PATCH /v1/organizations/${organizationId}/retention-policy`,
       ],
     );
+    expect(JSON.parse(requests[0]!.body!)).toEqual({
+      name: "Product team",
+      workspaceName: "General",
+      operationId,
+    });
+    expect(new URL(requests[2]!.url).searchParams.get("cursor")).toBe(invitationId);
+    expect(new URL(requests[2]!.url).searchParams.get("limit")).toBe("25");
     expect(new URL(requests[1]!.url).searchParams.get("cursor")).toBe(invitationId);
     expect(new URL(requests[1]!.url).searchParams.get("limit")).toBe("25");
-    expect(new URL(requests[0]!.url).searchParams.get("cursor")).toBe(invitationId);
-    expect(new URL(requests[0]!.url).searchParams.get("limit")).toBe("25");
-    expect(JSON.parse(requests[6]!.body!)).toEqual({
+    expect(JSON.parse(requests[7]!.body!)).toEqual({
       kind: "suspend",
       expectedAuthorizationRevision: 2,
       operationId,

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -12,8 +12,8 @@ afterEach(async () => {
 
 async function buildSchemaContract(directory?: string) {
   // Keep the shared published-history fixtures projected before the optional
-  // 0392-0396 compatibility migrations. This branch's 0397 contract is
-  // asserted separately below.
+  // 0392-0396 compatibility migrations. The full 0397 and latest forward
+  // contracts are asserted separately below.
   return directory === undefined
     ? await contractWithoutMigrations([
         "0392_context_compaction_pending_observability.sql",
@@ -21,6 +21,7 @@ async function buildSchemaContract(directory?: string) {
         "0394_session_selected_skill_activation.sql",
         "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
         "0396_model_call_equivalent_credit_cost.sql",
+        "0399_additional_managed_organization_creation.sql",
       ])
     : await buildCompleteSchemaContract(directory);
 }
@@ -124,10 +125,10 @@ describe("release schema contract", () => {
     );
   });
 
-  test("registers sandbox deadline rotation preemption before workspace management", async () => {
+  test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
     expect(completeSourceContract.latestMigration).toBe(
-      "0398_organization_workspace_management_entry.sql",
+      "0399_additional_managed_organization_creation.sql",
     );
     expect(
       completeSourceContract.migrations.find(
@@ -135,6 +136,14 @@ describe("release schema contract", () => {
       ),
     ).toMatchObject({
       sha256: "8bf2a1a39eb2518a661d89b17910fa702e084bbb4213c395a951903e135039df",
+      deploymentMode: "rolling",
+    });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0399_additional_managed_organization_creation.sql",
+      ),
+    ).toMatchObject({
+      sha256: "443b2d0871209845273e7dfe827e20f6ece806c95c08dadd24263c37e41d12ad",
       deploymentMode: "rolling",
     });
   });
@@ -420,12 +429,16 @@ describe("release schema contract", () => {
     const sandboxDeadlineRotationPreemption = completeSourceContract.migrations.some(
       (migration) => migration.path === "0397_sandbox_deadline_rotation_preemption.sql",
     );
+    const additionalManagedOrganizationCreation = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0399_additional_managed_organization_creation.sql",
+    );
 
     expect(completeSourceContract).toMatchObject({
       ...(sandboxDeadlineRotationPreemption
         ? { latestMigration: "0397_sandbox_deadline_rotation_preemption.sql" }
         : {}),
       fileCount:
+        (additionalManagedOrganizationCreation ? 1 : 0) +
         (sessionSelectedSkillActivation ? 1 : 0) +
         (scheduledTaskUnclaimedOccurrenceInvalidation ? 1 : 0) +
         (organizationWorkspaceManagementEntry &&
@@ -572,11 +585,16 @@ describe("release schema contract", () => {
       ...(modelCallEquivalentCreditCost
         ? { latestMigration: "0396_model_call_equivalent_credit_cost.sql" }
         : {}),
+      ...(additionalManagedOrganizationCreation
+        ? { latestMigration: "0399_additional_managed_organization_creation.sql" }
+        : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
-      organizationWorkspaceManagementEntry
-        ? "0398_organization_workspace_management_entry.sql"
-        : completeSourceContractWithModelCallEquivalentCreditCost.latestMigration,
+      additionalManagedOrganizationCreation
+        ? "0399_additional_managed_organization_creation.sql"
+        : organizationWorkspaceManagementEntry
+          ? "0398_organization_workspace_management_entry.sql"
+          : completeSourceContractWithModelCallEquivalentCreditCost.latestMigration,
     );
     expect(completeSourceContractWithContextCompaction.latestMigration).toBe(
       workspaceMemoryAndLearningDefaults
@@ -803,6 +821,7 @@ describe("release schema contract", () => {
       "0393_workspace_memory_and_learning_defaults.sql",
       "0396_model_call_equivalent_credit_cost.sql",
       "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
+      "0399_additional_managed_organization_creation.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -968,6 +987,9 @@ describe("release schema contract", () => {
     const scheduledTaskUnclaimedOccurrenceInvalidation = completeSourceContract.migrations.some(
       (migration) => migration.path === "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
     );
+    const additionalManagedOrganizationCreation = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0399_additional_managed_organization_creation.sql",
+    );
     if (workspaceMemoryAndLearningDefaults) {
       completeSourceContract = {
         ...completeSourceContract,
@@ -994,6 +1016,7 @@ describe("release schema contract", () => {
     }
     expect(completeSourceContract).toMatchObject({
       fileCount:
+        (additionalManagedOrganizationCreation ? 1 : 0) +
         (sessionSelectedSkillActivation ? 1 : 0) +
         (scheduledTaskUnclaimedOccurrenceInvalidation ? 1 : 0) +
         (organizationWorkspaceManagementEntry &&
@@ -1157,9 +1180,11 @@ describe("release schema contract", () => {
         : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
-      organizationWorkspaceManagementEntry
-        ? "0398_organization_workspace_management_entry.sql"
-        : completeSourceContractWithModelCallEquivalentCreditCost.latestMigration,
+      additionalManagedOrganizationCreation
+        ? "0399_additional_managed_organization_creation.sql"
+        : organizationWorkspaceManagementEntry
+          ? "0398_organization_workspace_management_entry.sql"
+          : completeSourceContractWithModelCallEquivalentCreditCost.latestMigration,
     );
     expect(completeSourceContractWithContextCompaction.latestMigration).toBe(
       workspaceMemoryAndLearningDefaults

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -143,7 +143,7 @@ describe("release schema contract", () => {
         (migration) => migration.path === "0399_additional_managed_organization_creation.sql",
       ),
     ).toMatchObject({
-      sha256: "443b2d0871209845273e7dfe827e20f6ece806c95c08dadd24263c37e41d12ad",
+      sha256: "a2cd5b0203aeba0530c19e69b29ef07421b849c472ac271f6a87a134e33ac81f",
       deploymentMode: "rolling",
     });
   });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -143,7 +143,7 @@ describe("release schema contract", () => {
         (migration) => migration.path === "0399_additional_managed_organization_creation.sql",
       ),
     ).toMatchObject({
-      sha256: "a2cd5b0203aeba0530c19e69b29ef07421b849c472ac271f6a87a134e33ac81f",
+      sha256: "851f5563db7540c47fe243caaabbe7b2a1e83104029ecb4e084009823cc57f22",
       deploymentMode: "rolling",
     });
   });


### PR DESCRIPTION
## Summary

- add a clean **New organization…** action to the organization switcher, with a reviewed desktop dialog and responsive phone bottom sheet
- create the organization, owner membership, Personal workspace, first shared workspace, and creator admin access atomically for an already-onboarded managed human
- keep one canonical authenticated user across organizations while isolating membership, roles, workspaces, and data per organization
- expose the flow through typed contracts, the API, and the SDK with idempotent receipts and FORCE-RLS lifecycle evidence
- preserve first-signup and invitation precedence, and update the architecture and tenancy documentation

## Testing

- [x] `bun run typecheck`
- [ ] `bun test` (targeted cross-layer suite run instead)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run --cwd apps/web build`
- [x] `bun run check:migration-ordinals`
- [x] `bun run check:migration-schema-contract`
- [x] `bun run check:migration-rls-backfills`
- [x] `bun run check:public-hygiene`
- [x] `bun run check:docs-refs`
- [x] 81 targeted DB, API, SDK, and web tests, including real PostgreSQL migration coverage
- [x] browser review at desktop and phone sizes with no console warnings or errors

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] The candidate is based on current `main`; merge-base and ancestry were verified before push.

## Notes

- Linear: [OPE-423](https://linear.app/cloudgeni/issue/OPE-423/let-an-authenticated-user-create-additional-organizations)
- The visual placement and copy were approved before this PR was opened.

## Summary by Sourcery

Enable already-onboarded managed humans to create and safely access isolated additional organizations from the organization switcher.

New Features:
- Add a managed-human API and SDK operation for creating additional organizations with a first shared workspace.
- Add organization-switcher creation entry points with responsive creation UI and safe retry handling.

Bug Fixes:
- Preserve onboarding and invitation precedence while preventing stale creation results from affecting a changed authenticated identity.

Enhancements:
- Create the organization, owner membership, Personal workspace, shared workspace, and creator administrator access atomically with idempotent operation receipts and a per-human creation limit.
- Refresh authoritative access before opening the newly created organization while keeping one canonical login isolated across tenants.

Deployment:
- Add migration and runtime database posture coverage for FORCE-RLS creation receipts and session-tenancy activation evidence.

Documentation:
- Document the additional-organization lifecycle, tenancy isolation, limits, activation behavior, and public API surface.

Tests:
- Add targeted API, SDK, web, PostgreSQL migration, concurrency, quota, replay, and runtime-posture coverage.