### PR TITLE
chore(release): advance product version to 0.23.17

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.16
-appVersion: "0.23.16"
+version: 0.23.17
+appVersion: "0.23.17"


### PR DESCRIPTION
Advances the Helm chart and application versions together to 0.23.17 for the release containing managed-user additional organization creation and the other changesets currently queued on main.\n\nValidated locally with the release-version contract test and Helm lint.

## Summary by Sourcery

Chores:
- Advance the Helm chart and application versions to 0.23.17 for the next release.