### PR TITLE
fix(codex): avoid false source conflicts during connect

### DIFF
--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -1124,6 +1124,8 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       upserted: Awaited<ReturnType<typeof upsertCodexSubscriptionCredential>>;
       isActive: boolean;
     }>(db, { workspaceId, reason: "codex_credential_connected" }, async (tx) => {
+      // The capacity mutation holds the source lock before entering this callback.
+      const sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource(tx, workspaceId);
       const upserted = await upsertCodexSubscriptionCredential(tx, {
         accountId: grant.accountId,
         workspaceId,
@@ -1151,12 +1153,12 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       }
       await ensureCodexRotationSettings(tx, grant.accountId, workspaceId);
       await setInitialActiveCodexCredential(tx, workspaceId, upserted.id);
-      const source = await getWorkspaceCodexSubscriptionSource(tx, workspaceId);
       await setWorkspaceCodexSubscriptionModeInTransaction(tx, {
         accountId: grant.accountId,
         workspaceId,
         subjectId: grant.subjectId,
-        mode: source.workspaceKind === "personal" ? "automatic" : "workspace",
+        mode: sourceBeforeConnect.workspaceKind === "personal" ? "automatic" : "workspace",
+        effectiveSourceBeforeMutation: sourceBeforeConnect.effectiveSource,
       });
       const rotation = await getCodexRotationSettings(tx, workspaceId);
       return {
@@ -1166,6 +1168,14 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
         },
         changed: true,
       };
+    }).catch((error: unknown) => {
+      const cause = (error as { cause?: unknown } | null)?.cause;
+      const message =
+        cause instanceof Error ? cause.message : error instanceof Error ? error.message : "";
+      if (message.includes("active turns are using it")) {
+        throw new HTTPException(409, { message });
+      }
+      throw error;
     });
     const { upserted, isActive } = mutation.result;
     if (upserted.kind === "unresolved_redemption") {

--- a/apps/api/test/codex-routes.test.ts
+++ b/apps/api/test/codex-routes.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
+import * as opengeniDb from "@opengeni/db";
 import { testSettings } from "@opengeni/testing";
 import { createApp } from "../src/app";
 
@@ -12,6 +13,7 @@ const ACCOUNT = "00000000-0000-4000-8000-0000000000c3";
 const settings = testSettings({
   productAccessMode: "managed",
   delegationSecret: DELEGATION_SECRET,
+  environmentsEncryptionKey: Buffer.alloc(32, 17).toString("base64"),
 });
 
 // db must never be touched on the paths under test (auth from token; start/poll
@@ -49,16 +51,23 @@ async function bearer(workspaceId: string, permissions: Permission[]): Promise<s
 }
 
 const realFetch = globalThis.fetch;
+const restores: Array<() => void> = [];
 afterEach(() => {
   globalThis.fetch = realFetch;
+  while (restores.length) restores.pop()!();
 });
 
-function mockDevice(handlers: { usercode?: () => Response; token?: () => Response }) {
+function mockDevice(handlers: {
+  usercode?: () => Response;
+  token?: () => Response;
+  exchange?: () => Response;
+}) {
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.includes("/deviceauth/usercode") && handlers.usercode) return handlers.usercode();
     if (url.includes("/deviceauth/token") && handlers.token) return handlers.token();
+    if (url.includes("/oauth/token") && handlers.exchange) return handlers.exchange();
     throw new Error(`unexpected fetch ${url}`);
   }) as typeof fetch;
 }
@@ -68,6 +77,11 @@ function json(body: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function jwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
 }
 
 async function start(
@@ -114,6 +128,50 @@ describe("codex connect routes", () => {
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "pending" });
+  });
+
+  test("connect/poll maps an active source cutover fence to 409", async () => {
+    mockDevice({
+      usercode: () => json({ device_auth_id: "dev_1", user_code: "ABCD-1234", interval: "5" }),
+    });
+    const { body } = await start(WS_A);
+    mockDevice({
+      token: () => json({ authorization_code: "authorization-code", code_verifier: "verifier" }),
+      exchange: () =>
+        json({
+          id_token: jwt({
+            email: "connector@example.com",
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "provider-account",
+              chatgpt_plan_type: "pro",
+            },
+          }),
+          access_token: jwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+          refresh_token: "refresh-token",
+        }),
+    });
+    const mutation = spyOn(opengeniDb, "withSessionCodexCapacityMutation").mockRejectedValue(
+      new Error("Codex subscription source cannot change while active turns are using it"),
+    );
+    restores.push(() => mutation.mockRestore());
+
+    const res = await app().request(`/v1/workspaces/${WS_A}/codex/connect/poll`, {
+      method: "POST",
+      headers: {
+        authorization: await bearer(WS_A, ["connections:write"]),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ state: body.state }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: "conflict",
+        message: "Codex subscription source cannot change while active turns are using it",
+        status: 409,
+      },
+    });
   });
 
   test("connect/poll rejects a state minted for a different workspace", async () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21844,6 +21844,20 @@ function codexCredentialPoolCondition(input: {
       )!;
 }
 
+function effectiveCodexSubscriptionSourceForMode(
+  current: Pick<
+    WorkspaceCodexSubscriptionSource,
+    "workspaceKind" | "workspaceAvailable" | "organizationAvailable"
+  >,
+  mode: WorkspaceCodexSubscriptionMode,
+): EffectiveCodexSubscriptionSource {
+  if (current.workspaceKind === "personal") return "workspace";
+  if (mode !== "automatic") return mode;
+  if (current.workspaceAvailable) return "workspace";
+  if (current.organizationAvailable) return "organization";
+  return "workspace";
+}
+
 async function effectiveCodexCredentialPoolCondition(
   scopedDb: Database,
   workspaceId: string,
@@ -21880,29 +21894,32 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
     throw new Error("personal workspaces always use workspace Codex subscriptions");
   }
   if (current.mode === input.mode) return current;
-  const [activeCodexTurn] = await scopedDb
-    .select({ id: schema.sessionTurns.id })
-    .from(schema.sessionTurns)
-    .where(
-      and(
-        eq(schema.sessionTurns.workspaceId, input.workspaceId),
-        inArray(schema.sessionTurns.status, ["running", "requires_action", "recovering"]),
-        sql`${schema.sessionTurns.model} like 'codex/%'`,
-      ),
-    )
-    .limit(1);
-  const [liveLease] = await scopedDb
-    .select({ id: schema.codexCredentialLeases.id })
-    .from(schema.codexCredentialLeases)
-    .where(
-      and(
-        eq(schema.codexCredentialLeases.workspaceId, input.workspaceId),
-        gt(schema.codexCredentialLeases.leasedUntil, new Date()),
-      ),
-    )
-    .limit(1);
-  if (activeCodexTurn || liveLease) {
-    throw new Error("Codex subscription source cannot change while active turns are using it");
+  const nextEffectiveSource = effectiveCodexSubscriptionSourceForMode(current, input.mode);
+  if (nextEffectiveSource !== current.effectiveSource) {
+    const [activeCodexTurn] = await scopedDb
+      .select({ id: schema.sessionTurns.id })
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, input.workspaceId),
+          inArray(schema.sessionTurns.status, ["running", "requires_action", "recovering"]),
+          sql`${schema.sessionTurns.model} like 'codex/%'`,
+        ),
+      )
+      .limit(1);
+    const [liveLease] = await scopedDb
+      .select({ id: schema.codexCredentialLeases.id })
+      .from(schema.codexCredentialLeases)
+      .where(
+        and(
+          eq(schema.codexCredentialLeases.workspaceId, input.workspaceId),
+          gt(schema.codexCredentialLeases.leasedUntil, new Date()),
+        ),
+      )
+      .limit(1);
+    if (activeCodexTurn || liveLease) {
+      throw new Error("Codex subscription source cannot change while active turns are using it");
+    }
   }
   await scopedDb
     .insert(schema.workspaceCodexSubscriptionPreferences)

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21844,20 +21844,6 @@ function codexCredentialPoolCondition(input: {
       )!;
 }
 
-function effectiveCodexSubscriptionSourceForMode(
-  current: Pick<
-    WorkspaceCodexSubscriptionSource,
-    "workspaceKind" | "workspaceAvailable" | "organizationAvailable"
-  >,
-  mode: WorkspaceCodexSubscriptionMode,
-): EffectiveCodexSubscriptionSource {
-  if (current.workspaceKind === "personal") return "workspace";
-  if (mode !== "automatic") return mode;
-  if (current.workspaceAvailable) return "workspace";
-  if (current.organizationAvailable) return "organization";
-  return "workspace";
-}
-
 async function effectiveCodexCredentialPoolCondition(
   scopedDb: Database,
   workspaceId: string,
@@ -21894,8 +21880,24 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
     throw new Error("personal workspaces always use workspace Codex subscriptions");
   }
   if (current.mode === input.mode) return current;
-  const nextEffectiveSource = effectiveCodexSubscriptionSourceForMode(current, input.mode);
-  if (nextEffectiveSource !== current.effectiveSource) {
+  await scopedDb
+    .insert(schema.workspaceCodexSubscriptionPreferences)
+    .values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      mode: input.mode,
+      updatedBySubjectId: input.subjectId,
+    })
+    .onConflictDoUpdate({
+      target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
+      set: {
+        mode: input.mode,
+        updatedBySubjectId: input.subjectId,
+        updatedAt: new Date(),
+      },
+    });
+  const next = await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
+  if (next.effectiveSource !== current.effectiveSource) {
     const [activeCodexTurn] = await scopedDb
       .select({ id: schema.sessionTurns.id })
       .from(schema.sessionTurns)
@@ -21921,23 +21923,7 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
       throw new Error("Codex subscription source cannot change while active turns are using it");
     }
   }
-  await scopedDb
-    .insert(schema.workspaceCodexSubscriptionPreferences)
-    .values({
-      accountId: input.accountId,
-      workspaceId: input.workspaceId,
-      mode: input.mode,
-      updatedBySubjectId: input.subjectId,
-    })
-    .onConflictDoUpdate({
-      target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
-      set: {
-        mode: input.mode,
-        updatedBySubjectId: input.subjectId,
-        updatedAt: new Date(),
-      },
-    });
-  return await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
+  return next;
 }
 
 export async function setWorkspaceCodexSubscriptionMode(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21869,6 +21869,8 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
     workspaceId: string;
     subjectId: string | null;
     mode: WorkspaceCodexSubscriptionMode;
+    /** Effective source captured under the source lock before caller-owned credential writes. */
+    effectiveSourceBeforeMutation?: EffectiveCodexSubscriptionSource;
   },
 ): Promise<WorkspaceCodexSubscriptionSource> {
   await lockWorkspaceCodexSubscriptionSource(scopedDb, input.workspaceId);
@@ -21879,25 +21881,29 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
   if (current.workspaceKind === "personal" && input.mode !== "automatic") {
     throw new Error("personal workspaces always use workspace Codex subscriptions");
   }
-  if (current.mode === input.mode) return current;
-  await scopedDb
-    .insert(schema.workspaceCodexSubscriptionPreferences)
-    .values({
-      accountId: input.accountId,
-      workspaceId: input.workspaceId,
-      mode: input.mode,
-      updatedBySubjectId: input.subjectId,
-    })
-    .onConflictDoUpdate({
-      target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
-      set: {
+  const effectiveSourceBeforeMutation =
+    input.effectiveSourceBeforeMutation ?? current.effectiveSource;
+  let next = current;
+  if (current.mode !== input.mode) {
+    await scopedDb
+      .insert(schema.workspaceCodexSubscriptionPreferences)
+      .values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
         mode: input.mode,
         updatedBySubjectId: input.subjectId,
-        updatedAt: new Date(),
-      },
-    });
-  const next = await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
-  if (next.effectiveSource !== current.effectiveSource) {
+      })
+      .onConflictDoUpdate({
+        target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
+        set: {
+          mode: input.mode,
+          updatedBySubjectId: input.subjectId,
+          updatedAt: new Date(),
+        },
+      });
+    next = await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
+  }
+  if (next.effectiveSource !== effectiveSourceBeforeMutation) {
     const [activeCodexTurn] = await scopedDb
       .select({ id: schema.sessionTurns.id })
       .from(schema.sessionTurns)

--- a/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
+++ b/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
@@ -254,6 +254,68 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
     expect(organizationOverride?.source).toBe("organization");
   });
 
+  test("allows an equivalent workspace-source preference while active work remains fenced", async () => {
+    if (!shared || !app || !client) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('codex-equivalent-source-preference') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'shared') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+    await shared.admin`
+      insert into codex_subscription_credentials (
+        account_id, workspace_id, authority_scope,
+        credential_encrypted, chatgpt_account_id, status
+      ) values (
+        ${account!.id}, ${workspace!.id}, 'workspace',
+        'ciphertext', 'workspace-provider-account', 'active'
+      )`;
+
+    const session = await createSession(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      initialMessage: "keep the effective workspace source",
+      resources: [],
+      tools: [],
+      metadata: {},
+      model: "codex/gpt-5",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    await shared.admin.begin(async (transaction) => {
+      await transaction`set local session_replication_role = replica`;
+      await transaction`
+        insert into session_turns (
+          account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+          status, position, prompt, model, reasoning_effort, sandbox_backend
+        ) values (
+          ${account!.id}, ${workspace!.id}, ${session.id}, ${crypto.randomUUID()},
+          ${`migration-0381-equivalent-${crypto.randomUUID()}`}, 'running', 0,
+          'keep the effective workspace source', 'codex/gpt-5', 'medium', 'none'
+        )`;
+    });
+
+    const pinned = await setWorkspaceCodexSubscriptionMode(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      subjectId: null,
+      mode: "workspace",
+    });
+    expect(pinned).toMatchObject({ mode: "workspace", effectiveSource: "workspace" });
+
+    await expect(
+      setWorkspaceCodexSubscriptionMode(client.db, {
+        accountId: account!.id,
+        workspaceId: workspace!.id,
+        subjectId: null,
+        mode: "disabled",
+      }),
+    ).rejects.toThrow("Codex subscription source cannot change while active turns are using it");
+  });
+
   test("allows an organization credential lease only in an inheriting shared workspace", async () => {
     if (!shared || !app || !client) return;
     const dbClient = client;

--- a/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
+++ b/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
@@ -9,7 +9,11 @@ import {
   createDb,
   createSession,
   disconnectOrganizationCodexAccount,
+  getWorkspaceCodexSubscriptionSource,
   setWorkspaceCodexSubscriptionMode,
+  setWorkspaceCodexSubscriptionModeInTransaction,
+  upsertCodexSubscriptionCredential,
+  withSessionCodexCapacityMutation,
   type DbClient,
 } from "../src";
 import { FORCE_RLS_TABLES, RUNTIME_FULL_DML_TABLES } from "../src/runtime-posture";
@@ -124,7 +128,7 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
       /wakeOrganizationCodexCapacityWaitersInTransaction[\s\S]*?list_organization_workspace_ids[\s\S]*?session-tenancy:/u,
     );
     expect(apiCodexRouteSource).toMatch(
-      /withSessionCodexCapacityMutation[\s\S]*?upsertCodexSubscriptionCredential[\s\S]*?ensureCodexRotationSettings[\s\S]*?setInitialActiveCodexCredential[\s\S]*?setWorkspaceCodexSubscriptionModeInTransaction/u,
+      /withSessionCodexCapacityMutation[\s\S]*?sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource[\s\S]*?upsertCodexSubscriptionCredential[\s\S]*?ensureCodexRotationSettings[\s\S]*?setInitialActiveCodexCredential[\s\S]*?setWorkspaceCodexSubscriptionModeInTransaction[\s\S]*?effectiveSourceBeforeMutation: sourceBeforeConnect\.effectiveSource/u,
     );
     for (const table of [
       "organization_codex_rotation_settings",
@@ -264,14 +268,6 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
     await shared.admin`
       insert into workspace_inference_controls (workspace_id, account_id)
       values (${workspace!.id}, ${account!.id})`;
-    await shared.admin`
-      insert into codex_subscription_credentials (
-        account_id, workspace_id, authority_scope,
-        credential_encrypted, chatgpt_account_id, status
-      ) values (
-        ${account!.id}, ${workspace!.id}, 'workspace',
-        'ciphertext', 'workspace-provider-account', 'active'
-      )`;
 
     const session = await createSession(client.db, {
       accountId: account!.id,
@@ -298,13 +294,47 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
         )`;
     });
 
-    const pinned = await setWorkspaceCodexSubscriptionMode(client.db, {
-      accountId: account!.id,
-      workspaceId: workspace!.id,
-      subjectId: null,
-      mode: "workspace",
+    const connected = await withSessionCodexCapacityMutation(
+      client.db,
+      { workspaceId: workspace!.id, reason: "codex_credential_connected" },
+      async (transaction) => {
+        const sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource(
+          transaction,
+          workspace!.id,
+        );
+        const upserted = await upsertCodexSubscriptionCredential(transaction, {
+          accountId: account!.id,
+          workspaceId: workspace!.id,
+          credentialEncrypted: "workspace-ciphertext",
+          chatgptAccountId: "workspace-provider-account",
+          scopes: null,
+          planType: "pro",
+          isFedramp: false,
+          expiresAt: null,
+          lastRefreshAt: new Date(),
+          connectedBySubjectId: null,
+        });
+        if (upserted.kind !== "upserted") throw new Error("expected credential upsert");
+        const pinned = await setWorkspaceCodexSubscriptionModeInTransaction(transaction, {
+          accountId: account!.id,
+          workspaceId: workspace!.id,
+          subjectId: null,
+          mode: "workspace",
+          effectiveSourceBeforeMutation: sourceBeforeConnect.effectiveSource,
+        });
+        return { result: { pinned, sourceBeforeConnect, upserted }, changed: true };
+      },
+    );
+    expect(connected.result.sourceBeforeConnect).toMatchObject({
+      mode: "automatic",
+      effectiveSource: "workspace",
+      workspaceAvailable: false,
+      organizationAvailable: false,
     });
-    expect(pinned).toMatchObject({ mode: "workspace", effectiveSource: "workspace" });
+    expect(connected.result.pinned).toMatchObject({
+      mode: "workspace",
+      effectiveSource: "workspace",
+    });
 
     await expect(
       setWorkspaceCodexSubscriptionMode(client.db, {
@@ -318,6 +348,108 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
       select mode from workspace_codex_subscription_preferences
       where workspace_id = ${workspace!.id}`;
     expect(retainedPreference?.mode).toBe("workspace");
+  });
+
+  test("fences a first workspace credential when the automatic source was organization", async () => {
+    if (!shared || !app || !client) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('codex-pre-connect-source-fence') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'shared') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+    const [organizationCredential] = await shared.admin<{ id: string }[]>`
+      insert into codex_subscription_credentials (
+        account_id, workspace_id, organization_id, authority_scope,
+        credential_encrypted, chatgpt_account_id, status
+      ) values (
+        ${account!.id}, null, ${account!.id}, 'organization',
+        'organization-ciphertext', 'organization-provider-account', 'active'
+      ) returning id`;
+    await shared.admin`
+      insert into organization_codex_rotation_settings (account_id, active_credential_id)
+      values (${account!.id}, ${organizationCredential!.id})`;
+
+    const session = await createSession(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      initialMessage: "keep the organization source",
+      resources: [],
+      tools: [],
+      metadata: {},
+      model: "codex/gpt-5",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    await shared.admin.begin(async (transaction) => {
+      await transaction`set local session_replication_role = replica`;
+      await transaction`
+        insert into session_turns (
+          account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+          status, position, prompt, model, reasoning_effort, sandbox_backend
+        ) values (
+          ${account!.id}, ${workspace!.id}, ${session.id}, ${crypto.randomUUID()},
+          ${`migration-0381-pre-connect-${crypto.randomUUID()}`}, 'running', 0,
+          'keep the organization source', 'codex/gpt-5', 'medium', 'none'
+        )`;
+    });
+
+    let sourceBeforeConnect: Awaited<
+      ReturnType<typeof getWorkspaceCodexSubscriptionSource>
+    > | null = null;
+    await expect(
+      withSessionCodexCapacityMutation(
+        client.db,
+        { workspaceId: workspace!.id, reason: "codex_credential_connected" },
+        async (transaction) => {
+          const source = await getWorkspaceCodexSubscriptionSource(transaction, workspace!.id);
+          sourceBeforeConnect = source;
+          const upserted = await upsertCodexSubscriptionCredential(transaction, {
+            accountId: account!.id,
+            workspaceId: workspace!.id,
+            credentialEncrypted: "workspace-ciphertext",
+            chatgptAccountId: "first-workspace-provider-account",
+            scopes: null,
+            planType: "pro",
+            isFedramp: false,
+            expiresAt: null,
+            lastRefreshAt: new Date(),
+            connectedBySubjectId: null,
+          });
+          if (upserted.kind !== "upserted") throw new Error("expected credential upsert");
+          await setWorkspaceCodexSubscriptionModeInTransaction(transaction, {
+            accountId: account!.id,
+            workspaceId: workspace!.id,
+            subjectId: null,
+            mode: "workspace",
+            effectiveSourceBeforeMutation: source.effectiveSource,
+          });
+          return { result: upserted, changed: true };
+        },
+      ),
+    ).rejects.toThrow("Codex subscription source cannot change while active turns are using it");
+    expect(sourceBeforeConnect).toMatchObject({
+      mode: "automatic",
+      effectiveSource: "organization",
+    });
+    const [rolledBack] = await shared.admin<
+      { workspace_credentials: number; preferences: number }[]
+    >`
+      select
+        count(*) filter (
+          where credential.workspace_id = ${workspace!.id}
+            and credential.authority_scope in ('workspace', 'user')
+        )::integer as workspace_credentials,
+        (
+          select count(*)::integer from workspace_codex_subscription_preferences preference
+          where preference.workspace_id = ${workspace!.id}
+        ) as preferences
+      from codex_subscription_credentials credential
+      where credential.account_id = ${account!.id}`;
+    expect(rolledBack).toEqual({ workspace_credentials: 0, preferences: 0 });
   });
 
   test("allows an organization credential lease only in an inheriting shared workspace", async () => {

--- a/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
+++ b/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
@@ -314,6 +314,10 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
         mode: "disabled",
       }),
     ).rejects.toThrow("Codex subscription source cannot change while active turns are using it");
+    const [retainedPreference] = await shared.admin<{ mode: string }[]>`
+      select mode from workspace_codex_subscription_preferences
+      where workspace_id = ${workspace!.id}`;
+    expect(retainedPreference?.mode).toBe("workspace");
   });
 
   test("allows an organization credential lease only in an inheriting shared workspace", async () => {


### PR DESCRIPTION
## Summary

- snapshot the effective Codex source under the capacity mutation’s source lock before inserting a workspace credential
- resolve the post-update effective source through PostgreSQL’s canonical resolver inside the same transaction
- allow a first workspace credential when an automatic workspace already resolves to the workspace pool
- retain active-turn and live-lease fencing for real organization/disabled-to-workspace cutovers and roll back the credential and preference when blocked
- return HTTP 409 instead of 500 when a connect attempt is legitimately blocked by active work

## Validation

- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts`
- `bun test --timeout 120000 apps/api/test/codex-routes.test.ts apps/api/test/codex-usage-routes.test.ts`
- `bun run --cwd packages/db typecheck`
- `bun run --cwd apps/api typecheck`
- `node_modules/.bin/oxfmt --check packages/db/src/index.ts packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts apps/api/src/routes/codex.ts apps/api/test/codex-routes.test.ts`
- `node_modules/.bin/oxlint --deny-warnings packages/db/src/index.ts packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts apps/api/src/routes/codex.ts apps/api/test/codex-routes.test.ts`

## Summary by Sourcery

Avoid false Codex source conflicts during credential connections while retaining safety checks for active work.

Bug Fixes:
- Prevent false Codex subscription source conflicts when connecting workspace credentials by comparing the effective source before and after the mutation.
- Return HTTP 409 conflicts when active turns or live leases legitimately block a Codex source cutover.

Enhancements:
- Preserve active-work fencing for genuine organization-to-workspace or disabled-to-workspace source changes while allowing equivalent workspace-source preference updates.
- Ensure blocked credential connections roll back their credential and subscription preference changes transactionally.

Tests:
- Add database coverage for equivalent workspace-source connections, genuine source-cutover fencing, and transactional rollback.
- Add API coverage for mapping active source-cutover errors to HTTP 409 responses.