### PR TITLE
chore(release): advance production pointer to current 0.23.17 source

### DIFF
--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -1124,6 +1124,8 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       upserted: Awaited<ReturnType<typeof upsertCodexSubscriptionCredential>>;
       isActive: boolean;
     }>(db, { workspaceId, reason: "codex_credential_connected" }, async (tx) => {
+      // The capacity mutation holds the source lock before entering this callback.
+      const sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource(tx, workspaceId);
       const upserted = await upsertCodexSubscriptionCredential(tx, {
         accountId: grant.accountId,
         workspaceId,
@@ -1151,12 +1153,12 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       }
       await ensureCodexRotationSettings(tx, grant.accountId, workspaceId);
       await setInitialActiveCodexCredential(tx, workspaceId, upserted.id);
-      const source = await getWorkspaceCodexSubscriptionSource(tx, workspaceId);
       await setWorkspaceCodexSubscriptionModeInTransaction(tx, {
         accountId: grant.accountId,
         workspaceId,
         subjectId: grant.subjectId,
-        mode: source.workspaceKind === "personal" ? "automatic" : "workspace",
+        mode: sourceBeforeConnect.workspaceKind === "personal" ? "automatic" : "workspace",
+        effectiveSourceBeforeMutation: sourceBeforeConnect.effectiveSource,
       });
       const rotation = await getCodexRotationSettings(tx, workspaceId);
       return {
@@ -1166,6 +1168,14 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
         },
         changed: true,
       };
+    }).catch((error: unknown) => {
+      const cause = (error as { cause?: unknown } | null)?.cause;
+      const message =
+        cause instanceof Error ? cause.message : error instanceof Error ? error.message : "";
+      if (message.includes("active turns are using it")) {
+        throw new HTTPException(409, { message });
+      }
+      throw error;
     });
     const { upserted, isActive } = mutation.result;
     if (upserted.kind === "unresolved_redemption") {

--- a/apps/api/test/codex-routes.test.ts
+++ b/apps/api/test/codex-routes.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
+import * as opengeniDb from "@opengeni/db";
 import { testSettings } from "@opengeni/testing";
 import { createApp } from "../src/app";
 
@@ -12,6 +13,7 @@ const ACCOUNT = "00000000-0000-4000-8000-0000000000c3";
 const settings = testSettings({
   productAccessMode: "managed",
   delegationSecret: DELEGATION_SECRET,
+  environmentsEncryptionKey: Buffer.alloc(32, 17).toString("base64"),
 });
 
 // db must never be touched on the paths under test (auth from token; start/poll
@@ -49,16 +51,23 @@ async function bearer(workspaceId: string, permissions: Permission[]): Promise<s
 }
 
 const realFetch = globalThis.fetch;
+const restores: Array<() => void> = [];
 afterEach(() => {
   globalThis.fetch = realFetch;
+  while (restores.length) restores.pop()!();
 });
 
-function mockDevice(handlers: { usercode?: () => Response; token?: () => Response }) {
+function mockDevice(handlers: {
+  usercode?: () => Response;
+  token?: () => Response;
+  exchange?: () => Response;
+}) {
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.includes("/deviceauth/usercode") && handlers.usercode) return handlers.usercode();
     if (url.includes("/deviceauth/token") && handlers.token) return handlers.token();
+    if (url.includes("/oauth/token") && handlers.exchange) return handlers.exchange();
     throw new Error(`unexpected fetch ${url}`);
   }) as typeof fetch;
 }
@@ -68,6 +77,11 @@ function json(body: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function jwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
 }
 
 async function start(
@@ -114,6 +128,50 @@ describe("codex connect routes", () => {
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "pending" });
+  });
+
+  test("connect/poll maps an active source cutover fence to 409", async () => {
+    mockDevice({
+      usercode: () => json({ device_auth_id: "dev_1", user_code: "ABCD-1234", interval: "5" }),
+    });
+    const { body } = await start(WS_A);
+    mockDevice({
+      token: () => json({ authorization_code: "authorization-code", code_verifier: "verifier" }),
+      exchange: () =>
+        json({
+          id_token: jwt({
+            email: "connector@example.com",
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "provider-account",
+              chatgpt_plan_type: "pro",
+            },
+          }),
+          access_token: jwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+          refresh_token: "refresh-token",
+        }),
+    });
+    const mutation = spyOn(opengeniDb, "withSessionCodexCapacityMutation").mockRejectedValue(
+      new Error("Codex subscription source cannot change while active turns are using it"),
+    );
+    restores.push(() => mutation.mockRestore());
+
+    const res = await app().request(`/v1/workspaces/${WS_A}/codex/connect/poll`, {
+      method: "POST",
+      headers: {
+        authorization: await bearer(WS_A, ["connections:write"]),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ state: body.state }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: "conflict",
+        message: "Codex subscription source cannot change while active turns are using it",
+        status: 409,
+      },
+    });
   });
 
   test("connect/poll rejects a state minted for a different workspace", async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1321,8 +1321,13 @@ data. The complete job graph, reusable admission gate, and local publication
 actions therefore come from reviewed controller bytes. Every job that checks
 out or executes candidate source depends on the read-only gate, which
 reconstructs the provider-owned merge, merged-source identity, retention, and
-required-check evidence. A merge composed against a different base fails before
-candidate source runs or candidate bytes exist. Acceptance, embedded
+required-check evidence. When GitHub squashes the immutable reviewed head after
+protected `main` advances, the gate accepts only a single-parent source whose
+complete parent-to-source Git-tree delta is byte-for-byte identical to the
+reviewed base-to-head delta and whose integration parent retains that reviewed
+base as an ancestor. An overlapping, truncated, extra, missing, or otherwise
+unproved composition fails before candidate source runs or candidate bytes
+exist. Acceptance, embedded
 distribution, and final publication all require that same controller SHA and
 revalidate its direct tag, immutable provider release, and successful admission
 job before trusting the candidate artifact.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21906,6 +21906,8 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
     workspaceId: string;
     subjectId: string | null;
     mode: WorkspaceCodexSubscriptionMode;
+    /** Effective source captured under the source lock before caller-owned credential writes. */
+    effectiveSourceBeforeMutation?: EffectiveCodexSubscriptionSource;
   },
 ): Promise<WorkspaceCodexSubscriptionSource> {
   await lockWorkspaceCodexSubscriptionSource(scopedDb, input.workspaceId);
@@ -21916,48 +21918,55 @@ export async function setWorkspaceCodexSubscriptionModeInTransaction(
   if (current.workspaceKind === "personal" && input.mode !== "automatic") {
     throw new Error("personal workspaces always use workspace Codex subscriptions");
   }
-  if (current.mode === input.mode) return current;
-  const [activeCodexTurn] = await scopedDb
-    .select({ id: schema.sessionTurns.id })
-    .from(schema.sessionTurns)
-    .where(
-      and(
-        eq(schema.sessionTurns.workspaceId, input.workspaceId),
-        inArray(schema.sessionTurns.status, ["running", "requires_action", "recovering"]),
-        sql`${schema.sessionTurns.model} like 'codex/%'`,
-      ),
-    )
-    .limit(1);
-  const [liveLease] = await scopedDb
-    .select({ id: schema.codexCredentialLeases.id })
-    .from(schema.codexCredentialLeases)
-    .where(
-      and(
-        eq(schema.codexCredentialLeases.workspaceId, input.workspaceId),
-        gt(schema.codexCredentialLeases.leasedUntil, new Date()),
-      ),
-    )
-    .limit(1);
-  if (activeCodexTurn || liveLease) {
-    throw new Error("Codex subscription source cannot change while active turns are using it");
-  }
-  await scopedDb
-    .insert(schema.workspaceCodexSubscriptionPreferences)
-    .values({
-      accountId: input.accountId,
-      workspaceId: input.workspaceId,
-      mode: input.mode,
-      updatedBySubjectId: input.subjectId,
-    })
-    .onConflictDoUpdate({
-      target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
-      set: {
+  const effectiveSourceBeforeMutation =
+    input.effectiveSourceBeforeMutation ?? current.effectiveSource;
+  let next = current;
+  if (current.mode !== input.mode) {
+    await scopedDb
+      .insert(schema.workspaceCodexSubscriptionPreferences)
+      .values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
         mode: input.mode,
         updatedBySubjectId: input.subjectId,
-        updatedAt: new Date(),
-      },
-    });
-  return await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
+      })
+      .onConflictDoUpdate({
+        target: schema.workspaceCodexSubscriptionPreferences.workspaceId,
+        set: {
+          mode: input.mode,
+          updatedBySubjectId: input.subjectId,
+          updatedAt: new Date(),
+        },
+      });
+    next = await getWorkspaceCodexSubscriptionSourceScoped(scopedDb, input.workspaceId);
+  }
+  if (next.effectiveSource !== effectiveSourceBeforeMutation) {
+    const [activeCodexTurn] = await scopedDb
+      .select({ id: schema.sessionTurns.id })
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, input.workspaceId),
+          inArray(schema.sessionTurns.status, ["running", "requires_action", "recovering"]),
+          sql`${schema.sessionTurns.model} like 'codex/%'`,
+        ),
+      )
+      .limit(1);
+    const [liveLease] = await scopedDb
+      .select({ id: schema.codexCredentialLeases.id })
+      .from(schema.codexCredentialLeases)
+      .where(
+        and(
+          eq(schema.codexCredentialLeases.workspaceId, input.workspaceId),
+          gt(schema.codexCredentialLeases.leasedUntil, new Date()),
+        ),
+      )
+      .limit(1);
+    if (activeCodexTurn || liveLease) {
+      throw new Error("Codex subscription source cannot change while active turns are using it");
+    }
+  }
+  return next;
 }
 
 export async function setWorkspaceCodexSubscriptionMode(

--- a/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
+++ b/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
@@ -9,7 +9,11 @@ import {
   createDb,
   createSession,
   disconnectOrganizationCodexAccount,
+  getWorkspaceCodexSubscriptionSource,
   setWorkspaceCodexSubscriptionMode,
+  setWorkspaceCodexSubscriptionModeInTransaction,
+  upsertCodexSubscriptionCredential,
+  withSessionCodexCapacityMutation,
   type DbClient,
 } from "../src";
 import { FORCE_RLS_TABLES, RUNTIME_FULL_DML_TABLES } from "../src/runtime-posture";
@@ -124,7 +128,7 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
       /wakeOrganizationCodexCapacityWaitersInTransaction[\s\S]*?list_organization_workspace_ids[\s\S]*?session-tenancy:/u,
     );
     expect(apiCodexRouteSource).toMatch(
-      /withSessionCodexCapacityMutation[\s\S]*?upsertCodexSubscriptionCredential[\s\S]*?ensureCodexRotationSettings[\s\S]*?setInitialActiveCodexCredential[\s\S]*?setWorkspaceCodexSubscriptionModeInTransaction/u,
+      /withSessionCodexCapacityMutation[\s\S]*?sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource[\s\S]*?upsertCodexSubscriptionCredential[\s\S]*?ensureCodexRotationSettings[\s\S]*?setInitialActiveCodexCredential[\s\S]*?setWorkspaceCodexSubscriptionModeInTransaction[\s\S]*?effectiveSourceBeforeMutation: sourceBeforeConnect\.effectiveSource/u,
     );
     for (const table of [
       "organization_codex_rotation_settings",
@@ -252,6 +256,200 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
         ${account!.id}, ${sharedWorkspace!.id}
       ) as source`;
     expect(organizationOverride?.source).toBe("organization");
+  });
+
+  test("allows an equivalent workspace-source preference while active work remains fenced", async () => {
+    if (!shared || !app || !client) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('codex-equivalent-source-preference') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'shared') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+
+    const session = await createSession(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      initialMessage: "keep the effective workspace source",
+      resources: [],
+      tools: [],
+      metadata: {},
+      model: "codex/gpt-5",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    await shared.admin.begin(async (transaction) => {
+      await transaction`set local session_replication_role = replica`;
+      await transaction`
+        insert into session_turns (
+          account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+          status, position, prompt, model, reasoning_effort, sandbox_backend
+        ) values (
+          ${account!.id}, ${workspace!.id}, ${session.id}, ${crypto.randomUUID()},
+          ${`migration-0381-equivalent-${crypto.randomUUID()}`}, 'running', 0,
+          'keep the effective workspace source', 'codex/gpt-5', 'medium', 'none'
+        )`;
+    });
+
+    const connected = await withSessionCodexCapacityMutation(
+      client.db,
+      { workspaceId: workspace!.id, reason: "codex_credential_connected" },
+      async (transaction) => {
+        const sourceBeforeConnect = await getWorkspaceCodexSubscriptionSource(
+          transaction,
+          workspace!.id,
+        );
+        const upserted = await upsertCodexSubscriptionCredential(transaction, {
+          accountId: account!.id,
+          workspaceId: workspace!.id,
+          credentialEncrypted: "workspace-ciphertext",
+          chatgptAccountId: "workspace-provider-account",
+          scopes: null,
+          planType: "pro",
+          isFedramp: false,
+          expiresAt: null,
+          lastRefreshAt: new Date(),
+          connectedBySubjectId: null,
+        });
+        if (upserted.kind !== "upserted") throw new Error("expected credential upsert");
+        const pinned = await setWorkspaceCodexSubscriptionModeInTransaction(transaction, {
+          accountId: account!.id,
+          workspaceId: workspace!.id,
+          subjectId: null,
+          mode: "workspace",
+          effectiveSourceBeforeMutation: sourceBeforeConnect.effectiveSource,
+        });
+        return { result: { pinned, sourceBeforeConnect, upserted }, changed: true };
+      },
+    );
+    expect(connected.result.sourceBeforeConnect).toMatchObject({
+      mode: "automatic",
+      effectiveSource: "workspace",
+      workspaceAvailable: false,
+      organizationAvailable: false,
+    });
+    expect(connected.result.pinned).toMatchObject({
+      mode: "workspace",
+      effectiveSource: "workspace",
+    });
+
+    await expect(
+      setWorkspaceCodexSubscriptionMode(client.db, {
+        accountId: account!.id,
+        workspaceId: workspace!.id,
+        subjectId: null,
+        mode: "disabled",
+      }),
+    ).rejects.toThrow("Codex subscription source cannot change while active turns are using it");
+    const [retainedPreference] = await shared.admin<{ mode: string }[]>`
+      select mode from workspace_codex_subscription_preferences
+      where workspace_id = ${workspace!.id}`;
+    expect(retainedPreference?.mode).toBe("workspace");
+  });
+
+  test("fences a first workspace credential when the automatic source was organization", async () => {
+    if (!shared || !app || !client) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('codex-pre-connect-source-fence') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'shared') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+    const [organizationCredential] = await shared.admin<{ id: string }[]>`
+      insert into codex_subscription_credentials (
+        account_id, workspace_id, organization_id, authority_scope,
+        credential_encrypted, chatgpt_account_id, status
+      ) values (
+        ${account!.id}, null, ${account!.id}, 'organization',
+        'organization-ciphertext', 'organization-provider-account', 'active'
+      ) returning id`;
+    await shared.admin`
+      insert into organization_codex_rotation_settings (account_id, active_credential_id)
+      values (${account!.id}, ${organizationCredential!.id})`;
+
+    const session = await createSession(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      initialMessage: "keep the organization source",
+      resources: [],
+      tools: [],
+      metadata: {},
+      model: "codex/gpt-5",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    await shared.admin.begin(async (transaction) => {
+      await transaction`set local session_replication_role = replica`;
+      await transaction`
+        insert into session_turns (
+          account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+          status, position, prompt, model, reasoning_effort, sandbox_backend
+        ) values (
+          ${account!.id}, ${workspace!.id}, ${session.id}, ${crypto.randomUUID()},
+          ${`migration-0381-pre-connect-${crypto.randomUUID()}`}, 'running', 0,
+          'keep the organization source', 'codex/gpt-5', 'medium', 'none'
+        )`;
+    });
+
+    let sourceBeforeConnect: Awaited<
+      ReturnType<typeof getWorkspaceCodexSubscriptionSource>
+    > | null = null;
+    await expect(
+      withSessionCodexCapacityMutation(
+        client.db,
+        { workspaceId: workspace!.id, reason: "codex_credential_connected" },
+        async (transaction) => {
+          const source = await getWorkspaceCodexSubscriptionSource(transaction, workspace!.id);
+          sourceBeforeConnect = source;
+          const upserted = await upsertCodexSubscriptionCredential(transaction, {
+            accountId: account!.id,
+            workspaceId: workspace!.id,
+            credentialEncrypted: "workspace-ciphertext",
+            chatgptAccountId: "first-workspace-provider-account",
+            scopes: null,
+            planType: "pro",
+            isFedramp: false,
+            expiresAt: null,
+            lastRefreshAt: new Date(),
+            connectedBySubjectId: null,
+          });
+          if (upserted.kind !== "upserted") throw new Error("expected credential upsert");
+          await setWorkspaceCodexSubscriptionModeInTransaction(transaction, {
+            accountId: account!.id,
+            workspaceId: workspace!.id,
+            subjectId: null,
+            mode: "workspace",
+            effectiveSourceBeforeMutation: source.effectiveSource,
+          });
+          return { result: upserted, changed: true };
+        },
+      ),
+    ).rejects.toThrow("Codex subscription source cannot change while active turns are using it");
+    expect(sourceBeforeConnect).toMatchObject({
+      mode: "automatic",
+      effectiveSource: "organization",
+    });
+    const [rolledBack] = await shared.admin<
+      { workspace_credentials: number; preferences: number }[]
+    >`
+      select
+        count(*) filter (
+          where credential.workspace_id = ${workspace!.id}
+            and credential.authority_scope in ('workspace', 'user')
+        )::integer as workspace_credentials,
+        (
+          select count(*)::integer from workspace_codex_subscription_preferences preference
+          where preference.workspace_id = ${workspace!.id}
+        ) as preferences
+      from codex_subscription_credentials credential
+      where credential.account_id = ${account!.id}`;
+    expect(rolledBack).toEqual({ workspace_credentials: 0, preferences: 0 });
   });
 
   test("allows an organization credential lease only in an inheriting shared workspace", async () => {

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { appendFileSync } from "node:fs";
 import {
+  directTreeManifest,
   verifyHistoricalSourceAdmission,
   verifySourceAdmission,
 } from "./check-source-admission.mjs";
@@ -61,6 +62,7 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
 
 const shaPattern = /^[0-9a-f]{40}$/;
 const positiveIntegerPattern = /^[1-9][0-9]*$/;
+const allowedReleaseTreeBlobModes = new Set(["100644", "100755", "120000"]);
 const retryableVersionProjectionErrors = new Set([
   "Version PR base SHA changed",
   "Version PR head SHA changed",
@@ -91,6 +93,40 @@ function assertSha(value, label) {
     `${label} is not a lowercase Git SHA`,
   );
   return value;
+}
+
+// Keep this release-only parser local. The hotfix admission workflow fetches
+// check-source-admission.mjs from the immutable production base, so changing
+// that helper's bytes on main would disable hotfix admission until production
+// caught up with the new digest.
+function canonicalReleaseLeafMap(value, expectedSha, label) {
+  invariant(value?.sha === expectedSha, `${label} identity changed`);
+  invariant(value?.truncated === false, `${label} is truncated`);
+  invariant(Array.isArray(value?.tree), `${label} entries are missing`);
+  const out = new Map();
+  for (const entry of value.tree) {
+    invariant(entry !== null && typeof entry === "object", `${label} has an invalid entry`);
+    if (entry.type === "tree") continue;
+    invariant(
+      typeof entry.path === "string" && entry.path.length > 0,
+      `${label} has an invalid path`,
+    );
+    invariant(!out.has(entry.path), `${label} has a duplicate path`);
+    const sha = assertSha(entry.sha, `${label} object ${entry.path}`);
+    if (entry.type === "blob") {
+      invariant(
+        allowedReleaseTreeBlobModes.has(entry.mode),
+        `${label} has an invalid blob mode: ${entry.path}`,
+      );
+    } else {
+      invariant(
+        entry.type === "commit" && entry.mode === "160000",
+        `${label} has an invalid leaf: ${entry.path}`,
+      );
+    }
+    out.set(entry.path, { mode: entry.mode, type: entry.type, sha });
+  }
+  return out;
 }
 
 function assertPositiveInteger(value, label) {
@@ -1983,6 +2019,84 @@ async function classifyMergeOutcome(api, source, pullIdentity) {
   return "rebase";
 }
 
+function treeManifestSha256(manifest) {
+  const text = `${manifest.map(({ line }) => line).join("\n")}\n`;
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function manifestsMatch(left, right) {
+  return (
+    left.length === right.length && left.every((entry, index) => entry.line === right[index]?.line)
+  );
+}
+
+async function classifyReleaseSourceComposition(api, source, base, head, pullIdentity) {
+  if (source.treeSha === head.treeSha) {
+    return {
+      mergeMethod: await classifyMergeOutcome(api, source, pullIdentity),
+      sourceComposition: {
+        type: "exact-reviewed-tree",
+        reviewedTreeSha: head.treeSha,
+      },
+    };
+  }
+
+  invariant(
+    source.parents.length === 1,
+    "release source tree differs from the exact reviewed head and is not a single-parent moving-main squash",
+  );
+  const integrationBaseSha = source.parents[0];
+  invariant(
+    integrationBaseSha !== pullIdentity.baseSha,
+    "release source tree differs from the exact reviewed head on its exact PR base",
+  );
+  await assertSourceAncestorOfCurrentMain(
+    api,
+    pullIdentity.baseSha,
+    integrationBaseSha,
+    "moving-main integration base",
+    "reviewed base",
+  );
+  const integrationBase = assertCommit(
+    await api.get(repositoryPath(`/git/commits/${integrationBaseSha}`)),
+    integrationBaseSha,
+    "moving-main integration-base commit",
+  );
+  const [baseTree, headTree, integrationBaseTree, sourceTree] = await Promise.all([
+    api.get(repositoryPath(`/git/trees/${base.treeSha}?recursive=1`)),
+    api.get(repositoryPath(`/git/trees/${head.treeSha}?recursive=1`)),
+    api.get(repositoryPath(`/git/trees/${integrationBase.treeSha}?recursive=1`)),
+    api.get(repositoryPath(`/git/trees/${source.treeSha}?recursive=1`)),
+  ]);
+  const reviewedManifest = directTreeManifest(
+    canonicalReleaseLeafMap(baseTree, base.treeSha, "reviewed base tree"),
+    canonicalReleaseLeafMap(headTree, head.treeSha, "reviewed head tree"),
+  );
+  const landedManifest = directTreeManifest(
+    canonicalReleaseLeafMap(
+      integrationBaseTree,
+      integrationBase.treeSha,
+      "moving-main integration-base tree",
+    ),
+    canonicalReleaseLeafMap(sourceTree, source.treeSha, "moving-main release source tree"),
+  );
+  invariant(reviewedManifest.length > 0, "reviewed release tree delta is empty");
+  invariant(
+    manifestsMatch(reviewedManifest, landedManifest),
+    "release source tree differs from the exact reviewed moving-main composition",
+  );
+  return {
+    mergeMethod: "provider-verified-moving-main-squash",
+    sourceComposition: {
+      type: "exact-reviewed-delta-on-moving-main",
+      integrationBaseSha,
+      integrationBaseTreeSha: integrationBase.treeSha,
+      manifestSha256: treeManifestSha256(reviewedManifest),
+      pathCount: reviewedManifest.length,
+    },
+  };
+}
+
 function releaseApprovalContext(env, suppliedSourceSha) {
   requiredEnvironment(env, [
     "GITHUB_API_URL",
@@ -2116,11 +2230,13 @@ export async function verifyApprovedMerge(options = {}) {
       "release controller tree differs from the exact reviewed base tree",
     );
   }
-  invariant(
-    source.treeSha === head.treeSha,
-    "release source tree differs from the exact reviewed head",
+  const { mergeMethod, sourceComposition } = await classifyReleaseSourceComposition(
+    api,
+    source,
+    base,
+    head,
+    pullIdentity,
   );
-  const mergeMethod = await classifyMergeOutcome(api, source, pullIdentity);
   const reviewUrl =
     `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
     `/pull/${pullNumber}`;
@@ -2198,6 +2314,7 @@ export async function verifyApprovedMerge(options = {}) {
     },
     pullRequestNumber: pullNumber,
     mergeMethod,
+    sourceComposition,
     providerPullCommitCount: pullIdentity.commitCount,
     mergedAt: new Date(pullIdentity.mergedAt).toISOString(),
     reviewedBaseSha: pullIdentity.baseSha,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -27,6 +27,7 @@ const releasePublicationAdmissionPath = join(
   ".github/workflows/release-publication-admission.yml",
 );
 const releaseAutomationPath = join(root, "scripts/check-release-pr-automation.mjs");
+const sourceAdmissionHelperPath = join(root, "scripts/check-source-admission.mjs");
 const baseSha = "b".repeat(40);
 const headSha = "c".repeat(40);
 const mergeSha = "d".repeat(40);
@@ -34,6 +35,10 @@ const controllerSha = baseSha;
 const currentMainSha = "9".repeat(40);
 const baseTreeSha = "e".repeat(40);
 const headTreeSha = "f".repeat(40);
+const movingMainParentSha = "01".repeat(20);
+const movingMainParentTreeSha = "23".repeat(20);
+const movingMainSourceTreeSha = "45".repeat(20);
+const movingMainOnlyBlobSha = "67".repeat(20);
 const staleEventBaseSha = "8".repeat(40);
 const staleMergeBaseSha = "7".repeat(40);
 const staleEventBaseTreeSha = "6".repeat(40);
@@ -2256,7 +2261,7 @@ function approvalEnv(overrides: Record<string, string> = {}) {
 
 function approvalFixture(
   options: {
-    mergeMethod?: "merge" | "squash" | "rebase" | "single";
+    mergeMethod?: "merge" | "squash" | "rebase" | "single" | "moving-main-squash";
     associatedPullCount?: number;
     authorId?: number;
     pullState?: string;
@@ -2297,6 +2302,10 @@ function approvalFixture(
     reviewedBaseSha?: string;
     discontinuousCompare?: boolean;
     mergeEvent?: Record<string, unknown> | null;
+    movingMainOverlap?: boolean;
+    movingMainSourceExtra?: boolean;
+    movingMainTreeTruncated?: "parent" | "source";
+    movingMainParentRetainsBase?: boolean;
   } = {},
 ) {
   const requests: RequestRecord[] = [];
@@ -2305,13 +2314,15 @@ function approvalFixture(
   const pullHeadSha = options.pullHeadSha ?? headSha;
   const reviewedBaseSha = options.reviewedBaseSha ?? baseSha;
   const retainedControllerSha = options.controllerSha ?? controllerSha;
-  const pullCommitCount = mergeMethod === "single" ? 1 : 2;
+  const pullCommitCount = mergeMethod === "single" || mergeMethod === "moving-main-squash" ? 1 : 2;
   const sourceParents =
     mergeMethod === "merge"
       ? [{ sha: baseSha }, { sha: pullHeadSha }]
       : mergeMethod === "rebase"
         ? [{ sha: rebasedFirstSha }]
-        : [{ sha: baseSha }];
+        : mergeMethod === "moving-main-squash"
+          ? [{ sha: movingMainParentSha }]
+          : [{ sha: baseSha }];
   const author =
     options.author ??
     (options.authorId === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id ||
@@ -2393,7 +2404,11 @@ function approvalFixture(
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
       return response({
         sha: mergeSha,
-        tree: { sha: options.sourceTreeSha ?? headTreeSha },
+        tree: {
+          sha:
+            options.sourceTreeSha ??
+            (mergeMethod === "moving-main-squash" ? movingMainSourceTreeSha : headTreeSha),
+        },
         parents: sourceParents,
       });
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${baseSha}`)
@@ -2412,6 +2427,12 @@ function approvalFixture(
       return response({
         sha: pullHeadSha,
         tree: { sha: headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${movingMainParentSha}`)
+      return response({
+        sha: movingMainParentSha,
+        tree: { sha: movingMainParentTreeSha },
         parents: [{ sha: baseSha }],
       });
     if (method === "GET" && url.pathname === `${prefix}/commits/${mergeSha}/pulls`)
@@ -2459,6 +2480,31 @@ function approvalFixture(
         total_commits: pullCommitCount,
         commits: [{ sha: pullHeadSha }],
       });
+    if (
+      method === "GET" &&
+      url.pathname === `${prefix}/compare/${baseSha}...${movingMainParentSha}`
+    )
+      return response(
+        options.movingMainParentRetainsBase === false
+          ? {
+              status: "diverged",
+              base_commit: { sha: baseSha },
+              merge_base_commit: { sha: "8".repeat(40) },
+              ahead_by: 1,
+              behind_by: 1,
+              total_commits: 1,
+              commits: [{ sha: movingMainParentSha }],
+            }
+          : {
+              status: "ahead",
+              base_commit: { sha: baseSha },
+              merge_base_commit: { sha: baseSha },
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: movingMainParentSha, parents: [{ sha: baseSha }] }],
+            },
+      );
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/files`)
       return response([{ filename: "package.json", status: "modified" }]);
     if (method === "GET" && url.pathname === `${prefix}/git/trees/${baseTreeSha}`)
@@ -2485,6 +2531,54 @@ function approvalFixture(
             type: "blob",
             sha: "2".repeat(40),
           },
+        ],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/trees/${movingMainParentTreeSha}`)
+      return response({
+        sha: movingMainParentTreeSha,
+        truncated: options.movingMainTreeTruncated === "parent",
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: options.movingMainOverlap ? "8".repeat(40) : "1".repeat(40),
+          },
+          {
+            path: "main.txt",
+            mode: "100644",
+            type: "blob",
+            sha: movingMainOnlyBlobSha,
+          },
+        ],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/trees/${movingMainSourceTreeSha}`)
+      return response({
+        sha: movingMainSourceTreeSha,
+        truncated: options.movingMainTreeTruncated === "source",
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "2".repeat(40),
+          },
+          {
+            path: "main.txt",
+            mode: "100644",
+            type: "blob",
+            sha: movingMainOnlyBlobSha,
+          },
+          ...(options.movingMainSourceExtra
+            ? [
+                {
+                  path: "unreviewed.txt",
+                  mode: "100644",
+                  type: "blob",
+                  sha: "9".repeat(40),
+                },
+              ]
+            : []),
         ],
       });
     if (method === "GET" && url.pathname === `${prefix}/issues/${pullNumber}/timeline`)
@@ -2870,6 +2964,88 @@ describe("release approval provenance", () => {
       ...RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
     ]);
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("accepts the exact reviewed tree delta squashed onto disjoint moving main", async () => {
+    const retainedControllerSha = "89".repeat(20);
+    const initialMainSha = "ab".repeat(20);
+    const terminalMainSha = "cd".repeat(20);
+    const fixture = approvalFixture({
+      mergeMethod: "moving-main-squash",
+      controllerSha: retainedControllerSha,
+      controllerTreeSha: "ef".repeat(20),
+      initialMainSha,
+      terminalMainSha,
+      sourceAncestorMainShas: [retainedControllerSha, initialMainSha, terminalMainSha],
+      controllerAncestorMainShas: [initialMainSha, terminalMainSha],
+    });
+
+    const result = await verifyApprovedMerge({
+      env: approvalEnv({
+        GITHUB_REF:
+          `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}` + retainedControllerSha,
+        GITHUB_SHA: retainedControllerSha,
+        GITHUB_WORKFLOW_SHA: retainedControllerSha,
+        RELEASE_CONTROLLER_SHA: retainedControllerSha,
+      }),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+
+    expect(result).toMatchObject({
+      sourceSha: mergeSha,
+      sourceTreeSha: movingMainSourceTreeSha,
+      mergeMethod: "provider-verified-moving-main-squash",
+      sourceComposition: {
+        type: "exact-reviewed-delta-on-moving-main",
+        integrationBaseSha: movingMainParentSha,
+        integrationBaseTreeSha: movingMainParentTreeSha,
+        manifestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        pathCount: 1,
+      },
+    });
+  });
+
+  test.each([
+    ["overlapping integration change", { movingMainOverlap: true }],
+    ["extra source path", { movingMainSourceExtra: true }],
+  ] as const)("rejects moving-main composition with %s", async (_label, options) => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          mergeMethod: "moving-main-squash",
+          ...options,
+        }).fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("differs from the exact reviewed moving-main composition");
+  });
+
+  test("rejects a moving-main source whose integration parent does not retain the reviewed base", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          mergeMethod: "moving-main-squash",
+          movingMainParentRetainsBase: false,
+        }).fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("moving-main integration base is not ahead of the reviewed base");
+  });
+
+  test("rejects truncated moving-main tree evidence", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          mergeMethod: "moving-main-squash",
+          movingMainTreeTruncated: "source",
+        }).fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("moving-main release source tree is truncated");
   });
 
   test("accepts an exact release source retained as a strict ancestor across both main fences", async () => {
@@ -3478,6 +3654,7 @@ describe("workflow contracts", () => {
   const releaseSourceAdmissionText = readFileSync(releaseSourceAdmissionPath, "utf8");
   const releasePublicationAdmissionText = readFileSync(releasePublicationAdmissionPath, "utf8");
   const releaseAutomationText = readFileSync(releaseAutomationPath, "utf8");
+  const sourceAdmissionHelperText = readFileSync(sourceAdmissionHelperPath, "utf8");
   const release = Bun.YAML.parse(releaseText) as any;
   const ci = Bun.YAML.parse(ciText) as any;
   const seal = Bun.YAML.parse(sealText) as any;
@@ -4197,6 +4374,11 @@ describe("workflow contracts", () => {
     expect(ciText).toContain("AUTOMATION_CHECK_KIND: automation-ci");
     expect(releaseAutomationText).toContain("releaseHeadTagPrefix");
     expect(releaseSourceAdmissionText).toContain("verify-approved-merge");
+  });
+
+  test("keeps moving-main tree normalization out of the base-owned hotfix helper", () => {
+    expect(releaseAutomationText).toContain("function canonicalReleaseLeafMap");
+    expect(sourceAdmissionHelperText).not.toContain("export function canonicalLeafMap");
   });
 
   test("runs final publication behind the historical retained-controller gate", () => {


### PR DESCRIPTION
Advances the protected production source pointer so the exact staging-tested 0.23.17 source (`f0eb7613df1df64b1d2aa18ec236a929c7e638c8`) remains admissible for immutable candidate creation and production promotion. This also carries the subsequent release-admission controller fix on `main`; it does not deploy production by itself.

## Summary by Sourcery

Advance production release admission safeguards while fixing Codex source-change conflict handling for the 0.23.17 release path.

Bug Fixes:
- Return HTTP 409 conflicts when Codex credential connection is blocked by active turns or leases.
- Preserve the pre-mutation Codex subscription source when validating whether a credential connection changes the effective source.

Enhancements:
- Allow release admission to verify an exact reviewed change squashed onto moving main while rejecting overlaps, extra changes, missing ancestry, or incomplete tree evidence.

Documentation:
- Document the stricter moving-main release source composition and tree-delta validation rules.

Tests:
- Add API and database coverage for Codex source fencing and conflict handling.
- Add release admission coverage for valid and invalid moving-main squash compositions.