### PR TITLE
Fix Connected Machine Files path namespaces

### DIFF
--- a/.changeset/canonical-machine-file-routes.md
+++ b/.changeset/canonical-machine-file-routes.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/core": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
+"@opengeni/react": patch
+---
+
+Keep Connected Machine file links in the target's canonical filesystem namespace, including Windows drive and UNC roots, and reject stale file requests with a retryable route conflict.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -108,6 +108,7 @@ import {
   getRetainedProcess,
   getSandbox,
   getSession,
+  readActiveSandbox,
   deleteSessionTreeIfQuiescent,
   getSessionEvent,
   getSessionForSubject,
@@ -218,6 +219,7 @@ import {
   NatsControlRpc,
   negotiateCapabilities,
   negotiateSelfhostedCapabilities,
+  resolveConnectedMachineWorkspaceRoot,
   selectBackend,
   SelfhostedSession,
 } from "@opengeni/runtime/sandbox";
@@ -3254,6 +3256,10 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         getEnrollment(db, grant, activeSandbox.enrollmentId),
         getLiveEnrollmentConnection(db, grant, activeSandbox.enrollmentId),
       ]);
+      const reportedWorkspaceRoot = liveConnection?.workspaceRoot ?? enrollment?.workspaceRoot;
+      const effectiveWorkspaceRoot = reportedWorkspaceRoot
+        ? resolveConnectedMachineWorkspaceRoot(reportedWorkspaceRoot, session.workingDir)
+        : null;
       let probeResponded = false;
       if (liveConnection?.connectionInstanceId) {
         const machine = new SelfhostedSession({
@@ -3262,7 +3268,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
           connectionInstanceId: liveConnection.connectionInstanceId,
           // Capability negotiation only pings, so a pre-root agent may still
           // report upgrade guidance without exposing a false filesystem root.
-          workspaceRoot: liveConnection.workspaceRoot ?? "/",
+          workspaceRoot: effectiveWorkspaceRoot ?? liveConnection.workspaceRoot ?? "/",
           controlRpc: new NatsControlRpc(async () => bus.getRequestConnection()),
           relay: relayConfigFromSettings(settings),
           epoch: session.activeEpoch,
@@ -3278,7 +3284,10 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         ...commonNegotiation,
         os: enrollment?.os ?? session.sandboxOs,
         leaseEpoch: session.activeEpoch,
-        enrollment,
+        enrollment:
+          enrollment && effectiveWorkspaceRoot
+            ? { ...enrollment, workspaceRoot: effectiveWorkspaceRoot }
+            : enrollment,
         probeResponded,
       });
     } else {
@@ -3327,17 +3336,17 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       ...capabilities,
       FileSystem: {
         ...capabilities.FileSystem,
-        root: selectBackend(
-          (selfhostedActive
-            ? "selfhosted"
-            : activeSandbox?.kind === "modal"
-              ? "modal"
-              : session.sandboxBackend === "selfhosted" &&
-                  settings.sandboxBackend !== "selfhosted" &&
-                  settings.sandboxBackend !== "none"
-                ? settings.sandboxBackend
-                : session.sandboxBackend) as SandboxBackend,
-        ).workspaceRoot,
+        root: selfhostedActive
+          ? capabilities.FileSystem.root
+          : selectBackend(
+              (activeSandbox?.kind === "modal"
+                ? "modal"
+                : session.sandboxBackend === "selfhosted" &&
+                    settings.sandboxBackend !== "selfhosted" &&
+                    settings.sandboxBackend !== "none"
+                  ? settings.sandboxBackend
+                  : session.sandboxBackend) as SandboxBackend,
+            ).workspaceRoot,
       },
       Git: {
         ...capabilities.Git,
@@ -3353,6 +3362,21 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         ...responseCapabilities,
         DesktopStream: { ...capabilities.DesktopStream, ...wire },
       };
+    }
+    if (selfhostedActive) {
+      const currentPointer = await readActiveSandbox(db, workspaceId, sessionId);
+      if (
+        !currentPointer ||
+        currentPointer.activeSandboxId !== session.activeSandboxId ||
+        currentPointer.activeEpoch !== session.activeEpoch ||
+        currentPointer.workingDir !== session.workingDir
+      ) {
+        throw new ApiHttpError(409, {
+          code: "conflict",
+          message: "sandbox route changed while capabilities were being negotiated; retry",
+          retryable: true,
+        });
+      }
     }
     return c.json(responseCapabilities);
   });

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -65,9 +65,11 @@ import {
   NatsOpStreamTransport,
   SandboxResumeIdentityMismatchError,
   SandboxResumeIdentityUnavailableError,
+  RoutingActiveRouteChangedError,
   RoutingWorkspaceRootChangedError,
   SelfhostedWorkspaceRootChangedError,
   ChannelAConflictError,
+  ChannelAFileSystemRouteChangedError,
   ChannelANotFoundError,
   ChannelAUnsupportedError,
   ChannelAUnavailableError,
@@ -612,11 +614,18 @@ async function withChannelAOperation<T>(
           codemodeTokenFileFromEnvironment(environment, session.id),
         )
       : credentialSession;
-    const fileSystemRoot = await routingSession.fileSystemRoot();
+    const fileSystemAuthority = await routingSession.fileSystemAuthority();
+    const fileSystemEpoch =
+      fileSystemAuthority.backendKind === "selfhosted"
+        ? fileSystemAuthority.activeEpoch
+        : (lease?.leaseEpoch ?? fileSystemAuthority.activeEpoch);
     const service = new SandboxChannelAService({
       session: scopedSession as ChannelASession,
-      workspaceRoot: fileSystemRoot,
-      leaseEpoch: lease?.leaseEpoch ?? session.activeEpoch,
+      workspaceRoot: fileSystemAuthority.root,
+      leaseEpoch: fileSystemEpoch,
+      ...(fileSystemAuthority.backendKind === "selfhosted"
+        ? { providerPathMode: "workspace-relative" as const }
+        : {}),
       emit,
     });
     const result = await fn({
@@ -1200,8 +1209,10 @@ export function mapChannelAError(error: unknown, waitSignal?: AbortSignal): unkn
   )
     return new HTTPException(409, { message: error.message });
   if (
+    error instanceof RoutingActiveRouteChangedError ||
     error instanceof RoutingWorkspaceRootChangedError ||
-    error instanceof SelfhostedWorkspaceRootChangedError
+    error instanceof SelfhostedWorkspaceRootChangedError ||
+    error instanceof ChannelAFileSystemRouteChangedError
   )
     return new ApiHttpError(409, {
       code: "conflict",
@@ -1299,8 +1310,10 @@ export function channelAOperationFailureDiagnostic(
   if (
     error instanceof SandboxResumeIdentityMismatchError ||
     error instanceof SandboxResumeIdentityUnavailableError ||
+    error instanceof RoutingActiveRouteChangedError ||
     error instanceof RoutingWorkspaceRootChangedError ||
     error instanceof SelfhostedWorkspaceRootChangedError ||
+    error instanceof ChannelAFileSystemRouteChangedError ||
     (error instanceof HTTPException && error.status === 409)
   ) {
     return {

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -10,9 +10,11 @@ import {
 } from "@opengeni/db";
 import {
   ChannelAConflictError,
+  ChannelAFileSystemRouteChangedError,
   ChannelAUnavailableError,
   ChannelAValidationError,
   BrowserControlTransportError,
+  RoutingActiveRouteChangedError,
   RoutingWorkspaceRootChangedError,
 } from "@opengeni/runtime/sandbox";
 import {
@@ -280,6 +282,50 @@ describe("P4.4 Channel-A route discipline", () => {
     const mapped = mapChannelAError(rootChanged);
     expect(mapped).toBeInstanceOf(HTTPException);
     expect(mapped).toMatchObject({ status: 409, code: "conflict", retryable: true });
+
+    const activeRouteChanged = new RoutingActiveRouteChangedError(
+      { activeSandboxId: null, activeEpoch: 4 },
+      { activeSandboxId: "target", activeEpoch: 5 },
+    );
+    expect(channelAOperationFailureDiagnostic(activeRouteChanged)).toEqual({
+      reason: "lifecycle_conflict",
+      status: 409,
+      errorCode: "sandbox_channel_a_lifecycle_conflict",
+    });
+    expect(mapChannelAError(activeRouteChanged)).toMatchObject({
+      status: 409,
+      code: "conflict",
+      retryable: true,
+    });
+
+    const capabilityRouteChanged = new ChannelAFileSystemRouteChangedError(
+      { epoch: 4, root: "/srv/old" },
+      { epoch: 5, root: "/srv/new" },
+    );
+    expect(channelAOperationFailureDiagnostic(capabilityRouteChanged)).toEqual({
+      reason: "lifecycle_conflict",
+      status: 409,
+      errorCode: "sandbox_channel_a_lifecycle_conflict",
+    });
+    expect(mapChannelAError(capabilityRouteChanged)).toMatchObject({
+      status: 409,
+      code: "conflict",
+      retryable: true,
+    });
+  });
+
+  test("Connected Machine capability roots come from the exact live working directory", () => {
+    const route = sessionsRoute.slice(
+      sessionsRoute.indexOf(
+        'app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/stream-capabilities"',
+      ),
+    );
+    const slice = route.slice(0, 12_000);
+    expect(slice).toContain("resolveConnectedMachineWorkspaceRoot(");
+    expect(slice).toContain("session.workingDir");
+    expect(slice).toMatch(/root:\s*selfhostedActive\s*\?\s*capabilities\.FileSystem\.root/u);
+    expect(slice).toContain("currentPointer.activeEpoch !== session.activeEpoch");
+    expect(slice).not.toContain('selfhostedActive\n            ? "selfhosted"');
   });
 
   test("an unrelated provider AbortError is not misreported as a client cancellation", () => {
@@ -594,10 +640,12 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(decorateAt).toBeGreaterThan(credentialAt);
     expect(decorateAt).toBeLessThan(serviceAt);
     expect(channelASeam.slice(decorateAt, serviceAt)).toContain("session.id");
-    expect(channelASeam.slice(decorateAt, serviceAt)).toContain("routingSession.fileSystemRoot()");
+    expect(channelASeam.slice(decorateAt, serviceAt)).toContain(
+      "routingSession.fileSystemAuthority()",
+    );
     expect(channelASeam.slice(serviceAt, serviceAt + 300)).toContain("session: scopedSession");
     expect(channelASeam.slice(serviceAt, serviceAt + 300)).toContain(
-      "workspaceRoot: fileSystemRoot",
+      "workspaceRoot: fileSystemAuthority.root",
     );
   });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -361,6 +361,14 @@ outcome; text-only reasoning can still begin without contacting it. OpenGeni
 never interprets an offline machine as permission to cold-create a rival box,
 snapshot it, or provider-terminate the user's computer.
 
+The structured Files boundary advertises the selected machine's effective
+host-native working directory as `FileSystem.root`. Canonical file links and
+tree nodes stay in that namespace, while provider commands use contained paths
+relative to the same root. Files requests carry the capability epoch plus root;
+the API binds one active route for the request and returns a retryable conflict
+if the selected target or root changes instead of reinterpreting the path on a
+different filesystem.
+
 Generated-session schedules follow the same explicit route: they persist an
 exact workspace- or organization-scoped machine target and seed the session's
 active pointer before its first turn. A targetless generated schedule cannot

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -49,9 +49,18 @@ already reports its absolute launch root; OpenGeni persists it and resolves an
 optional relative session folder once against that root. The SDK manifest,
 exec cwd, filesystem calls, editor, and PTY all use that same host-native path.
 Relative operation paths resolve from it and absolute paths stay literal, so
-`/workspace` has no special meaning on a machine. Durable artifact receipts and
-`sandbox:` UI links may still use their provider-independent `/workspace/...`
-identity, projected to cwd-relative paths when shown to the model.
+`/workspace` has no special meaning on a machine.
+
+The Files surface advertises that effective path as `FileSystem.root`, including
+Windows drive and UNC roots. A canonical absolute `sandbox:` link opens the tree
+in the same namespace and sends the negotiated `{ epoch, root }` identity with
+each list, read, or mutation. The API validates that the path remains beneath
+the advertised root, pins the request to the first resolved active route, and
+uses a contained workspace-relative path for machine execution. Responses keep
+the canonical host-native spelling; a route or root change returns a retryable
+conflict instead of a misleading outside-workspace validation error or a read
+from a different target. Provider-independent artifact receipts may still use
+their own portable identity where that receipt contract requires it.
 
 The exact model-visible tool catalog remains available through Codemode without
 installing a machine credential. OpenGeni sends no Codemode manifest pointer or

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12789,6 +12789,16 @@ export type TerminalPtyExitedPayload = z.infer<typeof TerminalPtyExitedPayload>;
 // --- A2 FileSystem request/response (NOT events; returned inline) ------------
 export const FsNodeType = z.enum(["file", "dir", "symlink", "other"]);
 export type FsNodeType = z.infer<typeof FsNodeType>;
+/** Optional identity copied from one stream-capabilities response. File callers
+ * use it to fail with a retryable route conflict instead of reinterpreting a
+ * canonical path after the selected sandbox or effective root changes. */
+export const FileSystemRouteIdentity = z
+  .object({
+    epoch: z.number().int().nonnegative(),
+    root: z.string().min(1).max(4_096),
+  })
+  .strict();
+export type FileSystemRouteIdentity = z.infer<typeof FileSystemRouteIdentity>;
 // The Pierre-tree node. `children` is present only when the dir was listed with
 // depth>0; the tree lazy-expands via repeated depth-1 lists at deeper paths.
 export interface FsTreeNode {
@@ -12823,6 +12833,7 @@ export const FsListRequest = z.object({
   depth: z.number().int().min(0).max(8).default(1),
   maxEntries: z.number().int().positive().max(20_000).default(2_000),
   includeHidden: z.boolean().default(true),
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsListRequest = z.infer<typeof FsListRequest>;
 export const FsListResponse = z.object({
@@ -12855,6 +12866,7 @@ export const FsReadRequest = z.object({
     .positive()
     .max(25 * 1024 * 1024)
     .default(5 * 1024 * 1024),
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsReadRequest = z.infer<typeof FsReadRequest>;
 export const FsReadResponse = z.object({
@@ -12874,6 +12886,7 @@ export const FsWriteRequest = z.object({
   content: z.string(),
   overwrite: z.boolean().default(true), // false + existing path => 409
   createParents: z.boolean().default(true),
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsWriteRequest = z.infer<typeof FsWriteRequest>;
 export const FsWriteResponse = z.object({
@@ -12886,6 +12899,7 @@ export type FsWriteResponse = z.infer<typeof FsWriteResponse>;
 export const FsDeleteRequest = z.object({
   path: z.string(),
   recursive: z.boolean().default(false), // required true to delete a non-empty dir
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsDeleteRequest = z.infer<typeof FsDeleteRequest>;
 export const FsDeleteResponse = z.object({
@@ -12898,6 +12912,7 @@ export const FsMoveRequest = z.object({
   newPath: z.string(),
   overwrite: z.boolean().default(false), // false + existing destination => 409
   createParents: z.boolean().default(true),
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsMoveRequest = z.infer<typeof FsMoveRequest>;
 export const FsMoveResponse = z.object({
@@ -12910,6 +12925,7 @@ export type FsMoveResponse = z.infer<typeof FsMoveResponse>;
 export const FsMkdirRequest = z.object({
   path: z.string(),
   recursive: z.boolean().default(true), // false + existing path => 400
+  route: FileSystemRouteIdentity.optional(),
 });
 export type FsMkdirRequest = z.infer<typeof FsMkdirRequest>;
 export const FsMkdirResponse = z.object({

--- a/packages/core/src/sandbox/routing.ts
+++ b/packages/core/src/sandbox/routing.ts
@@ -520,6 +520,7 @@ export function wrapChannelABoxWithRouting(
   });
 
   const proxy = new RoutingSandboxSession({
+    bindActiveRouteOnFirstResolve: true,
     defaultResolved: {
       session: established.session as RoutableBackendSession,
       sandboxId: null,

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -823,9 +823,15 @@ export class DockStateMockClient extends MockOpenGeniClient {
   // make the header chip lie about a live box once the Files tab warms it).
   override async attachViewer(): Promise<Awaited<ReturnType<MockOpenGeniClient["attachViewer"]>>> {
     const base = await super.attachViewer();
-    const liveness =
-      this.state.capabilities === "error" ? "cold" : this.state.capabilities.liveness;
-    return { ...base, liveness };
+    if (this.state.capabilities === "error") return { ...base, liveness: "cold" };
+    // The holder and descriptor describe one exact lease. Regressing the mock
+    // holder to the base fixture's epoch 0 makes a legitimate Files route fence
+    // reset the editor after its first edit intent.
+    return {
+      ...base,
+      liveness: this.state.capabilities.liveness,
+      leaseEpoch: this.state.capabilities.leaseEpoch,
+    };
   }
 
   override async getWorkspaceCapture(): Promise<GetWorkspaceCaptureResponse> {

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -102,6 +102,12 @@ function isWorkbenchSurface(value: string): value is SandboxWorkspaceSurface {
   return (WORKBENCH_SURFACES as readonly string[]).includes(value);
 }
 
+function isCanonicalAbsoluteSandboxPath(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const portable = value.replaceAll("\\", "/");
+  return portable.startsWith("/") || /^[A-Za-z]:\//u.test(portable);
+}
+
 function sourceDrivenDefaultTab(
   hasChanges: boolean,
   changesEnabled: boolean,
@@ -468,6 +474,9 @@ export function useSandboxWorkspaceTabs(
   // is still pending.
   const liveIoLiveness = liveness ?? null;
   const fileSystemOn = capabilities?.FileSystem.available ?? false;
+  const fileSystemRoute = capabilities
+    ? { epoch: capabilities.leaseEpoch, root: capabilities.FileSystem.root }
+    : undefined;
   // The FS is writable only when it's live AND not read-only. A self-hosted box
   // that's offline (or any read-only advertisement) or a capture-served cold tree
   // must not offer create/rename/delete/edit affordances — you cannot mutate a
@@ -575,9 +584,10 @@ export function useSandboxWorkspaceTabs(
     active: filesActive && !turnInFlight,
     // A deliberate canonical absolute-path open browses in the selected target's
     // advertised namespace, so the authoritative tree and link share exact paths.
-    ...(requestedFilePath?.startsWith("/") && capabilities?.FileSystem.root
+    ...(isCanonicalAbsoluteSandboxPath(requestedFilePath) && capabilities?.FileSystem.root
       ? { rootPath: capabilities.FileSystem.root }
       : {}),
+    ...(fileSystemRoute ? { route: fileSystemRoute } : {}),
     repoPaths,
     liveness: liveIoLiveness,
     capture: captureState.capture,

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -1,4 +1,5 @@
 import type {
+  FileSystemRouteIdentity,
   FsChangedPayload,
   FsReadResponse,
   FsTreeNode,
@@ -84,6 +85,9 @@ export type UseSandboxFilesOptions = ClientOverride & {
   events?: SessionEvent[] | undefined;
   /** Initial path to list (workspace root by default). */
   rootPath?: string | undefined;
+  /** Exact capability identity for the selected filesystem route. A route/root
+   * change resets this hook and makes stale provider requests fail retryably. */
+  route?: FileSystemRouteIdentity | undefined;
   /** Hold off the initial list (e.g. panel collapsed). Default true. */
   enabled?: boolean | undefined;
   /** Pause live reads/invalidation while preserving the last rendered result. */
@@ -169,8 +173,12 @@ function normalizeRoot(root: string): string {
   return normalized === "." ? "" : normalized;
 }
 
+function isAbsoluteTreePath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:\//u.test(path);
+}
+
 function joinTreeRoot(root: string, path: string): string {
-  if (!root || path.startsWith("/")) return path;
+  if (!root || isAbsoluteTreePath(path)) return path;
   return root === "/" ? `/${path}` : `${root}/${path}`;
 }
 
@@ -301,6 +309,7 @@ const FS_LIST_BATCH_REQUEST_LIMIT = 16;
 function initialDirectoryFrontier(rootPath: string, repoPaths: readonly string[]): string[] {
   const root = normalizeRoot(rootPath);
   const rootParts = root.split("/").filter(Boolean);
+  const rootPrefix = root.startsWith("//") ? "//" : root.startsWith("/") ? "/" : "";
   const paths = new Set<string>();
   for (const repoPath of repoPaths) {
     const canonicalRepoPath = joinTreeRoot(root, normalizeRoot(repoPath));
@@ -308,7 +317,7 @@ function initialDirectoryFrontier(rootPath: string, repoPaths: readonly string[]
     if (rootParts.some((part, index) => parts[index] !== part)) continue;
     for (let depth = rootParts.length + 1; depth <= parts.length; depth += 1) {
       const path = parts.slice(0, depth).join("/");
-      paths.add(root.startsWith("/") ? `/${path}` : path);
+      paths.add(`${rootPrefix}${path}`);
     }
   }
   // A workspace with hundreds of repositories should remain lazy. This still
@@ -491,6 +500,15 @@ export function useSandboxFiles(
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
   const active = options.active ?? true;
   const rootPath = options.rootPath ?? "";
+  const routeEpoch = options.route?.epoch ?? null;
+  const routeRoot = options.route?.root ?? null;
+  const route = useMemo<FileSystemRouteIdentity | undefined>(
+    () =>
+      routeEpoch !== null && routeRoot !== null
+        ? { epoch: routeEpoch, root: routeRoot }
+        : undefined,
+    [routeEpoch, routeRoot],
+  );
   const repoPathsKey = [
     ...new Set((options.repoPaths?.length ? options.repoPaths : [rootPath]).map(normalizeRoot)),
   ].join("\u0000");
@@ -503,7 +521,7 @@ export function useSandboxFiles(
   const acceptsEventReadsRef = useRef(acceptsEventReads);
   acceptsEventReadsRef.current = acceptsEventReads;
   const hasLiveIoFence = options.liveness !== undefined;
-  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${rootPath}\u0000${repoPathsKey}`;
+  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${rootPath}\u0000${repoPathsKey}\u0000${routeEpoch ?? ""}\u0000${routeRoot ?? ""}`;
 
   const [tree, setTree] = useState<FileTreeNode[]>([]);
   // A ref mirror of the current tree — lets the optimistic path snapshot the
@@ -597,6 +615,7 @@ export function useSandboxFiles(
       const listRequests = [rootPath, ...frontierPaths].map((path) => ({
         path,
         depth: 1,
+        ...(route ? { route } : {}),
       }));
       // Root plus the bounded repository frontier share one API request, one
       // direct holder, and one provider attach. The old per-directory fan-out
@@ -677,7 +696,7 @@ export function useSandboxFiles(
       if (refreshGenerationRef.current === generation) setGitLoading(false);
       if (refreshAbortRef.current === refreshAbort) refreshAbortRef.current = null;
     }
-  }, [client, workspaceId, sessionId, rootPath, repoPaths, applyStatus]);
+  }, [client, workspaceId, sessionId, rootPath, repoPaths, route, applyStatus]);
 
   // Seed (or re-seed) the tree from a turn-end capture — the COLD/offline paint,
   // zero Channel-A calls. The tree index is workspace-relative (`treeIndex`); the
@@ -737,7 +756,7 @@ export function useSandboxFiles(
         const listed = await client.fsList(
           workspaceId,
           sessionId,
-          { path, depth: 1 },
+          { path, depth: 1, ...(route ? { route } : {}) },
           { signal: identitySignal },
         );
         if (identityGenerationRef.current !== identityGeneration) return;
@@ -757,7 +776,7 @@ export function useSandboxFiles(
         }
       }
     },
-    [client, workspaceId, sessionId, capture, source, applyStatus],
+    [client, workspaceId, sessionId, capture, source, route, applyStatus],
   );
 
   const readFile = useCallback(
@@ -850,9 +869,14 @@ export function useSandboxFiles(
         }
         throw new Error("Captured file download failed after refreshing its URL.");
       }
-      return await client.fsRead(workspaceId, sessionId, { path }, { signal });
+      return await client.fsRead(
+        workspaceId,
+        sessionId,
+        { path, ...(route ? { route } : {}) },
+        { signal },
+      );
     },
-    [client, workspaceId, sessionId, capture, source],
+    [client, workspaceId, sessionId, capture, source, route],
   );
 
   // TARGETED reconcile of a single directory — re-list ONE parent at depth 1 and
@@ -874,7 +898,12 @@ export function useSandboxFiles(
       // visible to update; they re-list fresh on the next expand).
       if (!parentIsLoaded(treeRef.current, path, rootPath)) return;
       try {
-        const listed = await client.fsList(workspaceId, sessionId, { path, depth: 1 }, { signal });
+        const listed = await client.fsList(
+          workspaceId,
+          sessionId,
+          { path, depth: 1, ...(route ? { route } : {}) },
+          { signal },
+        );
         if (identityGenerationRef.current !== identityGeneration) return;
         const children = (listed.root.children ?? []).map((node) => fsNodeToTree(node));
         if (path === normalizeRoot(rootPath)) {
@@ -892,7 +921,7 @@ export function useSandboxFiles(
         // root-refresh here (that would collapse the tree the user is working in).
       }
     },
-    [client, workspaceId, sessionId, rootPath, applyStatus],
+    [client, workspaceId, sessionId, rootPath, route, applyStatus],
   );
 
   // Reconcile the visible directory frontier through bounded batch requests.
@@ -915,7 +944,13 @@ export function useSandboxFiles(
           const listed = await client.fsListBatch(
             workspaceId,
             sessionId,
-            { requests: chunk.map((path) => ({ path, depth: 1 })) },
+            {
+              requests: chunk.map((path) => ({
+                path,
+                depth: 1,
+                ...(route ? { route } : {}),
+              })),
+            },
             { signal },
           );
           if (identityGenerationRef.current !== identityGeneration) return;
@@ -943,7 +978,7 @@ export function useSandboxFiles(
         }
       }
     },
-    [client, workspaceId, sessionId, rootPath, applyStatus],
+    [client, workspaceId, sessionId, rootPath, route, applyStatus],
   );
 
   // Run a Channel-A op behind an OPTIMISTIC tree edit. `apply` splices the change
@@ -1027,7 +1062,7 @@ export function useSandboxFiles(
             const live = await client.fsRead(
               workspaceId,
               sessionId,
-              { path },
+              { path, ...(route ? { route } : {}) },
               { signal: identitySignal },
             );
             if (identityGenerationRef.current !== identityGeneration) {
@@ -1046,12 +1081,13 @@ export function useSandboxFiles(
             path,
             content,
             overwrite: true,
+            ...(route ? { route } : {}),
           });
         },
         exists ? [] : [parent],
       );
     },
-    [client, workspaceId, sessionId, tree, rootPath, runOptimistic],
+    [client, workspaceId, sessionId, tree, rootPath, route, runOptimistic],
   );
 
   const createFile = useCallback(
@@ -1072,11 +1108,12 @@ export function useSandboxFiles(
             path,
             content: "",
             overwrite: false,
+            ...(route ? { route } : {}),
           }),
         [parent],
       );
     },
-    [client, workspaceId, sessionId, rootPath, runOptimistic],
+    [client, workspaceId, sessionId, rootPath, route, runOptimistic],
   );
 
   const createDir = useCallback(
@@ -1094,11 +1131,16 @@ export function useSandboxFiles(
       await runOptimistic(
         "create folder",
         (nodes) => insertNode(nodes, parent, node, rootPath),
-        () => client.fsMkdir(workspaceId, sessionId, { path, recursive: true }),
+        () =>
+          client.fsMkdir(workspaceId, sessionId, {
+            path,
+            recursive: true,
+            ...(route ? { route } : {}),
+          }),
         [parent],
       );
     },
-    [client, workspaceId, sessionId, rootPath, runOptimistic],
+    [client, workspaceId, sessionId, rootPath, route, runOptimistic],
   );
 
   const deleteEntry = useCallback(
@@ -1107,11 +1149,16 @@ export function useSandboxFiles(
       await runOptimistic(
         "delete",
         (nodes) => removeNode(nodes, path, rootPath),
-        () => client.fsDelete(workspaceId, sessionId, { path, recursive }),
+        () =>
+          client.fsDelete(workspaceId, sessionId, {
+            path,
+            recursive,
+            ...(route ? { route } : {}),
+          }),
         [parentWithinTree(path, rootPath)],
       );
     },
-    [client, workspaceId, sessionId, rootPath, runOptimistic],
+    [client, workspaceId, sessionId, rootPath, route, runOptimistic],
   );
 
   const moveEntry = useCallback(
@@ -1133,11 +1180,12 @@ export function useSandboxFiles(
             path,
             newPath,
             overwrite: opts?.overwrite ?? false,
+            ...(route ? { route } : {}),
           }),
         to === from ? [from] : [from, to],
       );
     },
-    [client, workspaceId, sessionId, rootPath, runOptimistic],
+    [client, workspaceId, sessionId, rootPath, route, runOptimistic],
   );
 
   // Initial paint + reset on identity change. Source selection:

--- a/packages/react/src/hooks/use-workspace-edit.ts
+++ b/packages/react/src/hooks/use-workspace-edit.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { FileSystemRouteIdentity } from "@opengeni/sdk";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
@@ -39,6 +40,9 @@ export type UseWorkspaceEditOptions = ClientOverride & {
   path?: string | null | undefined;
   /** The capture-served content loaded into the editor — the flush base (C2). */
   baseContent?: string | null | undefined;
+  /** Exact capability identity for the selected filesystem route. A route/root
+   * change discards the buffered edit and makes stale flushes fail retryably. */
+  route?: FileSystemRouteIdentity | undefined;
   /** `capabilities.liveness` — "warm" | "draining" | "cold". Drives the flush. */
   liveness?: string | undefined;
   /** True while the host is actively warming the box (attach in flight, not warm
@@ -95,9 +99,18 @@ export function useWorkspaceEdit(
   const { client, workspaceId } = useOpenGeni(options);
   const path = options.path ?? null;
   const baseContent = options.baseContent ?? null;
+  const routeEpoch = options.route?.epoch;
+  const routeRoot = options.route?.root;
+  const route = useMemo<FileSystemRouteIdentity | undefined>(
+    () =>
+      routeEpoch !== undefined && routeRoot !== undefined
+        ? { epoch: routeEpoch, root: routeRoot }
+        : undefined,
+    [routeEpoch, routeRoot],
+  );
   const live = isLive(options.liveness);
   const offline = options.offline === true;
-  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${path ?? ""}`;
+  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${path ?? ""}\u0000${routeEpoch ?? ""}\u0000${routeRoot ?? ""}`;
 
   const [buffer, setBuffer] = useState<string | null>(null);
   const [wantsWarm, setWantsWarm] = useState(false);
@@ -178,7 +191,7 @@ export function useWorkspaceEdit(
           const liveRead = await client.fsRead(
             workspaceId,
             sessionId,
-            { path },
+            { path, ...(route ? { route } : {}) },
             { signal: readAbort.signal },
           );
           if (readAbortRef.current === readAbort) readAbortRef.current = null;
@@ -190,7 +203,12 @@ export function useWorkspaceEdit(
             return;
           }
         }
-        await client.fsWrite(workspaceId, sessionId, { path, content, overwrite: true });
+        await client.fsWrite(workspaceId, sessionId, {
+          path,
+          content,
+          overwrite: true,
+          ...(route ? { route } : {}),
+        });
         if (identityGenerationRef.current !== identityGeneration) return;
         setConflict(null);
         setFlush("flushed");
@@ -207,7 +225,7 @@ export function useWorkspaceEdit(
         }
       }
     },
-    [client, workspaceId, sessionId, path, baseContent, stateIdentity, identityKey],
+    [client, workspaceId, sessionId, path, baseContent, route, stateIdentity, identityKey],
   );
 
   // Auto-flush once the box is warm and a buffer is pending (the wake completed).

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -968,6 +968,7 @@ describe("useSandboxFiles", () => {
 
   test("canonical roots keep list, tree, status, and top-level mutations in one namespace", async () => {
     const listedPaths: string[] = [];
+    const route = { epoch: 9, root: "/workspace" };
     let created = false;
     const client = fakeClient({
       gitStatus: async (_workspaceId, _sessionId, request) => {
@@ -994,6 +995,7 @@ describe("useSandboxFiles", () => {
       fsList: async (_workspaceId, _sessionId, request) => {
         const path = request?.path ?? "";
         listedPaths.push(path);
+        expect(request?.route).toEqual(route);
         return {
           root: {
             name: "workspace",
@@ -1035,6 +1037,7 @@ describe("useSandboxFiles", () => {
       },
       fsMkdir: async (_workspaceId, _sessionId, request) => {
         expect(request.path).toBe("/workspace/new");
+        expect(request.route).toEqual(route);
         created = true;
         return { path: request.path, revision: 2 };
       },
@@ -1045,6 +1048,7 @@ describe("useSandboxFiles", () => {
           client,
           workspaceId: WORKSPACE_ID,
           rootPath: "/workspace",
+          route,
         }),
       undefined,
     );
@@ -1059,6 +1063,58 @@ describe("useSandboxFiles", () => {
     await flush();
     expect(hook.result.current.tree.some((node) => node.path === "/workspace/new")).toBe(true);
     expect(listedPaths).toContain("/workspace");
+    await hook.unmount();
+  });
+
+  test("UNC roots keep both leading separators across repository frontier prefetch", async () => {
+    const root = "//server/share/repo";
+    const listedPaths: string[] = [];
+    const client = fakeClient({
+      fsList: async (_workspaceId, _sessionId, request) => {
+        const path = request?.path ?? "";
+        listedPaths.push(path);
+        return {
+          root: {
+            name: path.split("/").filter(Boolean).at(-1) ?? "",
+            path,
+            type: "dir",
+            sizeBytes: null,
+            mtimeMs: null,
+            mode: null,
+            children: [],
+            truncated: false,
+          },
+          revision: 1,
+          truncated: false,
+        };
+      },
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 1,
+      }),
+    });
+    const hook = await renderHook(
+      () =>
+        useSandboxFiles(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          rootPath: root,
+          repoPaths: ["packages/app"],
+        }),
+      undefined,
+    );
+    await flush();
+
+    expect(listedPaths).toContain(root);
+    expect(listedPaths).toContain("//server/share/repo/packages");
+    expect(listedPaths).toContain("//server/share/repo/packages/app");
+    expect(listedPaths.some((path) => path.startsWith("/server/"))).toBe(false);
     await hook.unmount();
   });
 

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -991,6 +991,72 @@ describe("capture-driven default tab (Refinement 2)", () => {
     await hook.unmount();
   });
 
+  test("a Connected Machine canonical link lists its exact capability root with a route fence", async () => {
+    const requests: Array<{ path?: string; route?: { epoch: number; root: string } }> = [];
+    const root = "C:/work/repo";
+    const capabilities = fakeCapabilities({
+      backend: "selfhosted",
+      os: "windows",
+      leaseEpoch: 12,
+      FileSystem: {
+        available: true,
+        readOnly: false,
+        root,
+        pathSep: "\\",
+        treeMode: "lazy",
+        reason: null,
+      },
+      Git: { available: true, repos: [], reason: null },
+    });
+    const { client } = coldClient({
+      getStreamCapabilities: async () => capabilities,
+      getWorkspaceCapture: async () => ({ available: false }),
+      attachViewer: async () => fakeAttachResponse({ leaseEpoch: 12 }),
+      fsList: async (_workspaceId, _sessionId, request) => {
+        requests.push(request ?? {});
+        return {
+          root: {
+            name: "repo",
+            path: request?.path ?? "",
+            type: "dir",
+            sizeBytes: null,
+            mtimeMs: null,
+            mode: null,
+            truncated: false,
+            children: [],
+          },
+          revision: 1,
+          truncated: false,
+        };
+      },
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 1,
+      }),
+    });
+    const hook = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [],
+      initialTab: WORKBENCH_TAB_FILES,
+      requestedFilePath: "C:/work/repo/src/app.ts",
+      requestedFileRequestId: 73,
+    });
+    await flush(60);
+
+    expect(requests[0]).toMatchObject({
+      path: root,
+      route: { epoch: 12, root },
+    });
+    expect(requests.some((request) => request.path === "/")).toBe(false);
+    await hook.unmount();
+  });
+
   test("a cold-start turn defers automatic Files reads until the turn settles", async () => {
     let fileReads = 0;
     const { client } = coldClient({

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -27,6 +27,7 @@ import {
 import { OpenGeniProvider } from "../src/provider";
 import { OpenGeniContext, type OpenGeniContextValue } from "../src/session-context";
 import type { MachinesResponse } from "../src/types/machines";
+import { DOCK_STATES, DockStateMockClient } from "../demo/workbench-dock-states";
 import {
   useSandboxWorkspaceTabs,
   initialWorkspaceTab,
@@ -357,6 +358,15 @@ describe("workbench surface allowlist", () => {
 // ── Refinement 1: prewarm gated to intent ────────────────────────────────────
 
 describe("workbench prewarm gating (Refinement 1)", () => {
+  test("the dock fixture keeps viewer and capability lease epochs aligned", async () => {
+    const client = new DockStateMockClient(DOCK_STATES["warm-live"]!);
+    const capabilities = await client.getStreamCapabilities();
+    const holder = await client.attachViewer();
+
+    expect(holder.leaseEpoch).toBe(capabilities.leaseEpoch);
+    expect(holder.liveness).toBe(capabilities.liveness);
+  });
+
   test("workspace interaction lifecycle changes refresh the truthful machine liveness", async () => {
     let warm = false;
     let capabilityReads = 0;

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -2143,20 +2143,25 @@ describe("useSandboxGit — capture source", () => {
 
 describe("useWorkspaceEdit", () => {
   test("happy path: cold edit → warm → guarded flush (hash matches)", async () => {
-    const writes: { path: string; content: string }[] = [];
+    const route = { epoch: 7, root: "C:\\workspace" };
+    const reads: unknown[] = [];
+    const writes: { path: string; content: string; route: unknown }[] = [];
     let warmRequests = 0;
     const client = fakeClient({
-      fsRead: async (_ws, _s, req) => ({
-        path: req.path,
-        encoding: "utf8" as const,
-        content: "hello\n",
-        sizeBytes: 6,
-        truncated: false,
-        isBinary: false,
-        revision: 0,
-      }),
+      fsRead: async (_ws, _s, req) => {
+        reads.push(req.route);
+        return {
+          path: req.path,
+          encoding: "utf8" as const,
+          content: "hello\n",
+          sizeBytes: 6,
+          truncated: false,
+          isBinary: false,
+          revision: 0,
+        };
+      },
       fsWrite: async (_ws, _s, req) => {
-        writes.push({ path: req.path, content: req.content });
+        writes.push({ path: req.path, content: req.content, route: req.route });
         return { path: req.path, sizeBytes: req.content.length, revision: 9 };
       },
     });
@@ -2167,6 +2172,7 @@ describe("useWorkspaceEdit", () => {
           client,
           path: "a.txt",
           baseContent: "hello\n",
+          route,
           liveness: props.liveness,
           onWarmRequested: () => {
             warmRequests += 1;
@@ -2191,7 +2197,8 @@ describe("useWorkspaceEdit", () => {
     await flush();
     expect(hook.result.current.state).toBe("flushed");
     expect(hook.result.current.wantsWarm).toBe(false);
-    expect(writes).toEqual([{ path: "a.txt", content: "hello world\n" }]);
+    expect(reads).toEqual([route]);
+    expect(writes).toEqual([{ path: "a.txt", content: "hello world\n", route }]);
     await hook.unmount();
   });
 
@@ -2246,6 +2253,7 @@ describe("useWorkspaceEdit", () => {
   });
 
   test("conflict path: live diverged from base → conflict, NO write (C2)", async () => {
+    const route = { epoch: 11, root: "//server/share/workspace" };
     const writes: unknown[] = [];
     const client = fakeClient({
       // The live file changed on the box since capture.
@@ -2258,8 +2266,8 @@ describe("useWorkspaceEdit", () => {
         isBinary: false,
         revision: 0,
       }),
-      fsWrite: async () => {
-        writes.push(true);
+      fsWrite: async (_workspaceId, _sessionId, request) => {
+        writes.push(request.route);
         return { path: "a.txt", sizeBytes: 0, revision: 0 };
       },
     });
@@ -2270,6 +2278,7 @@ describe("useWorkspaceEdit", () => {
           client,
           path: "a.txt",
           baseContent: "hello\n",
+          route,
           liveness: props.liveness,
         }),
       { liveness: "cold" },
@@ -2288,7 +2297,55 @@ describe("useWorkspaceEdit", () => {
     await actRun(() => hook.result.current.overwrite());
     await flush();
     expect(hook.result.current.state).toBe("flushed");
-    expect(writes.length).toBe(1);
+    expect(writes).toEqual([route]);
+    await hook.unmount();
+  });
+
+  test("a filesystem route change discards a buffered edit before the successor warms", async () => {
+    const reads: unknown[] = [];
+    const writes: unknown[] = [];
+    const client = fakeClient({
+      fsRead: async (_workspaceId, _sessionId, request) => {
+        reads.push(request);
+        return {
+          path: request.path,
+          encoding: "utf8" as const,
+          content: "base\n",
+          sizeBytes: 5,
+          truncated: false,
+          isBinary: false,
+          revision: 0,
+        };
+      },
+      fsWrite: async (_workspaceId, _sessionId, request) => {
+        writes.push(request);
+        return { path: request.path, sizeBytes: request.content.length, revision: 1 };
+      },
+    });
+    const hook = await renderHook(
+      (props: { liveness: string; route: { epoch: number; root: string } }) =>
+        useWorkspaceEdit(SESSION_ID, {
+          ...ctx,
+          client,
+          path: "a.txt",
+          baseContent: "base\n",
+          liveness: props.liveness,
+          route: props.route,
+        }),
+      { liveness: "cold", route: { epoch: 21, root: "/first" } },
+    );
+    await flush();
+    await actRun(() => hook.result.current.edit("edited\n"));
+    await flush();
+    expect(hook.result.current.buffer).toBe("edited\n");
+
+    await hook.rerender({ liveness: "warm", route: { epoch: 22, root: "/second" } });
+    await flush();
+
+    expect(hook.result.current.state).toBe("viewing-cold");
+    expect(hook.result.current.buffer).toBeNull();
+    expect(reads).toEqual([]);
+    expect(writes).toEqual([]);
     await hook.unmount();
   });
 

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -21,6 +21,7 @@
 // `createEditor` for text when `exec` is absent.
 
 import type {
+  FileSystemRouteIdentity,
   FsChangedPayload,
   FsDeleteRequest,
   FsDeleteResponse,
@@ -59,6 +60,14 @@ import type {
   TerminalExecRequest,
   TerminalExecResponse,
 } from "@opengeni/contracts";
+import {
+  connectedMachinePathWithinRoot,
+  connectedMachineWorkspaceRootsEqual,
+  isConnectedMachineAbsolutePath,
+  isWindowsConnectedMachinePath,
+  relativeConnectedMachinePath,
+  resolveConnectedMachinePath,
+} from "./selfhosted/workspace-path";
 import {
   isExecSessionLostBanner,
   parseExecBannerExitCode,
@@ -232,6 +241,20 @@ export class ChannelAConflictError extends Error {
     this.name = "ChannelAConflictError";
   }
 }
+/** A caller used a filesystem identity negotiated for a different active route
+ * or effective root. This is retryable after refreshing capabilities; it must
+ * never be downgraded to a bad-path response. */
+export class ChannelAFileSystemRouteChangedError extends Error {
+  readonly retryable = true;
+
+  constructor(
+    public readonly expected: FileSystemRouteIdentity,
+    public readonly actual: FileSystemRouteIdentity,
+  ) {
+    super("filesystem route changed; refresh capabilities and retry");
+    this.name = "ChannelAFileSystemRouteChangedError";
+  }
+}
 export class ChannelANotFoundError extends Error {
   constructor(message: string) {
     super(message);
@@ -267,6 +290,10 @@ export type SandboxChannelAServiceOptions = {
   // resolve beneath it; already-canonical absolute paths stay byte-for-byte paths
   // after validation that they remain inside this authority.
   workspaceRoot?: string;
+  // Connected Machine providers already resolve relative paths against their
+  // exact host root. Keep provider commands relative while preserving the
+  // canonical host-native root as the public FileSystem namespace.
+  providerPathMode?: "canonical" | "workspace-relative";
   // The lease epoch the box was resumed under (paired with `revision` for cache
   // invalidation — H3). 0 when ownership is off / no lease.
   leaseEpoch?: number;
@@ -386,6 +413,7 @@ async function settleConcurrentReads<const T extends readonly unknown[]>(reads: 
 export class SandboxChannelAService {
   private readonly session: ChannelASession;
   private readonly workspaceRoot: string;
+  private readonly providerPathMode: "canonical" | "workspace-relative";
   private readonly leaseEpoch: number;
   private revision: number;
   private readonly emit?: ChannelAEmitter | undefined;
@@ -394,11 +422,27 @@ export class SandboxChannelAService {
   constructor(opts: SandboxChannelAServiceOptions) {
     this.session = opts.session;
     const workspaceRoot = opts.workspaceRoot ?? "";
-    this.workspaceRoot = workspaceRoot === "/" ? "/" : workspaceRoot.replace(/\/+$/, "");
+    this.workspaceRoot = isConnectedMachineAbsolutePath(workspaceRoot)
+      ? resolveConnectedMachinePath(workspaceRoot, undefined)
+      : workspaceRoot === "."
+        ? ""
+        : workspaceRoot.replace(/\/+$/, "");
+    this.providerPathMode = opts.providerPathMode ?? "canonical";
     this.leaseEpoch = opts.leaseEpoch ?? 0;
     this.revision = opts.revision ?? 0;
     this.emit = opts.emit;
     this.runAs = opts.runAs;
+  }
+
+  private assertFileSystemRoute(route: FileSystemRouteIdentity | undefined): void {
+    if (!route) return;
+    const actual = { epoch: this.leaseEpoch, root: this.workspaceRoot };
+    if (
+      route.epoch !== actual.epoch ||
+      !connectedMachineWorkspaceRootsEqual(route.root, actual.root)
+    ) {
+      throw new ChannelAFileSystemRouteChangedError(route, actual);
+    }
   }
 
   /** Capability probe — the compact Channel-A projection. */
@@ -509,6 +553,7 @@ export class SandboxChannelAService {
     req: FsListRequest,
     pruneDirectoryNames: readonly string[],
   ): Promise<FsListResponse> {
+    this.assertFileSystemRoute(req.route);
     const root = assertSafeRelPathOrRoot(req.path, this.workspaceRoot);
     const pruneNames = [...new Set(pruneDirectoryNames)].map(assertSafePruneDirectoryName);
     if (pruneNames.length === 0 && this.session.listDir && Math.max(req.depth, 1) === 1) {
@@ -655,6 +700,7 @@ export class SandboxChannelAService {
   }
 
   async fsRead(req: FsReadRequest): Promise<FsReadResponse> {
+    this.assertFileSystemRoute(req.route);
     const path = assertSafeRelPath(req.path, this.workspaceRoot);
     if (!this.session.readFile) {
       // No native readFile: open the file once, prove that exact descriptor is
@@ -694,7 +740,7 @@ export class SandboxChannelAService {
   }
 
   private async assertConfinedExistingDirectory(path: string): Promise<void> {
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const abs = this.joinRoot(path);
     const rejectLink = path
       ? `test ! -L ${shellQuote(abs)} || { printf '__OPENGENI_FS_SYMLINK__'; exit 68; }`
@@ -716,7 +762,7 @@ export class SandboxChannelAService {
     path: string,
     options: { allowMissingParents: boolean; rejectFinalSymlink: boolean },
   ): Promise<void> {
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const abs = this.joinRoot(path);
     const rejectLink = options.rejectFinalSymlink
       ? `test ! -L ${shellQuote(abs)} || { printf '__OPENGENI_FS_SYMLINK__'; exit 68; }`
@@ -771,7 +817,7 @@ export class SandboxChannelAService {
    * before its resolved path is root-checked and matched to the descriptor's
    * inode, so a symlink/path swap cannot redirect the subsequent read. */
   private async fsReadViaExec(path: string, req: FsReadRequest): Promise<FsReadResponse> {
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const abs = this.joinRoot(path);
     const script = [
       PORTABLE_REALPATH_EXISTING_FUNCTION,
@@ -842,6 +888,7 @@ export class SandboxChannelAService {
   }
 
   async fsWrite(req: FsWriteRequest): Promise<FsWriteResponse> {
+    this.assertFileSystemRoute(req.route);
     const path = assertSafeRelPath(req.path, this.workspaceRoot);
     const abs = this.joinRoot(path);
     const bytes =
@@ -1048,7 +1095,7 @@ export class SandboxChannelAService {
     const destination = this.workspaceRoot
       ? this.joinRoot(destinationPath)
       : `./${destinationPath}`;
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const frame = crypto.randomUUID().replaceAll("-", "");
     const replayMarker = `__OPENGENI_WORKSPACE_INSPECT_${frame}_REPLAY__`;
     const absentMarker = `__OPENGENI_WORKSPACE_INSPECT_${frame}_ABSENT__`;
@@ -1177,7 +1224,7 @@ export class SandboxChannelAService {
     const escapeMarker = `__OPENGENI_WORKSPACE_IMPORT_${frame}_ESCAPE__`;
     const unavailableMarker = `__OPENGENI_WORKSPACE_IMPORT_${frame}_UNAVAILABLE__`;
     const integrityMarker = `__OPENGENI_WORKSPACE_IMPORT_${frame}_INTEGRITY__`;
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const tempName = `.opengeni-download-${operationId}-${frame}.tmp`;
     const allowReplace = req.overwrite && req.mayReplaceExisting;
     const script = [
@@ -1320,6 +1367,7 @@ export class SandboxChannelAService {
   }
 
   async fsDelete(req: FsDeleteRequest): Promise<FsDeleteResponse> {
+    this.assertFileSystemRoute(req.route);
     const path = assertSafeRelPath(req.path, this.workspaceRoot);
     const abs = this.joinRoot(path);
     await this.assertConfinedMutationParent(path, {
@@ -1339,6 +1387,7 @@ export class SandboxChannelAService {
   }
 
   async fsMove(req: FsMoveRequest): Promise<FsMoveResponse> {
+    this.assertFileSystemRoute(req.route);
     const path = assertSafeRelPath(req.path, this.workspaceRoot);
     const newPath = assertSafeRelPath(req.newPath, this.workspaceRoot);
     const abs = this.joinRoot(path);
@@ -1392,6 +1441,7 @@ export class SandboxChannelAService {
   }
 
   async fsMkdir(req: FsMkdirRequest): Promise<FsMkdirResponse> {
+    this.assertFileSystemRoute(req.route);
     const path = assertSafeRelPath(req.path, this.workspaceRoot);
     const abs = this.joinRoot(path);
     await this.assertConfinedMutationParent(path, {
@@ -2156,7 +2206,7 @@ export class SandboxChannelAService {
       ].join("\n");
       const { stdout } = await this.runReadOnly({
         cmd: internalBashCommand(command),
-        workdir: this.workspaceRoot || undefined,
+        workdir: this.providerWorkspaceRoot(),
         yieldTimeMs: 20_000,
         // At most 256 Unix paths (PATH_MAX each) plus the status trailer. This
         // prevents a provider's ordinary output cap from dropping the trailer
@@ -2369,10 +2419,24 @@ export class SandboxChannelAService {
   }
 
   private joinRoot(rel: string): string {
-    if (rel.startsWith("/")) return rel;
+    if (this.providerPathMode === "workspace-relative") {
+      if (isConnectedMachineAbsolutePath(rel)) {
+        const relative = relativeConnectedMachinePath(this.workspaceRoot, rel);
+        if (relative === null) {
+          throw new ChannelAValidationError(`absolute path is outside the workspace root: ${rel}`);
+        }
+        return relative || ".";
+      }
+      return rel === "" ? "." : rel;
+    }
+    if (isConnectedMachineAbsolutePath(rel)) return rel;
     if (!this.workspaceRoot) return rel === "" ? "." : rel;
     if (rel === "") return this.workspaceRoot;
     return this.workspaceRoot === "/" ? `/${rel}` : `${this.workspaceRoot}/${rel}`;
+  }
+
+  private providerWorkspaceRoot(): string {
+    return this.providerPathMode === "workspace-relative" ? "." : this.workspaceRoot || ".";
   }
 
   private async fsListFromNativeListDir(req: FsListRequest): Promise<FsListResponse> {
@@ -2438,7 +2502,7 @@ export class SandboxChannelAService {
     wallTimeSeconds: number;
   }> {
     const safe = assertSafeRelPathOrRoot(rel, this.workspaceRoot);
-    const root = this.workspaceRoot || ".";
+    const root = this.providerWorkspaceRoot();
     const abs = this.joinRoot(safe);
     const rejectLink = safe
       ? `test ! -L ${shellQuote(abs)} || { printf '__OPENGENI_FS_SYMLINK__'; exit 68; }`
@@ -2646,27 +2710,18 @@ function normalizeRelPath(p: string): string {
   return trimmed;
 }
 
-function normalizeAbsolutePath(p: string): string {
-  return p === "/" ? p : p.replace(/\/+$/, "");
-}
-
-function pathIsWithinRoot(path: string, root: string): boolean {
-  return root === "/" ? path.startsWith("/") : path === root || path.startsWith(`${root}/`);
-}
-
 function assertSafeRelPathOrRoot(p: string, workspaceRoot = ""): string {
-  const segments = p.split("/");
+  const portable = isWindowsConnectedMachinePath(workspaceRoot) ? p.replaceAll("\\", "/") : p;
+  const segments = portable.split("/");
   if (segments.some((segment) => segment === "..")) {
     throw new ChannelAValidationError(`path traversal is not allowed: ${p}`);
   }
-  if (!p.startsWith("/")) return normalizeRelPath(p);
+  if (!isConnectedMachineAbsolutePath(portable)) return normalizeRelPath(portable);
 
-  const root = workspaceRoot.startsWith("/") ? normalizeAbsolutePath(workspaceRoot) : "";
-  const path = normalizeAbsolutePath(p);
-  if (!root || !pathIsWithinRoot(path, root)) {
+  if (!workspaceRoot || !connectedMachinePathWithinRoot(workspaceRoot, portable)) {
     throw new ChannelAValidationError(`absolute path is outside the workspace root: ${p}`);
   }
-  return path;
+  return resolveConnectedMachinePath(workspaceRoot, portable);
 }
 
 // Relative paths remain supported for compatibility. An absolute path is valid
@@ -2872,49 +2927,33 @@ function dirnameRel(p: string, root: string): string {
   return p.slice(0, idx);
 }
 
-function joinPathRoot(root: string, path: string): string {
-  if (!path) return root;
-  return root === "/" ? `/${path}` : `${root}/${path}`;
-}
-
 function stripDotSlash(rawPath: string, root: string, workspaceRoot = ""): string {
-  let p = rawPath.startsWith("./") ? rawPath.slice(2) : rawPath;
-  if (p.startsWith("/")) {
-    const absolute = normalizeAbsolutePath(p);
-    if (root.startsWith("/")) {
-      if (!pathIsWithinRoot(absolute, normalizeAbsolutePath(root))) {
-        throw new ChannelAValidationError(`listed path is outside the requested root: ${p}`);
-      }
-      return absolute;
+  const windows = isWindowsConnectedMachinePath(workspaceRoot);
+  let p = windows ? rawPath.replaceAll("\\", "/") : rawPath;
+  p = p.startsWith("./") ? p.slice(2) : p;
+  if (isConnectedMachineAbsolutePath(p)) {
+    const containmentRoot = isConnectedMachineAbsolutePath(root) ? root : workspaceRoot;
+    if (!containmentRoot || !connectedMachinePathWithinRoot(containmentRoot, p)) {
+      throw new ChannelAValidationError(
+        `listed path is outside the ${isConnectedMachineAbsolutePath(root) ? "requested" : "workspace"} root: ${p}`,
+      );
     }
-    const canonicalWorkspaceRoot = workspaceRoot.startsWith("/")
-      ? normalizeAbsolutePath(workspaceRoot)
-      : "";
-    if (!canonicalWorkspaceRoot || !pathIsWithinRoot(absolute, canonicalWorkspaceRoot)) {
+    const absolute = resolveConnectedMachinePath(containmentRoot, p);
+    if (isConnectedMachineAbsolutePath(root)) return absolute;
+    const relative = relativeConnectedMachinePath(workspaceRoot, absolute);
+    if (relative === null) {
       throw new ChannelAValidationError(`listed path is outside the workspace root: ${p}`);
     }
-    p =
-      absolute === canonicalWorkspaceRoot
-        ? ""
-        : canonicalWorkspaceRoot === "/"
-          ? absolute.slice(1)
-          : absolute.slice(canonicalWorkspaceRoot.length + 1);
+    p = relative;
   }
 
-  if (root.startsWith("/")) {
-    const canonicalWorkspaceRoot = workspaceRoot.startsWith("/")
-      ? normalizeAbsolutePath(workspaceRoot)
-      : root;
-    const rootRelative =
-      canonicalWorkspaceRoot === "/"
-        ? root.slice(1)
-        : root === canonicalWorkspaceRoot
-          ? ""
-          : root.slice(canonicalWorkspaceRoot.length + 1);
+  if (isConnectedMachineAbsolutePath(root)) {
+    const canonicalWorkspaceRoot = workspaceRoot || root;
+    const rootRelative = relativeConnectedMachinePath(canonicalWorkspaceRoot, root) ?? "";
     if (rootRelative && (p === rootRelative || p.startsWith(`${rootRelative}/`))) {
-      return joinPathRoot(canonicalWorkspaceRoot, p);
+      return resolveConnectedMachinePath(canonicalWorkspaceRoot, p);
     }
-    return joinPathRoot(root, p);
+    return resolveConnectedMachinePath(root, p);
   }
 
   // find run with workdir=root and findRoot="." gives paths relative to root,

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -392,6 +392,7 @@ export {
   ChannelAValidationError,
   ChannelAUnavailableError,
   ChannelAConflictError,
+  ChannelAFileSystemRouteChangedError,
   ChannelANotFoundError,
   ChannelAUnsupportedError,
   stripExecBanner,
@@ -489,9 +490,12 @@ export {
   type SelfhostedOpStreamDeps,
 } from "./selfhosted/session";
 export {
+  connectedMachinePathWithinRoot,
   connectedMachineWorkspaceRootsEqual,
+  isConnectedMachineAbsolutePath,
   isWindowsConnectedMachinePath,
   normalizeConnectedMachineWorkspaceRoot,
+  relativeConnectedMachinePath,
   resolveConnectedMachinePath,
   resolveConnectedMachineWorkspaceRoot,
   type ConnectedMachineOs,
@@ -557,6 +561,7 @@ export {
   RoutingRetainedProcessNotFoundError,
   RoutingSandboxSession,
   RoutingWorkspaceRootChangedError,
+  RoutingActiveRouteChangedError,
   RoutingUnsupportedError,
   type ActivePointer,
   type DefaultBackendLossResult,

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -30,7 +30,11 @@
 import type { ExposedPortEndpoint } from "../stream-port";
 import { CAPABILITY_DESCRIPTORS, type SandboxBackend } from "@opengeni/contracts";
 import { SelfhostedControlError } from "../selfhosted/control-rpc";
-import { connectedMachineWorkspaceRootsEqual } from "../selfhosted/workspace-path";
+import {
+  connectedMachineWorkspaceRootsEqual,
+  isConnectedMachineAbsolutePath,
+  resolveConnectedMachinePath,
+} from "../selfhosted/workspace-path";
 import { renderSelfhostedFault } from "../selfhosted/fault-rendering";
 import {
   ChannelAPartialMutationError,
@@ -166,6 +170,10 @@ export interface RoutingSandboxSessionDeps {
    * seeding it here is byte-identical to what the first `resolve()` would produce.
    */
   defaultResolved?: ResolvedActiveBackend;
+  /** API-direct requests resolve one active route and retain it for the complete
+   * request. Worker turns omit this so an explicit mid-turn swap remains visible
+   * to the next tool call. */
+  bindActiveRouteOnFirstResolve?: boolean;
   /** Re-read the per-session active pointer. Called on EVERY op (the per-call
    *  re-resolve that makes a mid-turn swap visible to the next tool call). */
   readPointer(): Promise<ActivePointer>;
@@ -366,6 +374,21 @@ export class RoutingWorkspaceRootChangedError extends Error {
     super(
       `Active sandbox workspace root changed from "${expectedWorkspaceRoot}" to "${actualWorkspaceRoot}"; continue in a fresh attempt`,
     );
+  }
+}
+
+/** One API-direct request was bound to an active route, then the pointer moved
+ * before a later provider dispatch. The caller must refresh route capabilities
+ * rather than letting a canonical path land on a different backend. */
+export class RoutingActiveRouteChangedError extends Error {
+  readonly name = "RoutingActiveRouteChangedError";
+  readonly retryable = true;
+
+  constructor(
+    public readonly expected: ActivePointer,
+    public readonly actual: ActivePointer,
+  ) {
+    super("Active sandbox route changed during the request; refresh capabilities and retry");
   }
 }
 
@@ -627,7 +650,8 @@ function structuredExecResultFromBanner(result: string): {
 export class RoutingSandboxSession implements RoutableBackendSession {
   private readonly deps: RoutingSandboxSessionDeps;
   private readonly maxFenceRetries: number;
-  private readonly boundWorkspaceRoot: string | null;
+  private boundWorkspaceRoot: string | null;
+  private boundActiveRoute: ActivePointer | null = null;
   // The resolved-backend cache. Keyed by the FULL pointer tuple
   // `(activeEpoch, activeSandboxId)` — NOT the epoch alone. A swap bumps the epoch,
   // but a pointer can also change its target id WITHOUT an epoch bump: the
@@ -658,7 +682,9 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   constructor(deps: RoutingSandboxSessionDeps) {
     this.deps = deps;
     this.maxFenceRetries = deps.maxFenceRetries ?? 3;
-    this.boundWorkspaceRoot = workspaceRootForBackend(deps.defaultResolved?.session);
+    this.boundWorkspaceRoot = deps.bindActiveRouteOnFirstResolve
+      ? null
+      : workspaceRootForBackend(deps.defaultResolved?.session);
     this.rememberOpStreamBackend(deps.defaultResolved?.session);
   }
 
@@ -719,6 +745,13 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   private async resolve(): Promise<ResolvedActiveBackend> {
     const pointer = await this.deps.readPointer();
     if (
+      this.boundActiveRoute &&
+      (this.boundActiveRoute.activeEpoch !== pointer.activeEpoch ||
+        this.boundActiveRoute.activeSandboxId !== pointer.activeSandboxId)
+    ) {
+      throw new RoutingActiveRouteChangedError(this.boundActiveRoute, pointer);
+    }
+    if (
       this.cachedEpoch === pointer.activeEpoch &&
       this.cachedSandboxId === pointer.activeSandboxId &&
       this.cached
@@ -741,7 +774,20 @@ export class RoutingSandboxSession implements RoutableBackendSession {
       ...resolved,
       activeEpoch: pointer.activeEpoch,
     };
+    if (this.deps.bindActiveRouteOnFirstResolve) {
+      if (
+        this.boundActiveRoute &&
+        (this.boundActiveRoute.activeEpoch !== pointer.activeEpoch ||
+          this.boundActiveRoute.activeSandboxId !== pointer.activeSandboxId)
+      ) {
+        throw new RoutingActiveRouteChangedError(this.boundActiveRoute, pointer);
+      }
+      this.boundActiveRoute ??= { ...pointer };
+    }
     const resolvedWorkspaceRoot = workspaceRootForBackend(routed.session);
+    if (this.deps.bindActiveRouteOnFirstResolve && this.boundWorkspaceRoot === null) {
+      this.boundWorkspaceRoot = resolvedWorkspaceRoot;
+    }
     if (
       this.boundWorkspaceRoot !== null &&
       resolvedWorkspaceRoot !== null &&
@@ -1620,16 +1666,20 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   /** Resolve the FileSystem root from the exact backend selected for this call.
    * Channel A uses this authority to validate canonical absolute paths without
    * teaching the renderer or host about provider-specific filesystem layouts. */
-  async fileSystemRoot(): Promise<string> {
+  async fileSystemAuthority(): Promise<{
+    root: string;
+    activeEpoch: number;
+    backendKind: string;
+  }> {
     const backend = await this.resolve();
-    // Channel A speaks workspace-relative paths. The SelfhostedSession resolves
-    // those against its exact host-native root, which also keeps the dock's
-    // portable path validation independent of Windows drive/UNC syntax.
-    if (backend.kind === "selfhosted") return ".";
     const state = backend.session.state as { manifest?: { root?: unknown } } | undefined;
     const manifestRoot = state?.manifest?.root;
-    if (typeof manifestRoot === "string" && manifestRoot.startsWith("/")) {
-      return manifestRoot === "/" ? "/" : manifestRoot.replace(/\/+$/, "");
+    if (typeof manifestRoot === "string" && isConnectedMachineAbsolutePath(manifestRoot)) {
+      return {
+        root: resolveConnectedMachinePath(manifestRoot, undefined),
+        activeEpoch: backend.activeEpoch ?? 0,
+        backendKind: backend.kind,
+      };
     }
     const descriptor =
       CAPABILITY_DESCRIPTORS[backend.kind as SandboxBackend] ??
@@ -1639,7 +1689,15 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     if (!descriptor) {
       throw new RoutingUnsupportedError("fileSystemRoot", backend.kind);
     }
-    return descriptor.workspaceRoot;
+    return {
+      root: descriptor.workspaceRoot,
+      activeEpoch: backend.activeEpoch ?? 0,
+      backendKind: backend.kind,
+    };
+  }
+
+  async fileSystemRoot(): Promise<string> {
+    return (await this.fileSystemAuthority()).root;
   }
 
   async writeFile(args: unknown): Promise<unknown> {
@@ -1705,10 +1763,13 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   async importWorkspaceFileOnResolvedBackend(
     input: ChannelARoutedWorkspaceImportRequest,
   ): Promise<WorkspaceFileImportReceipt> {
-    return await this.dispatch("importWorkspaceFile", true, async (session) => {
+    return await this.dispatch("importWorkspaceFile", true, async (session, backend) => {
       const channel = new SandboxChannelAService({
         session: session as ChannelASession,
         workspaceRoot: input.workspaceRoot,
+        ...(backend.kind === "selfhosted"
+          ? { providerPathMode: "workspace-relative" as const }
+          : {}),
         revision: input.revision,
         ...(input.runAs ? { runAs: input.runAs } : {}),
       });
@@ -1723,10 +1784,13 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   async importWorkspaceFilesOnResolvedBackend(
     input: ChannelARoutedWorkspaceImportBatchRequest,
   ): Promise<readonly WorkspaceFileImportReceipt[]> {
-    return await this.dispatch("importWorkspaceFiles", true, async (session) => {
+    return await this.dispatch("importWorkspaceFiles", true, async (session, backend) => {
       const channel = new SandboxChannelAService({
         session: session as ChannelASession,
         workspaceRoot: input.workspaceRoot,
+        ...(backend.kind === "selfhosted"
+          ? { providerPathMode: "workspace-relative" as const }
+          : {}),
         revision: input.revision,
         ...(input.runAs ? { runAs: input.runAs } : {}),
       });
@@ -1739,10 +1803,13 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   async inspectWorkspaceFilesOnResolvedBackend(
     input: ChannelARoutedWorkspaceImportBatchRequest,
   ): Promise<readonly WorkspaceFileImportReceipt[] | null> {
-    return await this.dispatch("inspectWorkspaceFiles", false, async (session) => {
+    return await this.dispatch("inspectWorkspaceFiles", false, async (session, backend) => {
       const channel = new SandboxChannelAService({
         session: session as ChannelASession,
         workspaceRoot: input.workspaceRoot,
+        ...(backend.kind === "selfhosted"
+          ? { providerPathMode: "workspace-relative" as const }
+          : {}),
         revision: input.revision,
         ...(input.runAs ? { runAs: input.runAs } : {}),
       });

--- a/packages/runtime/src/sandbox/selfhosted/workspace-path.ts
+++ b/packages/runtime/src/sandbox/selfhosted/workspace-path.ts
@@ -86,11 +86,48 @@ export function isWindowsConnectedMachinePath(value: string): boolean {
   return WINDOWS_DRIVE_ABSOLUTE.test(portable) || WINDOWS_UNC_ABSOLUTE.test(portable);
 }
 
+export function isConnectedMachineAbsolutePath(value: string): boolean {
+  const portable = value.replaceAll("\\", "/");
+  return (
+    portable.startsWith("/") ||
+    WINDOWS_DRIVE_ABSOLUTE.test(portable) ||
+    WINDOWS_UNC_ABSOLUTE.test(portable)
+  );
+}
+
 export function connectedMachineWorkspaceRootsEqual(left: string, right: string): boolean {
   if (isWindowsConnectedMachinePath(left) || isWindowsConnectedMachinePath(right)) {
     return left.replaceAll("\\", "/").toLowerCase() === right.replaceAll("\\", "/").toLowerCase();
   }
   return left === right;
+}
+
+/** True only when an absolute host-native path stays beneath an already-
+ * normalized absolute workspace root. Windows drive and UNC comparisons are
+ * case-insensitive; POSIX comparisons remain byte-sensitive. */
+export function connectedMachinePathWithinRoot(workspaceRoot: string, value: string): boolean {
+  if (!isConnectedMachineAbsolutePath(value)) return false;
+  let path: string;
+  try {
+    path = resolveConnectedMachinePath(workspaceRoot, value);
+  } catch {
+    return false;
+  }
+  const windows = isWindowsConnectedMachinePath(workspaceRoot);
+  if (windows !== isWindowsConnectedMachinePath(path)) return false;
+  const comparisonRoot = windows ? workspaceRoot.toLowerCase() : workspaceRoot;
+  const comparisonPath = windows ? path.toLowerCase() : path;
+  const rootPrefix = comparisonRoot.endsWith("/") ? comparisonRoot : `${comparisonRoot}/`;
+  return comparisonPath === comparisonRoot || comparisonPath.startsWith(rootPrefix);
+}
+
+/** Return the portable slash-separated path relative to workspaceRoot, or null
+ * when the absolute candidate is outside that authority. */
+export function relativeConnectedMachinePath(workspaceRoot: string, value: string): string | null {
+  if (!connectedMachinePathWithinRoot(workspaceRoot, value)) return null;
+  const path = resolveConnectedMachinePath(workspaceRoot, value);
+  if (connectedMachineWorkspaceRootsEqual(path, workspaceRoot)) return "";
+  return path.slice(workspaceRoot.endsWith("/") ? workspaceRoot.length : workspaceRoot.length + 1);
 }
 
 function normalizeAbsoluteOperationPath(value: string, windows: boolean): string {

--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -32,6 +32,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
   SandboxChannelAService,
+  ChannelAFileSystemRouteChangedError,
   ChannelANotFoundError,
   ChannelAConflictError,
   ChannelAUnavailableError,
@@ -984,6 +985,102 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
     await expect(
       svc.fsRead({ path: "/etc/passwd", encoding: "utf8", maxBytes: 16 }),
     ).rejects.toThrow(/outside the workspace root/);
+  });
+
+  test("Windows drive and UNC namespaces stay canonical while provider paths stay relative", async () => {
+    for (const fixture of [
+      {
+        root: "C:/work/repo",
+        inside: String.raw`c:\work\repo\src\app.ts`,
+        canonical: "C:/work/repo/src/app.ts",
+        outside: "D:/secrets/token.txt",
+      },
+      {
+        root: "//server/share/repo",
+        inside: String.raw`\\SERVER\SHARE\repo\src\app.ts`,
+        canonical: "//SERVER/SHARE/repo/src/app.ts",
+        outside: "//server/other/secrets/token.txt",
+      },
+    ]) {
+      const requested: string[] = [];
+      const listed: string[] = [];
+      const svc = new SandboxChannelAService({
+        workspaceRoot: fixture.root,
+        providerPathMode: "workspace-relative",
+        session: {
+          listDir: async ({ path }) => {
+            listed.push(path);
+            return [
+              {
+                name: "app.ts",
+                path: fixture.canonical,
+                type: "file" as const,
+              },
+            ];
+          },
+          readFile: async ({ path }) => {
+            requested.push(path);
+            return new TextEncoder().encode("ok");
+          },
+        },
+      });
+
+      const listing = await svc.fsList({
+        path: fixture.root,
+        depth: 1,
+        maxEntries: 20,
+        includeHidden: true,
+      });
+      expect(listing.root.path).toBe(fixture.root);
+      expect(listing.root.children?.[0]?.path).toBe(fixture.canonical);
+      expect(listed).toEqual(["."]);
+
+      const read = await svc.fsRead({
+        path: fixture.inside,
+        encoding: "utf8",
+        maxBytes: 16,
+      });
+      expect(read.path).toBe(fixture.canonical);
+      expect(requested).toEqual(["src/app.ts"]);
+      await expect(
+        svc.fsRead({ path: fixture.outside, encoding: "utf8", maxBytes: 16 }),
+      ).rejects.toThrow(/outside the workspace root/);
+    }
+  });
+
+  test("a stale capability filesystem identity fails as a retryable route conflict", async () => {
+    const svc = new SandboxChannelAService({
+      workspaceRoot: "/srv/project",
+      leaseEpoch: 7,
+      session: {
+        readFile: async () => new TextEncoder().encode("ok"),
+      },
+    });
+
+    await expect(
+      svc.fsRead({
+        path: "/srv/project/app.ts",
+        encoding: "utf8",
+        maxBytes: 16,
+        route: { epoch: 6, root: "/srv/project" },
+      }),
+    ).rejects.toBeInstanceOf(ChannelAFileSystemRouteChangedError);
+    await expect(
+      svc.fsRead({
+        path: "/srv/project/app.ts",
+        encoding: "utf8",
+        maxBytes: 16,
+        route: { epoch: 7, root: "/srv/previous" },
+      }),
+    ).rejects.toMatchObject({ retryable: true });
+
+    const read = await svc.fsRead({
+      path: "/srv/project/app.ts",
+      encoding: "utf8",
+      maxBytes: 16,
+      route: { epoch: 7, root: "/srv/project" },
+    });
+    expect(read.content).toBe("ok");
   });
 
   test("reads an internal symlink but rejects an escaping symlink", async () => {

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -22,6 +22,7 @@ import {
   ChannelANotFoundError,
   SandboxChannelAService,
   RoutingBackendRecoveryRequiredError,
+  RoutingActiveRouteChangedError,
   RoutingMutationOutcomeUnknownError,
   RoutingSandboxSession,
   RoutingWorkspaceRootChangedError,
@@ -977,7 +978,7 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
 
     expect(await proxy.fileSystemRoot()).toBe("/workspace");
     kind = "selfhosted";
-    expect(await proxy.fileSystemRoot()).toBe(".");
+    expect(await proxy.fileSystemRoot()).toBe("/workspace");
     expect(operations).toBe(0);
   });
 
@@ -1678,6 +1679,49 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
     );
     expect(oldCalls).toEqual(["exec"]);
     expect(newCalls).toEqual([]);
+  });
+
+  test("an API-bound route adopts the active root once and rejects a later swap", async () => {
+    const ptr = mutablePointer({ activeSandboxId: "machine", activeEpoch: 4 });
+    const homeCalls: string[] = [];
+    const machineCalls: string[] = [];
+    const home: RoutableBackendSession = {
+      state: { manifest: { root: "/workspace" } },
+      async readFile() {
+        homeCalls.push("read");
+        return new TextEncoder().encode("home");
+      },
+    };
+    const machine: RoutableBackendSession = {
+      state: { manifest: { root: "C:/work/repo" } },
+      async readFile() {
+        machineCalls.push("read");
+        return new TextEncoder().encode("machine");
+      },
+    };
+    const proxy = new RoutingSandboxSession({
+      bindActiveRouteOnFirstResolve: true,
+      defaultResolved: { session: home, sandboxId: null, kind: "modal" },
+      readPointer: ptr.read,
+      resolveActiveBackend: async (pointer) =>
+        pointer.activeSandboxId === null
+          ? { session: home, sandboxId: null, kind: "modal" }
+          : { session: machine, sandboxId: pointer.activeSandboxId, kind: "selfhosted" },
+    });
+
+    await expect(proxy.fileSystemAuthority()).resolves.toEqual({
+      root: "C:/work/repo",
+      activeEpoch: 4,
+      backendKind: "selfhosted",
+    });
+    await expect(proxy.readFile({ path: "src/app.ts" })).resolves.toBeInstanceOf(Uint8Array);
+    expect(machineCalls).toEqual(["read"]);
+
+    ptr.swap(null);
+    await expect(proxy.readFile({ path: "README.md" })).rejects.toBeInstanceOf(
+      RoutingActiveRouteChangedError,
+    );
+    expect(homeCalls).toEqual([]);
   });
 
   test("(2) stale-epoch in-flight read: the backend fences a stale epoch -> the proxy retries against the new active sandbox", async () => {

--- a/packages/runtime/test/selfhosted-workspace-path.test.ts
+++ b/packages/runtime/test/selfhosted-workspace-path.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Manifest } from "@openai/agents/sandbox";
 import {
+  connectedMachinePathWithinRoot,
   connectedMachineWorkspaceRootsEqual,
+  isConnectedMachineAbsolutePath,
   normalizeConnectedMachineWorkspaceRoot,
+  relativeConnectedMachinePath,
   resolveConnectedMachinePath,
   resolveConnectedMachineWorkspaceRoot,
 } from "../src/sandbox";
@@ -41,6 +44,27 @@ describe("Connected Machine workspace path normalization", () => {
       normalizeConnectedMachineWorkspaceRoot(String.raw`\\?\C:\repo`, "windows"),
     ).toThrow("device-namespace");
     expect(() => resolveConnectedMachinePath("C:/repo", "D:relative")).toThrow("drive-relative");
+  });
+
+  test("classifies and confines host-native absolute paths across operating systems", () => {
+    expect(isConnectedMachineAbsolutePath("/srv/repo/src/app.ts")).toBe(true);
+    expect(isConnectedMachineAbsolutePath(String.raw`C:\repo\src\app.ts`)).toBe(true);
+    expect(isConnectedMachineAbsolutePath(String.raw`\\server\share\repo\app.ts`)).toBe(true);
+    expect(isConnectedMachineAbsolutePath("src/app.ts")).toBe(false);
+
+    expect(connectedMachinePathWithinRoot("/srv/repo", "/srv/repo/src/app.ts")).toBe(true);
+    expect(connectedMachinePathWithinRoot("/srv/repo", "/srv/other/app.ts")).toBe(false);
+    expect(connectedMachinePathWithinRoot("C:/Work/Repo", "c:/work/repo/src/app.ts")).toBe(true);
+    expect(connectedMachinePathWithinRoot("C:/Work/Repo", "D:/work/repo/src/app.ts")).toBe(false);
+    expect(
+      connectedMachinePathWithinRoot(
+        "//server/share/repo",
+        String.raw`\\SERVER\SHARE\repo\src\app.ts`,
+      ),
+    ).toBe(true);
+    expect(relativeConnectedMachinePath("C:/Work/Repo", "c:/work/repo/src/app.ts")).toBe(
+      "src/app.ts",
+    );
   });
 
   test("configured cwd is absolute or relative to Hello root; tilde is never guessed", () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -920,6 +920,7 @@ export type {
   FsNodeType,
   FsTreeNode,
   FsEncoding,
+  FileSystemRouteIdentity,
   FsListRequest,
   FsListResponse,
   FsListBatchRequest,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2227,11 +2227,16 @@ export type FsTreeNode = {
   truncated: boolean;
 };
 export type FsEncoding = "utf8" | "base64";
+export type FileSystemRouteIdentity = {
+  epoch: number;
+  root: string;
+};
 export type FsListRequest = {
   path?: string;
   depth?: number;
   maxEntries?: number;
   includeHidden?: boolean;
+  route?: FileSystemRouteIdentity;
 };
 export type FsListResponse = {
   root: FsTreeNode;
@@ -2244,6 +2249,7 @@ export type FsReadRequest = {
   path: string;
   encoding?: FsEncoding;
   maxBytes?: number;
+  route?: FileSystemRouteIdentity;
 };
 export type FsReadResponse = {
   path: string;
@@ -2268,26 +2274,36 @@ export type FsWriteRequest = {
   content: string;
   overwrite?: boolean;
   createParents?: boolean;
+  route?: FileSystemRouteIdentity;
 };
 export type FsWriteResponse = {
   path: string;
   sizeBytes: number;
   revision: number;
 };
-export type FsDeleteRequest = { path: string; recursive?: boolean };
+export type FsDeleteRequest = {
+  path: string;
+  recursive?: boolean;
+  route?: FileSystemRouteIdentity;
+};
 export type FsDeleteResponse = { revision: number };
 export type FsMoveRequest = {
   path: string;
   newPath: string;
   overwrite?: boolean;
   createParents?: boolean;
+  route?: FileSystemRouteIdentity;
 };
 export type FsMoveResponse = {
   path: string;
   newPath: string;
   revision: number;
 };
-export type FsMkdirRequest = { path: string; recursive?: boolean };
+export type FsMkdirRequest = {
+  path: string;
+  recursive?: boolean;
+  route?: FileSystemRouteIdentity;
+};
 export type FsMkdirResponse = { path: string; revision: number };
 
 // A2 Git request/response (the Pierre-diff feed).


### PR DESCRIPTION
## Summary

- Advertise the selected Connected Machine's effective host-native working directory as the Files root instead of replacing it with a static backend descriptor.
- Bind each API-direct Channel-A request to one active route and carry an optional `{ epoch, root }` identity on Files operations so stale paths fail with a retryable conflict.
- Keep POSIX, Windows drive, and UNC paths canonical in the UI/API while dispatching contained workspace-relative paths to the Connected Machine provider.

## Testing

- [x] Affected-project TypeScript checks: contracts, SDK, runtime, core, React, and API
- [x] `bun test packages/runtime/test/selfhosted-workspace-path.test.ts packages/runtime/test/routing-proxy.test.ts packages/runtime/test/channel-a.test.ts --timeout 30000` (156 passed)
- [x] `bun test apps/api/test/channel-a-routes.test.ts packages/react/test/sandbox-hooks.test.tsx packages/react/test/workbench-prewarm.test.tsx --timeout 30000` (127 passed)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run check:public-hygiene`
- [x] `bun run check:docs-refs`
- [ ] Full `bun test` (delegated to focused impact CI)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] The candidate head is frozen and its merge tree was verified conflict-free against current `main` on September 3, 2026.

## Notes

- The request route identity is additive and optional for compatibility with existing SDK callers.

## Summary by Sourcery

Preserve Connected Machine filesystem namespaces end to end and reject stale file operations with retryable route conflicts.

New Features:
- Expose each Connected Machine's effective host-native working directory as the Filesystem root, preserving POSIX, Windows drive, and UNC namespaces.
- Add optional filesystem route identities to Files requests so operations can detect stale capability routes and retry safely.

Bug Fixes:
- Prevent canonical file paths from being reinterpreted against a different active sandbox or filesystem root during route changes.
- Ensure Connected Machine provider operations receive contained workspace-relative paths while responses retain canonical host-native paths.

Enhancements:
- Bind API-direct Channel-A requests to the active route resolved at request start and return retryable conflicts when the route or filesystem root changes.
- Extend path normalization and containment handling across POSIX, Windows drive, and UNC paths.

Documentation:
- Document Connected Machine Filesystem namespaces, route identities, path containment, and retryable conflicts.

Tests:
- Add coverage for route conflicts, active-route changes, Windows and UNC path handling, canonical Files roots, and route propagation through React filesystem and editing hooks.