### PR TITLE
fix(web): compact and clarify session rail navigation

### DIFF
--- a/apps/web/src/components/rail/primary-nav.tsx
+++ b/apps/web/src/components/rail/primary-nav.tsx
@@ -1,5 +1,5 @@
 import { useRouterState } from "@tanstack/react-router";
-import { ChevronDownIcon, SquarePenIcon } from "lucide-react";
+import { ChevronDownIcon, CompassIcon, SquarePenIcon } from "lucide-react";
 import { useState } from "react";
 
 import { ForYouLink } from "@/components/rail/for-you-link";
@@ -9,6 +9,7 @@ import { WorkspaceConfigLink } from "@/components/rail/workspace-config-link";
 import { isConfigItemActive, PRIMARY_WORKSPACE_ITEMS } from "@/components/rail/workspace-nav-data";
 import { Button } from "@/components/ui/button";
 import { NEW_SESSION_SHORTCUT, shortcutLabel } from "@/lib/keyboard-shortcuts";
+import { workspacePriorityPath } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
 const WORKSPACE_SHORTCUTS_EXPANDED_KEY = "opengeni.rail.nav";
@@ -17,9 +18,9 @@ function initialWorkspaceShortcutsExpanded(): boolean {
   if (typeof window === "undefined") return true;
   try {
     const raw = window.localStorage.getItem(WORKSPACE_SHORTCUTS_EXPANDED_KEY);
-    return raw ? raw === "true" : window.innerHeight >= 760;
+    return raw === null ? true : raw === "true";
   } catch {
-    return window.innerHeight >= 760;
+    return true;
   }
 }
 
@@ -29,6 +30,7 @@ export function WorkspaceShortcutLinks({ className }: { className?: string }) {
 
   return (
     <div className={cn("grid gap-0.5", className)}>
+      <ForYouLink embedded />
       {PRIMARY_WORKSPACE_ITEMS.map((item) => (
         <WorkspaceConfigLink
           key={item.to}
@@ -52,6 +54,9 @@ export function PrimaryNav() {
   const activeWorkspaceItem = PRIMARY_WORKSPACE_ITEMS.find((item) =>
     isConfigItemActive(pathname, rail.workspaceId, item.to),
   );
+  const activeWorkspaceSection =
+    activeWorkspaceItem?.label ??
+    (pathname === workspacePriorityPath(rail.workspaceId) ? "For you" : undefined);
   const [shortcutsExpanded, setShortcutsExpandedState] = useState(
     initialWorkspaceShortcutsExpanded,
   );
@@ -86,40 +91,55 @@ export function PrimaryNav() {
         {rail.collapsed ? null : <span className="min-w-0 truncate">New session</span>}
       </NewSessionLink>
 
-      <ForYouLink embedded />
-
       {rail.isMobile ? null : rail.collapsed ? (
         <WorkspaceShortcutLinks />
       ) : (
         <div className="grid gap-0.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            aria-expanded={shortcutsExpanded}
-            aria-label={
-              activeWorkspaceItem
-                ? `Workspace, current section ${activeWorkspaceItem.label}`
-                : undefined
-            }
-            data-active={activeWorkspaceItem ? "true" : undefined}
-            onClick={() => setShortcutsExpanded(!shortcutsExpanded)}
-            className={cn(
-              "group relative w-full justify-between text-fg-muted pointer-coarse:h-10",
-              activeWorkspaceItem && "bg-surface-2 text-fg",
-            )}
-          >
-            <span
-              aria-hidden="true"
+          {shortcutsExpanded ? (
+            <>
+              <WorkspaceShortcutLinks />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-expanded="true"
+                onClick={() => setShortcutsExpanded(false)}
+                className="h-6 w-full justify-start gap-1.5 px-2.5 text-2xs font-normal text-fg-subtle hover:text-fg-muted"
+              >
+                <ChevronDownIcon aria-hidden="true" className="size-3 rotate-180" />
+                Show less
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-expanded="false"
+              aria-label={
+                activeWorkspaceSection
+                  ? `Explore, current section ${activeWorkspaceSection}`
+                  : undefined
+              }
+              data-active={activeWorkspaceSection ? "true" : undefined}
+              onClick={() => setShortcutsExpanded(true)}
               className={cn(
-                "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand transition-opacity",
-                activeWorkspaceItem ? "opacity-100" : "opacity-0",
+                "group relative w-full justify-start gap-2.5 px-2.5 text-fg-muted pointer-coarse:h-10",
+                activeWorkspaceSection && "bg-surface-2 text-fg",
               )}
-            />
-            <span className="truncate text-left">Workspace</span>
-            <ChevronDownIcon className={cn("size-3.5", shortcutsExpanded && "rotate-180")} />
-          </Button>
-          {shortcutsExpanded ? <WorkspaceShortcutLinks /> : null}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand transition-opacity",
+                  activeWorkspaceSection ? "opacity-100" : "opacity-0",
+                )}
+              />
+              <CompassIcon className="size-4 shrink-0" />
+              <span className="min-w-0 flex-1 truncate text-left">Explore</span>
+              <ChevronDownIcon aria-hidden="true" className="size-3.5 shrink-0" />
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/rail/rail-density.test.tsx
+++ b/apps/web/src/components/rail/rail-density.test.tsx
@@ -69,27 +69,34 @@ async function render(node: ReactNode) {
   return { container, root };
 }
 
-function workspaceDisclosure(container: HTMLElement): HTMLButtonElement {
+function exploreDisclosure(container: HTMLElement): HTMLButtonElement {
   const button = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
-    (candidate) => candidate.textContent?.trim() === "Workspace",
+    (candidate) => candidate.textContent?.trim() === "Explore",
   );
-  if (!button) throw new Error("Missing Workspace disclosure");
+  if (!button) throw new Error("Missing Explore disclosure");
+  return button;
+}
+
+function showLessButton(container: HTMLElement): HTMLButtonElement {
+  const button = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (candidate) => candidate.textContent?.trim() === "Show less",
+  );
+  if (!button) throw new Error("Missing Show less control");
   return button;
 }
 
 describe("session-first rail density", () => {
-  test("defaults short viewports to compact shortcuts and persists the user's choice", async () => {
-    Object.defineProperty(window, "innerHeight", { configurable: true, value: 700 });
+  test("defaults desktop shortcuts open and remembers when the user collapses them", async () => {
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
     const first = await render(<PrimaryNav />);
     try {
-      const disclosure = workspaceDisclosure(first.container);
-      expect(disclosure.getAttribute("aria-expanded")).toBe("false");
-      expect(first.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(0);
-
-      await act(async () => disclosure.click());
-      expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+      expect(first.container.textContent).not.toContain("Explore");
       expect(first.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(5);
-      expect(window.localStorage.getItem("opengeni.rail.nav")).toBe("true");
+
+      await act(async () => showLessButton(first.container).click());
+      expect(exploreDisclosure(first.container).getAttribute("aria-expanded")).toBe("false");
+      expect(first.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(0);
+      expect(window.localStorage.getItem("opengeni.rail.nav")).toBe("false");
     } finally {
       await act(async () => first.root.unmount());
       first.container.remove();
@@ -97,9 +104,9 @@ describe("session-first rail density", () => {
 
     const persisted = await render(<PrimaryNav />);
     try {
-      expect(workspaceDisclosure(persisted.container).getAttribute("aria-expanded")).toBe("true");
+      expect(exploreDisclosure(persisted.container).getAttribute("aria-expanded")).toBe("false");
       expect(persisted.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(
-        5,
+        0,
       );
     } finally {
       await act(async () => persisted.root.unmount());
@@ -112,7 +119,7 @@ describe("session-first rail density", () => {
     const primary = await render(<PrimaryNav />);
     try {
       expect(primary.container.textContent).toContain("New session");
-      expect(primary.container.textContent).toContain("For you");
+      expect(primary.container.textContent).not.toContain("For you");
       expect(primary.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(
         0,
       );
@@ -124,12 +131,14 @@ describe("session-first rail density", () => {
 
     const workspace = await render(<WorkspaceShortcutLinks />);
     try {
+      expect(workspace.container.textContent).toContain("For you");
       expect(workspace.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(
         5,
       );
       expect(railShell).toMatch(
-        /id="mobile-nav-panel-workspace"[\s\S]*?<WorkspaceShortcutLinks className="px-2" \/>/,
+        /id="mobile-nav-panel-workspace"[\s\S]*?<SwitcherBlock \/>[\s\S]*?<WorkspaceShortcutLinks className="px-2" \/>/,
       );
+      expect(railShell).toMatch(/\{rail\.isMobile \? null : <SwitcherBlock \/>\}/);
     } finally {
       await act(async () => workspace.root.unmount());
       workspace.container.remove();
@@ -138,16 +147,31 @@ describe("session-first rail density", () => {
 
   test("identifies an active shortcut when the compact disclosure hides its link", async () => {
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 700 });
+    window.localStorage.setItem("opengeni.rail.nav", "false");
     pathname = "/workspaces/workspace-1/plugins";
     const rendered = await render(<PrimaryNav />);
     try {
-      const disclosure = workspaceDisclosure(rendered.container);
+      const disclosure = exploreDisclosure(rendered.container);
       expect(disclosure.getAttribute("aria-expanded")).toBe("false");
       expect(disclosure.getAttribute("data-active")).toBe("true");
-      expect(disclosure.getAttribute("aria-label")).toBe("Workspace, current section Plugins");
+      expect(disclosure.getAttribute("aria-label")).toBe("Explore, current section Plugins");
       expect(rendered.container.querySelectorAll('[data-workspace-shortcut="true"]')).toHaveLength(
         0,
       );
+    } finally {
+      await act(async () => rendered.root.unmount());
+      rendered.container.remove();
+    }
+  });
+
+  test("identifies For you when the compact disclosure hides its link", async () => {
+    window.localStorage.setItem("opengeni.rail.nav", "false");
+    pathname = "/workspaces/workspace-1/priority";
+    const rendered = await render(<PrimaryNav />);
+    try {
+      const disclosure = exploreDisclosure(rendered.container);
+      expect(disclosure.getAttribute("data-active")).toBe("true");
+      expect(disclosure.getAttribute("aria-label")).toBe("Explore, current section For you");
     } finally {
       await act(async () => rendered.root.unmount());
       rendered.container.remove();

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -77,7 +77,7 @@ function RailBody() {
       {/* Brand */}
       <div
         className={cn(
-          "flex h-12 shrink-0 items-center gap-2",
+          "flex h-10 shrink-0 items-center gap-2",
           rail.collapsed ? "justify-center px-2" : "px-3",
         )}
       >
@@ -106,7 +106,7 @@ function RailBody() {
         ) : null}
       </div>
 
-      <SwitcherBlock />
+      {rail.isMobile ? null : <SwitcherBlock />}
 
       {rail.isMobile ? (
         <>
@@ -180,6 +180,8 @@ function RailBody() {
               aria-labelledby="mobile-nav-tab-workspace"
               className="mt-2 flex min-h-0 flex-1 flex-col overflow-y-auto border-t border-border pt-2"
             >
+              <SwitcherBlock />
+              <div className="my-2 border-t border-border" />
               <WorkspaceShortcutLinks className="px-2" />
               <div className="my-2 border-t border-border" />
               <WorkspaceNav />

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -1,8 +1,7 @@
-// The rail's top switcher: a muted Organization line over a prominent Workspace
-// line. The org line opens organization switching, creation, and settings; the
-// workspace line lists the current org's workspaces plus workspace actions.
-// Collapsed, the whole block reduces to a workspace-initial avatar that opens
-// the same workspace menu.
+// The rail's compact workspace switcher. Its menu groups workspaces by
+// organization and carries workspace/organization creation and settings so the
+// rail does not spend permanent vertical space on a second organization row.
+// Collapsed, it reduces to a workspace-initial avatar that opens the same menu.
 import { Link } from "@tanstack/react-router";
 import { OpenGeniApiError } from "@opengeni/sdk";
 import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon, SettingsIcon } from "lucide-react";
@@ -19,11 +18,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useAppContext } from "@/context";
 import { useRail } from "@/components/rail/rail-context";
-import {
-  activeOrganizationLabel,
-  WorkspaceSwitcherMenu,
-} from "@/components/rail/workspace-switcher";
-import { organizationsForSubject, type OrgOption } from "@/lib/org";
+import { WorkspaceSwitcherMenu } from "@/components/rail/workspace-switcher";
+import type { OrgOption } from "@/lib/org";
 import { canCreateAdditionalOrganization } from "@/lib/managed-self-context";
 
 const LazyCreateOrganizationDialog = lazy(() =>
@@ -52,19 +48,11 @@ export function additionalOrganizationCreationAttemptIsCurrent(input: {
   );
 }
 
-export const WORKSPACE_SWITCHER_GRID_CLASS =
-  "grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-3 pt-1";
+export const WORKSPACE_SWITCHER_GRID_CLASS = "grid min-w-0 grid-cols-[minmax(0,1fr)] px-2";
 
 export function SwitcherBlock() {
   const context = useAppContext();
   const rail = useRail();
-  const activeWorkspace =
-    context.workspaces.find((workspace) => workspace.id === rail.workspaceId) ?? null;
-  const activeAccountId =
-    activeWorkspace?.accountId ?? context.accessContext.defaultAccountId ?? null;
-
-  const orgs = organizationsForSubject(context.accessContext, context.workspaces);
-  const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
   const managedUserId = context.authSession?.user.id ?? null;
   const canCreateOrganization =
     context.clientConfig.auth.mode === "managedSession" &&
@@ -224,14 +212,6 @@ export function SwitcherBlock() {
 
   return (
     <div className={WORKSPACE_SWITCHER_GRID_CLASS}>
-      <OrganizationSwitcherLine
-        orgs={orgs}
-        currentLabel={currentOrgLabel}
-        activeAccountId={activeAccountId}
-        onSelect={rail.openOrg}
-        onCreate={canCreateOrganization ? () => setCreateOpen(true) : undefined}
-        workspaceId={rail.workspaceId}
-      />
       {createOpen ? (
         <Suspense fallback={null}>
           <LazyCreateOrganizationDialog
@@ -253,6 +233,7 @@ export function SwitcherBlock() {
         collapsed={false}
         align="start"
         onSelect={rail.openWorkspace}
+        onCreateOrganization={canCreateOrganization ? () => setCreateOpen(true) : undefined}
       />
     </div>
   );

--- a/apps/web/src/components/rail/workspace-switcher.tsx
+++ b/apps/web/src/components/rail/workspace-switcher.tsx
@@ -1,4 +1,12 @@
-import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PauseIcon, PlusIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import {
+  BuildingIcon,
+  CheckIcon,
+  ChevronsUpDownIcon,
+  PauseIcon,
+  PlusIcon,
+  SettingsIcon,
+} from "lucide-react";
 import { forwardRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { toast } from "sonner";
 
@@ -101,6 +109,7 @@ export function WorkspaceSwitcherMenu(props: {
         onSelect={props.onSelect}
         onCreate={() => setCreateOpen(true)}
         onCreateOrganization={props.onCreateOrganization}
+        workspaceId={props.workspaceId}
         managedSelfContext={context.managedSelfContext}
         align={props.align}
       >
@@ -204,6 +213,7 @@ export function WorkspaceMenu(props: {
   onSelect: (workspaceId: string) => void;
   onCreate: () => void;
   onCreateOrganization?: () => void;
+  workspaceId?: string;
   managedSelfContext: ManagedSelfContext | null;
   align: "start" | "end";
   children: ReactNode;
@@ -272,6 +282,17 @@ export function WorkspaceMenu(props: {
           >
             <BuildingIcon className="size-4" />
             New organization…
+          </DropdownMenuItem>
+        ) : null}
+        {props.workspaceId ? (
+          <DropdownMenuItem asChild>
+            <Link
+              to="/workspaces/$workspaceId/organization"
+              params={{ workspaceId: props.workspaceId }}
+            >
+              <SettingsIcon className="size-4" />
+              Organization settings
+            </Link>
           </DropdownMenuItem>
         ) : null}
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- compact the workspace selector and keep organization settings in its menu
- make secondary navigation, including For you, collapsible with a remembered desktop preference
- keep mobile Sessions focused and move workspace navigation into the Workspace tab

## Validation
- targeted rail tests
- web typecheck and lint
- full repository check running locally

## Summary by Sourcery

Streamline rail navigation around session-first workflows with a compact, collapsible Explore section and consolidated workspace controls.

New Features:
- Add a compact Explore section that groups For you and workspace navigation behind a collapsible desktop control.
- Move workspace and organization settings into the workspace switcher menu.

Bug Fixes:
- Keep mobile session navigation focused by moving workspace switching and navigation into the Workspace tab.

Enhancements:
- Reduce rail header and workspace switcher footprint while preserving active-section context and remembered desktop expansion state.

Tests:
- Update rail density coverage for the compact Explore navigation, mobile workspace placement, persistence, and active-section states.