### PR TITLE
fix(codex): respect live model visibility

### DIFF
--- a/apps/api/test/codex-realtime.test.ts
+++ b/apps/api/test/codex-realtime.test.ts
@@ -89,7 +89,7 @@ describe("session Codex realtime broker", () => {
     expect(capturedAuth?.accessToken).toBe(BEARER_DEFAULT);
     expect(capturedAuth?.chatgptAccountId).toBe("account-bound");
     expect(capturedAuth?.isFedramp).toBe(true);
-    expect(capturedAuth?.clientVersion).toBe("0.145.0");
+    expect(capturedAuth?.clientVersion).toBe("0.153.0");
     expect(capturedInput).toEqual({
       ...request,
       sessionId: "session-one",

--- a/packages/codex/src/api-client.ts
+++ b/packages/codex/src/api-client.ts
@@ -55,8 +55,11 @@ export async function fetchCodexModels(
       await res.arrayBuffer().catch(() => undefined);
       return { ok: false, status: res.status, slugs: [] as string[] };
     }
-    const body = (await res.json()) as { models?: Array<{ slug?: string }> };
+    const body = (await res.json()) as {
+      models?: Array<{ slug?: string; visibility?: "list" | "hide" | "none" }>;
+    };
     const slugs = (body.models ?? [])
+      .filter((model) => model.visibility === "list")
       .map((model) => model.slug)
       .filter((slug): slug is string => typeof slug === "string");
     return { ok: true, status: res.status, slugs };

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -48,11 +48,11 @@ export const CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT = Math.floor(
   (CODEX_MODEL_CONTEXT_WINDOW_TOKENS * CODEX_AUTO_COMPACTION_PERCENT) / 100,
 );
 
-// Sent as the `version` header and inside the User-Agent. Staging-proven on
-// 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models, while the
-// official Codex 0.144.0+ releases return all three exact slugs above. Keep
-// this pinned to the latest stable Codex release we have verified end-to-end.
-export const CODEX_CLIENT_VERSION = "0.145.0";
+// Sent as the `version` header and inside the User-Agent. Verified 2026-09-03
+// against the official Codex 0.153.0 release and its authenticated live model
+// catalog. Keep this pinned to the latest stable Codex release we have verified
+// end-to-end; hidden and internal catalog entries remain excluded separately.
+export const CODEX_CLIENT_VERSION = "0.153.0";
 
 // Public OpenGeni selector for native ChatGPT/Codex subscription WebRTC. This
 // remains stable for persisted sessions; the provider's remotely configured

--- a/packages/codex/test/api-client.test.ts
+++ b/packages/codex/test/api-client.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { CODEX_CLIENT_VERSION, fetchCodexModels } from "../src";
+
+const auth = {
+  accessToken: "server-only-token",
+  chatgptAccountId: "acct_123",
+  isFedramp: false,
+  clientVersion: "0.153.0",
+};
+
+describe("Codex API client", () => {
+  test("uses the latest verified official Codex client version", () => {
+    expect(CODEX_CLIENT_VERSION).toBe("0.153.0");
+  });
+
+  test("returns only picker-visible models from the live catalog", async () => {
+    expect(
+      await fetchCodexModels(auth, async () =>
+        Response.json({
+          models: [
+            { slug: "gpt-current", visibility: "list" },
+            { slug: "gpt-future-hidden", visibility: "hide" },
+            { slug: "gpt-internal", visibility: "none" },
+            { slug: "gpt-missing-visibility" },
+          ],
+        }),
+      ),
+    ).toEqual({ ok: true, status: 200, slugs: ["gpt-current"] });
+  });
+});


### PR DESCRIPTION
## Summary

- pin ChatGPT/Codex client headers to the verified official Codex CLI 0.153.0 release
- retain only live catalog entries explicitly marked `visibility: "list"`
- keep hidden, internal, and malformed future entries out of the OpenGeni picker
- add focused regression coverage for the version pin and visibility boundary

This deliberately does not publish unreleased model identifiers. The final public model slugs and reviewed capability metadata can be added on this branch once OpenAI exposes them as picker-visible.

## Verification

- `bun test packages/codex/test/api-client.test.ts packages/codex/test/reset-credits.test.ts apps/api/test/codex-model-catalog.test.ts`
- `bun test apps/api/test/codex-realtime.test.ts packages/codex/test/api-client.test.ts`
- `bun x oxfmt --check packages/codex/src/api-client.ts packages/codex/src/constants.ts packages/codex/test/api-client.test.ts`
- `bun x oxlint --deny-warnings packages/codex/src/api-client.ts packages/codex/src/constants.ts packages/codex/test/api-client.test.ts`
- `bun run typecheck`


