### PR TITLE
Support legacy MCP OAuth discovery when PRM is absent

### DIFF
--- a/.changeset/legacy-mcp-oauth-discovery.md
+++ b/.changeset/legacy-mcp-oauth-discovery.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/network": minor
+---
+
+Support safe same-origin legacy MCP OAuth discovery when RFC 9728 Protected Resource Metadata is absent, and expose shared runtime/catalog discovery classifications.

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -31,12 +31,20 @@ import {
 import { createSignedState, readSignedState } from "@opengeni/github";
 import {
   DestinationPolicyError,
+  McpOAuthDiscoveryError,
   OAUTH_MAX_RESPONSE_BYTES,
   RequestDeadlineError,
   isLocalTestEnvironment,
+  parseMcpOAuthChallenge,
   pinnedFetch,
   readResponseJsonBounded,
+  resolveMcpOAuthDiscovery,
   validateHttpUrl,
+  type McpAuthorizationServerMetadata,
+  type McpOAuthChallenge,
+  type McpOAuthDiscoveryMode,
+  type McpOAuthMetadataFetchResult,
+  type McpProtectedResourceMetadata,
 } from "@opengeni/network";
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes } from "node:crypto";
@@ -100,30 +108,9 @@ export type OAuthCallbackResult = {
   redirectTo: string;
 };
 
-type WwwAuthenticateChallenge = {
-  resourceMetadata?: string;
-  scope?: string[];
-  error?: string;
-};
-
-type ProtectedResourceMetadata = {
-  resource?: string;
-  authorizationServers: string[];
-  scopesSupported: string[];
-  raw: Record<string, unknown>;
-};
-
-type AuthorizationServerMetadata = {
-  issuer: string;
-  authorizationServer: string;
-  authorizationEndpoint: string;
-  tokenEndpoint: string;
-  registrationEndpoint?: string;
-  clientIdMetadataDocumentSupported: boolean;
-  tokenEndpointAuthMethodsSupported: string[];
-  codeChallengeMethodsSupported: string[];
-  raw: Record<string, unknown>;
-};
+type WwwAuthenticateChallenge = McpOAuthChallenge;
+type ProtectedResourceMetadata = McpProtectedResourceMetadata;
+type AuthorizationServerMetadata = McpAuthorizationServerMetadata;
 
 type OAuthClientRegistration = {
   method: "operator" | "manual" | "cimd" | "dcr";
@@ -151,6 +138,10 @@ type OAuthStatePayload = {
   tokenEndpoint: string;
   authorizationServer: string;
   issuer: string;
+  discoveryMode: McpOAuthDiscoveryMode;
+  discoveryMetadataSha256?: string;
+  protectedResourceMetadataUrl?: string;
+  authorizationServerMetadataUrl?: string;
   clientRegistrationMethod: OAuthClientRegistration["method"];
   tokenEndpointAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"];
   resourceParameterSupported: boolean;
@@ -389,8 +380,9 @@ async function startMcpOAuthWithinDeadline(
 
   const discovery = await discoverMcpOAuth(mcpUrl, settings, deadline);
   assertDiscoveredAuthorizationServer(settings, discovery.as, profile, providerDomain);
-  const resourceParameterSupported = profile.sendResourceParameter;
-  const resource = discovery.prm.resource ? canonicalOAuthResource(discovery.prm.resource) : mcpUrl;
+  const resourceParameterSupported =
+    discovery.mode === "rfc9728_protected_resource" && profile.sendResourceParameter;
+  const resource = discovery.resource;
   const verifier = randomPkceVerifier();
   // A profile's exact scope override wins outright: the reviewed connector
   // never lets a caller widen the capability contract.
@@ -433,6 +425,14 @@ async function startMcpOAuthWithinDeadline(
     tokenEndpoint: discovery.as.tokenEndpoint,
     authorizationServer: client.authorizationServer,
     issuer: client.issuer,
+    discoveryMode: discovery.mode,
+    discoveryMetadataSha256: discovery.provenance.metadataSha256,
+    ...(discovery.provenance.protectedResourceMetadataUrl
+      ? {
+          protectedResourceMetadataUrl: discovery.provenance.protectedResourceMetadataUrl,
+        }
+      : {}),
+    authorizationServerMetadataUrl: discovery.provenance.authorizationServerMetadataUrl,
     clientRegistrationMethod: client.method,
     tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
     resourceParameterSupported,
@@ -711,6 +711,18 @@ async function completeMcpOAuthCallbackWithinDeadline(
       tokenEndpoint: state.tokenEndpoint,
       clientId: client.clientId,
       clientRegistrationMethod: state.clientRegistrationMethod,
+      oauthDiscovery: {
+        mode: state.discoveryMode,
+        resource: state.resource,
+        issuer: state.issuer,
+        ...(state.discoveryMetadataSha256 ? { metadataSha256: state.discoveryMetadataSha256 } : {}),
+        ...(state.protectedResourceMetadataUrl
+          ? { protectedResourceMetadataUrl: state.protectedResourceMetadataUrl }
+          : {}),
+        ...(state.authorizationServerMetadataUrl
+          ? { authorizationServerMetadataUrl: state.authorizationServerMetadataUrl }
+          : {}),
+      },
       mcpToolsVerification: verification.metadata,
       ...(verification.tools ? { mcpTools: verification.tools } : {}),
     };
@@ -835,28 +847,50 @@ async function discoverMcpOAuth(
   challenge: WwwAuthenticateChallenge;
   prm: ProtectedResourceMetadata;
   as: AuthorizationServerMetadata;
+  mode: McpOAuthDiscoveryMode;
+  resource: string;
+  provenance: {
+    protectedResourceMetadataUrl: string | null;
+    authorizationServerMetadataUrl: string;
+    metadataSha256: string;
+  };
 }> {
   const challenge = await deadline.run("mcp_challenge", (signal) =>
     probeMcpChallenge(resource, settings, signal),
   );
-  const prm = await deadline.run("protected_resource_metadata", (signal) =>
-    discoverProtectedResourceMetadata(resource, settings, challenge.resourceMetadata, signal),
-  );
-  const authorizationServer = prm.authorizationServers[0];
-  if (!authorizationServer) {
-    throw new HTTPException(422, {
-      message: "MCP protected resource metadata did not advertise an authorization server",
+  try {
+    const discovery = await resolveMcpOAuthDiscovery({
+      resourceUrl: resource,
+      challenge,
+      fetchMetadata: ({ kind, url }) =>
+        deadline.run(
+          kind === "protected_resource"
+            ? "protected_resource_metadata"
+            : "authorization_server_metadata",
+          (signal) => fetchOAuthMetadata(url, settings, signal),
+        ),
+      validateEndpoint: (rawUrl, label) => oauthEndpointUrl(rawUrl, settings, label),
+      canonicalizeResource: canonicalOAuthResource,
     });
+    return {
+      challenge: discovery.challenge,
+      prm: discovery.protectedResourceMetadata,
+      as: discovery.authorizationServerMetadata,
+      mode: discovery.mode,
+      resource: discovery.resource,
+      provenance: discovery.provenance,
+    };
+  } catch (error) {
+    if (error instanceof OAuthStartStageError) throw error;
+    if (error instanceof McpOAuthDiscoveryError) {
+      throw new OAuthStartStageError(
+        error.stage,
+        error.classification,
+        new HTTPException(422, { message: error.message }),
+      );
+    }
+    throw error;
   }
-  const as = await deadline.run("authorization_server_metadata", (signal) =>
-    discoverAuthorizationServerMetadata(authorizationServer, settings, signal),
-  );
-  if (!as.codeChallengeMethodsSupported.includes("S256")) {
-    throw new HTTPException(422, {
-      message: "authorization server does not support required PKCE S256",
-    });
-  }
-  return { challenge, prm, as };
 }
 
 async function probeMcpChallenge(
@@ -871,115 +905,45 @@ async function probeMcpChallenge(
   });
   try {
     if (response.status !== 401) {
-      return {};
+      return { scheme: null, scope: [] };
     }
-    return parseWwwAuthenticate(response.headers.get("www-authenticate"));
+    return parseMcpOAuthChallenge(response.headers.get("www-authenticate"));
   } finally {
     await cancelResponseBody(response);
   }
 }
 
-async function discoverProtectedResourceMetadata(
-  resource: string,
-  settings: Settings,
-  advertisedUrl?: string,
-  signal?: AbortSignal,
-): Promise<ProtectedResourceMetadata> {
-  const candidates = uniqueStrings([
-    ...(advertisedUrl ? [advertisedUrl] : []),
-    ...wellKnownCandidates(resource, "oauth-protected-resource"),
-  ]);
-  for (const candidate of candidates) {
-    const payload = await fetchJsonObject(candidate, settings, signal).catch((error) => {
-      if (error instanceof HTTPException) {
-        throw error;
-      }
-      return null;
-    });
-    if (!payload) {
-      continue;
-    }
-    const authorizationServers = stringArray(payload.authorization_servers);
-    if (authorizationServers.length === 0) {
-      continue;
-    }
-    return {
-      authorizationServers,
-      scopesSupported: stringArray(payload.scopes_supported),
-      raw: payload,
-      ...(stringValue(payload.resource) ? { resource: stringValue(payload.resource)! } : {}),
-    };
-  }
-  throw new HTTPException(422, {
-    message: "could not discover MCP protected resource metadata",
-  });
-}
-
-async function discoverAuthorizationServerMetadata(
-  authorizationServer: string,
+async function fetchOAuthMetadata(
+  url: string,
   settings: Settings,
   signal: AbortSignal,
-): Promise<AuthorizationServerMetadata> {
-  const safeAuthorizationServer = oauthEndpointUrl(
-    authorizationServer,
-    settings,
-    "OAuth authorization server",
-  ).replace(/\/+$/, "");
-  const candidates = uniqueStrings([
-    // Prefer the RFC metadata locations before probing the issuer itself. Some
-    // providers (including Linear) redirect their issuer root to a human docs
-    // page; following that redirect can leave discovery waiting on an unrelated
-    // streaming response even though the well-known metadata is immediately
-    // available.
-    ...wellKnownCandidates(safeAuthorizationServer, "oauth-authorization-server"),
-    ...wellKnownCandidates(safeAuthorizationServer, "openid-configuration"),
-    safeAuthorizationServer,
-  ]);
-  for (const candidate of candidates) {
-    const payload = await fetchJsonObject(candidate, settings, signal).catch((error) => {
-      if (error instanceof HTTPException) {
-        throw error;
-      }
-      return null;
-    });
-    if (!payload) {
-      continue;
-    }
-    const authorizationEndpoint = stringValue(payload.authorization_endpoint);
-    const tokenEndpoint = stringValue(payload.token_endpoint);
-    if (!authorizationEndpoint || !tokenEndpoint) {
-      continue;
-    }
-    const safeAuthorizationEndpoint = oauthEndpointUrl(
-      authorizationEndpoint,
-      settings,
-      "OAuth authorization endpoint",
-    );
-    const safeTokenEndpoint = oauthEndpointUrl(tokenEndpoint, settings, "OAuth token endpoint");
-    const registrationEndpoint = stringValue(payload.registration_endpoint);
-    const issuer = oauthEndpointUrl(
-      stringValue(payload.issuer) ?? safeAuthorizationServer,
-      settings,
-      "OAuth issuer",
-    );
-    const safeRegistrationEndpoint = registrationEndpoint
-      ? oauthEndpointUrl(registrationEndpoint, settings, "OAuth registration endpoint")
-      : undefined;
-    return {
-      issuer,
-      authorizationServer: safeAuthorizationServer,
-      authorizationEndpoint: safeAuthorizationEndpoint,
-      tokenEndpoint: safeTokenEndpoint,
-      clientIdMetadataDocumentSupported: payload.client_id_metadata_document_supported === true,
-      tokenEndpointAuthMethodsSupported: stringArray(payload.token_endpoint_auth_methods_supported),
-      codeChallengeMethodsSupported: stringArray(payload.code_challenge_methods_supported),
-      raw: payload,
-      ...(safeRegistrationEndpoint ? { registrationEndpoint: safeRegistrationEndpoint } : {}),
-    };
-  }
-  throw new HTTPException(422, {
-    message: "could not discover OAuth authorization server metadata",
+): Promise<McpOAuthMetadataFetchResult> {
+  const response = await fetchOAuth(url, settings, {
+    headers: { accept: "application/json" },
+    signal,
   });
+  if (response.status === 404 || response.status === 410) {
+    await cancelResponseBody(response);
+    return { status: "absent", url, httpStatus: response.status };
+  }
+  if (!response.ok) {
+    await cancelResponseBody(response);
+    throw new Error(`OAuth metadata endpoint returned HTTP ${response.status}`);
+  }
+  const payload = await readResponseJsonBounded<unknown>(
+    response,
+    OAUTH_MAX_RESPONSE_BYTES,
+    "OAuth metadata response",
+    { signal },
+  );
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("OAuth metadata response was not a JSON object");
+  }
+  return {
+    status: "present",
+    url,
+    document: payload as Record<string, unknown>,
+  };
 }
 
 async function registerOAuthClient(
@@ -1433,6 +1397,29 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
     throw new HTTPException(400, { message: "invalid or expired OAuth state" });
   }
   const resource = requiredString(payload.resource, "state.resource");
+  const encodedDiscoveryMode = stringValue(payload.discoveryMode);
+  const discoveryMode = discoveryModeValue(encodedDiscoveryMode);
+  const discoveryMetadataSha256 = stringValue(payload.discoveryMetadataSha256);
+  if (
+    encodedDiscoveryMode &&
+    (!discoveryMetadataSha256 || !/^[0-9a-f]{64}$/.test(discoveryMetadataSha256))
+  ) {
+    throw new HTTPException(400, { message: "invalid OAuth discovery state" });
+  }
+  const protectedResourceMetadataUrl = stringValue(payload.protectedResourceMetadataUrl);
+  const authorizationServerMetadataUrl = stringValue(payload.authorizationServerMetadataUrl);
+  if (
+    encodedDiscoveryMode &&
+    (!authorizationServerMetadataUrl ||
+      (discoveryMode === "rfc9728_protected_resource" && !protectedResourceMetadataUrl) ||
+      (discoveryMode === "legacy_2025_03_26_metadata" && protectedResourceMetadataUrl))
+  ) {
+    throw new HTTPException(400, { message: "invalid OAuth discovery provenance state" });
+  }
+  const resourceParameterSupported = payload.resourceParameterSupported !== false;
+  if (discoveryMode === "legacy_2025_03_26_metadata" && resourceParameterSupported) {
+    throw new HTTPException(400, { message: "invalid legacy OAuth resource parameter state" });
+  }
   const parsed = {
     accountId: requiredString(payload.accountId, "state.accountId"),
     workspaceId: requiredString(payload.workspaceId, "state.workspaceId"),
@@ -1467,11 +1454,31 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
       settings,
       "OAuth issuer",
     ),
+    discoveryMode,
+    ...(discoveryMetadataSha256 ? { discoveryMetadataSha256 } : {}),
+    ...(protectedResourceMetadataUrl
+      ? {
+          protectedResourceMetadataUrl: oauthEndpointUrl(
+            protectedResourceMetadataUrl,
+            settings,
+            "OAuth protected resource metadata",
+          ),
+        }
+      : {}),
+    ...(authorizationServerMetadataUrl
+      ? {
+          authorizationServerMetadataUrl: oauthEndpointUrl(
+            authorizationServerMetadataUrl,
+            settings,
+            "OAuth authorization server metadata",
+          ),
+        }
+      : {}),
     clientRegistrationMethod: registrationMethod(payload.clientRegistrationMethod),
     tokenEndpointAuthMethod: tokenAuthMethod(stringValue(payload.tokenEndpointAuthMethod), false),
     // States minted before provider-specific compatibility was introduced used
     // the RFC 8707 resource parameter.
-    resourceParameterSupported: payload.resourceParameterSupported !== false,
+    resourceParameterSupported,
     ...(stringValue(payload.encryptedClientSecret)
       ? { encryptedClientSecret: stringValue(payload.encryptedClientSecret)! }
       : {}),
@@ -1484,11 +1491,29 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
   if (Boolean(connectionId) !== Boolean(connectionVersion)) {
     throw new HTTPException(400, { message: "invalid OAuth reconnect state" });
   }
+  if (
+    parsed.discoveryMode === "legacy_2025_03_26_metadata" &&
+    (normalizedIssuerKey(parsed.authorizationServer) !== normalizedIssuerKey(parsed.issuer) ||
+      new URL(parsed.resource).origin !== new URL(parsed.issuer).origin)
+  ) {
+    throw new HTTPException(400, { message: "invalid OAuth discovery binding state" });
+  }
   return {
     ...parsed,
     ...(connectionId ? { connectionId } : {}),
     ...(connectionVersion !== undefined ? { connectionVersion } : {}),
   };
+}
+
+function discoveryModeValue(value: string | undefined): McpOAuthDiscoveryMode {
+  if (!value) {
+    // Every state minted before discovery modes existed used RFC 9728 PRM.
+    return "rfc9728_protected_resource";
+  }
+  if (value === "rfc9728_protected_resource" || value === "legacy_2025_03_26_metadata") {
+    return value;
+  }
+  throw new HTTPException(400, { message: "invalid OAuth discovery mode state" });
 }
 
 function connectionOwnership(value: unknown): ConnectionOwnership | undefined {
@@ -2033,31 +2058,6 @@ function safeReturnPath(value: string): string {
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }
 
-async function fetchJsonObject(
-  url: string,
-  settings: Settings,
-  signal?: AbortSignal,
-): Promise<Record<string, unknown>> {
-  const response = await fetchOAuth(url, settings, {
-    headers: { accept: "application/json" },
-    ...(signal ? { signal } : {}),
-  });
-  if (!response.ok) {
-    await cancelResponseBody(response);
-    throw new Error(`HTTP ${response.status}`);
-  }
-  const payload = await readResponseJsonBounded<unknown>(
-    response,
-    OAUTH_MAX_RESPONSE_BYTES,
-    "OAuth metadata response",
-    { ...(signal ? { signal } : {}) },
-  );
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new Error("metadata response was not a JSON object");
-  }
-  return payload as Record<string, unknown>;
-}
-
 async function fetchOAuth(
   rawUrl: string,
   settings: Settings,
@@ -2128,41 +2128,6 @@ function oauthRequestMayFollowRedirect(init: RequestInit): boolean {
 
 async function cancelResponseBody(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined);
-}
-
-function parseWwwAuthenticate(header: string | null): WwwAuthenticateChallenge {
-  if (!header) {
-    return {};
-  }
-  const bearerIndex = header.toLowerCase().indexOf("bearer");
-  if (bearerIndex < 0) {
-    return {};
-  }
-  const paramsText = header.slice(bearerIndex + "bearer".length);
-  const params: Record<string, string> = {};
-  const re = /([a-zA-Z_][a-zA-Z0-9_-]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,\s]+)/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(paramsText)) !== null) {
-    const raw = match[2]!;
-    params[match[1]!.toLowerCase()] = raw.startsWith('"')
-      ? raw.slice(1, -1).replace(/\\"/g, '"')
-      : raw;
-  }
-  return {
-    ...(params.resource_metadata ? { resourceMetadata: params.resource_metadata } : {}),
-    ...(params.scope ? { scope: params.scope.split(/\s+/).filter(Boolean) } : {}),
-    ...(params.error ? { error: params.error } : {}),
-  };
-}
-
-function wellKnownCandidates(rawUrl: string, name: string): string[] {
-  const url = new URL(rawUrl);
-  const path = url.pathname.replace(/^\/+|\/+$/g, "");
-  return uniqueStrings([
-    `${url.origin}/.well-known/${name}${path ? `/${path}` : ""}`,
-    `${url.origin}${path ? `/${path}` : ""}/.well-known/${name}`,
-    `${url.origin}/.well-known/${name}`,
-  ]);
 }
 
 function chooseAuthorizeScopes(

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -1846,6 +1846,138 @@ describe("connections routes", () => {
     }
   });
 
+  test("oauth start/callback supports same-origin 2025-03-26 metadata without RFC 8707 resource parameters", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const upstreamMcp = startTestMcpServer();
+    const tokenRequests: URLSearchParams[] = [];
+    const metadataRequests: string[] = [];
+    let origin = "";
+    const legacy = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/mcp") {
+          if (request.headers.get("authorization") !== "Bearer legacy-access-token") {
+            return new Response(JSON.stringify({ error: "invalid_token" }), {
+              status: 401,
+              headers: {
+                "content-type": "application/json",
+                "www-authenticate": 'Bearer error="invalid_token", scope="documents:read"',
+              },
+            });
+          }
+          return await fetch(upstreamMcp.url, {
+            method: request.method,
+            headers: request.headers,
+            ...(request.method === "GET" || request.method === "HEAD"
+              ? {}
+              : { body: await request.arrayBuffer() }),
+          });
+        }
+        if (url.pathname.includes("oauth-protected-resource")) {
+          metadataRequests.push(url.pathname);
+          return new Response("not found", { status: 404 });
+        }
+        if (url.pathname === "/.well-known/oauth-authorization-server") {
+          metadataRequests.push(url.pathname);
+          return Response.json({
+            issuer: origin,
+            authorization_endpoint: `${origin}/authorize`,
+            token_endpoint: `${origin}/token`,
+            code_challenge_methods_supported: ["S256"],
+            token_endpoint_auth_methods_supported: ["none"],
+            client_id_metadata_document_supported: true,
+          });
+        }
+        if (url.pathname === "/token") {
+          const body = new URLSearchParams(await request.text());
+          tokenRequests.push(body);
+          return Response.json({
+            access_token: "legacy-access-token",
+            refresh_token: "legacy-refresh-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+            scope: body.get("scope") ?? "documents:read",
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    origin = `http://127.0.0.1:${legacy.port}`;
+    const mcpUrl = `${origin}/mcp`;
+    try {
+      const response = await app().request(
+        `/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`,
+        {
+          method: "POST",
+          headers: {
+            authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            providerDomain: "legacy.example.com",
+            mcpUrl,
+            returnPath: "/integrations",
+          }),
+        },
+      );
+      const responseText = await response.clone().text();
+      expect(response.status, responseText).toBe(200);
+      const body = (await response.json()) as { state: string; authorizationUrl: string };
+      const authorizationUrl = new URL(body.authorizationUrl);
+      expect(authorizationUrl.searchParams.get("resource")).toBeNull();
+      expect(authorizationUrl.searchParams.get("scope")).toBe("documents:read");
+      expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown>;
+      expect(state).toMatchObject({
+        discoveryMode: "legacy_2025_03_26_metadata",
+        resource: mcpUrl,
+        resourceParameterSupported: false,
+        authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server`,
+      });
+      expect(state.protectedResourceMetadataUrl).toBeUndefined();
+      expect(state.discoveryMetadataSha256).toMatch(/^[0-9a-f]{64}$/);
+
+      const callback = await publicApp(client.db).request(
+        `/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`,
+      );
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(tokenRequests).toHaveLength(1);
+      expect(tokenRequests[0]!.get("resource")).toBeNull();
+      expect(metadataRequests).toEqual([
+        "/.well-known/oauth-protected-resource/mcp",
+        "/mcp/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-authorization-server",
+      ]);
+
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "legacy.example.com",
+        kind: "oauth2",
+        allowSubjectOwned: false,
+      });
+      expect(loaded?.credential).toMatchObject({
+        access_token: "legacy-access-token",
+        resource: mcpUrl,
+        resource_parameter_supported: false,
+      });
+      expect(loaded?.metadata.oauthDiscovery).toMatchObject({
+        mode: "legacy_2025_03_26_metadata",
+        resource: mcpUrl,
+        issuer: `${origin}/`,
+        authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server`,
+      });
+      expect(loaded?.metadata.oauthDiscovery).not.toHaveProperty("protectedResourceMetadataUrl");
+    } finally {
+      legacy.stop(true);
+      upstreamMcp.close();
+    }
+  });
+
   test("oauth start fails promptly with a structured stage when metadata streaming stalls", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -967,7 +967,7 @@ handlers because its host owns process lifecycle.
 | --- | --- | --- |
 | `packages/contracts` | `@opengeni/contracts` | Cross-boundary schemas, enums, permissions, events, capability descriptors, and tokens |
 | `packages/config` | `@opengeni/config` | Settings parsing, validation, defaults, and derived runtime configuration |
-| `packages/network` | `@opengeni/network` | DNS-pinned, bounded credential-bearing HTTP transport |
+| `packages/network` | `@opengeni/network` | DNS-pinned, bounded credential-bearing HTTP transport and shared MCP OAuth discovery semantics |
 | `packages/core` | `@opengeni/core` | Framework-neutral access, domain, billing, and dependency seams |
 | `packages/db` | `@opengeni/db` | Drizzle schema, scoped repositories, migrations, RLS posture, and role provisioning |
 | `packages/runtime` | `@opengeni/runtime` | Agent construction, model routing, tool execution, history projection, and sandbox abstraction |
@@ -1429,7 +1429,7 @@ This index intentionally routes at subsystem granularity. Use
 | Generated images or media | `apps/worker/src/activities/generated-images.ts`, `packages/contracts/src/image-generation.ts` | [`image-generation.md`](image-generation.md) |
 | Composer voice input or resumable transcription | `packages/contracts/src/transcription-recordings.ts`, `apps/api/src/routes/transcription-recordings.ts`, `packages/react/src/hooks/use-voice-input.ts` | [`transcription.md`](transcription.md) |
 | Composer draft submission or native embedding host seam | `packages/core/src/application/composer-submit.ts`, `apps/api/src/routes/sessions.ts`, `packages/react/src/embedded-session-client.ts` | [`embedding.md`](embedding.md), package READMEs, and §7.1 |
-| Provider integrations and social connectors | `apps/api/src/integrations/`, `packages/github/` | [`integrations-design.md`](integrations-design.md), [`github-app.md`](github-app.md), [`google-drive.md`](google-drive.md), [`slack-bot.md`](slack-bot.md), [`social-connectors.md`](social-connectors.md), [`fiken.md`](fiken.md) |
+| Provider integrations and social connectors | `apps/api/src/integrations/`, `packages/network/src/mcp-oauth-discovery.ts`, `packages/github/` | [`integrations-design.md`](integrations-design.md), [`github-app.md`](github-app.md), [`google-drive.md`](google-drive.md), [`slack-bot.md`](slack-bot.md), [`social-connectors.md`](social-connectors.md), [`fiken.md`](fiken.md) |
 | OpenGeni Review Bot and pull-request automation | `packages/core/src/domain/pr-review.ts`, `apps/api/src/routes/pr-review.ts`, `apps/api/src/routes/pr-review-github.ts` | [`automations.md`](automations.md), [`pr-review-pack.md`](pr-review-pack.md) |
 | HTTP routes or SSE | `apps/api/src/app.ts`, `apps/api/src/http/sse.ts` | §4 and [`../packages/sdk/README.md`](../packages/sdk/README.md) |
 | SDK, React, or browser bundle surface | `packages/sdk/src/`, `packages/react/src/`, `packages/sdk/test/core-bundle-boundary.test.ts`, `packages/sdk/test/browser-client-surface.test.ts` | Package READMEs, §3.10, and §7.6 |

--- a/docs/integrations-design.md
+++ b/docs/integrations-design.md
@@ -198,7 +198,7 @@ Broker rules:
 
 The broker passes resolved connection credentials directly to the outbound request rather than deliberately copying them into session configuration, events, run state, or Temporal inputs. OpenGeni does not heuristically scan or rewrite arbitrary provider, user, agent, or tool content if that content contains credential-shaped text; internal persisted and model-visible data remains exact.
 
-## 5. MCP OAuth client (spec rev 2025-11-25)
+## 5. MCP OAuth client (current profile with 2025-03-26 compatibility)
 
 ### 5.1 Flow
 
@@ -206,6 +206,9 @@ The broker passes resolved connection credentials directly to the outbound reque
 DISCOVER   probe server URL unauthenticated
            → 401 + WWW-Authenticate: parse resource_metadata URL + scope hint
            → RFC 9728 Protected Resource Metadata (well-known fallback probing)
+           → only when the challenge has no resource_metadata and every PRM
+             candidate is explicitly absent (404/410), probe the MCP origin's
+             RFC 8414 metadata as the legacy 2025-03-26 profile
            → pick AS; RFC 8414 / OIDC-discovery metadata (both well-known path orders)
            → REQUIRE code_challenge_methods_supported ∋ S256, else abort with clear error
 REGISTER   priority: (1) operator pre-registered creds for this AS
@@ -216,7 +219,8 @@ REGISTER   priority: (1) operator pre-registered creds for this AS
            (4) manual client-credential entry in UI
            A reviewed provider profile may explicitly force DCR or CIMD.
 AUTHORIZE  authorize URL: PKCE S256, state = signed payload (§5.2),
-           resource = canonical MCP server URI (RFC 8707, ALWAYS sent),
+           resource = canonical MCP server URI (RFC 8707 in modern PRM mode;
+           omitted in legacy 2025-03-26 mode),
            scope = requestedScopes when supplied (step-up), else 401-challenge
            scope if present, else PRM scopes_supported
            → browser → provider consent → redirect to callback
@@ -231,7 +235,7 @@ STEP-UP    runtime 403 error="insufficient_scope" → tool.auth_needed → re-AU
 
 ### 5.2 Stateless grant state (decision)
 
-No pending-grant table. The `state` parameter is a **signed, time-limited payload** using the established `createSignedState`/`verifySignedState` pattern from `@opengeni/github`, with a dedicated `integrationsStateSecret`: `{ workspaceId, accountId, subjectId, providerDomain, resource, requestedScopes, authorizeScopes, encryptedPkceVerifier, clientId, tokenEndpoint, authorizationServer, issuer, returnPath, nonce, iat }`. The PKCE verifier is **encrypted** (variable-sets key) inside the signed state — state transits browser URLs and provider logs, and a plaintext verifier there would defeat PKCE's interception protection. Single-use is enforced by inserting the consumed nonce into `integration_oauth_state_nonces` with a short TTL; the primary key makes replay fail across API instances. This survives multi-instance API deployments (the callback may land on any instance) — which is also why a random per-process fallback secret is forbidden: `integrationsStateSecret` is required whenever integrations are enabled outside local dev.
+No pending-grant table. The `state` parameter is a **signed, time-limited payload** using the established `createSignedState`/`verifySignedState` pattern from `@opengeni/github`, with a dedicated `integrationsStateSecret`: `{ workspaceId, accountId, subjectId, providerDomain, resource, requestedScopes, authorizeScopes, encryptedPkceVerifier, clientId, tokenEndpoint, authorizationServer, issuer, discoveryMode, discoveryMetadataSha256, protectedResourceMetadataUrl?, authorizationServerMetadataUrl, returnPath, nonce, iat }`. The discovery mode, selected issuer/resource, and exact metadata provenance hash are therefore frozen before the browser redirect; a callback cannot reinterpret a legacy grant as modern (or vice versa) after a deploy or discovery race. The PKCE verifier is **encrypted** (variable-sets key) inside the signed state — state transits browser URLs and provider logs, and a plaintext verifier there would defeat PKCE's interception protection. Single-use is enforced by inserting the consumed nonce into `integration_oauth_state_nonces` with a short TTL; the primary key makes replay fail across API instances. This survives multi-instance API deployments (the callback may land on any instance) — which is also why a random per-process fallback secret is forbidden: `integrationsStateSecret` is required whenever integrations are enabled outside local dev.
 
 The callback route must NOT call `requireAccessGrant` — a browser redirect carries only `code`+`state`. It trusts exclusively the verified, unexpired signed state minted by the authenticated start route.
 
@@ -292,7 +296,17 @@ Served publicly at `GET /v1/integrations/oauth/client-metadata.json`:
 
 - PKCE S256 always; refuse ASes not advertising it.
 - `state` signed, single-use, TTL-bound, workspace+subject-bound; callback validates all of it.
-- `resource` (RFC 8707) on both authorize and token requests regardless of AS support.
+- RFC 9728 PRM is authoritative whenever present. Malformed, contradictory,
+  unreachable, redirected-to-unsafe, or otherwise invalid PRM is a hard failure;
+  it never causes a legacy downgrade.
+- Automatic legacy discovery requires a real Bearer/OAuth challenge without
+  `resource_metadata`, explicit absence of every PRM candidate, valid RFC 8414
+  metadata at the MCP URL's own origin, an issuer matching that metadata
+  authority, and a same-origin MCP-resource-to-issuer binding. Cross-origin
+  legacy servers require a reviewed profile/manual decision.
+- `resource` (RFC 8707) is sent on both authorize and token requests in modern
+  PRM mode, subject to reviewed provider-profile suppression. It is always
+  omitted in legacy 2025-03-26 mode.
 - Exact-match redirect URI only; never follow AS-supplied alternative redirects.
 - SSRF guard on PRM/AS-metadata/token-endpoint fetches: no private-range targets unless running in local/test or `OPENGENI_INTEGRATIONS_ALLOW_PRIVATE_NETWORK_TARGETS=true`.
 - No token passthrough: tokens minted for an MCP server go only to that server; our own first-party MCP servers keep validating audience on inbound tokens.
@@ -337,6 +351,14 @@ Config additions in `packages/config/src/index.ts`: `integrationsEnabled` (`EnvB
 - **In-session:** the `tool.auth_needed` chip folds into the turn per existing timeline fold rules.
 
 ## 10. Discovery & catalog (I4)
+
+Runtime OAuth discovery and catalog OAuth diagnostics share
+`packages/network/src/mcp-oauth-discovery.ts`. Catalog results are diagnostic
+cache only; a connection attempt always performs fresh runtime discovery under
+the current DNS/IP/SSRF and redirect policy. Auth-gated rows carry one of:
+`oauth_rfc9728`, `oauth_legacy_same_origin_metadata`,
+`oauth_legacy_default_endpoints_unverified`, `oauth_requires_profile`, or
+`oauth_discovery_broken`.
 
 - Source-of-truth order: (1) the service's own well-known signals probed at add-by-domain time, (2) a **vendored, reviewed snapshot** of the integrations.sh registry (MIT) — import pipeline re-verifies `detected` entries (probe endpoint, confirm PRM) and demotes the rest to `community`, (3) the committed **curated overlay** `data/catalog/curated.json`, keyed by exact MCP URL, which wins over the snapshot field-by-field and carries reviewed first-party contracts, branding, category, and the checkable `featured` / `official` flags. Never live-consume the registry at request time; snapshots are versioned with import provenance. See `docs/capabilities.md` § Curated overlay.
 - Catalog rows extend `capability_catalog_items` with surface type, MCP URL, transports, credential facts, tier, provenance.

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -41,3 +41,29 @@ The package also exports `readJsonBase64Field` for provider APIs that return
 large binary artifacts inside JSON. It validates declared and streamed limits,
 decodes canonical base64 incrementally, and avoids retaining the JSON envelope
 or encoded string. Callers remain responsible for validating the decoded media.
+
+## MCP OAuth discovery
+
+`resolveMcpOAuthDiscovery` provides the shared MCP OAuth discovery state machine
+used by runtime connections and catalog diagnostics. It prefers RFC 9728
+Protected Resource Metadata and permits the MCP 2025-03-26 compatibility path
+only after every PRM candidate is explicitly absent with HTTP 404 or 410. The
+legacy path requires a Bearer/OAuth challenge, RFC 8414 metadata on the MCP
+origin, an exact issuer match, same-origin resource binding, and PKCE S256.
+
+The resolver is transport-independent. Its `fetchMetadata` callback must
+validate each candidate before I/O, bound response size and duration, disable
+automatic redirects, and independently validate and DNS-pin every redirect
+hop. It must return `status: "absent"` only for HTTP 404 or 410 and throw for
+network, redirect, destination-policy, HTTP, body, and JSON failures; otherwise
+an unsafe or unreachable PRM endpoint could be mistaken for legacy absence.
+`validateEndpoint` and `canonicalizeResource` provide the caller's deployment
+policy and canonical identifier rules.
+
+Successful results include the discovery mode, normalized metadata, structured
+classification, and a stable SHA-256 provenance digest. Fail-closed errors carry
+classifications for broken discovery, unverified legacy defaults, or a legacy
+cross-origin configuration that requires an explicit reviewed profile. These
+classifications are diagnostics; callers still decide whether a provider
+profile is supported and must perform fresh runtime discovery before granting
+credentials.

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opengeni/network",
   "version": "0.2.3",
-  "description": "DNS-pinned outbound HTTP transport for OpenGeni credential-bearing requests.",
+  "description": "DNS-pinned outbound HTTP transport and shared MCP OAuth discovery primitives.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -5,6 +5,7 @@ import { lookup as nodeLookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
 export * from "./json-base64";
+export * from "./mcp-oauth-discovery";
 
 export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -131,7 +131,7 @@ export async function resolveMcpOAuthDiscovery(
     });
   }
 
-  if (input.challenge.resourceMetadata) {
+  if (input.challenge.resourceMetadata !== undefined) {
     throw new McpOAuthDiscoveryError(
       "protected_resource_metadata",
       "oauth_discovery_broken",
@@ -181,11 +181,22 @@ export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge
   if (!header) return { scheme: null, scope: [] };
   const challenges = parseAuthenticateChallenges(header);
   if (!challenges) return { scheme: null, scope: [] };
-  const challenge = challenges.find((candidate) => {
-    const scheme = candidate.scheme.toLowerCase();
-    return scheme === "bearer" || scheme === "oauth";
-  });
-  if (!challenge) return { scheme: null, scope: [] };
+  const oauthChallenges = challenges
+    .filter((candidate) => {
+      const scheme = candidate.scheme.toLowerCase();
+      return scheme === "bearer" || scheme === "oauth";
+    })
+    .map(parseOAuthChallenge);
+  return (
+    oauthChallenges.find((challenge) => challenge.resourceMetadata !== undefined) ??
+    oauthChallenges[0] ?? { scheme: null, scope: [] }
+  );
+}
+
+function parseOAuthChallenge(challenge: {
+  scheme: string;
+  parameterParts: string[];
+}): McpOAuthChallenge {
   const scheme = challenge.scheme.toLowerCase() as "bearer" | "oauth";
   const paramsText = challenge.parameterParts.join(",");
   const params: Record<string, string> = {};
@@ -200,7 +211,7 @@ export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge
   return {
     scheme,
     scope: params.scope ? params.scope.split(/\s+/).filter(Boolean) : [],
-    ...(params.resource_metadata ? { resourceMetadata: params.resource_metadata } : {}),
+    ...("resource_metadata" in params ? { resourceMetadata: params.resource_metadata } : {}),
     ...(params.error ? { error: params.error } : {}),
   };
 }
@@ -270,7 +281,7 @@ export function protectedResourceMetadataCandidates(
   advertisedUrl?: string,
 ): string[] {
   return uniqueStrings([
-    ...(advertisedUrl ? [advertisedUrl] : []),
+    ...(advertisedUrl !== undefined ? [advertisedUrl] : []),
     ...oauthWellKnownCandidates(resourceUrl, "oauth-protected-resource"),
   ]);
 }

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -1,0 +1,477 @@
+import { createHash } from "node:crypto";
+
+export type McpOAuthDiscoveryMode = "rfc9728_protected_resource" | "legacy_2025_03_26_metadata";
+
+export type McpOAuthDiscoveryClassification =
+  | "oauth_rfc9728"
+  | "oauth_legacy_same_origin_metadata"
+  | "oauth_legacy_default_endpoints_unverified"
+  | "oauth_requires_profile"
+  | "oauth_discovery_broken";
+
+export type McpOAuthChallenge = {
+  scheme: "bearer" | "oauth" | null;
+  resourceMetadata?: string;
+  scope: string[];
+  error?: string;
+};
+
+export type McpProtectedResourceMetadata = {
+  resource?: string;
+  authorizationServers: string[];
+  scopesSupported: string[];
+  raw: Record<string, unknown>;
+  metadataUrl: string;
+};
+
+export type McpAuthorizationServerMetadata = {
+  issuer: string;
+  authorizationServer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint?: string;
+  clientIdMetadataDocumentSupported: boolean;
+  tokenEndpointAuthMethodsSupported: string[];
+  codeChallengeMethodsSupported: string[];
+  raw: Record<string, unknown>;
+  metadataUrl: string;
+};
+
+export type McpOAuthMetadataKind = "protected_resource" | "authorization_server";
+
+export type McpOAuthMetadataFetchResult =
+  | {
+      status: "present";
+      url: string;
+      document: Record<string, unknown>;
+    }
+  | {
+      status: "absent";
+      url: string;
+      httpStatus: 404 | 410;
+    };
+
+export type McpOAuthDiscoveryResult = {
+  mode: McpOAuthDiscoveryMode;
+  classification: Extract<
+    McpOAuthDiscoveryClassification,
+    "oauth_rfc9728" | "oauth_legacy_same_origin_metadata"
+  >;
+  challenge: McpOAuthChallenge;
+  resource: string;
+  protectedResourceMetadata: McpProtectedResourceMetadata;
+  authorizationServerMetadata: McpAuthorizationServerMetadata;
+  provenance: {
+    protectedResourceMetadataUrl: string | null;
+    authorizationServerMetadataUrl: string;
+    metadataSha256: string;
+  };
+};
+
+export class McpOAuthDiscoveryError extends Error {
+  constructor(
+    readonly stage: "protected_resource_metadata" | "authorization_server_metadata",
+    readonly classification: Exclude<
+      McpOAuthDiscoveryClassification,
+      "oauth_rfc9728" | "oauth_legacy_same_origin_metadata"
+    >,
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "McpOAuthDiscoveryError";
+  }
+}
+
+export type ResolveMcpOAuthDiscoveryInput = {
+  resourceUrl: string;
+  challenge: McpOAuthChallenge;
+  fetchMetadata: (input: {
+    kind: McpOAuthMetadataKind;
+    url: string;
+  }) => Promise<McpOAuthMetadataFetchResult>;
+  validateEndpoint: (rawUrl: string, label: string) => string;
+  canonicalizeResource: (rawResource: string) => string;
+};
+
+/**
+ * Resolve modern MCP OAuth discovery first, with the 2025-03-26 same-origin
+ * metadata profile as a narrowly bounded compatibility fallback.
+ *
+ * Only an explicit 404/410 result is absence. Callers must throw for network,
+ * redirect, destination-policy, body, JSON, and other HTTP failures so none of
+ * those failures can silently downgrade a server to the legacy profile.
+ */
+export async function resolveMcpOAuthDiscovery(
+  input: ResolveMcpOAuthDiscoveryInput,
+): Promise<McpOAuthDiscoveryResult> {
+  const prmCandidates = protectedResourceMetadataCandidates(
+    input.resourceUrl,
+    input.challenge.resourceMetadata,
+  );
+  let prmDocument: (McpOAuthMetadataFetchResult & { status: "present" }) | null = null;
+  for (const candidate of prmCandidates) {
+    const fetched = await input.fetchMetadata({ kind: "protected_resource", url: candidate });
+    if (fetched.status === "absent") continue;
+    prmDocument = fetched;
+    break;
+  }
+
+  if (prmDocument) {
+    const prm = parseProtectedResourceMetadata(prmDocument, input);
+    const authorizationServer = prm.authorizationServers[0]!;
+    const as = await discoverAuthorizationServerMetadata(authorizationServer, "modern", input);
+    return discoveryResult({
+      mode: "rfc9728_protected_resource",
+      classification: "oauth_rfc9728",
+      challenge: input.challenge,
+      resource: prm.resource ?? input.canonicalizeResource(input.resourceUrl),
+      prm,
+      as,
+    });
+  }
+
+  if (input.challenge.resourceMetadata) {
+    throw new McpOAuthDiscoveryError(
+      "protected_resource_metadata",
+      "oauth_discovery_broken",
+      "MCP advertised protected resource metadata, but no metadata document was found",
+    );
+  }
+  if (!input.challenge.scheme) {
+    throw new McpOAuthDiscoveryError(
+      "protected_resource_metadata",
+      "oauth_discovery_broken",
+      "MCP protected resource metadata was absent and the server returned no Bearer/OAuth challenge",
+    );
+  }
+
+  const resource = input.canonicalizeResource(input.resourceUrl);
+  const resourceOrigin = new URL(resource).origin;
+  const as = await discoverAuthorizationServerMetadata(resourceOrigin, "legacy", input);
+  if (new URL(as.issuer).origin !== resourceOrigin) {
+    throw new McpOAuthDiscoveryError(
+      "authorization_server_metadata",
+      "oauth_requires_profile",
+      "legacy MCP OAuth discovery requires the authorization server issuer to share the MCP server origin",
+    );
+  }
+  const syntheticPrm: McpProtectedResourceMetadata = {
+    resource,
+    authorizationServers: [as.issuer],
+    scopesSupported: [...input.challenge.scope],
+    raw: {
+      resource,
+      authorization_servers: [as.issuer],
+      scopes_supported: [...input.challenge.scope],
+    },
+    metadataUrl: "",
+  };
+  return discoveryResult({
+    mode: "legacy_2025_03_26_metadata",
+    classification: "oauth_legacy_same_origin_metadata",
+    challenge: input.challenge,
+    resource,
+    prm: syntheticPrm,
+    as,
+  });
+}
+
+export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge {
+  if (!header) return { scheme: null, scope: [] };
+  const schemeMatch = /(?:^|,)\s*(Bearer|OAuth)(?:\s+|$)/i.exec(header);
+  if (!schemeMatch) return { scheme: null, scope: [] };
+  const scheme = schemeMatch[1]!.toLowerCase() as "bearer" | "oauth";
+  const paramsText = header.slice(schemeMatch.index + schemeMatch[0].length);
+  const params: Record<string, string> = {};
+  const re = /([a-zA-Z_][a-zA-Z0-9_-]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,\s]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(paramsText)) !== null) {
+    const raw = match[2]!;
+    params[match[1]!.toLowerCase()] = raw.startsWith('"')
+      ? raw.slice(1, -1).replace(/\\"/g, '"')
+      : raw;
+  }
+  return {
+    scheme,
+    scope: params.scope ? params.scope.split(/\s+/).filter(Boolean) : [],
+    ...(params.resource_metadata ? { resourceMetadata: params.resource_metadata } : {}),
+    ...(params.error ? { error: params.error } : {}),
+  };
+}
+
+export function protectedResourceMetadataCandidates(
+  resourceUrl: string,
+  advertisedUrl?: string,
+): string[] {
+  return uniqueStrings([
+    ...(advertisedUrl ? [advertisedUrl] : []),
+    ...oauthWellKnownCandidates(resourceUrl, "oauth-protected-resource"),
+  ]);
+}
+
+export function authorizationServerMetadataCandidates(authorizationServer: string): string[] {
+  return uniqueStrings([
+    ...oauthWellKnownCandidates(authorizationServer, "oauth-authorization-server"),
+    ...oauthWellKnownCandidates(authorizationServer, "openid-configuration"),
+    authorizationServer,
+  ]);
+}
+
+export function legacyAuthorizationServerMetadataCandidates(resourceUrl: string): string[] {
+  const origin = new URL(resourceUrl).origin;
+  return [`${origin}/.well-known/oauth-authorization-server`];
+}
+
+function oauthWellKnownCandidates(rawUrl: string, name: string): string[] {
+  const url = new URL(rawUrl);
+  const path = url.pathname.replace(/^\/+|\/+$/g, "");
+  return uniqueStrings([
+    `${url.origin}/.well-known/${name}${path ? `/${path}` : ""}`,
+    `${url.origin}${path ? `/${path}` : ""}/.well-known/${name}`,
+    `${url.origin}/.well-known/${name}`,
+  ]);
+}
+
+function parseProtectedResourceMetadata(
+  fetched: McpOAuthMetadataFetchResult & { status: "present" },
+  input: ResolveMcpOAuthDiscoveryInput,
+): McpProtectedResourceMetadata {
+  const authorizationServers = stringArray(fetched.document.authorization_servers).map((value) =>
+    validateDiscoveryEndpoint(
+      input,
+      value,
+      "OAuth authorization server",
+      "protected_resource_metadata",
+    ),
+  );
+  if (authorizationServers.length === 0) {
+    throw new McpOAuthDiscoveryError(
+      "protected_resource_metadata",
+      "oauth_discovery_broken",
+      "MCP protected resource metadata did not advertise an authorization server",
+    );
+  }
+  const resourceValue = stringValue(fetched.document.resource);
+  return {
+    authorizationServers,
+    scopesSupported: stringArray(fetched.document.scopes_supported),
+    raw: fetched.document,
+    metadataUrl: fetched.url,
+    ...(resourceValue ? { resource: input.canonicalizeResource(resourceValue) } : {}),
+  };
+}
+
+async function discoverAuthorizationServerMetadata(
+  authorizationServer: string,
+  profile: "modern" | "legacy",
+  input: ResolveMcpOAuthDiscoveryInput,
+): Promise<McpAuthorizationServerMetadata> {
+  const safeAuthorizationServer = validateDiscoveryEndpoint(
+    input,
+    authorizationServer,
+    "OAuth authorization server",
+    "authorization_server_metadata",
+  ).replace(/\/+$/, "");
+  const candidates =
+    profile === "legacy"
+      ? legacyAuthorizationServerMetadataCandidates(safeAuthorizationServer)
+      : authorizationServerMetadataCandidates(safeAuthorizationServer);
+  let fetched: (McpOAuthMetadataFetchResult & { status: "present" }) | null = null;
+  for (const candidate of candidates) {
+    const result = await input.fetchMetadata({ kind: "authorization_server", url: candidate });
+    if (result.status === "absent") continue;
+    fetched = result;
+    break;
+  }
+  if (!fetched) {
+    throw new McpOAuthDiscoveryError(
+      "authorization_server_metadata",
+      profile === "legacy" ? "oauth_legacy_default_endpoints_unverified" : "oauth_discovery_broken",
+      profile === "legacy"
+        ? "legacy MCP OAuth metadata was absent; default authorization endpoints require explicit verification"
+        : "could not discover OAuth authorization server metadata",
+    );
+  }
+
+  const authorizationEndpoint = requiredString(
+    fetched.document.authorization_endpoint,
+    "authorization_endpoint",
+    "authorization_server_metadata",
+  );
+  const tokenEndpoint = requiredString(
+    fetched.document.token_endpoint,
+    "token_endpoint",
+    "authorization_server_metadata",
+  );
+  const issuerValue = stringValue(fetched.document.issuer);
+  if (profile === "legacy" && !issuerValue) {
+    throw new McpOAuthDiscoveryError(
+      "authorization_server_metadata",
+      "oauth_discovery_broken",
+      "legacy MCP OAuth metadata did not include issuer",
+    );
+  }
+  const issuer = validateDiscoveryEndpoint(
+    input,
+    issuerValue ?? safeAuthorizationServer,
+    "OAuth issuer",
+    "authorization_server_metadata",
+  );
+  if (
+    profile === "legacy" &&
+    normalizedIssuerIdentifier(issuer) !== normalizedIssuerIdentifier(safeAuthorizationServer)
+  ) {
+    const crossOrigin = new URL(issuer).origin !== new URL(safeAuthorizationServer).origin;
+    throw new McpOAuthDiscoveryError(
+      "authorization_server_metadata",
+      crossOrigin ? "oauth_requires_profile" : "oauth_discovery_broken",
+      "OAuth authorization server metadata issuer did not match the selected authorization server",
+    );
+  }
+  const registrationEndpoint = stringValue(fetched.document.registration_endpoint);
+  const parsed: McpAuthorizationServerMetadata = {
+    issuer,
+    authorizationServer: safeAuthorizationServer,
+    authorizationEndpoint: validateDiscoveryEndpoint(
+      input,
+      authorizationEndpoint,
+      "OAuth authorization endpoint",
+      "authorization_server_metadata",
+    ),
+    tokenEndpoint: validateDiscoveryEndpoint(
+      input,
+      tokenEndpoint,
+      "OAuth token endpoint",
+      "authorization_server_metadata",
+    ),
+    clientIdMetadataDocumentSupported:
+      fetched.document.client_id_metadata_document_supported === true,
+    tokenEndpointAuthMethodsSupported: stringArray(
+      fetched.document.token_endpoint_auth_methods_supported,
+    ),
+    codeChallengeMethodsSupported: stringArray(fetched.document.code_challenge_methods_supported),
+    raw: fetched.document,
+    metadataUrl: fetched.url,
+    ...(registrationEndpoint
+      ? {
+          registrationEndpoint: validateDiscoveryEndpoint(
+            input,
+            registrationEndpoint,
+            "OAuth registration endpoint",
+            "authorization_server_metadata",
+          ),
+        }
+      : {}),
+  };
+  if (!parsed.codeChallengeMethodsSupported.includes("S256")) {
+    throw new McpOAuthDiscoveryError(
+      "authorization_server_metadata",
+      "oauth_discovery_broken",
+      "authorization server does not support required PKCE S256",
+    );
+  }
+  return parsed;
+}
+
+function discoveryResult(input: {
+  mode: McpOAuthDiscoveryMode;
+  classification: "oauth_rfc9728" | "oauth_legacy_same_origin_metadata";
+  challenge: McpOAuthChallenge;
+  resource: string;
+  prm: McpProtectedResourceMetadata;
+  as: McpAuthorizationServerMetadata;
+}): McpOAuthDiscoveryResult {
+  const protectedResourceMetadataUrl = input.prm.metadataUrl || null;
+  return {
+    mode: input.mode,
+    classification: input.classification,
+    challenge: input.challenge,
+    resource: input.resource,
+    protectedResourceMetadata: input.prm,
+    authorizationServerMetadata: input.as,
+    provenance: {
+      protectedResourceMetadataUrl,
+      authorizationServerMetadataUrl: input.as.metadataUrl,
+      metadataSha256: createHash("sha256")
+        .update(
+          stableJson({
+            mode: input.mode,
+            resource: input.resource,
+            challenge: input.challenge,
+            protectedResourceMetadata: {
+              url: protectedResourceMetadataUrl,
+              document: input.prm.raw,
+            },
+            authorizationServerMetadata: {
+              url: input.as.metadataUrl,
+              document: input.as.raw,
+            },
+          }),
+        )
+        .digest("hex"),
+    },
+  };
+}
+
+function validateDiscoveryEndpoint(
+  input: ResolveMcpOAuthDiscoveryInput,
+  rawUrl: string,
+  label: string,
+  stage: McpOAuthDiscoveryError["stage"],
+): string {
+  try {
+    return input.validateEndpoint(rawUrl, label);
+  } catch (error) {
+    throw new McpOAuthDiscoveryError(
+      stage,
+      "oauth_discovery_broken",
+      error instanceof Error ? error.message : `${label} was invalid`,
+      error,
+    );
+  }
+}
+
+function normalizedIssuerIdentifier(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? uniqueStrings(value.filter((entry): entry is string => typeof entry === "string"))
+    : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function requiredString(
+  value: unknown,
+  field: string,
+  stage: McpOAuthDiscoveryError["stage"],
+): string {
+  const parsed = stringValue(value);
+  if (!parsed) {
+    throw new McpOAuthDiscoveryError(
+      stage,
+      "oauth_discovery_broken",
+      `OAuth metadata did not include ${field}`,
+    );
+  }
+  return parsed;
+}

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -179,10 +179,15 @@ export async function resolveMcpOAuthDiscovery(
 
 export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge {
   if (!header) return { scheme: null, scope: [] };
-  const schemeMatch = /(?:^|,)\s*(Bearer|OAuth)(?=\s|,|$)/i.exec(header);
-  if (!schemeMatch) return { scheme: null, scope: [] };
-  const scheme = schemeMatch[1]!.toLowerCase() as "bearer" | "oauth";
-  const paramsText = challengeParametersText(header, schemeMatch.index + schemeMatch[0].length);
+  const challenges = parseAuthenticateChallenges(header);
+  if (!challenges) return { scheme: null, scope: [] };
+  const challenge = challenges.find((candidate) => {
+    const scheme = candidate.scheme.toLowerCase();
+    return scheme === "bearer" || scheme === "oauth";
+  });
+  if (!challenge) return { scheme: null, scope: [] };
+  const scheme = challenge.scheme.toLowerCase() as "bearer" | "oauth";
+  const paramsText = challenge.parameterParts.join(",");
   const params: Record<string, string> = {};
   const re = /([a-zA-Z_][a-zA-Z0-9_-]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,\s]+)/g;
   let match: RegExpExecArray | null;
@@ -200,10 +205,41 @@ export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge
   };
 }
 
-function challengeParametersText(header: string, start: number): string {
+function parseAuthenticateChallenges(
+  header: string,
+): Array<{ scheme: string; parameterParts: string[] }> | null {
+  const segments = splitAuthenticateHeader(header);
+  if (!segments) return null;
+  const challenges: Array<{ scheme: string; parameterParts: string[] }> = [];
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (!trimmed) return null;
+    const token = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+/.exec(trimmed)?.[0];
+    if (!token) return null;
+    let cursor = token.length;
+    while (/\s/.test(trimmed[cursor] ?? "")) cursor += 1;
+    if (trimmed[cursor] === "=") {
+      const current = challenges.at(-1);
+      if (!current) return null;
+      current.parameterParts.push(trimmed);
+      continue;
+    }
+    const remainder = trimmed.slice(token.length);
+    if (remainder && !/^\s/.test(remainder)) return null;
+    challenges.push({
+      scheme: token,
+      parameterParts: remainder.trim() ? [remainder.trim()] : [],
+    });
+  }
+  return challenges;
+}
+
+function splitAuthenticateHeader(header: string): string[] | null {
+  const segments: string[] = [];
+  let segmentStart = 0;
   let quoted = false;
   let escaped = false;
-  for (let index = start; index < header.length; index += 1) {
+  for (let index = 0; index < header.length; index += 1) {
     const character = header[index]!;
     if (quoted) {
       if (escaped) {
@@ -219,19 +255,14 @@ function challengeParametersText(header: string, start: number): string {
       quoted = true;
       continue;
     }
-    if (character !== ",") continue;
-
-    let cursor = index + 1;
-    while (/\s/.test(header[cursor] ?? "")) cursor += 1;
-    const token = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+/.exec(header.slice(cursor))?.[0];
-    if (!token) continue;
-    cursor += token.length;
-    while (/\s/.test(header[cursor] ?? "")) cursor += 1;
-    if (header[cursor] !== "=") {
-      return header.slice(start, index);
+    if (character === ",") {
+      segments.push(header.slice(segmentStart, index));
+      segmentStart = index + 1;
     }
   }
-  return header.slice(start);
+  if (quoted) return null;
+  segments.push(header.slice(segmentStart));
+  return segments;
 }
 
 export function protectedResourceMetadataCandidates(

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -198,6 +198,9 @@ function parseOAuthChallenge(challenge: {
   parameterParts: string[];
 }): McpOAuthChallenge {
   const scheme = challenge.scheme.toLowerCase() as "bearer" | "oauth";
+  const resourceMetadataPresent = challenge.parameterParts.some((part) =>
+    /^resource_metadata\s*=/i.test(part.trim()),
+  );
   const paramsText = challenge.parameterParts.join(",");
   const params: Record<string, string> = {};
   const re = /([a-zA-Z_][a-zA-Z0-9_-]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,\s]+)/g;
@@ -211,10 +214,12 @@ function parseOAuthChallenge(challenge: {
   return {
     scheme,
     scope: params.scope ? params.scope.split(/\s+/).filter(Boolean) : [],
-    ...("resource_metadata" in params ? { resourceMetadata: params.resource_metadata } : {}),
+    ...(resourceMetadataPresent ? { resourceMetadata: params.resource_metadata ?? "" } : {}),
     ...(params.error ? { error: params.error } : {}),
   };
 }
+
+const MAX_EMPTY_AUTHENTICATE_LIST_ELEMENTS = 8;
 
 function parseAuthenticateChallenges(
   header: string,
@@ -222,9 +227,14 @@ function parseAuthenticateChallenges(
   const segments = splitAuthenticateHeader(header);
   if (!segments) return null;
   const challenges: Array<{ scheme: string; parameterParts: string[] }> = [];
+  let emptyElements = 0;
   for (const segment of segments) {
     const trimmed = segment.trim();
-    if (!trimmed) return null;
+    if (!trimmed) {
+      emptyElements += 1;
+      if (emptyElements > MAX_EMPTY_AUTHENTICATE_LIST_ELEMENTS) return null;
+      continue;
+    }
     const token = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+/.exec(trimmed)?.[0];
     if (!token) return null;
     let cursor = token.length;

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -179,10 +179,10 @@ export async function resolveMcpOAuthDiscovery(
 
 export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge {
   if (!header) return { scheme: null, scope: [] };
-  const schemeMatch = /(?:^|,)\s*(Bearer|OAuth)(?:\s+|$)/i.exec(header);
+  const schemeMatch = /(?:^|,)\s*(Bearer|OAuth)(?=\s|,|$)/i.exec(header);
   if (!schemeMatch) return { scheme: null, scope: [] };
   const scheme = schemeMatch[1]!.toLowerCase() as "bearer" | "oauth";
-  const paramsText = header.slice(schemeMatch.index + schemeMatch[0].length);
+  const paramsText = challengeParametersText(header, schemeMatch.index + schemeMatch[0].length);
   const params: Record<string, string> = {};
   const re = /([a-zA-Z_][a-zA-Z0-9_-]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,\s]+)/g;
   let match: RegExpExecArray | null;
@@ -198,6 +198,40 @@ export function parseMcpOAuthChallenge(header: string | null): McpOAuthChallenge
     ...(params.resource_metadata ? { resourceMetadata: params.resource_metadata } : {}),
     ...(params.error ? { error: params.error } : {}),
   };
+}
+
+function challengeParametersText(header: string, start: number): string {
+  let quoted = false;
+  let escaped = false;
+  for (let index = start; index < header.length; index += 1) {
+    const character = header[index]!;
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        quoted = false;
+      }
+      continue;
+    }
+    if (character === '"') {
+      quoted = true;
+      continue;
+    }
+    if (character !== ",") continue;
+
+    let cursor = index + 1;
+    while (/\s/.test(header[cursor] ?? "")) cursor += 1;
+    const token = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+/.exec(header.slice(cursor))?.[0];
+    if (!token) continue;
+    cursor += token.length;
+    while (/\s/.test(header[cursor] ?? "")) cursor += 1;
+    if (header[cursor] !== "=") {
+      return header.slice(start, index);
+    }
+  }
+  return header.slice(start);
 }
 
 export function protectedResourceMetadataCandidates(

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import {
+  McpOAuthDiscoveryError,
+  parseMcpOAuthChallenge,
+  resolveMcpOAuthDiscovery,
+  type McpOAuthMetadataFetchResult,
+} from "../src/mcp-oauth-discovery";
+
+const resourceUrl = "https://mcp.example.test/v1/mcp";
+
+function metadataFetcher(
+  documents: Record<string, Record<string, unknown> | 404>,
+): (input: { url: string }) => Promise<McpOAuthMetadataFetchResult> {
+  return async ({ url }) => {
+    const document = documents[url] ?? 404;
+    return document === 404
+      ? { status: "absent", url, httpStatus: 404 }
+      : { status: "present", url, document };
+  };
+}
+
+function validateEndpoint(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "https:") throw new Error("OAuth endpoint must use https");
+  return url.toString();
+}
+
+function canonicalizeResource(rawResource: string): string {
+  const url = new URL(rawResource);
+  url.hash = "";
+  return url.toString();
+}
+
+const modernPrmUrl = "https://mcp.example.test/.well-known/oauth-protected-resource/v1/mcp";
+const modernAsMetadataUrl =
+  "https://auth.example.test/.well-known/oauth-authorization-server/tenant";
+const modernAs = {
+  issuer: "https://auth.example.test/tenant",
+  authorization_endpoint: "https://auth.example.test/authorize",
+  token_endpoint: "https://auth.example.test/token",
+  registration_endpoint: "https://auth.example.test/register",
+  code_challenge_methods_supported: ["S256"],
+};
+
+describe("MCP OAuth discovery", () => {
+  test("prefers RFC 9728 protected resource metadata and binds provenance", async () => {
+    const result = await resolveMcpOAuthDiscovery({
+      resourceUrl,
+      challenge: parseMcpOAuthChallenge(
+        `Bearer resource_metadata="${modernPrmUrl}", scope="documents:read"`,
+      ),
+      fetchMetadata: metadataFetcher({
+        [modernPrmUrl]: {
+          resource: "urn:example:mcp",
+          authorization_servers: ["https://auth.example.test/tenant"],
+          scopes_supported: ["documents:read"],
+        },
+        [modernAsMetadataUrl]: modernAs,
+      }),
+      validateEndpoint,
+      canonicalizeResource: (value) =>
+        value.startsWith("urn:") ? value : canonicalizeResource(value),
+    });
+
+    expect(result.mode).toBe("rfc9728_protected_resource");
+    expect(result.classification).toBe("oauth_rfc9728");
+    expect(result.resource).toBe("urn:example:mcp");
+    expect(result.provenance).toMatchObject({
+      protectedResourceMetadataUrl: modernPrmUrl,
+      authorizationServerMetadataUrl: modernAsMetadataUrl,
+    });
+    expect(result.provenance.metadataSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("uses same-origin legacy RFC 8414 metadata only after every PRM candidate is absent", async () => {
+    const legacyMetadataUrl = "https://mcp.example.test/.well-known/oauth-authorization-server";
+    const result = await resolveMcpOAuthDiscovery({
+      resourceUrl,
+      challenge: parseMcpOAuthChallenge('Bearer error="invalid_token", scope="documents:read"'),
+      fetchMetadata: metadataFetcher({
+        [legacyMetadataUrl]: {
+          issuer: "https://mcp.example.test",
+          authorization_endpoint: "https://mcp.example.test/authorize",
+          token_endpoint: "https://mcp.example.test/token",
+          registration_endpoint: "https://mcp.example.test/register",
+          code_challenge_methods_supported: ["S256"],
+        },
+      }),
+      validateEndpoint,
+      canonicalizeResource,
+    });
+
+    expect(result.mode).toBe("legacy_2025_03_26_metadata");
+    expect(result.classification).toBe("oauth_legacy_same_origin_metadata");
+    expect(result.resource).toBe(resourceUrl);
+    expect(result.protectedResourceMetadata.raw).toEqual({
+      resource: resourceUrl,
+      authorization_servers: ["https://mcp.example.test/"],
+      scopes_supported: ["documents:read"],
+    });
+    expect(result.provenance.protectedResourceMetadataUrl).toBeNull();
+  });
+
+  test("never downgrades an advertised but missing PRM document", async () => {
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge(`Bearer resource_metadata="${modernPrmUrl}"`),
+        fetchMetadata: metadataFetcher({
+          "https://mcp.example.test/.well-known/oauth-authorization-server": {
+            issuer: "https://mcp.example.test",
+            authorization_endpoint: "https://mcp.example.test/authorize",
+            token_endpoint: "https://mcp.example.test/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({
+      classification: "oauth_discovery_broken",
+      stage: "protected_resource_metadata",
+    });
+  });
+
+  test("treats malformed PRM as broken instead of trying legacy discovery", async () => {
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({
+          [modernPrmUrl]: { scopes_supported: ["documents:read"] },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toBeInstanceOf(McpOAuthDiscoveryError);
+  });
+
+  test("classifies absent legacy metadata as unverified default endpoints", async () => {
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({}),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({
+      classification: "oauth_legacy_default_endpoints_unverified",
+      stage: "authorization_server_metadata",
+    });
+  });
+
+  test("requires a profile for cross-origin legacy issuers and rejects issuer mismatches", async () => {
+    const legacyMetadataUrl = "https://mcp.example.test/.well-known/oauth-authorization-server";
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({
+          [legacyMetadataUrl]: {
+            issuer: "https://auth.example.test",
+            authorization_endpoint: "https://auth.example.test/authorize",
+            token_endpoint: "https://auth.example.test/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({ classification: "oauth_requires_profile" });
+
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({
+          [legacyMetadataUrl]: {
+            issuer: "https://mcp.example.test/other-issuer",
+            authorization_endpoint: "https://mcp.example.test/authorize",
+            token_endpoint: "https://mcp.example.test/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({ classification: "oauth_discovery_broken" });
+  });
+
+  test("rejects unsafe endpoints and missing S256", async () => {
+    const legacyMetadataUrl = "https://mcp.example.test/.well-known/oauth-authorization-server";
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({
+          [legacyMetadataUrl]: {
+            issuer: "https://mcp.example.test",
+            authorization_endpoint: "http://mcp.example.test/authorize",
+            token_endpoint: "https://mcp.example.test/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({ classification: "oauth_discovery_broken" });
+
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge("Bearer"),
+        fetchMetadata: metadataFetcher({
+          [legacyMetadataUrl]: {
+            issuer: "https://mcp.example.test",
+            authorization_endpoint: "https://mcp.example.test/authorize",
+            token_endpoint: "https://mcp.example.test/token",
+            code_challenge_methods_supported: ["plain"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({ classification: "oauth_discovery_broken" });
+  });
+});

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -53,6 +53,17 @@ describe("MCP OAuth discovery", () => {
         'Basic realm="mcp", OAuth scope="documents:read", Basic scope="must-not-leak"',
       ),
     ).toEqual({ scheme: "oauth", scope: ["documents:read"] });
+    expect(parseMcpOAuthChallenge('Basic realm="x, Bearer, y"')).toEqual({
+      scheme: null,
+      scope: [],
+    });
+    expect(parseMcpOAuthChallenge('Basic realm="x, OAuth scope=realm-value", Bearer')).toEqual({
+      scheme: "bearer",
+      scope: [],
+    });
+    expect(
+      parseMcpOAuthChallenge('Bearer error="unterminated, Basic realm=x, scope=must-not-leak'),
+    ).toEqual({ scheme: null, scope: [] });
   });
 
   test("prefers RFC 9728 protected resource metadata and binds provenance", async () => {

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -64,6 +64,20 @@ describe("MCP OAuth discovery", () => {
     expect(
       parseMcpOAuthChallenge('Bearer error="unterminated, Basic realm=x, scope=must-not-leak'),
     ).toEqual({ scheme: null, scope: [] });
+    expect(
+      parseMcpOAuthChallenge(
+        `Bearer, OAuth resource_metadata="${modernPrmUrl}", scope="documents:read"`,
+      ),
+    ).toEqual({
+      scheme: "oauth",
+      resourceMetadata: modernPrmUrl,
+      scope: ["documents:read"],
+    });
+    expect(parseMcpOAuthChallenge('Bearer, OAuth resource_metadata=""')).toEqual({
+      scheme: "oauth",
+      resourceMetadata: "",
+      scope: [],
+    });
   });
 
   test("prefers RFC 9728 protected resource metadata and binds provenance", async () => {
@@ -129,6 +143,26 @@ describe("MCP OAuth discovery", () => {
       resolveMcpOAuthDiscovery({
         resourceUrl,
         challenge: parseMcpOAuthChallenge(`Bearer resource_metadata="${modernPrmUrl}"`),
+        fetchMetadata: metadataFetcher({
+          "https://mcp.example.test/.well-known/oauth-authorization-server": {
+            issuer: "https://mcp.example.test",
+            authorization_endpoint: "https://mcp.example.test/authorize",
+            token_endpoint: "https://mcp.example.test/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        }),
+        validateEndpoint,
+        canonicalizeResource,
+      }),
+    ).rejects.toMatchObject({
+      classification: "oauth_discovery_broken",
+      stage: "protected_resource_metadata",
+    });
+
+    await expect(
+      resolveMcpOAuthDiscovery({
+        resourceUrl,
+        challenge: parseMcpOAuthChallenge('Bearer resource_metadata=""'),
         fetchMetadata: metadataFetcher({
           "https://mcp.example.test/.well-known/oauth-authorization-server": {
             issuer: "https://mcp.example.test",

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -78,6 +78,16 @@ describe("MCP OAuth discovery", () => {
       resourceMetadata: "",
       scope: [],
     });
+    for (const header of ["Bearer,", ", Bearer", "Bearer,,Basic"]) {
+      expect(parseMcpOAuthChallenge(header)).toEqual({ scheme: "bearer", scope: [] });
+    }
+    for (const header of ["Bearer resource_metadata=", "Bearer, resource_metadata="]) {
+      expect(parseMcpOAuthChallenge(header)).toEqual({
+        scheme: "bearer",
+        resourceMetadata: "",
+        scope: [],
+      });
+    }
   });
 
   test("prefers RFC 9728 protected resource metadata and binds provenance", async () => {
@@ -178,6 +188,28 @@ describe("MCP OAuth discovery", () => {
       classification: "oauth_discovery_broken",
       stage: "protected_resource_metadata",
     });
+
+    for (const header of ["Bearer resource_metadata=", "Bearer, resource_metadata="]) {
+      await expect(
+        resolveMcpOAuthDiscovery({
+          resourceUrl,
+          challenge: parseMcpOAuthChallenge(header),
+          fetchMetadata: metadataFetcher({
+            "https://mcp.example.test/.well-known/oauth-authorization-server": {
+              issuer: "https://mcp.example.test",
+              authorization_endpoint: "https://mcp.example.test/authorize",
+              token_endpoint: "https://mcp.example.test/token",
+              code_challenge_methods_supported: ["S256"],
+            },
+          }),
+          validateEndpoint,
+          canonicalizeResource,
+        }),
+      ).rejects.toMatchObject({
+        classification: "oauth_discovery_broken",
+        stage: "protected_resource_metadata",
+      });
+    }
   });
 
   test("treats malformed PRM as broken instead of trying legacy discovery", async () => {

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -43,6 +43,18 @@ const modernAs = {
 };
 
 describe("MCP OAuth discovery", () => {
+  test("parses parameterless challenges and stops before the next auth scheme", () => {
+    expect(parseMcpOAuthChallenge('Bearer, Basic scope="must-not-leak"')).toEqual({
+      scheme: "bearer",
+      scope: [],
+    });
+    expect(
+      parseMcpOAuthChallenge(
+        'Basic realm="mcp", OAuth scope="documents:read", Basic scope="must-not-leak"',
+      ),
+    ).toEqual({ scheme: "oauth", scope: ["documents:read"] });
+  });
+
   test("prefers RFC 9728 protected resource metadata and binds provenance", async () => {
     const result = await resolveMcpOAuthDiscovery({
       resourceUrl,

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -1137,6 +1137,49 @@ describe("integrations.sh MCP endpoint probe", () => {
       },
     });
     expect(timedOut).toMatchObject({ status: "unverified", reason: "timeout" });
+
+    const normalized = normalizeCatalogSnapshot(
+      {
+        generatedAt: "2026-09-03T00:00:00.000Z",
+        importRows: [
+          row({ domain: "rate-limited.example", mcpUrl: "https://rate-limited.example/mcp" }),
+        ],
+      },
+      { allowUnprobedCandidates: true },
+    );
+    const attempts = new Map<string, number>();
+    const sleeps: number[] = [];
+    const retried = await probeCatalogSnapshot(normalized, {
+      concurrency: 1,
+      transientRetries: 1,
+      transientRetryDelayMs: 10,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      fetchImpl: async (input) => {
+        const url = String(input);
+        const attempt = (attempts.get(url) ?? 0) + 1;
+        attempts.set(url, attempt);
+        if (url === "https://rate-limited.example/mcp") {
+          return new Response("Unauthorized", {
+            status: 401,
+            headers: { "www-authenticate": "Bearer" },
+          });
+        }
+        if (url === "https://rate-limited.example/.well-known/oauth-authorization-server") {
+          return new Response(attempt === 1 ? "rate limited" : "not found", {
+            status: attempt === 1 ? 429 : 404,
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    expect(retried.rows.map((candidate) => candidate.domain)).toEqual(["rate-limited.example"]);
+    expect(attempts.get("https://rate-limited.example/mcp")).toBe(2);
+    expect(
+      attempts.get("https://rate-limited.example/.well-known/oauth-authorization-server"),
+    ).toBe(2);
+    expect(sleeps).toEqual([10]);
   });
 
   test("classifies 404s, HTML, generic JSON, and DNS failures as junk", async () => {

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -1078,6 +1078,67 @@ describe("integrations.sh MCP endpoint probe", () => {
     ).resolves.toMatchObject({ oauthDiscovery: "oauth_discovery_broken" });
   });
 
+  test("keeps unsafe metadata blocked and transient metadata failures retryable", async () => {
+    const unsafeCalls: string[] = [];
+    const unsafe = await probeMcpEndpoint("https://unsafe.example/mcp", {
+      fetchImpl: async (input) => {
+        const url = String(input);
+        unsafeCalls.push(url);
+        if (url === "https://unsafe.example/mcp") {
+          return new Response("Unauthorized", {
+            status: 401,
+            headers: {
+              "www-authenticate":
+                'Bearer resource_metadata="http://127.0.0.1/.well-known/oauth-protected-resource"',
+            },
+          });
+        }
+        throw new Error("unsafe metadata URL must not be fetched");
+      },
+    });
+    expect(unsafe).toMatchObject({
+      status: "real",
+      reason: "auth_challenge",
+      oauthDiscovery: "oauth_discovery_broken",
+    });
+    expect(unsafeCalls).toEqual(["https://unsafe.example/mcp"]);
+
+    const unavailable = await probeMcpEndpoint("https://unavailable.example/mcp", {
+      fetchImpl: async (input) =>
+        String(input) === "https://unavailable.example/mcp"
+          ? new Response("Unauthorized", {
+              status: 401,
+              headers: { "www-authenticate": "Bearer" },
+            })
+          : new Response("unavailable", { status: 503 }),
+    });
+    expect(unavailable).toMatchObject({
+      status: "unverified",
+      reason: "http_status",
+      httpStatus: 503,
+    });
+
+    const timedOut = await probeMcpEndpoint("https://timeout.example/mcp", {
+      timeoutMs: 10,
+      fetchImpl: async (input, init) => {
+        if (String(input) === "https://timeout.example/mcp") {
+          return new Response("Unauthorized", {
+            status: 401,
+            headers: { "www-authenticate": "Bearer" },
+          });
+        }
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+    expect(timedOut).toMatchObject({ status: "unverified", reason: "timeout" });
+  });
+
   test("classifies 404s, HTML, generic JSON, and DNS failures as junk", async () => {
     await expect(
       probeMcpEndpoint("https://missing.example/mcp", {
@@ -1230,7 +1291,7 @@ describe("integrations.sh MCP endpoint probe", () => {
         const url = String(input);
         const attempt = (attempts.get(url) ?? 0) + 1;
         attempts.set(url, attempt);
-        if (url.includes("flaky.example")) {
+        if (url === "https://flaky.example/mcp") {
           if (attempt === 1) {
             throw new Error("getaddrinfo EAI_AGAIN flaky.example");
           }
@@ -1239,7 +1300,7 @@ describe("integrations.sh MCP endpoint probe", () => {
             headers: { "www-authenticate": 'Bearer realm="mcp"' },
           });
         }
-        if (url.includes("dead.example")) {
+        if (url === "https://dead.example/mcp") {
           throw new Error("connect ECONNREFUSED");
         }
         return new Response("not found", { status: 404 });
@@ -1248,6 +1309,7 @@ describe("integrations.sh MCP endpoint probe", () => {
 
     expect(probed.rows.map((candidate) => candidate.domain)).toEqual(["flaky.example"]);
     expect(attempts.get("https://flaky.example/mcp")).toBe(2);
+    expect(attempts.get("https://flaky.example/.well-known/oauth-authorization-server")).toBe(1);
     expect(attempts.get("https://dead.example/mcp")).toBe(3);
     // A definitive 404 is not transient and is never retried.
     expect(attempts.get("https://gone.example/mcp")).toBe(1);

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { DestinationPolicyError } from "../packages/network/src/index";
 import {
   CATALOG_IMPORT_SEMANTIC_VERSION,
   catalogCapabilityId,
@@ -1180,6 +1181,51 @@ describe("integrations.sh MCP endpoint probe", () => {
       attempts.get("https://rate-limited.example/.well-known/oauth-authorization-server"),
     ).toBe(2);
     expect(sleeps).toEqual([10]);
+
+    for (const dnsReason of ["dns_failed", "dns_empty"] as const) {
+      const domain = dnsReason.replace("_", "-") + ".example";
+      const mcpUrl = `https://${domain}/mcp`;
+      const metadataUrl = `https://${domain}/.well-known/oauth-protected-resource/mcp`;
+      const dnsNormalized = normalizeCatalogSnapshot(
+        {
+          generatedAt: "2026-09-03T00:00:00.000Z",
+          importRows: [row({ domain, mcpUrl })],
+        },
+        { allowUnprobedCandidates: true },
+      );
+      const dnsAttempts = new Map<string, number>();
+      const dnsSleeps: number[] = [];
+      const dnsRetried = await probeCatalogSnapshot(dnsNormalized, {
+        concurrency: 1,
+        transientRetries: 1,
+        transientRetryDelayMs: 10,
+        sleep: async (ms) => {
+          dnsSleeps.push(ms);
+        },
+        fetchImpl: async (input) => {
+          const url = String(input);
+          const attempt = (dnsAttempts.get(url) ?? 0) + 1;
+          dnsAttempts.set(url, attempt);
+          if (url === mcpUrl) {
+            return new Response("Unauthorized", {
+              status: 401,
+              headers: { "www-authenticate": "Bearer" },
+            });
+          }
+          if (url === metadataUrl && attempt === 1) {
+            throw new DestinationPolicyError(
+              dnsReason,
+              `catalog OAuth metadata hostname returned ${dnsReason}`,
+            );
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      expect(dnsRetried.rows.map((candidate) => candidate.domain)).toEqual([domain]);
+      expect(dnsAttempts.get(mcpUrl)).toBe(2);
+      expect(dnsAttempts.get(metadataUrl)).toBe(2);
+      expect(dnsSleeps).toEqual([10]);
+    }
   });
 
   test("classifies 404s, HTML, generic JSON, and DNS failures as junk", async () => {

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -993,7 +993,89 @@ describe("integrations.sh MCP endpoint probe", () => {
       status: "real",
       reason: "auth_challenge",
       httpStatus: 401,
+      oauthDiscovery: "oauth_discovery_broken",
     });
+  });
+
+  test("classifies OAuth challenges with the shared runtime discovery resolver", async () => {
+    const probe = async (
+      mcpUrl: string,
+      challenge: string,
+      responses: Record<string, { status?: number; body?: Record<string, unknown> }>,
+    ) =>
+      await probeMcpEndpoint(mcpUrl, {
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url === mcpUrl) {
+            return new Response("Unauthorized", {
+              status: 401,
+              headers: { "www-authenticate": challenge },
+            });
+          }
+          const response = responses[url];
+          if (!response) return new Response("not found", { status: 404 });
+          return response.body
+            ? Response.json(response.body, { status: response.status ?? 200 })
+            : new Response("not found", { status: response.status ?? 404 });
+        },
+      });
+
+    await expect(
+      probe("https://modern.example/mcp", 'Bearer resource_metadata="https://modern.example/prm"', {
+        "https://modern.example/prm": {
+          body: {
+            resource: "urn:modern:mcp",
+            authorization_servers: ["https://auth.modern.example/tenant"],
+          },
+        },
+        "https://auth.modern.example/.well-known/oauth-authorization-server/tenant": {
+          body: {
+            issuer: "https://auth.modern.example/tenant",
+            authorization_endpoint: "https://auth.modern.example/authorize",
+            token_endpoint: "https://auth.modern.example/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ oauthDiscovery: "oauth_rfc9728" });
+
+    await expect(
+      probe("https://legacy.example/mcp", 'Bearer error="invalid_token"', {
+        "https://legacy.example/.well-known/oauth-authorization-server": {
+          body: {
+            issuer: "https://legacy.example",
+            authorization_endpoint: "https://legacy.example/authorize",
+            token_endpoint: "https://legacy.example/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ oauthDiscovery: "oauth_legacy_same_origin_metadata" });
+
+    await expect(probe("https://defaults.example/mcp", "Bearer", {})).resolves.toMatchObject({
+      oauthDiscovery: "oauth_legacy_default_endpoints_unverified",
+    });
+
+    await expect(
+      probe("https://profile.example/mcp", "Bearer", {
+        "https://profile.example/.well-known/oauth-authorization-server": {
+          body: {
+            issuer: "https://auth.profile.example",
+            authorization_endpoint: "https://auth.profile.example/authorize",
+            token_endpoint: "https://auth.profile.example/token",
+            code_challenge_methods_supported: ["S256"],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ oauthDiscovery: "oauth_requires_profile" });
+
+    await expect(
+      probe("https://broken.example/mcp", 'Bearer resource_metadata="https://broken.example/prm"', {
+        "https://broken.example/prm": {
+          body: { scopes_supported: ["documents:read"] },
+        },
+      }),
+    ).resolves.toMatchObject({ oauthDiscovery: "oauth_discovery_broken" });
   });
 
   test("classifies 404s, HTML, generic JSON, and DNS failures as junk", async () => {

--- a/scripts/integrations-catalog-probe.ts
+++ b/scripts/integrations-catalog-probe.ts
@@ -2,6 +2,16 @@ import type {
   CatalogIntegrationRow,
   NormalizedCatalogSnapshot,
 } from "./import-integrations-catalog";
+import {
+  McpOAuthDiscoveryError,
+  OAUTH_MAX_RESPONSE_BYTES,
+  parseMcpOAuthChallenge,
+  readResponseJsonBounded,
+  resolveMcpOAuthDiscovery,
+  validateHttpUrl,
+  type McpOAuthDiscoveryClassification,
+  type McpOAuthMetadataFetchResult,
+} from "../packages/network/src/index";
 
 export type CatalogProbeStatus = "real" | "junk" | "unverified";
 export type CatalogProbeReason =
@@ -21,6 +31,7 @@ export type CatalogProbeOutcome = {
   reason: CatalogProbeReason;
   httpStatus?: number;
   detail?: string;
+  oauthDiscovery?: McpOAuthDiscoveryClassification;
 };
 
 export type CatalogProbeFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
@@ -204,7 +215,28 @@ export async function probeMcpEndpoint(
       }),
       signal: controller.signal,
     });
-    return classifyProbeResponse(response, await safeResponseText(response));
+    const outcome = classifyProbeResponse(response, await safeResponseText(response));
+    if (outcome.reason !== "auth_challenge") {
+      return outcome;
+    }
+    const challenge = parseMcpOAuthChallenge(response.headers.get("www-authenticate"));
+    try {
+      const discovery = await resolveMcpOAuthDiscovery({
+        resourceUrl: url,
+        challenge,
+        fetchMetadata: ({ url: metadataUrl }) =>
+          fetchCatalogOAuthMetadata(metadataUrl, fetchImpl, controller.signal),
+        validateEndpoint: (rawUrl, label) => validateHttpUrl(rawUrl, { label }),
+        canonicalizeResource: canonicalCatalogOAuthResource,
+      });
+      return { ...outcome, oauthDiscovery: discovery.classification };
+    } catch (error) {
+      return {
+        ...outcome,
+        oauthDiscovery:
+          error instanceof McpOAuthDiscoveryError ? error.classification : "oauth_discovery_broken",
+      };
+    }
   } catch (error) {
     if (isAbortError(error)) {
       return { status: "unverified", reason: "timeout" };
@@ -221,7 +253,10 @@ export async function probeMcpEndpoint(
 
 export function classifyProbeResponse(response: Response, body: string): CatalogProbeOutcome {
   const httpStatus = response.status;
-  if ((httpStatus === 401 || httpStatus === 403) && hasAuthChallenge(response.headers)) {
+  if (
+    (httpStatus === 401 || httpStatus === 403) &&
+    parseMcpOAuthChallenge(response.headers.get("www-authenticate")).scheme
+  ) {
     return { status: "real", reason: "auth_challenge", httpStatus };
   }
   if (httpStatus === 404 || httpStatus === 410) {
@@ -268,8 +303,56 @@ function withProbeMetadata(
             status: outcome.status,
             reason: outcome.reason,
             httpStatus: outcome.httpStatus ?? null,
+            ...(outcome.oauthDiscovery ? { oauthDiscovery: outcome.oauthDiscovery } : {}),
           },
   };
+}
+
+async function fetchCatalogOAuthMetadata(
+  url: string,
+  fetchImpl: CatalogProbeFetch,
+  signal: AbortSignal,
+): Promise<McpOAuthMetadataFetchResult> {
+  const response = await fetchImpl(url, {
+    headers: { accept: "application/json" },
+    signal,
+  });
+  if (response.status === 404 || response.status === 410) {
+    await response.body?.cancel().catch(() => undefined);
+    return { status: "absent", url, httpStatus: response.status };
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`OAuth metadata endpoint returned HTTP ${response.status}`);
+  }
+  const payload = await readResponseJsonBounded<unknown>(
+    response,
+    OAUTH_MAX_RESPONSE_BYTES,
+    "catalog OAuth metadata response",
+    { signal },
+  );
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("catalog OAuth metadata response was not a JSON object");
+  }
+  return { status: "present", url, document: payload as Record<string, unknown> };
+}
+
+function canonicalCatalogOAuthResource(rawResource: string): string {
+  const trimmed = rawResource.trim();
+  if (!trimmed) throw new Error("OAuth resource was empty");
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.hash = "";
+      return validateHttpUrl(url.toString(), { label: "OAuth resource" });
+    }
+    return trimmed;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error("OAuth resource was invalid", { cause: error });
+    }
+    throw error;
+  }
 }
 
 async function safeResponseText(response: Response): Promise<string> {
@@ -278,10 +361,6 @@ async function safeResponseText(response: Response): Promise<string> {
   } catch {
     return "";
   }
-}
-
-function hasAuthChallenge(headers: Headers): boolean {
-  return !!(headers.get("www-authenticate") || headers.get("www-authenticate".toLowerCase()));
 }
 
 function looksLikeSse(text: string): boolean {

--- a/scripts/integrations-catalog-probe.ts
+++ b/scripts/integrations-catalog-probe.ts
@@ -22,6 +22,7 @@ export type CatalogProbeReason =
   | "auth_challenge"
   | "http_not_found"
   | "connection_error"
+  | "rate_limited"
   | "timeout"
   | "html_response"
   | "non_mcp_json"
@@ -45,7 +46,7 @@ export type ProbeCatalogOptions = {
   overallBudgetMs?: number;
   now?: () => number;
   /**
-   * Extra attempts for a transient outcome (connection error, timeout, 5xx).
+   * Extra attempts for a transient outcome (connection error, timeout, rate limit, 5xx).
    * A live endpoint that flakes once under probe concurrency must not be
    * evicted from the snapshot on that single observation.
    */
@@ -76,7 +77,11 @@ export function isTransientProbeOutcome(outcome: CatalogProbeOutcome): boolean {
   if (outcome.status === "real") {
     return false;
   }
-  if (outcome.reason === "connection_error" || outcome.reason === "timeout") {
+  if (
+    outcome.reason === "connection_error" ||
+    outcome.reason === "rate_limited" ||
+    outcome.reason === "timeout"
+  ) {
     return true;
   }
   return outcome.reason === "http_status" && (outcome.httpStatus ?? 0) >= 500;
@@ -256,7 +261,7 @@ export async function probeMcpEndpoint(
     if (error instanceof CatalogOAuthMetadataTransientError) {
       return {
         status: "unverified",
-        reason: "http_status",
+        reason: error.httpStatus === 429 ? "rate_limited" : "http_status",
         httpStatus: error.httpStatus,
       };
     }

--- a/scripts/integrations-catalog-probe.ts
+++ b/scripts/integrations-catalog-probe.ts
@@ -242,6 +242,12 @@ export async function probeMcpEndpoint(
       if (!(error instanceof McpOAuthDiscoveryError)) {
         if (error instanceof CatalogOAuthMetadataTransientError) throw error;
         if (
+          error instanceof DestinationPolicyError &&
+          (error.reason === "dns_failed" || error.reason === "dns_empty")
+        ) {
+          throw error;
+        }
+        if (
           !(error instanceof CatalogOAuthMetadataBrokenError) &&
           !(error instanceof DestinationPolicyError)
         ) {

--- a/scripts/integrations-catalog-probe.ts
+++ b/scripts/integrations-catalog-probe.ts
@@ -3,9 +3,11 @@ import type {
   NormalizedCatalogSnapshot,
 } from "./import-integrations-catalog";
 import {
+  DestinationPolicyError,
   McpOAuthDiscoveryError,
   OAUTH_MAX_RESPONSE_BYTES,
   parseMcpOAuthChallenge,
+  pinnedFetch,
   readResponseJsonBounded,
   resolveMcpOAuthDiscovery,
   validateHttpUrl,
@@ -231,6 +233,16 @@ export async function probeMcpEndpoint(
       });
       return { ...outcome, oauthDiscovery: discovery.classification };
     } catch (error) {
+      if (controller.signal.aborted || isAbortError(error)) throw error;
+      if (!(error instanceof McpOAuthDiscoveryError)) {
+        if (error instanceof CatalogOAuthMetadataTransientError) throw error;
+        if (
+          !(error instanceof CatalogOAuthMetadataBrokenError) &&
+          !(error instanceof DestinationPolicyError)
+        ) {
+          throw error;
+        }
+      }
       return {
         ...outcome,
         oauthDiscovery:
@@ -238,8 +250,15 @@ export async function probeMcpEndpoint(
       };
     }
   } catch (error) {
-    if (isAbortError(error)) {
+    if (controller.signal.aborted || isAbortError(error)) {
       return { status: "unverified", reason: "timeout" };
+    }
+    if (error instanceof CatalogOAuthMetadataTransientError) {
+      return {
+        status: "unverified",
+        reason: "http_status",
+        httpStatus: error.httpStatus,
+      };
     }
     return {
       status: "junk",
@@ -313,28 +332,108 @@ async function fetchCatalogOAuthMetadata(
   fetchImpl: CatalogProbeFetch,
   signal: AbortSignal,
 ): Promise<McpOAuthMetadataFetchResult> {
-  const response = await fetchImpl(url, {
-    headers: { accept: "application/json" },
-    signal,
-  });
+  const response = await fetchCatalogOAuthResponse(url, fetchImpl, signal);
   if (response.status === 404 || response.status === 410) {
     await response.body?.cancel().catch(() => undefined);
     return { status: "absent", url, httpStatus: response.status };
   }
   if (!response.ok) {
     await response.body?.cancel().catch(() => undefined);
-    throw new Error(`OAuth metadata endpoint returned HTTP ${response.status}`);
+    const message = `OAuth metadata endpoint returned HTTP ${response.status}`;
+    if (response.status === 429 || response.status >= 500) {
+      throw new CatalogOAuthMetadataTransientError(message, response.status);
+    }
+    throw new CatalogOAuthMetadataBrokenError(message);
   }
-  const payload = await readResponseJsonBounded<unknown>(
-    response,
-    OAUTH_MAX_RESPONSE_BYTES,
-    "catalog OAuth metadata response",
-    { signal },
-  );
+  let payload: unknown;
+  try {
+    payload = await readResponseJsonBounded<unknown>(
+      response,
+      OAUTH_MAX_RESPONSE_BYTES,
+      "catalog OAuth metadata response",
+      { signal },
+    );
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) throw error;
+    throw new CatalogOAuthMetadataBrokenError("catalog OAuth metadata response was invalid", {
+      cause: error,
+    });
+  }
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new Error("catalog OAuth metadata response was not a JSON object");
+    throw new CatalogOAuthMetadataBrokenError(
+      "catalog OAuth metadata response was not a JSON object",
+    );
   }
   return { status: "present", url, document: payload as Record<string, unknown> };
+}
+
+async function fetchCatalogOAuthResponse(
+  rawUrl: string,
+  fetchImpl: CatalogProbeFetch,
+  signal: AbortSignal,
+  hop = 0,
+): Promise<Response> {
+  const url = validateHttpUrl(rawUrl, { label: "catalog OAuth metadata" });
+  const init: RequestInit = {
+    headers: { accept: "application/json" },
+    signal,
+    redirect: "manual",
+  };
+  const response =
+    fetchImpl === fetch
+      ? await pinnedFetch(
+          url,
+          init,
+          { environment: "production", integrationsAllowPrivateNetworkTargets: false },
+          {
+            label: "catalog OAuth metadata",
+            requireHttpsOutsideLocalTest: true,
+          },
+        )
+      : await fetchImpl(url, init);
+  if (response.status < 300 || response.status >= 400) return response;
+  if (hop >= 3) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new CatalogOAuthMetadataBrokenError(
+      "catalog OAuth metadata exceeded maximum redirect hops",
+    );
+  }
+  const location = response.headers.get("location");
+  if (!location) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new CatalogOAuthMetadataBrokenError(
+      "catalog OAuth metadata redirect was missing Location",
+    );
+  }
+  let nextUrl: string;
+  try {
+    nextUrl = new URL(location, url).toString();
+  } catch (error) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new CatalogOAuthMetadataBrokenError(
+      "catalog OAuth metadata redirect Location was invalid",
+      { cause: error },
+    );
+  }
+  await response.body?.cancel().catch(() => undefined);
+  return await fetchCatalogOAuthResponse(nextUrl, fetchImpl, signal, hop + 1);
+}
+
+class CatalogOAuthMetadataBrokenError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CatalogOAuthMetadataBrokenError";
+  }
+}
+
+class CatalogOAuthMetadataTransientError extends Error {
+  constructor(
+    message: string,
+    readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "CatalogOAuthMetadataTransientError";
+  }
 }
 
 function canonicalCatalogOAuthResource(rawResource: string): string {


### PR DESCRIPTION
## Summary

- add one shared MCP OAuth discovery resolver for runtime and catalog diagnostics
- prefer RFC 9728 Protected Resource Metadata and allow the 2025-03-26 same-origin RFC 8414 fallback only after every PRM candidate is explicitly absent
- bind discovery mode, issuer, resource, and metadata provenance in signed OAuth state; omit RFC 8707 `resource` in legacy mode
- classify catalog OAuth challenges as modern, safe legacy, unverified default endpoints, profile-required, or broken

## Safety

Malformed, unreachable, unsafe, contradictory, or advertised-but-missing PRM never downgrades to legacy. The fallback retains existing HTTPS, redirect, DNS/IP/SSRF, S256, DCR/CIMD, operator-client, and provider-profile controls and automatically admits only same-origin issuers.

## Validation

- `bun test packages/network/test/mcp-oauth-discovery.test.ts packages/network/test/index.test.ts`
- `bun test scripts/import-integrations-catalog.test.ts`
- `bun test --timeout 120000 apps/api/test/connections-routes.test.ts -t "oauth|OAuth"`
- `bun run typecheck` in `packages/network` and `apps/api`
- changed-file oxlint and oxfmt checks
- docs-reference and public-repository hygiene checks

Closes #2191

Responsible session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/1c7d1a07-58e9-4d94-b8ac-eecf09a1d133

## Summary by Sourcery

Add fail-closed legacy MCP OAuth discovery with shared runtime and catalog diagnostics while preserving modern PRM and OAuth security controls.

New Features:
- Support safe same-origin legacy MCP OAuth discovery using RFC 8414 metadata when all RFC 9728 Protected Resource Metadata candidates are explicitly absent.
- Expose shared MCP OAuth discovery resolution and diagnostic classifications for runtime connections and catalog probing.

Bug Fixes:
- Prevent malformed, unsafe, unreachable, contradictory, or advertised-but-missing protected resource metadata from silently downgrading to legacy discovery.
- Preserve OAuth discovery mode, resource, issuer, and metadata provenance across signed OAuth state and callbacks.

Enhancements:
- Omit RFC 8707 resource parameters for legacy MCP OAuth flows while retaining them for modern PRM-based flows.
- Classify catalog OAuth endpoints as modern, safe legacy, unverified defaults, profile-required, or broken while retaining retry handling for transient failures.

Documentation:
- Document the current MCP OAuth profile, legacy compatibility rules, discovery safety requirements, and catalog diagnostics.

Tests:
- Add coverage for shared discovery resolution, challenge parsing, legacy fallback safety, provenance, catalog classifications, redirects, retries, and runtime OAuth start/callback behavior.