### PR TITLE
feat(codex): add GPT-6 Astra subscription model

### DIFF
--- a/.changeset/codex-gpt6-astra.md
+++ b/.changeset/codex-gpt6-astra.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/codex": patch
+"@opengeni/config": patch
+---
+
+Add GPT-6 Astra to the static Codex subscription catalog using the current Codex client version and the existing 272k context policy.

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -7,7 +7,7 @@
 // is added to isAuthExempt. Secrets never leave the server: status/usage read the
 // decrypted token only to call the codex backend; the token is never returned.
 
-import { environmentsEncryptionKeyBytes } from "@opengeni/config";
+import { environmentsEncryptionKeyBytes, productLabelForModelId } from "@opengeni/config";
 import {
   accessTokenExpiry,
   buildCodexUsageWindowFromCache,
@@ -193,21 +193,16 @@ function codexUsageJson(payload: CodexUsagePayload): {
   return { status: payload.status, usage: payload };
 }
 
-export function codexModelsForPicker(liveSlugs: readonly string[]): Array<{
+export function codexModelsForPicker(): Array<{
   id: string;
   label: string;
   provider: string;
   providerLabel: string;
   api: "responses";
 }> {
-  const available = new Set(liveSlugs);
-  const missing = CODEX_FALLBACK_MODEL_SLUGS.filter((slug) => !available.has(slug));
-  if (missing.length > 0) {
-    throw new Error(`Codex catalog is missing required models: ${missing.join(", ")}`);
-  }
   return CODEX_FALLBACK_MODEL_SLUGS.map((slug) => ({
     id: `${CODEX_MODEL_ID_PREFIX}${slug}`,
-    label: slug.replace(/^gpt-/, "GPT-"),
+    label: productLabelForModelId(slug),
     provider: CODEX_PROVIDER_ID,
     providerLabel: CODEX_PROVIDER_LABEL,
     api: "responses" as const,
@@ -1287,7 +1282,7 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       now: new Date(),
     });
     let valid = false;
-    let models: ReturnType<typeof codexModelsForPicker> = [];
+    const models = codexModelsForPicker();
     let catalogError: string | null = null;
     try {
       const cred = status?.credentialId
@@ -1301,7 +1296,6 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
           clientVersion: CODEX_CLIENT_VERSION,
         });
         if (live.ok) {
-          models = codexModelsForPicker(live.slugs);
           valid = true;
         } else {
           catalogError = `Codex models request failed with status ${live.status}`;

--- a/apps/api/test/codex-model-catalog.test.ts
+++ b/apps/api/test/codex-model-catalog.test.ts
@@ -2,30 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { codexModelsForPicker } from "../src/routes/codex";
 
 describe("Codex model catalog", () => {
-  const expected = ["codex/gpt-5.6-sol", "codex/gpt-5.6-terra", "codex/gpt-5.6-luna"];
+  const expected = [
+    "codex/gpt-5.6-sol",
+    "codex/gpt-5.6-terra",
+    "codex/gpt-5.6-luna",
+    "codex/gpt-6-astra",
+  ];
 
-  test("keeps exactly the three exact GPT-5.6 slugs from a broader live catalog", () => {
-    const models = codexModelsForPicker([
-      "gpt-5.6-luna",
-      "gpt-5.5",
-      "gpt-5.6-sol",
-      "gpt-5.4",
-      "gpt-5.6-terra",
-      "gpt-5.4-mini",
-      "gpt-5.3-codex-spark",
-      "codex-auto-review",
-    ]);
+  test("always returns the static approved catalog including Astra", () => {
+    const models = codexModelsForPicker();
 
     expect(models.map((model) => model.id)).toEqual(expected);
-  });
-
-  test("an unrelated catalog fails closed instead of exposing older models", () => {
-    expect(() =>
-      codexModelsForPicker(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "codex-auto-review"]),
-    ).toThrow("Codex catalog is missing required models");
-  });
-
-  test("an empty live catalog fails closed", () => {
-    expect(() => codexModelsForPicker([])).toThrow("Codex catalog is missing required models");
+    expect(models.at(-1)?.label).toBe("GPT-6 Astra");
   });
 });

--- a/apps/api/test/codex-realtime.test.ts
+++ b/apps/api/test/codex-realtime.test.ts
@@ -89,7 +89,7 @@ describe("session Codex realtime broker", () => {
     expect(capturedAuth?.accessToken).toBe(BEARER_DEFAULT);
     expect(capturedAuth?.chatgptAccountId).toBe("account-bound");
     expect(capturedAuth?.isFedramp).toBe(true);
-    expect(capturedAuth?.clientVersion).toBe("0.145.0");
+    expect(capturedAuth?.clientVersion).toBe("0.153.2");
     expect(capturedInput).toEqual({
       ...request,
       sessionId: "session-one",

--- a/apps/api/test/codex-routes.test.ts
+++ b/apps/api/test/codex-routes.test.ts
@@ -182,6 +182,12 @@ describe("Codex status readiness semantics", () => {
         chatgptAccountId: active.chatgptAccountId,
       },
       accountCount: 1,
+      models: [
+        { id: "codex/gpt-5.6-sol" },
+        { id: "codex/gpt-5.6-terra" },
+        { id: "codex/gpt-5.6-luna" },
+        { id: "codex/gpt-6-astra", label: "GPT-6 Astra" },
+      ],
     });
   });
 });

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -25,14 +25,19 @@ export const CODEX_PROVIDER_ID = "codex-subscription";
 export const CODEX_PROVIDER_BASE_URL = "https://chatgpt.com/backend-api";
 export const CODEX_MODEL_ID_PREFIX = "codex/";
 
-// The only Codex subscription models OpenGeni exposes. The live GET /models
-// catalog must contain every exact slug; older or internal models never broaden
-// this product allowlist.
-export const CODEX_FALLBACK_MODEL_SLUGS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
+// The only Codex subscription models OpenGeni exposes. Astra is deliberately
+// pre-advertised before an account receives provider rollout access so the
+// picker becomes runnable without another OpenGeni release once access arrives.
+// Older or internal live models never broaden this product allowlist.
+export const CODEX_FALLBACK_MODEL_SLUGS = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-6-astra",
+] as const;
 
-// Live Codex model-catalog values for every exposed gpt-5.6 subscription slug.
-// Verified 2026-07-18 against Codex CLI 0.144.6's freshly fetched
-// ~/.codex/models_cache.json and the matching openai/codex core derivations:
+// Live Codex model-catalog values for every exposed subscription slug.
+// Verified 2026-09-04 against Codex CLI 0.153.2's bundled model catalog:
 //   raw context window                = 272,000
 //   effective input window (95%)      = 258,400
 //   automatic compaction limit (90%)  = 244,800
@@ -49,10 +54,10 @@ export const CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT = Math.floor(
 );
 
 // Sent as the `version` header and inside the User-Agent. Staging-proven on
-// 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models, while the
-// official Codex 0.144.0+ releases return all three exact slugs above. Keep
-// this pinned to the latest stable Codex release we have verified end-to-end.
-export const CODEX_CLIENT_VERSION = "0.145.0";
+// 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models. Keep this
+// pinned to the latest stable Codex release whose bundled catalog and transport
+// contract have been reviewed here.
+export const CODEX_CLIENT_VERSION = "0.153.2";
 
 // Public OpenGeni selector for native ChatGPT/Codex subscription WebRTC. This
 // remains stable for persisted sessions; the provider's remotely configured

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4184,6 +4184,8 @@ export function productShortLabelForModelId(modelId: string): string | null {
       return "5.6 Terra";
     case "gpt-5.6-luna":
       return "5.6 Luna";
+    case "gpt-6-astra":
+      return "6 Astra";
     default:
       return null;
   }
@@ -4219,7 +4221,11 @@ function builtinLatencyModesForModel(modelId: string): Array<{
   runnable: boolean;
   billingMultiplierBps?: number;
 }> {
-  if (isBuiltinGpt56ModelId(modelId) || modelId.startsWith("codex/gpt-5.6-")) {
+  if (
+    isBuiltinGpt56ModelId(modelId) ||
+    modelId.startsWith("codex/gpt-5.6-") ||
+    modelId === "codex/gpt-6-astra"
+  ) {
     return [
       { id: "standard", upstream: "supported", runnable: true },
       {
@@ -4598,7 +4604,7 @@ export function withCodexCatalogProvider(settings: Settings): Settings {
         ...legacyModelCapabilities(settings, {
           reasoningEffort: true,
           hostedWebSearch: true,
-          vision: slug.startsWith("gpt-5.6-"),
+          vision: slug.startsWith("gpt-5.6-") || slug === "gpt-6-astra",
         }),
         ...(builtinPromptCachingForModel(`${CODEX_MODEL_ID_PREFIX}${slug}`)
           ? {

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -982,6 +982,8 @@ describe("productLabelForModelId", () => {
     expect(productLabelForModelId("gpt-5.6-sol")).toBe("GPT-5.6 Sol");
     expect(productLabelForModelId("codex/gpt-5.6-sol")).toBe("GPT-5.6 Sol");
     expect(productLabelForModelId("gpt-5.6-terra")).toBe("GPT-5.6 Terra");
+    expect(productLabelForModelId("gpt-6-astra")).toBe("GPT-6 Astra");
+    expect(productLabelForModelId("codex/gpt-6-astra")).toBe("GPT-6 Astra");
     expect(productLabelForModelId("gpt-5.4-mini")).toBe("GPT-5.4 Mini");
   });
 });
@@ -992,6 +994,7 @@ describe("productShortLabelForModelId", () => {
     expect(productShortLabelForModelId("codex/gpt-5.6-sol")).toBe("5.6 Sol");
     expect(productShortLabelForModelId("gpt-5.6-luna")).toBe("5.6 Luna");
     expect(productShortLabelForModelId("gpt-5.6-terra")).toBe("5.6 Terra");
+    expect(productShortLabelForModelId("codex/gpt-6-astra")).toBe("6 Astra");
     expect(productShortLabelForModelId("grok-4.6")).toBe("4.6");
     expect(productShortLabelForModelId("gpt-5.4-mini")).toBeNull();
   });
@@ -1102,6 +1105,19 @@ describe("configuredModels", () => {
     expect(
       models.find((model) => model.id === "codex/gpt-5.6-luna")?.capabilities.inputModalities,
     ).toEqual(["text", "image"]);
+    const astra = models.find((model) => model.id === "codex/gpt-6-astra");
+    expect(astra).toMatchObject({
+      label: "GPT-6 Astra",
+      shortLabel: "6 Astra",
+      contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
+      effectiveContextWindowTokens: CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
+      autoCompactTokenLimit: CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
+    });
+    expect(astra?.capabilities.latencyModes.map(({ id, runnable }) => ({ id, runnable }))).toEqual([
+      { id: "standard", runnable: true },
+      { id: "fast", runnable: true },
+    ]);
+    expect(astra?.capabilities.inputModalities).toEqual(["text", "image"]);
   });
 
   test("with no registry returns exactly the built-in allow-list, default model first", () => {


### PR DESCRIPTION
Connected Codex subscriptions do not currently offer GPT-6 Astra as a selectable model.

This adds `codex/gpt-6-astra` to the static approved subscription catalog, updates the Codex client version to 0.153.2, and uses the existing 272k Codex context policy. The model is visible before provider rollout reaches an account, so no later OpenGeni release is needed when access arrives.

Validation:
- `git diff --check`
- `bunx oxfmt --check` on all changed source and test files
- `bun test packages/config/test/model-providers.test.ts apps/api/test/codex-model-catalog.test.ts apps/api/test/codex-routes.test.ts apps/api/test/codex-realtime.test.ts` — 117 pass, 0 fail
- full repository validation delegated to required CI checks
