### PR TITLE
fix(worker): recover unsettled cancelled turns

### DIFF
--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -95,6 +95,14 @@ export function deferredResultMayContinue(entryWakeups: number, currentWakeups: 
   return currentWakeups !== entryWakeups;
 }
 
+/** A typed activity cancellation is recoverable unless its exact-attempt
+ * redispatch budget was atomically exhausted. */
+export function cancelledAttemptRecoveryMayContinue(
+  action: activities.RecoverDispatchResult["action"],
+): boolean {
+  return action !== "exceeded";
+}
+
 /**
  * Bound repeated failures that happen before an attempt row exists. The
  * activity mirrors this deterministic delay into the durable wake outbox, so
@@ -1093,8 +1101,28 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       return true;
     }
 
-    if (outcome.result.status === "failed" || outcome.result.status === "cancelled") {
-      return outcome.result.status === "cancelled";
+    if (outcome.result.status === "failed") {
+      return false;
+    }
+
+    if (outcome.result.status === "cancelled") {
+      // A typed cancellation is normally observed through the control-signal
+      // branch above, after Pause/Steer has durably fenced the attempt. A
+      // worker can nevertheless return the same shape after a shutdown or a
+      // stale settlement race without closing its attempt row. Blindly
+      // re-peeking then retries forever against `turn.status = running` and
+      // strands every later prompt. Reconcile the exact attempt through the
+      // same bounded, generation-fenced redispatch transaction used after an
+      // activity heartbeat loss. If the attempt actually settled meanwhile,
+      // the transaction is a stale no-op and the next peek observes truth.
+      const recovery = await activity.recoverDispatch({
+        accountId,
+        workspaceId,
+        sessionId,
+        attemptId: outcome.result.attemptId,
+        timeoutType: "HEARTBEAT",
+      });
+      return cancelledAttemptRecoveryMayContinue(recovery.action);
     }
 
     if (outcome.result.capacityWait) {

--- a/apps/worker/test/session-continuation-hold.test.ts
+++ b/apps/worker/test/session-continuation-hold.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import {
+  cancelledAttemptRecoveryMayContinue,
   continuationHoldMs,
   deferredResultMayContinue,
   humanInputDeadlineWaitMs,
   unclaimedAttemptRetryDelayMs,
   unclaimedAttemptWakeChanged,
 } from "../src/workflows/session";
+
+describe("cancelled activity result recovery", () => {
+  test("continues only while exact-attempt redispatch remains bounded", () => {
+    expect(cancelledAttemptRecoveryMayContinue("recovering")).toBe(true);
+    expect(cancelledAttemptRecoveryMayContinue("stale")).toBe(true);
+    expect(cancelledAttemptRecoveryMayContinue("unclaimed")).toBe(true);
+    expect(cancelledAttemptRecoveryMayContinue("exceeded")).toBe(false);
+  });
+});
 
 // P3 all-capped infinite-loop bugfix (fix #6). session.ts must treat a rotation
 // all-capped idle (`idleUntilReset`) as a MANDATORY hold: a 0/elapsed continueDelayMs


### PR DESCRIPTION
## Summary
- reconcile typed cancelled activity results through exact-attempt bounded redispatch
- prevent infinite `peekSessionWork` retry against a still-owned running turn
- preserve stale/settled cancellation races as no-op recovery

## Verification
- `bun test apps/worker/test/session-continuation-hold.test.ts`
- `bun run typecheck --project apps/worker`
- `git diff --check`

## Summary by Sourcery

Recover unsettled cancelled turns without allowing repeated peeks to retry indefinitely.

Bug Fixes:
- Recover typed cancelled activity results through bounded exact-attempt redispatch, preventing stuck running turns from blocking later prompts.
- Treat stale or already-settled cancellation races as no-op recovery while stopping retries when the redispatch budget is exhausted.

Tests:
- Add coverage for the bounded cancellation recovery decision.