### PR TITLE
fix(worker): version cancelled-attempt recovery

### DIFF
--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -350,6 +350,10 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
   const writerSetQuiescenceRecovery = patched("session-attempt-writer-set-quiescence-v1");
   const staleControlSignalIsOnlyWakeHint = patched("session-control-stale-wake-v1");
   const unclaimedAttemptRecovery = patched("session-unclaimed-attempt-recovery-v1");
+  // PR #2208 changed a typed-cancelled result from a plain re-peek into a
+  // recoverDispatch activity. Version that new command so histories which
+  // already recorded the legacy re-peek remain deterministic on replay.
+  const cancelledAttemptRecovery = patched("session-cancelled-attempt-recovery-v1");
   const turnActivity = turnActivityForTaskQueue(workflowInfo().taskQueue, receiptGatedCancellation);
   let approvalWakeups = 0;
   let interruptionWakeups = 0;
@@ -1106,6 +1110,11 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
     }
 
     if (outcome.result.status === "cancelled") {
+      // Histories created before session-cancelled-attempt-recovery-v1 must
+      // preserve the old command sequence. Their durable state is still safe:
+      // operator recovery or a later fresh workflow run can close a stranded
+      // owner, while new histories use the bounded exact-attempt transaction.
+      if (!cancelledAttemptRecovery) return true;
       // A typed cancellation is normally observed through the control-signal
       // branch above, after Pause/Steer has durably fenced the attempt. A
       // worker can nevertheless return the same shape after a shutdown or a


### PR DESCRIPTION
## Summary
- gate PR #2208 cancelled-result recovery behind a Temporal patch marker
- preserve the legacy re-peek command sequence for existing workflow histories
- keep bounded exact-attempt recovery for new histories

## Root cause
PR #2208 added a new recovery activity command on a replayed branch without workflow versioning. Existing session histories therefore failed workflow tasks with `WorkflowTaskFailedCauseNonDeterministicError`.

## Verification
- `bun test apps/worker/test/session-continuation-hold.test.ts`
- `bun run --cwd apps/worker typecheck`
- `git diff --check`

Forward-only staging incident recovery; no rollback.

## Summary by Sourcery

Version cancelled-attempt recovery to maintain deterministic replay while supporting improved recovery for new session histories.

Bug Fixes:
- Prevent non-deterministic workflow-task failures when replaying existing histories after cancelled-attempt recovery changes.

Enhancements:
- Preserve the legacy recovery command sequence for existing workflow histories while enabling bounded exact-attempt recovery for newly created histories.