### PR TITLE
fix(react): keep timeline in place when older history prepends

### DIFF
--- a/.changeset/timeline-compact-tail-prepend-snap.md
+++ b/.changeset/timeline-compact-tail-prepend-snap.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep an unpinned timeline reader in place when older history prepends into a compact tail. Restoring the row offset no longer looks like a scroll back to the live tip, so the view does not snap to the bottom after loading earlier messages.

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -66,11 +66,20 @@ function reprojectedItem(timelineItem: TimelineItem): TimelineItem {
 }
 
 function Harness() {
-  const adjacentPrepend = new URLSearchParams(window.location.search).has("adjacent");
-  const [items, setItems] = useState(() => [
-    ...(adjacentPrepend ? range(1_040, 80) : range(1_000, 120)),
-    streamedItem("Initial streamed response"),
-  ]);
+  const params = new URLSearchParams(window.location.search);
+  const adjacentPrepend = params.has("adjacent");
+  // Compact newest-suffix: barely overflows a 400px shell so the reader can
+  // sit at the top (loading older history) while still inside PIN_THRESHOLD
+  // of the live tip after a prepend restore.
+  const compactTail = params.has("compact-tail");
+  const [items, setItems] = useState(() =>
+    compactTail
+      ? range(13, 6)
+      : [
+          ...(adjacentPrepend ? range(1_040, 80) : range(1_000, 120)),
+          streamedItem("Initial streamed response"),
+        ],
+  );
   const [grown, setGrown] = useState(false);
   const [streamed, setStreamed] = useState(false);
   const [nextSequence, setNextSequence] = useState(1_120);
@@ -104,11 +113,11 @@ function Harness() {
   const prepend = useCallback(() => {
     flushSync(() =>
       setItems((current) => [
-        ...(adjacentPrepend ? range(1_000, 40) : range(900, 100)),
+        ...(compactTail ? range(1, 14) : adjacentPrepend ? range(1_000, 40) : range(900, 100)),
         ...current,
       ]),
     );
-  }, [adjacentPrepend]);
+  }, [adjacentPrepend, compactTail]);
   const prependDeferred = useCallback(() => {
     startTransition(() => {
       setItems((current) => [
@@ -149,13 +158,23 @@ function Harness() {
     <main style={{ padding: 32 }} data-og-theme="light">
       <section data-timeline-test style={{ margin: "0 auto", maxWidth: 900 }}>
         <MessageTimeline
-          className="timeline-test-shell"
+          className={
+            compactTail
+              ? "timeline-test-shell timeline-test-shell-compact"
+              : "timeline-test-shell"
+          }
           items={items}
           hasOlder
           renderMessageText={(text, timelineItem) => {
             const isStream = timelineItem.id === "stream-1";
             const sequence = Number(timelineItem.id.replace("row-", ""));
-            const baseHeight = isStream ? (streamed ? 220 : 48) : 34 + (sequence % 7) * 13;
+            const baseHeight = compactTail
+              ? 48
+              : isStream
+                ? streamed
+                  ? 220
+                  : 48
+                : 34 + (sequence % 7) * 13;
             // Models delayed image/font/tool-fold measurement strictly ABOVE the
             // reader (anchored near row 1040). Native scroll anchoring owns this
             // compensation; browsers intentionally suppress it when the anchor

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -159,9 +159,7 @@ function Harness() {
       <section data-timeline-test style={{ margin: "0 auto", maxWidth: 900 }}>
         <MessageTimeline
           className={
-            compactTail
-              ? "timeline-test-shell timeline-test-shell-compact"
-              : "timeline-test-shell"
+            compactTail ? "timeline-test-shell timeline-test-shell-compact" : "timeline-test-shell"
           }
           items={items}
           hasOlder

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -113,7 +113,7 @@ function Harness() {
   const prepend = useCallback(() => {
     flushSync(() =>
       setItems((current) => [
-        ...(compactTail ? range(1, 14) : adjacentPrepend ? range(1_000, 40) : range(900, 100)),
+        ...(compactTail ? range(1, 12) : adjacentPrepend ? range(1_000, 40) : range(900, 100)),
         ...current,
       ]),
     );

--- a/packages/react/demo/timeline-scroll-test.html
+++ b/packages/react/demo/timeline-scroll-test.html
@@ -25,6 +25,9 @@
         flex-direction: column;
         overflow: hidden;
       }
+      .timeline-test-shell-compact {
+        height: 400px;
+      }
       .timeline-test-shell > div {
         min-height: 0;
         flex: 1;

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1183,17 +1183,24 @@ export function MessageTimeline({
         applyPinned(false);
       }
     } else if (prepended) {
+      const olderAttemptState = olderLoadAttemptRef.current?.[1];
+      const underfillOwned =
+        !!olderLoadAttemptRef.current &&
+        olderAttemptState !== 1 &&
+        olderAttemptState !== 2 &&
+        olderAttemptState !== 3;
       if (
         autoFollow &&
         pinnedRef.current &&
         !hasNewer &&
         !pendingReaderLeaveRef.current &&
-        (wasAtLiveTailBeforeCommit || olderLoadAttemptRef.current)
+        !olderPrefetchArmedRef.current &&
+        (wasAtLiveTailBeforeCommit || underfillOwned)
       ) {
-        // A pending short-window load owns the prepend even when live growth
-        // has left its still-pinned camera with raw geometry debt. Unrelated
-        // prepends retain the prior-tip fallback so a stale pin after an
-        // extension/programmatic history jump still restores its row anchor.
+        // Automatic underfill (the reader never left the live tip) must stay
+        // parked there when the short window finally grows. A reader-driven
+        // sentinel load arms prefetch first; those prepends restore in place
+        // even if a stale pin or short-window gap still looks like the tip.
         clearPendingReaderLeave();
         snapToBottom(node);
       } else {
@@ -1598,6 +1605,19 @@ export function MessageTimeline({
       return;
     }
 
+    if (programmatic && !pinnedRef.current) {
+      // Restore/camera writes while reading history are not a return to the tip.
+      // Still expire a pending Jump-to-latest latch: the in-window jump itself
+      // is a programmatic snap, and a later reader scroll-away can arrive
+      // before that echo is consumed. Skipping this left the latch armed and
+      // snapped the reader when hasNewer later flipped false.
+      syncScrollBaseline(node);
+      if (wantPinRef.current && !isNearBottom(node)) {
+        wantPinRef.current = false;
+      }
+      return;
+    }
+
     if (autoFollow && pinnedRef.current && !hasNewer) {
       // Fold / composer / SessionChrome: viewport shrink raises maxScroll without
       // growing content. Must hit tipFollow before we adopt the new clientHeight
@@ -1659,10 +1679,18 @@ export function MessageTimeline({
     syncScrollBaseline(node);
     const nearBottom = isNearBottom(node);
 
-    // Re-pin only when the reader moved toward/at the tip — not when a fold
-    // clamp dragged scrollTop down onto nearBottom.
+    // Re-pin only when the reader moved toward/at the tip without a content
+    // insertion. Prepend restore and overflow-anchor raise scrollTop by
+    // roughly the same amount as maxScroll; treating that as a scroll-down
+    // re-pinned a compact-tail history reader (their preserved gap falls
+    // inside PIN_THRESHOLD once the window is tall) and snapped them back.
+    const inserted = Math.max(0, nextMaxScroll - previousMaxScroll);
+    const towardTip = nextTop - previousTop - inserted;
     const nextPinned =
-      !hasNewer && nearBottom && nextTop >= previousTop - TIP_FOLLOW_READER_UP_EPS_PX;
+      !hasNewer &&
+      nearBottom &&
+      towardTip >= -TIP_FOLLOW_READER_UP_EPS_PX &&
+      inserted <= 1;
     if (!nextPinned) {
       stopFollow();
     }

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1194,13 +1194,12 @@ export function MessageTimeline({
         pinnedRef.current &&
         !hasNewer &&
         !pendingReaderLeaveRef.current &&
-        !olderPrefetchArmedRef.current &&
         (wasAtLiveTailBeforeCommit || underfillOwned)
       ) {
-        // Automatic underfill (the reader never left the live tip) must stay
-        // parked there when the short window finally grows. A reader-driven
-        // sentinel load arms prefetch first; those prepends restore in place
-        // even if a stale pin or short-window gap still looks like the tip.
+        // Still following the live tip: underfill, or a prefetch the reader
+        // started and then returned from. Park at the new tip. A stale pin
+        // while they are actually up in a short window (gap is not inside
+        // PIN_THRESHOLD of maxScroll, so wasAtLiveTail is false) restores.
         clearPendingReaderLeave();
         snapToBottom(node);
       } else {

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1686,10 +1686,7 @@ export function MessageTimeline({
     const inserted = Math.max(0, nextMaxScroll - previousMaxScroll);
     const towardTip = nextTop - previousTop - inserted;
     const nextPinned =
-      !hasNewer &&
-      nearBottom &&
-      towardTip >= -TIP_FOLLOW_READER_UP_EPS_PX &&
-      inserted <= 1;
+      !hasNewer && nearBottom && towardTip >= -TIP_FOLLOW_READER_UP_EPS_PX && inserted <= 1;
     if (!nextPinned) {
       stopFollow();
     }

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -642,9 +642,7 @@ describe("MessageTimeline pagination affordances", () => {
     expect(scroller.scrollTop).toBe(0);
 
     layout.setContentHeight(2_440);
-    await r.rerender(
-      <MessageTimeline events={manyEvents(20)} hasOlder loadingOlder={false} />,
-    );
+    await r.rerender(<MessageTimeline events={manyEvents(20)} hasOlder loadingOlder={false} />);
     await flush();
     await drainFrames(frames);
 

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -593,6 +593,162 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test("a reader-driven prepend on a compact tail does not snap back to the live tip", async () => {
+    // Initial paint is a compact newest-suffix window. When that tail only
+    // barely overflows, the reader can be at the top (loading older history)
+    // while still within PIN_THRESHOLD of the live tip AFTER the prepend
+    // restores their gap. A restore write looks like a scroll-down toward the
+    // tip and used to re-pin, then the next commit snapped them to the bottom.
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const tail = manyEvents(8).map((evt) => event(evt.sequence + 12)); // 13..20
+    const r = await renderComponent(
+      <MessageTimeline events={tail} hasOlder loadingOlder={false} />,
+    );
+    await drainFrames(frames);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 440,
+      tipHeight: 80,
+      paddingBottom: 24,
+      emitScrollOnWrite: true,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(distanceFromBottom(scroller)).toBe(0);
+
+    await actRun(() => {
+      scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
+      scroller.scrollTop = 0;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(0);
+
+    await r.rerender(<MessageTimeline events={tail} hasOlder loadingOlder={false} />);
+    await flush();
+    expect(scroller.scrollTop).toBe(0);
+
+    layout.setContentHeight(2_440);
+    await r.rerender(
+      <MessageTimeline events={manyEvents(20)} hasOlder loadingOlder={false} />,
+    );
+    await flush();
+    await drainFrames(frames);
+
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(2_000);
+    expect(distanceFromBottom(scroller)).toBe(40);
+
+    // An actual reader move toward the now-distant live tip still re-pins.
+    await actRun(() => {
+      scroller.scrollTop = 2_040;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    expect(distanceFromBottom(scroller)).toBeLessThan(2);
+    expect(scroller.className).toContain("[overflow-anchor:none]");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("a sentinel-owned prepend restores an unpinned compact tail instead of snapping to the tip", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    let intersectionCallback: IntersectionObserverCallback = () => undefined;
+    let intersectionObserver: IntersectionObserver | null = null;
+    const observed: Element[] = [];
+    globalThis.IntersectionObserver = class implements IntersectionObserver {
+      readonly root: Element | Document | null = null;
+      readonly rootMargin = "400px 0px 0px 0px";
+      readonly scrollMargin = "0px 0px 0px 0px";
+      readonly thresholds = [0];
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+        intersectionObserver = this;
+      }
+      observe(target: Element): void {
+        observed.push(target);
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    };
+
+    const tail = manyEvents(8).map((evt) => event(evt.sequence + 12));
+    const load = deferred<boolean>();
+    const controlled = controlledOlderReceipt(load.promise);
+    const onLoadOlder: OlderHistoryLoader = () => controlled.receipt;
+    const r = await renderComponent(
+      <PublicMessageTimeline events={tail} hasOlder onLoadOlder={onLoadOlder} />,
+    );
+    const scroller = r.container.querySelector("[data-og-timeline-scroller]");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 440,
+      tipHeight: 80,
+      paddingBottom: 24,
+      emitScrollOnWrite: true,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await readerScrollUp(scroller, 0);
+    expect(r.container.textContent).toContain("Jump to latest");
+
+    const target = observed.at(-1);
+    if (!target) {
+      throw new Error("expected observed top sentinel");
+    }
+    await actRun(() =>
+      intersectionCallback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        intersectionObserver!,
+      ),
+    );
+    expect(scroller.scrollTop).toBe(0);
+
+    controlled.commit();
+    layout.setContentHeight(2_440);
+    await r.rerender(
+      <PublicMessageTimeline events={manyEvents(20)} hasOlder onLoadOlder={onLoadOlder} />,
+    );
+    await flush();
+    await drainFrames(frames);
+
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(2_000);
+    expect(distanceFromBottom(scroller)).toBe(40);
+
+    await actRun(() => load.resolve(true));
+    await flush();
+    layout.restore();
+    await r.unmount();
+  });
+
   test("near-top prepend restores place when scrollHeight is unchanged (tip truncated)", async () => {
     // loadOlder uses an oldest-directed window: older rows prepend AND the live
     // tip can be evicted. Net scrollHeight may not grow, so height-delta restore
@@ -3956,6 +4112,11 @@ function mockScrollerLayout(
     paddingBottom: number;
     /** Snap scrollTop writes to whole pixels like a real browser at dpr 1. */
     quantize?: boolean;
+    /**
+     * Chromium fires `scroll` from programmatic `scrollTop` writes. Opt in so
+     * restore/camera assignments exercise the same echo path as the browser.
+     */
+    emitScrollOnWrite?: boolean;
   },
 ) {
   let contentHeight = options.contentHeight;
@@ -3990,7 +4151,14 @@ function mockScrollerLayout(
     set: (value: number) => {
       const max = Math.max(0, contentHeight - options.clientHeight);
       const clamped = Math.max(0, Math.min(max, value));
-      currentScrollTop = options.quantize ? Math.floor(clamped) : clamped;
+      const next = options.quantize ? Math.floor(clamped) : clamped;
+      if (next === currentScrollTop) {
+        return;
+      }
+      currentScrollTop = next;
+      if (options.emitScrollOnWrite) {
+        scroller.dispatchEvent(new Event("scroll"));
+      }
     },
   });
 

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -495,7 +495,11 @@ describe("timeline scroll ownership browser regression", () => {
     expect(atTop.gap).toBeGreaterThan(1);
     expect(atTop.gap).toBeLessThanOrEqual(48);
 
+    const anchor = page.locator('[data-timeline-row="row-13"]').first();
+    const beforeAnchorTop = await anchor.evaluate((node) => node.getBoundingClientRect().top);
+
     await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    await page.locator('[data-timeline-row="row-1"]').waitFor({ timeout: 5_000 });
     await page.waitForTimeout(80);
 
     const after = await scroller.evaluate((node) => ({
@@ -504,10 +508,12 @@ describe("timeline scroll ownership browser regression", () => {
       height: node.scrollHeight,
       pin: node.getAttribute("data-og-bottom-follow"),
     }));
+    const afterAnchorTop = await anchor.evaluate((node) => node.getBoundingClientRect().top);
     expect(after.height).toBeGreaterThan(atTop.height + 200);
     expect(after.scrollTop).toBeGreaterThan(200);
     expect(after.gap).toBeCloseTo(atTop.gap, 0);
     expect(after.pin).toBe("false");
+    expect(afterAnchorTop).toBeCloseTo(beforeAnchorTop, 0);
     expect(await page.locator("[data-og-jump-to-latest]").count()).toBe(1);
   }, 30_000);
 

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -425,6 +425,92 @@ describe("timeline scroll ownership browser regression", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
   }, 30_000);
 
+  test("a compact newest-suffix prepend keeps the reader instead of snapping to the live tip", async () => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html?compact-tail`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-13"]').waitFor({ timeout: 15_000 });
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+    await page.waitForFunction(() => {
+      const node = document.querySelector<HTMLElement>(
+        "[data-timeline-test] [data-og-timeline-scroller]",
+      );
+      return !!node && node.style.visibility !== "hidden" && node.scrollHeight > 0;
+    });
+
+    // Size the shell so the newest suffix barely overflows. That is the
+    // production first-paint shape: the reader can sit at y=0 while the
+    // restored gap after prepend is still inside PIN_THRESHOLD of the tip.
+    await page.evaluate(() => {
+      const shell = document.querySelector<HTMLElement>(".timeline-test-shell-compact");
+      const node = document.querySelector<HTMLElement>(
+        "[data-timeline-test] [data-og-timeline-scroller]",
+      );
+      if (!shell || !node) {
+        throw new Error("compact tail scroller missing");
+      }
+      const targetMaxScroll = 36;
+      const chrome = shell.clientHeight - node.clientHeight;
+      shell.style.height = `${Math.max(chrome + 80, node.scrollHeight - targetMaxScroll + chrome)}px`;
+    });
+    await page.waitForTimeout(50);
+
+    const scroller = page.locator("[data-timeline-test] [data-og-timeline-scroller]");
+    const beforeWheel = await scroller.evaluate((node) => ({
+      scrollTop: node.scrollTop,
+      maxScroll: node.scrollHeight - node.clientHeight,
+      gap: node.scrollHeight - node.clientHeight - node.scrollTop,
+    }));
+    expect(beforeWheel.maxScroll).toBeGreaterThan(1);
+    expect(beforeWheel.maxScroll).toBeLessThanOrEqual(48);
+    expect(beforeWheel.gap).toBeLessThan(2);
+
+    await scroller.hover();
+    for (let index = 0; index < 8; index += 1) {
+      await page.mouse.wheel(0, -120);
+      if ((await scroller.evaluate((node) => node.scrollTop)) < 2) {
+        break;
+      }
+    }
+    await page.waitForFunction(
+      () => {
+        const node = document.querySelector<HTMLElement>(
+          "[data-timeline-test] [data-og-timeline-scroller]",
+        );
+        return !!node && node.scrollTop < 2;
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+    await page.locator("[data-og-jump-to-latest]").waitFor({ timeout: 5_000 });
+
+    const atTop = await scroller.evaluate((node) => ({
+      scrollTop: node.scrollTop,
+      gap: node.scrollHeight - node.clientHeight - node.scrollTop,
+      height: node.scrollHeight,
+    }));
+    expect(atTop.scrollTop).toBeLessThan(2);
+    expect(atTop.gap).toBeGreaterThan(1);
+    expect(atTop.gap).toBeLessThanOrEqual(48);
+
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    await page.waitForTimeout(80);
+
+    const after = await scroller.evaluate((node) => ({
+      scrollTop: node.scrollTop,
+      gap: node.scrollHeight - node.clientHeight - node.scrollTop,
+      height: node.scrollHeight,
+      pin: node.getAttribute("data-og-bottom-follow"),
+    }));
+    expect(after.height).toBeGreaterThan(atTop.height + 200);
+    expect(after.scrollTop).toBeGreaterThan(200);
+    expect(after.gap).toBeCloseTo(atTop.gap, 0);
+    expect(after.pin).toBe("false");
+    expect(await page.locator("[data-og-jump-to-latest]").count()).toBe(1);
+  }, 30_000);
+
   test("keeps a nested row anchored when prepend merges into its activity group", async () => {
     await page.goto(`${baseUrl}/timeline-scroll-merge-test.html`);
     await page.waitForFunction(() => window.timelineMergeHarness !== undefined);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scrolling up in the session timeline to load earlier chat often snapped the view back to the live tip.

The first paint is a compact newest-suffix window. That tail frequently only barely overflows, so a reader can be at the **top** of it (loading older history) while still within `PIN_THRESHOLD` of the live tip **after** the prepend restores their gap. Restoring `scrollTop` by the prepend height looked like a scroll-down, re-pinned, and the next commit snapped them to the bottom.

This change:

- Restores reader-driven / sentinel-owned prepends in place when the reader is not actually at the live tip (automatic underfill, or a prefetch they started and then returned from, still parks at the tip).
- Ignores insertion-driven `scrollTop` growth when deciding whether to re-pin.
- Still expires a pending Jump-to-latest latch when the reader leaves the tip, including when that scroll arrives before a programmatic snap echo is consumed.

## Walkthrough

Reproduced on the live OpenGeni stack (`bun run dev`, web `http://127.0.0.1:3000`, API `http://127.0.0.1:8000`) against a seeded session whose compact newest-suffix is three short turns.

Before the fix, a single mouse-wheel scroll up loads earlier chat and then snaps the camera back to the live tip (`Reply 403`). Jump to latest appears and vanishes.

[timeline_scroll_up_snaps_back_on_live_opengeni_dev_server_before_fix.mp4](https://cursor.com/agents/bc-f07646c5-6c44-446f-86c0-369e9fdeba34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimeline_scroll_up_snaps_back_on_live_opengeni_dev_server_before_fix.mp4)

After the fix, the same wheel-up on the same session keeps the reader in history. Jump to latest stays on screen (`gap` remains ~29px, unpinned).

[timeline_scroll_up_stays_in_history_on_live_opengeni_dev_server_after_fix.mp4](https://cursor.com/agents/bc-f07646c5-6c44-446f-86c0-369e9fdeba34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimeline_scroll_up_stays_in_history_on_live_opengeni_dev_server_after_fix.mp4)

## Testing

- [x] `bun scripts/typecheck.ts --project packages/react`
- [x] `bun test packages/react/test/message-timeline-pagination.test.tsx packages/react/test/tip-follow.test.ts` (106 pass)
- [x] `bun scripts/run-browser-e2e.ts ./test/e2e/timeline-scroll.browser.e2e.ts` (34 pass)
- [x] Live OpenGeni web on `:3000` after seeding: unfixed source snaps on one wheel-up; restored fix stays in history
- [x] `oxfmt` on the three compact-tail files so `format:check` matches CI

New coverage:

- Compact-tail unit cases in `packages/react/test/message-timeline-pagination.test.tsx`
- Chromium harness case `a compact newest-suffix prepend keeps the reader instead of snapping to the live tip` in `test/e2e/timeline-scroll.browser.e2e.ts`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advanced, I kept the candidate head frozen and verified mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change. Freeze-head source admission is required only for `hotfix/*` into `production`.

## Notes

Reproduction: start the full local stack, open a session whose compact tail barely overflows the viewport, mouse-wheel up once to load earlier messages, and watch whether the restored place holds. The previous behavior yanked back to the live tip as soon as the older page landed.

Format-only follow-up: `style(react): format compact-tail timeline prepend changes` so CI `format:check` is green. No behavior change.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f07646c5-6c44-446f-86c0-369e9fdeba34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f07646c5-6c44-446f-86c0-369e9fdeba34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep readers in place while loading older timeline history without snapping them back to the live tip.

Bug Fixes:
- Keep unpinned timeline readers in their current history position when older messages prepend to a compact newest-message window.
- Prevent prepend-induced scroll offset changes and programmatic scroll echoes from incorrectly re-pinning the timeline or leaving Jump-to-latest state stale.

Tests:
- Add unit and browser regression coverage for compact-tail reader-driven and sentinel-owned prepends.