### PR TITLE
fix(react): show waiting for goals during human turns

### DIFF
--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -228,6 +228,7 @@ export function sessionChromeGoalPillState(
   // next evaluation at `nextAttemptAt`) is an ordinary scheduled state.
   if (continuation.state === "scheduled") return "scheduled";
   if (continuation.state === "blocked") {
+    if (continuation.reason === "human_turn_running") return "waiting";
     // `held_for_input` is the agent's own wait_for_input hold (waiting for child
     // results / external input until a deadline); it shares the Held pill.
     return continuation.reason === "workstream_paused" || continuation.reason === "held_for_input"

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -202,6 +202,16 @@ describe("sessionChromeGoalPillState", () => {
     expect(
       sessionChromeGoalPillState("active", {
         state: "blocked",
+        reason: "human_turn_running",
+        wakeRevision: 1,
+        observedRevision: 1,
+        nextAttemptAt: null,
+        lastError: null,
+      }),
+    ).toBe("waiting");
+    expect(
+      sessionChromeGoalPillState("active", {
+        state: "blocked",
         reason: "workstream_paused",
         wakeRevision: 1,
         observedRevision: 1,


### PR DESCRIPTION
A running user-requested turn showed a `Blocked` goal pill beside the `Running` session header.
Map the backend's `blocked / human_turn_running` projection to the existing `Waiting` presentation, since autonomous goal work waits for the foreground turn to finish.

## Verification

- The regression fails on the original code and passes with the fix.
- React suite: 25 tests passed, 114 assertions.
- React package typecheck and formatting checks passed.

## Before and after

Captured in the local test instance during active human turns.

| Before | After |
| --- | --- |
| ![Running session with a Blocked goal](https://raw.githubusercontent.com/VasuBansal7576/opengeni/2ed3bcc1bab8eb6410e3a55c358f253e471a0951/evidence/goal-pill-human-turn-before.jpg) | ![Running session with a Waiting goal](https://raw.githubusercontent.com/VasuBansal7576/opengeni/2ed3bcc1bab8eb6410e3a55c358f253e471a0951/evidence/goal-pill-human-turn-after.jpg) |
