### PR TITLE
fix: prevent workspace instructions from staying on Saving

### DIFF
--- a/.changeset/instruction-save-completion.md
+++ b/.changeset/instruction-save-completion.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Bound instruction draft and activation requests, including response-body reads, and accept caller cancellation and timeout options. The web instruction editor confirms saves directly from activation responses and reuses operation IDs when retrying uncertain saves.

--- a/apps/web/src/lib/workspace-instruction-save.test.ts
+++ b/apps/web/src/lib/workspace-instruction-save.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import type { OpenGeniClient } from "@opengeni/sdk";
+import { createWorkspaceInstructionSave } from "./workspace-instruction-save";
+
+test("an uncertain save belongs to its exact client, workspace, text, and baseline", () => {
+  const client = {} as OpenGeniClient;
+  const head = { revisionId: "initial", activationVersion: 1 };
+  const save = createWorkspaceInstructionSave(client, "workspace", "text", head);
+  expect(save.matches(client, "workspace", "text", { ...head })).toBe(true);
+  expect(save.matches({} as OpenGeniClient, "workspace", "text", head)).toBe(false);
+  expect(save.matches(client, "another", "text", head)).toBe(false);
+  expect(save.matches(client, "workspace", "edited", head)).toBe(false);
+  expect(save.matches(client, "workspace", "text", { ...head, activationVersion: 2 })).toBe(false);
+  expect(save.matches(client, "workspace", "text", { ...head, revisionId: "new" })).toBe(false);
+});

--- a/apps/web/src/lib/workspace-instruction-save.ts
+++ b/apps/web/src/lib/workspace-instruction-save.ts
@@ -1,0 +1,55 @@
+import type { OpenGeniClient, WorkspaceInstructionPolicyHead } from "@opengeni/sdk";
+
+/** Keep one logical save's operation IDs across uncertain transport outcomes. */
+export function createWorkspaceInstructionSave(
+  client: Pick<
+    OpenGeniClient,
+    "createWorkspaceInstructionPolicyDraft" | "activateWorkspaceInstructionPolicyRevision"
+  >,
+  workspaceId: string,
+  content: string,
+  head: Pick<WorkspaceInstructionPolicyHead, "revisionId" | "activationVersion"> | null,
+) {
+  const draftRequest = {
+    operationId: crypto.randomUUID(),
+    kind: "policy" as const,
+    scope: "global" as const,
+    roleKey: null,
+    content,
+    provenanceSource: "human" as const,
+    provenanceSourceId: null,
+    supersedesRevisionId: head?.revisionId ?? null,
+  };
+  const activationRequest = {
+    operationId: crypto.randomUUID(),
+    expectedCurrentRevisionId: head?.revisionId ?? null,
+    expectedActivationVersion: head?.activationVersion ?? 0,
+    reason: "Updated by a workspace admin from Agent Knowledge",
+  };
+  return {
+    content,
+    matches(
+      nextClient: typeof client,
+      nextWorkspaceId: string,
+      nextContent: string,
+      nextHead: typeof head,
+    ) {
+      return (
+        client === nextClient &&
+        workspaceId === nextWorkspaceId &&
+        content === nextContent &&
+        (head?.revisionId ?? null) === (nextHead?.revisionId ?? null) &&
+        (head?.activationVersion ?? 0) === (nextHead?.activationVersion ?? 0)
+      );
+    },
+    async run() {
+      const draft = await client.createWorkspaceInstructionPolicyDraft(workspaceId, draftRequest);
+      const activated = await client.activateWorkspaceInstructionPolicyRevision(
+        workspaceId,
+        draft.id,
+        activationRequest,
+      );
+      return { head: activated.head, content: draft.content };
+    },
+  };
+}

--- a/apps/web/src/routes/workspace-state-instruction-save.test.tsx
+++ b/apps/web/src/routes/workspace-state-instruction-save.test.tsx
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { OpenGeniClient, type WorkspaceStateResponse } from "@opengeni/sdk";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+const workspaceId = "00000000-0000-4000-8000-000000000001";
+const initialHead = {
+  workspaceId,
+  kind: "policy",
+  scope: "global",
+  roleKey: null,
+  revisionId: "initial",
+  revision: 1,
+  activationVersion: 1,
+  contentHash: "a".repeat(64),
+  activatedAt: "2026-09-01T00:00:00.000Z",
+};
+const requests: { path: string; body: any }[] = [];
+let failActivation = false;
+const client = new OpenGeniClient({
+  baseUrl: "https://api.example.test",
+  sessionCommandTimeoutMs: 20,
+  fetch: (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    requests.push({ path, body });
+    const json = (value: unknown) =>
+      new Response(JSON.stringify(value), {
+        headers: { "content-type": "application/json" },
+      });
+    if (path.endsWith("/initial") || path.endsWith("/new"))
+      return json({ content: "Keep updates concise." });
+    if (path.endsWith("/drafts")) return json({ id: "saved", content: body.content });
+    if (path.endsWith("/activate")) {
+      if (failActivation) return await new Promise<Response>(() => {});
+      return json({
+        head: {
+          ...initialHead,
+          revisionId: "saved",
+          revision: 2,
+          activationVersion: 2,
+        },
+      });
+    }
+    // Re-reading either the full inventory or the saved revision never completes.
+    return await new Promise<Response>(() => {});
+  }) as typeof fetch,
+});
+mock.module("@/context", () => ({
+  useAppContext: () => ({
+    client,
+    accessContext: {
+      accountGrants: [],
+      workspaceGrants: [
+        {
+          workspaceId,
+          permissions: ["workspace:admin", "workspace:read"],
+        },
+      ],
+    },
+  }),
+}));
+mock.module("./agent-brain-prompt", () => ({ AgentKnowledgePrompt: () => null }));
+const { FocusedInstructions } = await import("./workspace-state");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+async function mount() {
+  requests.length = 0;
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const render = async (head = initialHead) =>
+    await act(async () =>
+      root.render(
+        <FocusedInstructions
+          workspaceId={workspaceId}
+          personalWorkspace={false}
+          state={
+            {
+              policy: {
+                activeHeads: [head],
+                legacyRuntime: {
+                  workspaceOverrideConfigured: false,
+                },
+              },
+            } as unknown as WorkspaceStateResponse
+          }
+        />,
+      ),
+    );
+  await render();
+  const submit = async () => {
+    await act(async () => {
+      container
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    });
+  };
+  return { container, root, submit, render };
+}
+
+test("confirms activation without another read and uses its head for the next save", async () => {
+  failActivation = false;
+  const { container, root, submit } = await mount();
+  try {
+    await submit();
+    expect(container.querySelector('[role="status"]')?.textContent).toContain("Saved.");
+    expect(container.querySelector("textarea")!.disabled).toBe(false);
+    expect(container.querySelector("textarea")!.value).toBe("Keep updates concise.");
+    expect(requests.filter((request) => !request.body)).toHaveLength(1);
+    await submit();
+    const activations = requests.filter((request) => request.path.endsWith("/activate"));
+    expect(activations[1]!.body.expectedCurrentRevisionId).toBe("saved");
+    expect(activations[1]!.body.expectedActivationVersion).toBe(2);
+  } finally {
+    await act(async () => root.unmount());
+  }
+});
+
+test("unlocks after a stalled activation and retries the same logical save", async () => {
+  failActivation = true;
+  const { container, root, submit } = await mount();
+  try {
+    await submit();
+    expect(container.textContent).not.toContain("Saving…");
+    expect(container.querySelector("textarea")!.disabled).toBe(false);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    failActivation = false;
+    await submit();
+    const drafts = requests.filter((request) => request.path.endsWith("/drafts"));
+    const activations = requests.filter((request) => request.path.endsWith("/activate"));
+    expect(drafts[1]!.body).toEqual(drafts[0]!.body);
+    expect(activations[1]!.body).toEqual(activations[0]!.body);
+    expect(container.querySelector('[role="status"]')?.textContent).toContain("Saved.");
+  } finally {
+    await act(async () => root.unmount());
+  }
+});
+
+test("a refreshed baseline starts a new save even when the instruction text is unchanged", async () => {
+  failActivation = true;
+  const { root, submit, render } = await mount();
+  try {
+    await submit();
+    await render({ ...initialHead, revisionId: "new", activationVersion: 2 });
+    failActivation = false;
+    await submit();
+    const activations = requests.filter((request) => request.path.endsWith("/activate"));
+    expect(activations[1]!.body.expectedCurrentRevisionId).toBe("new");
+    expect(activations[1]!.body.expectedActivationVersion).toBe(2);
+    expect(activations[1]!.body.operationId).not.toBe(activations[0]!.body.operationId);
+  } finally {
+    await act(async () => root.unmount());
+  }
+});

--- a/apps/web/src/routes/workspace-state-loader.ts
+++ b/apps/web/src/routes/workspace-state-loader.ts
@@ -4,6 +4,7 @@ import type {
   PreferenceRegistryDetailResponse,
   PreferenceRegistryListResponse,
   WorkspaceInstructionPolicyOnboardingProposalListResponse,
+  WorkspaceInstructionPolicyHead,
   WorkspaceStateResponse,
 } from "@opengeni/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -25,8 +26,11 @@ export function useWorkspaceStateInventory(
   attemptId?: string,
 ): Omit<WorkspaceStateLoad, "client" | "workspaceId" | "attemptId"> & {
   reload: () => Promise<void>;
+  acceptInstructionHead: (head: WorkspaceInstructionPolicyHead) => void;
 } {
   const generation = useRef(0);
+  const currentScope = useRef({ client, workspaceId, attemptId });
+  currentScope.current = { client, workspaceId, attemptId };
   const [result, setResult] = useState<WorkspaceStateLoad>(() => ({
     client,
     workspaceId,
@@ -73,6 +77,55 @@ export function useWorkspaceStateInventory(
     }
   }, [attemptId, client, workspaceId]);
 
+  const acceptInstructionHead = useCallback(
+    (head: WorkspaceInstructionPolicyHead) => {
+      if (
+        head.workspaceId !== workspaceId ||
+        currentScope.current.client !== client ||
+        currentScope.current.workspaceId !== workspaceId ||
+        currentScope.current.attemptId !== attemptId
+      )
+        return;
+      // A refresh started before activation must not restore its old snapshot.
+      generation.current += 1;
+      setResult((previous) => {
+        if (
+          previous.client !== client ||
+          previous.workspaceId !== workspaceId ||
+          previous.attemptId !== attemptId ||
+          !previous.state
+        )
+          return previous;
+        const sameTarget = (
+          candidate:
+            | WorkspaceInstructionPolicyHead
+            | WorkspaceStateResponse["policy"]["activeHeads"][number],
+        ) =>
+          candidate.kind === head.kind &&
+          candidate.scope === head.scope &&
+          candidate.roleKey === head.roleKey;
+        const current = previous.state.policy.activeHeads.find(sameTarget);
+        if (current && current.activationVersion > head.activationVersion) return previous;
+        return {
+          ...previous,
+          loading: false,
+          error: null,
+          state: {
+            ...previous.state,
+            policy: {
+              ...previous.state.policy,
+              activeHeads: [
+                ...previous.state.policy.activeHeads.filter((candidate) => !sameTarget(candidate)),
+                head,
+              ],
+            },
+          },
+        };
+      });
+    },
+    [attemptId, client, workspaceId],
+  );
+
   useEffect(() => {
     void reload();
     return () => {
@@ -85,9 +138,15 @@ export function useWorkspaceStateInventory(
     result.workspaceId !== workspaceId ||
     result.attemptId !== attemptId
   ) {
-    return { state: null, error: null, loading: true, reload };
+    return { state: null, error: null, loading: true, reload, acceptInstructionHead };
   }
-  return { state: result.state, error: result.error, loading: result.loading, reload };
+  return {
+    state: result.state,
+    error: result.error,
+    loading: result.loading,
+    reload,
+    acceptInstructionHead,
+  };
 }
 
 type OnboardingProposalClient = Pick<

--- a/apps/web/src/routes/workspace-state.test.tsx
+++ b/apps/web/src/routes/workspace-state.test.tsx
@@ -34,6 +34,51 @@ function response(workspaceId: string): WorkspaceStateResponse {
 }
 
 describe("Workspace State loader", () => {
+  test("retains an activated instruction head across view remounts and a stale in-flight refresh", async () => {
+    const workspaceId = "00000000-0000-4000-8000-000000000001";
+    const oldState = {
+      ...response(workspaceId),
+      policy: { activeHeads: [] },
+    } as unknown as WorkspaceStateResponse;
+    const staleRefresh = deferred<WorkspaceStateResponse>();
+    let calls = 0;
+    const client = {
+      getWorkspaceState: async () => (++calls === 1 ? oldState : await staleRefresh.promise),
+    };
+    let observed!: ReturnType<typeof useWorkspaceStateInventory>;
+    function Harness({ show }: { show: boolean }) {
+      observed = useWorkspaceStateInventory(client, workspaceId);
+      return show ? <output>{observed.state?.policy.activeHeads[0]?.revisionId}</output> : null;
+    }
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const head = {
+      workspaceId,
+      kind: "policy" as const,
+      scope: "global" as const,
+      roleKey: null,
+      revisionId: "saved",
+      revision: 1,
+      activationVersion: 1,
+      contentHash: "a".repeat(64),
+      activatedAt: "2026-09-05T00:00:00.000Z",
+    };
+    try {
+      await act(async () => root.render(<Harness show />));
+      await act(async () => {
+        void observed.reload();
+      });
+      await act(async () => observed.acceptInstructionHead(head));
+      expect(observed.loading).toBe(false);
+      await act(async () => root.render(<Harness show={false} />));
+      await act(async () => root.render(<Harness show />));
+      expect(container.textContent).toBe("saved");
+      await act(async () => staleRefresh.resolve(oldState));
+      expect(container.textContent).toBe("saved");
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
   test("does not reuse a resolved review summary across workspace authority", () => {
     type Review = { status: "loading" | "ready"; pendingCount: number };
     const ready: Review = { status: "ready", pendingCount: 0 };
@@ -72,10 +117,24 @@ describe("Workspace State loader", () => {
     const root = createRoot(container);
     await act(async () => root.render(<Harness workspaceId={workspaceA} />));
     expect(container.textContent).toBe("loading");
+    const acceptOldWorkspaceHead = current().acceptInstructionHead;
 
     await act(async () => root.render(<Harness workspaceId={workspaceB} />));
     expect(container.textContent).toBe("loading");
     expect(current().state).toBeNull();
+    await act(async () =>
+      acceptOldWorkspaceHead({
+        workspaceId: workspaceA,
+        kind: "policy",
+        scope: "global",
+        roleKey: null,
+        revisionId: "old-workspace-save",
+        revision: 1,
+        activationVersion: 1,
+        contentHash: "a".repeat(64),
+        activatedAt: "2026-09-05T00:00:00.000Z",
+      }),
+    );
 
     await act(async () => pendingB.resolve(response(workspaceB)));
     expect(container.textContent).toBe(workspaceB);

--- a/apps/web/src/routes/workspace-state.tsx
+++ b/apps/web/src/routes/workspace-state.tsx
@@ -6,6 +6,7 @@ import {
   WORKSPACE_INSTRUCTION_POLICY_CONTENT_MAX_CHARS,
   normalizeWorkspaceInstructionPolicyRoleKey,
   type WorkspaceInstructionPolicyKind,
+  type WorkspaceInstructionPolicyHead,
   type WorkspaceInstructionPolicyOnboardingProposal,
   type WorkspaceInstructionPolicyScope,
   type WorkspaceStateGovernanceDriftStatus,
@@ -1051,10 +1052,12 @@ export function FocusedInstructions({
   state,
   workspaceId,
   personalWorkspace,
+  onInstructionSaved,
 }: {
   state: WorkspaceStateResponse;
   workspaceId: string;
   personalWorkspace: boolean;
+  onInstructionSaved?: (head: WorkspaceInstructionPolicyHead) => void;
 }) {
   const context = useAppContext();
   const { client } = context;
@@ -1133,7 +1136,9 @@ export function FocusedInstructions({
           activeHead,
         );
       }
-      setConfirmedSave(await pendingSave.current.run());
+      const saved = await pendingSave.current.run();
+      setConfirmedSave(saved);
+      onInstructionSaved?.(saved.head);
       pendingSave.current = null;
       setMessage("Saved. New agent turns will use these workspace instructions.");
     } catch (error) {
@@ -1270,7 +1275,10 @@ export function WorkspaceStateRoute({
   const { client } = context;
   const workspace = context.workspaces.find((candidate) => candidate.id === workspaceId) ?? null;
   const personalWorkspace = isPersonalWorkspace(workspace, context.managedSelfContext);
-  const { state, error, loading, reload } = useWorkspaceStateInventory(client, workspaceId);
+  const { state, error, loading, reload, acceptInstructionHead } = useWorkspaceStateInventory(
+    client,
+    workspaceId,
+  );
 
   return (
     <ContentPage width="standard">
@@ -1338,6 +1346,7 @@ export function WorkspaceStateRoute({
                 state={state}
                 workspaceId={workspaceId}
                 personalWorkspace={personalWorkspace}
+                onInstructionSaved={acceptInstructionHead}
               />
             ) : null}
             {view === "skills" ? (

--- a/apps/web/src/routes/workspace-state.tsx
+++ b/apps/web/src/routes/workspace-state.tsx
@@ -13,7 +13,7 @@ import {
 } from "@opengeni/sdk";
 import { Link } from "@tanstack/react-router";
 import { ArrowLeftIcon, BrainCircuitIcon, ChevronDownIcon } from "lucide-react";
-import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 
 import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
 import { ContentPage } from "@/components/ui/content-layout";
@@ -23,6 +23,7 @@ import { useAppContext } from "@/context";
 import { isPersonalWorkspace } from "@/lib/managed-self-context";
 import { hasAccountPermission, hasWorkspacePermission } from "@/lib/permissions";
 import { activeGlobalWorkspaceInstructionHead } from "@/lib/workspace-instructions";
+import { createWorkspaceInstructionSave } from "@/lib/workspace-instruction-save";
 
 import { BrainOverview } from "./agent-brain-overview";
 import { AgentKnowledgePrompt } from "./agent-brain-prompt";
@@ -1046,21 +1047,27 @@ export function AttemptGovernanceInventory({
   );
 }
 
-function FocusedInstructions({
+export function FocusedInstructions({
   state,
   workspaceId,
   personalWorkspace,
-  onWorkspaceStateReload,
 }: {
   state: WorkspaceStateResponse;
   workspaceId: string;
   personalWorkspace: boolean;
-  onWorkspaceStateReload: () => Promise<void>;
 }) {
   const context = useAppContext();
   const { client } = context;
   const canEdit = hasWorkspacePermission(context.accessContext, workspaceId, "workspace:admin");
-  const activeHead = activeGlobalWorkspaceInstructionHead(state);
+  const [confirmedSave, setConfirmedSave] = useState<Awaited<
+    ReturnType<ReturnType<typeof createWorkspaceInstructionSave>["run"]>
+  > | null>(null);
+  const projectedHead = activeGlobalWorkspaceInstructionHead(state);
+  const activeHead =
+    confirmedSave && confirmedSave.head.activationVersion >= (projectedHead?.activationVersion ?? 0)
+      ? confirmedSave.head
+      : projectedHead;
+  const pendingSave = useRef<ReturnType<typeof createWorkspaceInstructionSave> | null>(null);
   const activeRevisionId = activeHead?.revisionId ?? null;
   const instructionConfigured =
     activeRevisionId !== null || state.policy.legacyRuntime.workspaceOverrideConfigured;
@@ -1072,6 +1079,13 @@ function FocusedInstructions({
 
   useEffect(() => {
     let cancelled = false;
+    // Activation already returned the durable head and draft content. Do not
+    // gate completion (or the next edit's baseline) on another inventory read.
+    if (confirmedSave?.head.revisionId === activeRevisionId) {
+      setContent(confirmedSave.content);
+      setLoadingContent(false);
+      return;
+    }
     setLoadingContent(true);
     setContent("");
     setMessage(null);
@@ -1098,6 +1112,7 @@ function FocusedInstructions({
     };
   }, [
     activeRevisionId,
+    confirmedSave,
     client,
     state.policy.legacyRuntime.workspaceOverrideConfigured,
     workspaceId,
@@ -1105,31 +1120,32 @@ function FocusedInstructions({
 
   const save = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    if (!canEdit || saving || !content.trim()) return;
+    if (!canEdit || saving || loadingContent || !content.trim()) return;
     setSaving(true);
     setMessage(null);
     setEditorError(null);
     try {
-      const draft = await client.createWorkspaceInstructionPolicyDraft(workspaceId, {
-        operationId: crypto.randomUUID(),
-        kind: "policy",
-        scope: "global",
-        roleKey: null,
-        content,
-        provenanceSource: "human",
-        provenanceSourceId: null,
-        supersedesRevisionId: activeHead?.revisionId ?? null,
-      });
-      await client.activateWorkspaceInstructionPolicyRevision(workspaceId, draft.id, {
-        operationId: crypto.randomUUID(),
-        expectedCurrentRevisionId: activeHead?.revisionId ?? null,
-        expectedActivationVersion: activeHead?.activationVersion ?? 0,
-        reason: "Updated by a workspace admin from Agent Knowledge",
-      });
-      await onWorkspaceStateReload();
+      if (!pendingSave.current?.matches(client, workspaceId, content, activeHead)) {
+        pendingSave.current = createWorkspaceInstructionSave(
+          client,
+          workspaceId,
+          content,
+          activeHead,
+        );
+      }
+      setConfirmedSave(await pendingSave.current.run());
+      pendingSave.current = null;
       setMessage("Saved. New agent turns will use these workspace instructions.");
     } catch (error) {
-      setEditorError(error instanceof Error ? error.message : String(error));
+      const uncertain = error instanceof OpenGeniApiError && error.outcomeUnknown;
+      if (!uncertain) pendingSave.current = null;
+      setEditorError(
+        uncertain
+          ? "Could not confirm whether these instructions were saved. Your text is still here. Save again to retry."
+          : error instanceof Error
+            ? error.message
+            : String(error),
+      );
     } finally {
       setSaving(false);
     }
@@ -1318,10 +1334,10 @@ export function WorkspaceStateRoute({
             ) : null}
             {view === "instructions" ? (
               <FocusedInstructions
+                key={workspaceId}
                 state={state}
                 workspaceId={workspaceId}
                 personalWorkspace={personalWorkspace}
-                onWorkspaceStateReload={reload}
               />
             ) : null}
             {view === "skills" ? (

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4873,11 +4873,13 @@ export class OpenGeniClient {
   async createWorkspaceInstructionPolicyDraft(
     workspaceId: string,
     request: CreateWorkspaceInstructionPolicyDraftRequest,
+    options: OpenGeniRequestOptions = {},
   ): Promise<WorkspaceInstructionPolicyRevision> {
-    return await this.requestJson<WorkspaceInstructionPolicyRevision>(
+    return await this.requestSessionCommand<WorkspaceInstructionPolicyRevision>(
       "POST",
       `/v1/workspaces/${workspaceId}/instruction-policies/drafts`,
       request,
+      options,
     );
   }
 
@@ -4937,11 +4939,13 @@ export class OpenGeniClient {
     workspaceId: string,
     revisionId: string,
     request: ActivateWorkspaceInstructionPolicyRequest,
+    options: OpenGeniRequestOptions = {},
   ): Promise<WorkspaceInstructionPolicyActivationResponse> {
-    return await this.requestJson<WorkspaceInstructionPolicyActivationResponse>(
+    return await this.requestSessionCommand<WorkspaceInstructionPolicyActivationResponse>(
       "POST",
       `/v1/workspaces/${workspaceId}/instruction-policies/${encodeURIComponent(revisionId)}/activate`,
       request,
+      options,
     );
   }
 
@@ -7663,14 +7667,18 @@ export class OpenGeniClient {
         throw error;
       }
       assertApiContractResponse(response);
-      if (!response.ok) {
-        throw await apiErrorFromResponse(response, { method, correlationId });
-      }
-      await assertJsonResponse(response, { method, correlationId });
       try {
-        return (await response.json()) as T;
+        if (!response.ok) {
+          throw await awaitWithAbort(
+            apiErrorFromResponse(response, { method, correlationId }),
+            abort.signal,
+          );
+        }
+        await awaitWithAbort(assertJsonResponse(response, { method, correlationId }), abort.signal);
+        return (await awaitWithAbort(response.json(), abort.signal)) as T;
       } catch (error) {
         if (options.signal?.aborted) throw error;
+        if (error instanceof OpenGeniApiError) throw error;
         if (isMutationMethod(method)) {
           throw mutationTransportError(correlationId);
         }

--- a/packages/sdk/test/workspace-instruction-policies.test.ts
+++ b/packages/sdk/test/workspace-instruction-policies.test.ts
@@ -11,6 +11,38 @@ const ROLLBACK_OPERATION = "00000000-0000-4000-8000-000000000007";
 const PROPOSAL_OPERATION = "00000000-0000-4000-8000-000000000008";
 
 describe("workspace instruction-policy SDK", () => {
+  for (const stalledStage of ["headers", "body", "error body"] as const) {
+    test(`bounds instruction mutations stalled at ${stalledStage}`, async () => {
+      const client = new OpenGeniClient({
+        baseUrl: "https://api.example.test",
+        sessionCommandTimeoutMs: 10,
+        fetch: (async () => {
+          if (stalledStage === "headers") return await new Promise<Response>(() => {});
+          return new Response(new ReadableStream({ start() {} }), {
+            status: stalledStage === "error body" ? 500 : 200,
+            headers: { "content-type": "application/json" },
+          });
+        }) as unknown as typeof fetch,
+      });
+      await expect(
+        client.createWorkspaceInstructionPolicyDraft(WORKSPACE_ID, {
+          operationId: DRAFT_OPERATION,
+          kind: "policy",
+          scope: "global",
+          roleKey: null,
+          content: "Keep updates concise.",
+        }),
+      ).rejects.toMatchObject({ code: "network_error", outcomeUnknown: true });
+      await expect(
+        client.activateWorkspaceInstructionPolicyRevision(WORKSPACE_ID, REVISION_A, {
+          operationId: ACTIVATE_OPERATION,
+          expectedCurrentRevisionId: null,
+          expectedActivationVersion: 0,
+          reason: "Initial activation",
+        }),
+      ).rejects.toMatchObject({ code: "network_error", outcomeUnknown: true });
+    });
+  }
   test("maps the complete backend control surface to stable routes", async () => {
     const requests: Request[] = [];
     const client = new OpenGeniClient({

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -440,7 +440,11 @@ const effectiveBudgets = {
   directSessionGzip: Math.max(
     budgets.directSessionGzip,
     PR_REVIEW_EXECUTION_CURRENT_MAIN_BROWSER_GZIP_BUDGET,
-    625 * kib,
+    // Untouched main 0f3dc9a02 measures 640,863 gzip bytes on macOS/arm64;
+    // the instruction-save head measures 640,920 locally and 640,937 in the
+    // configured Linux/x64 acceptance build. Use the established whole-KiB
+    // envelope with at least 1 KiB headroom; all other limits stay fixed.
+    627 * kib,
   ),
   directSessionFiles: Math.max(
     budgets.directSessionFiles,


### PR DESCRIPTION
Manual instruction saves could remain on “Saving…” after activation succeeded because completion awaited the full workspace inventory refresh. The editor and parent inventory now accept the confirmed activation head immediately, preserving the saved revision across view navigation and using it for subsequent edits. Older in-flight refreshes cannot overwrite it.

Draft and activation requests have bounded waits, including successful and error response bodies. Uncertain retries reuse operation IDs within the same client, workspace, text, and baseline; definitive failures discard the attempt. Timeouts retain the text and restore editing.

Validation: focused SDK/editor/loader tests, web and SDK typechecks, targeted lint, and independent review. Desktop local preview verified success without follow-up reads and recovery from a stalled activation.

The untouched base already exceeds the direct-session gzip limit (640,863 bytes locally). Candidate measurements are 640,920 locally and 640,937 in Linux acceptance before the parent-state follow-up. Update only that stale envelope from 625 to 627 KiB under the existing measured-headroom policy; other limits stay fixed.
