### PR TITLE
fix(sdk): preserve compact coverage through proxies

### DIFF
--- a/.changeset/preserve-proxy-stream-coverage.md
+++ b/.changeset/preserve-proxy-stream-coverage.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Preserve compact session-event coverage when re-streaming through the SDK proxy helpers so downstream gap recovery does not replay already-covered deltas.

--- a/packages/sdk/src/proxy.ts
+++ b/packages/sdk/src/proxy.ts
@@ -1,5 +1,5 @@
 import type { OpenGeniClient } from "./client";
-import type { StreamSessionEventsOptions } from "./stream";
+import { sessionEventStreamCoveredThrough, type StreamSessionEventsOptions } from "./stream";
 import type { SessionEvent } from "./types";
 
 /**
@@ -12,12 +12,22 @@ import type { SessionEvent } from "./types";
  * OpenGeni's own SSE stream (`id: <sequence>`, `event: <type>`,
  * `data: <event JSON>`), so the browser side can consume it with this same
  * SDK's streaming core (or a plain `EventSource`), including resume via
- * `?after=` / `Last-Event-ID`.
+ * `?after=` / `Last-Event-ID`. An ordinary event uses its own sequence as the
+ * SSE `id`; a compact event uses the server-owned sequence it covers through.
  */
 
-/** Format one event exactly as OpenGeni's API emits it over SSE. */
+/** Format one event with the exact OpenGeni data and resume-cursor semantics. */
 export function formatSseEvent(event: SessionEvent): string {
-  return `id: ${event.sequence}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+  const streamedCoverage = sessionEventStreamCoveredThrough(event);
+  const projectedCoverage = event.coveredThrough;
+  const coveredThrough =
+    streamedCoverage ??
+    (typeof projectedCoverage === "number" &&
+    Number.isSafeInteger(projectedCoverage) &&
+    projectedCoverage >= event.sequence
+      ? projectedCoverage
+      : event.sequence);
+  return `id: ${coveredThrough}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
 }
 
 export type SseReStreamOptions = {
@@ -115,8 +125,9 @@ export function sessionEventsToSseResponse(
 
 /**
  * Read the resume cursor a reconnecting SSE client sent: the `after` query
- * parameter, or the standard `Last-Event-ID` header (the re-emitted stream
- * sets `id:` to the sequence). Returns 0 (full replay) when absent.
+ * parameter, or the standard `Last-Event-ID` header. Re-emitted streams set
+ * `id:` to the event sequence for ordinary events and the covered high-water
+ * sequence for compact events. Returns 0 (full replay) when absent.
  */
 export function resumeSequenceFromRequest(request: Request): number {
   const url = new URL(request.url);

--- a/packages/sdk/test/proxy.test.ts
+++ b/packages/sdk/test/proxy.test.ts
@@ -8,8 +8,10 @@ import {
   sessionEventsToSseStream,
 } from "../src/proxy";
 import { parseSseStream } from "../src/sse";
+import { streamSessionEvents, type SessionEventStreamTransport } from "../src/stream";
 import type { SessionEvent } from "../src/types";
 import {
+  bytesStream,
   collect,
   hangingBytesStream,
   makeEvent,
@@ -32,6 +34,13 @@ describe("proxy re-streaming", () => {
     );
   });
 
+  test("formatSseEvent preserves valid REST compact coverage", () => {
+    const event = { ...makeEvent(7), coveredThrough: 42 };
+    expect(formatSseEvent(event)).toBe(
+      `id: 42\nevent: agent.message.delta\ndata: ${JSON.stringify(event)}\n\n`,
+    );
+  });
+
   test("re-emitted stream round-trips through the SDK parser unchanged", async () => {
     const source = [
       makeEvent(1, "session.created", {}),
@@ -48,6 +57,36 @@ describe("proxy re-streaming", () => {
       "turn.completed",
     ]);
     expect(messages.map((message) => JSON.parse(message.data))).toEqual(source as never);
+  });
+
+  test("preserves compact coverage so downstream gap recovery does not replay covered deltas", async () => {
+    const compact = makeEvent(1, "agent.message.delta", { text: "complete streamed answer" });
+    const upstreamFetch = (async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(bytesStream([sseBlock(compact, 100), sseBlock(makeEvent(101))]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })) as typeof fetch;
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      apiKey: "og_test_key",
+      fetch: upstreamFetch,
+    });
+    const proxied = proxySessionEventStream(client, WORKSPACE_ID, SESSION_ID, {
+      reconnect: false,
+    });
+    const listCalls: Array<{ after: number; limit: number }> = [];
+    const downstream: SessionEventStreamTransport = {
+      openStream: async () => proxied.body!,
+      listEvents: async (after, limit) => {
+        listCalls.push({ after, limit });
+        return Array.from({ length: limit }, (_, index) => makeEvent(after + index + 1));
+      },
+    };
+
+    const received = await collect(streamSessionEvents(downstream, { reconnect: false }));
+
+    expect(received.map((event) => event.sequence)).toEqual([1, 101]);
+    expect(listCalls).toEqual([]);
   });
 
   test("cancelling the downstream fires onCancel and ends the upstream iterator", async () => {


### PR DESCRIPTION
## Summary

- preserve the trusted SSE high-water mark when compact session events are re-streamed through SDK proxy helpers
- prevent downstream gap recovery from replaying deltas already covered by a compact frame
- add a nested upstream → proxy → downstream lifecycle regression with zero synthetic gap-backfill calls

## Verification

- `bun test packages/sdk/test/proxy.test.ts packages/sdk/test/stream.test.ts`
- `bun test packages/sdk/test --max-concurrency=8 --timeout=30000`
- `bun run --cwd packages/sdk typecheck`
- `bun run --cwd packages/sdk build`
- `bun run check:public-hygiene`
- `bun run lint -- packages/sdk/src/proxy.ts packages/sdk/test/proxy.test.ts`
- `git diff --check`

Agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/582205fb-3bfc-4e28-a2bf-e762cd7212f3

## Summary by Sourcery

Preserve compact event coverage across SDK proxy streams so reconnect and gap recovery use the correct resume cursor.

Bug Fixes:
- Preserve compact session-event coverage when SDK proxy helpers re-stream SSE events, preventing downstream recovery from replaying deltas already represented by the compact event.

Tests:
- Add regression coverage for REST compact-event cursors and nested upstream-to-proxy-to-downstream streaming without synthetic gap backfill.