### PR TITLE
Fix file links outside Connected Machine working directories

### DIFF
--- a/.changeset/connected-machine-file-reads.md
+++ b/.changeset/connected-machine-file-reads.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Open absolute file links outside a Connected Machine session's working directory, including sibling worktrees. Preserve route identity checks and managed sandbox confinement.

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -624,7 +624,7 @@ async function withChannelAOperation<T>(
       workspaceRoot: fileSystemAuthority.root,
       leaseEpoch: fileSystemEpoch,
       ...(fileSystemAuthority.backendKind === "selfhosted"
-        ? { providerPathMode: "workspace-relative" as const }
+        ? { providerPathMode: "workspace-relative" as const, fileReadScope: "machine" as const }
         : {}),
       emit,
     });

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -647,6 +647,9 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(channelASeam.slice(serviceAt, serviceAt + 300)).toContain(
       "workspaceRoot: fileSystemAuthority.root",
     );
+    expect(channelASeam.slice(serviceAt, serviceAt + 650)).toContain(
+      'fileSystemAuthority.backendKind === "selfhosted"\n        ? { providerPathMode: "workspace-relative" as const, fileReadScope: "machine" as const }',
+    );
   });
 
   test("the PTY write route adopts the exact durable process identity", () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -375,8 +375,10 @@ snapshot it, or provider-terminate the user's computer.
 
 The structured Files boundary advertises the selected machine's effective
 host-native working directory as `FileSystem.root`. Canonical file links and
-tree nodes stay in that namespace, while provider commands use contained paths
-relative to the same root. Files requests carry the capability epoch plus root;
+tree nodes stay in that namespace. Connected Machine file reads also accept
+absolute paths outside the working directory, subject to the machine account’s
+OS permissions; the working directory is a browsing default, not a read boundary.
+Managed provider reads and structured mutations retain workspace confinement. Files requests carry the capability epoch plus root;
 the API binds one active route for the request and returns a retryable conflict
 if the selected target or root changes instead of reinterpreting the path on a
 different filesystem.

--- a/packages/runtime/src/operational-instructions.ts
+++ b/packages/runtime/src/operational-instructions.ts
@@ -65,7 +65,8 @@ Your answer is being rendered by an application for the user. Follow these guide
   * If a file path has spaces, wrap the target in angle brackets: [My Report.md](<sandbox:/workspace/My Project/My Report.md:3>).
   * Use the active workspace path exactly as exposed to you. Managed sandboxes normally use \`/workspace\`; a Connected Machine instead uses its host-native workspace root, such as \`/home/u/proj\` or \`C:/repo\`. Both are valid inside a \`sandbox:\` link when they are the active workspace.
   * Connected Machine examples are [app.py](sandbox:/home/u/proj/app.py:12) on POSIX and [app.ts](<sandbox:C:/repo/app.ts:12>) on Windows.
-  * Never link directly to \`/tmp\` or any file outside the current workspace. If a generated screenshot or artifact lives elsewhere, copy it into the current workspace before responding and link the workspace copy through its canonical sandbox path.
+  * On a Connected Machine, absolute file links may point outside the working directory (including sibling worktrees and temporary files); use the real path on the selected machine.
+  * In managed sandboxes, never link directly to \`/tmp\` or any file outside the current workspace. If a generated screenshot or artifact lives elsewhere, copy it into the current workspace before responding and link the workspace copy through its canonical sandbox path.
   * Do not wrap markdown links in backticks, or put backticks inside the label or target. This confuses the markdown renderer.
   * Do not use URIs like file://, vscode://, or https:// for local file links, and do not invent or translate the active workspace root.
   * Do not provide ranges of lines.

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -288,12 +288,15 @@ export type SandboxChannelAServiceOptions = {
   session: ChannelASession;
   // Canonical filesystem root advertised by the selected target. Relative paths
   // resolve beneath it; already-canonical absolute paths stay byte-for-byte paths
-  // after validation that they remain inside this authority.
+  // after validation against the operation's path scope.
   workspaceRoot?: string;
   // Connected Machine providers already resolve relative paths against their
   // exact host root. Keep provider commands relative while preserving the
   // canonical host-native root as the public FileSystem namespace.
   providerPathMode?: "canonical" | "workspace-relative";
+  // Selected Connected Machines can read host-absolute paths outside their cwd.
+  // This is server-derived; managed providers retain workspace confinement.
+  fileReadScope?: "workspace" | "machine";
   // The lease epoch the box was resumed under (paired with `revision` for cache
   // invalidation — H3). 0 when ownership is off / no lease.
   leaseEpoch?: number;
@@ -414,6 +417,7 @@ export class SandboxChannelAService {
   private readonly session: ChannelASession;
   private readonly workspaceRoot: string;
   private readonly providerPathMode: "canonical" | "workspace-relative";
+  private readonly fileReadScope: "workspace" | "machine";
   private readonly leaseEpoch: number;
   private revision: number;
   private readonly emit?: ChannelAEmitter | undefined;
@@ -428,6 +432,7 @@ export class SandboxChannelAService {
         ? ""
         : workspaceRoot.replace(/\/+$/, "");
     this.providerPathMode = opts.providerPathMode ?? "canonical";
+    this.fileReadScope = opts.fileReadScope ?? "workspace";
     this.leaseEpoch = opts.leaseEpoch ?? 0;
     this.revision = opts.revision ?? 0;
     this.emit = opts.emit;
@@ -701,16 +706,19 @@ export class SandboxChannelAService {
 
   async fsRead(req: FsReadRequest): Promise<FsReadResponse> {
     this.assertFileSystemRoute(req.route);
-    const path = assertSafeRelPath(req.path, this.workspaceRoot);
+    const path =
+      this.fileReadScope === "machine" && isConnectedMachineAbsolutePath(req.path)
+        ? resolveConnectedMachinePath(this.workspaceRoot, req.path)
+        : assertSafeRelPath(req.path, this.workspaceRoot);
     if (!this.session.readFile) {
-      // No native readFile: open the file once, prove that exact descriptor is
-      // rooted beneath the workspace, then base64 it through exec.
+      // No native readFile: read an exact descriptor through exec, retaining
+      // workspace confinement for managed providers.
       return await this.fsReadViaExec(path, req);
     }
     let raw: string | Uint8Array;
     try {
       raw = await this.session.readFile({
-        path: this.joinRoot(path),
+        path: this.fileReadPath(path),
         maxBytes: req.maxBytes,
         ...(this.runAs ? { runAs: this.runAs } : {}),
       });
@@ -725,7 +733,7 @@ export class SandboxChannelAService {
         throw new ChannelANotFoundError(`file not found: ${path}`);
       }
       // A native provider read can fail while exec on the same live box remains
-      // healthy. The descriptor path below is equally confined and binary-safe,
+      // healthy. The descriptor path below uses the same scope and is binary-safe,
       // so use it as a single recovery path. Unknown provider failures must never
       // be downgraded into a false 404.
       if (this.session.exec || this.session.execCommand) {
@@ -813,19 +821,27 @@ export class SandboxChannelAService {
     );
   }
 
-  /** Binary-safe fallback for sessions without native reads. The file is opened
-   * before its resolved path is root-checked and matched to the descriptor's
-   * inode, so a symlink/path swap cannot redirect the subsequent read. */
+  /** Binary-safe fallback for sessions without native reads. Match the resolved
+   * path to the open descriptor's inode before reading; managed providers also
+   * require that path to remain beneath the workspace. */
   private async fsReadViaExec(path: string, req: FsReadRequest): Promise<FsReadResponse> {
     const root = this.providerWorkspaceRoot();
-    const abs = this.joinRoot(path);
+    const abs = this.fileReadPath(path);
     const script = [
       PORTABLE_REALPATH_EXISTING_FUNCTION,
       PORTABLE_DESCRIPTOR_FUNCTIONS,
-      `root=$(opengeni_realpath_existing ${shellQuote(root)}) || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
+      ...(this.fileReadScope === "workspace"
+        ? [
+            `root=$(opengeni_realpath_existing ${shellQuote(root)}) || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
+          ]
+        : []),
       `exec 3<${shellQuote(abs)} || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
       `target=$(opengeni_realpath_existing ${shellQuote(abs)}) || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
-      `case "$target" in "$root"|"$root"/*) ;; *) printf '__OPENGENI_FS_ESCAPE__'; exit 67 ;; esac`,
+      ...(this.fileReadScope === "workspace"
+        ? [
+            `case "$target" in "$root"|"$root"/*) ;; *) printf '__OPENGENI_FS_ESCAPE__'; exit 67 ;; esac`,
+          ]
+        : []),
       `test -f "$target" || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
       `opened_identity=$(opengeni_fd_identity 3) || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
       `target_identity=$(opengeni_path_identity "$target") || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
@@ -2416,6 +2432,11 @@ export class SandboxChannelAService {
   /** The current FS revision (for the caller to persist/seed). */
   currentRevision(): number {
     return this.revision;
+  }
+
+  private fileReadPath(path: string): string {
+    if (this.fileReadScope === "machine" && isConnectedMachineAbsolutePath(path)) return path;
+    return this.joinRoot(path);
   }
 
   private joinRoot(rel: string): string {

--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -1048,6 +1048,83 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
     }
   });
 
+  test("Connected Machine file links read sibling worktrees and Windows volumes", async () => {
+    for (const [root, path] of [
+      ["/home/jorge/repos/peloton", "/home/jorge/peloton-worktrees/unified/.agent/brief.md"],
+      ["C:/repos/peloton", "D:/worktrees/unified/brief.md"],
+      ["//server/share/repo", "//server/other/worktree/brief.md"],
+    ] as const) {
+      const requested: string[] = [];
+      const svc = new SandboxChannelAService({
+        workspaceRoot: root,
+        providerPathMode: "workspace-relative",
+        fileReadScope: "machine",
+        leaseEpoch: 7,
+        session: {
+          readFile: async ({ path: requestedPath }) => {
+            requested.push(requestedPath);
+            return "brief";
+          },
+        },
+      });
+      const read = await svc.fsRead({
+        path,
+        encoding: "utf8",
+        maxBytes: 1024,
+        route: { root, epoch: 7 },
+      });
+      expect(read.path).toBe(path);
+      expect(read.content).toBe("brief");
+      expect(requested).toEqual([path]);
+      await svc.fsRead({ path: ".agent/brief.md", encoding: "utf8", maxBytes: 1024 });
+      expect(requested[1]).toBe(".agent/brief.md");
+      await expect(
+        svc.fsRead({ path, encoding: "utf8", maxBytes: 1024, route: { root, epoch: 6 } }),
+      ).rejects.toBeInstanceOf(ChannelAFileSystemRouteChangedError);
+      expect(requested).toHaveLength(2);
+      await expect(
+        svc.fsWrite({
+          path,
+          encoding: "utf8",
+          content: "changed",
+          overwrite: true,
+          createParents: false,
+        }),
+      ).rejects.toThrow(/outside the workspace root/);
+    }
+  });
+
+  test("Connected Machine exec fallback reads actual outside files with byte limits", async () => {
+    const { session, root } = await makeBox();
+    const outside = mkdtempSync(join(tmpdir(), "opengeni-machine-read-"));
+    temporaryRoots.push(outside);
+    const path = join(outside, "brief with spaces.bin");
+    writeFileSync(path, Buffer.from([0, 1, 2, 3, 255]));
+    for (const nativeFailure of [false, true]) {
+      const svc = new SandboxChannelAService({
+        workspaceRoot: root,
+        providerPathMode: "workspace-relative",
+        fileReadScope: "machine",
+        session: {
+          exec: session.exec!.bind(session),
+          ...(nativeFailure
+            ? {
+                readFile: async () => {
+                  throw new Error("transient native read failure");
+                },
+              }
+            : {}),
+        },
+      });
+      const read = await svc.fsRead({ path, encoding: "base64", maxBytes: 4 });
+      expect(read.path).toBe(path);
+      expect(read.content).toBe(Buffer.from([0, 1, 2, 3]).toString("base64"));
+      await expect(
+        svc.fsRead({ path: join(outside, "missing"), encoding: "utf8", maxBytes: 16 }),
+      ).rejects.toBeInstanceOf(ChannelANotFoundError);
+    }
+  });
+
   test("a stale capability filesystem identity fails as a retryable route conflict", async () => {
     const svc = new SandboxChannelAService({
       workspaceRoot: "/srv/project",

--- a/packages/runtime/test/operational-instructions.test.ts
+++ b/packages/runtime/test/operational-instructions.test.ts
@@ -29,7 +29,9 @@ describe("provider-neutral operational instructions", () => {
     );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.py](sandbox:/home/u/proj/app.py:12)");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("[app.ts](<sandbox:C:/repo/app.ts:12>)");
-    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Never link directly to `/tmp`");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "In managed sandboxes, never link directly to `/tmp`",
+    );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
       "or any file outside the current workspace",
     );
@@ -37,6 +39,9 @@ describe("provider-neutral operational instructions", () => {
       "copy it into the current workspace before responding",
     );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("canonical sandbox path");
+    expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain(
+      "absolute file links may point outside the working directory",
+    );
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("a host path");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).not.toContain("host-absolute paths");
     expect(OPENGENI_OPERATIONAL_INSTRUCTIONS).toContain("Do not provide ranges of lines.");


### PR DESCRIPTION
## Summary

Opening an absolute file link in a sibling worktree currently returns HTTP 400 because Files treats the Connected Machine session working directory as a read boundary. Permit absolute reads on the selected machine, preserving the path through native and fallback readers. Keep managed sandbox and mutation confinement, plus route epoch/root checks.

Update file-link instructions to distinguish Connected Machines from managed sandboxes. Covers the VM2 `/home/jorge/repos/peloton` → `/home/jorge/peloton-worktrees/...` failure.

## Testing

- 131 passed, 2 platform-specific skips across Channel-A, API route contracts, and operational instructions.
- Targeted lint and formatting passed.
- Regression coverage: sibling worktree, Windows drive/UNC, relative paths, stale route, mutation confinement, binary byte-limited fallback, missing files.

## Delivery integrity

- Substantive fix based on current main; candidate remains frozen while checks run.

## Summary by Sourcery

Permit Connected Machine file reads outside the working directory while preserving managed sandbox confinement and filesystem route safety.

New Features:
- Allow Connected Machine file links to read absolute paths outside the session working directory, including sibling worktrees, Windows volumes, and UNC paths.

Bug Fixes:
- Preserve absolute paths through native and exec fallback readers while retaining route identity validation and mutation confinement.

Enhancements:
- Clarify file-link guidance and architecture documentation for Connected Machines versus managed sandboxes.

Documentation:
- Update operational instructions to permit external absolute links on Connected Machines while keeping managed sandbox links confined to the workspace.

Tests:
- Add regression coverage for sibling worktrees, Windows and UNC paths, binary-limited fallback reads, missing files, stale routes, and mutation confinement.