### PR TITLE
test(runtime): use generic connected-machine fixtures

### DIFF
--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -1050,9 +1050,9 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
 
   test("Connected Machine file links read sibling worktrees and Windows volumes", async () => {
     for (const [root, path] of [
-      ["/home/jorge/repos/peloton", "/home/jorge/peloton-worktrees/unified/.agent/brief.md"],
-      ["C:/repos/peloton", "D:/worktrees/unified/brief.md"],
-      ["//server/share/repo", "//server/other/worktree/brief.md"],
+      ["/home/user/repos/example-app", "/home/user/worktrees/example-app-feature/notes/brief.md"],
+      ["C:/repos/example-app", "D:/worktrees/example-app-feature/notes/brief.md"],
+      ["//server/share/repo", "//server/other/worktree/notes/brief.md"],
     ] as const) {
       const requested: string[] = [];
       const svc = new SandboxChannelAService({
@@ -1076,8 +1076,8 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
       expect(read.path).toBe(path);
       expect(read.content).toBe("brief");
       expect(requested).toEqual([path]);
-      await svc.fsRead({ path: ".agent/brief.md", encoding: "utf8", maxBytes: 1024 });
-      expect(requested[1]).toBe(".agent/brief.md");
+      await svc.fsRead({ path: "notes/brief.md", encoding: "utf8", maxBytes: 1024 });
+      expect(requested[1]).toBe("notes/brief.md");
       await expect(
         svc.fsRead({ path, encoding: "utf8", maxBytes: 1024, route: { root, epoch: 6 } }),
       ).rejects.toBeInstanceOf(ChannelAFileSystemRouteChangedError);


### PR DESCRIPTION
## Summary

- replace machine-specific Connected Machine path examples with portable generic fixtures
- preserve POSIX, Windows drive, UNC, sibling-worktree, relative-read, stale-route, and write-confinement coverage
- restore the public-repository hygiene gate on current `main`

## Verification

- `bun run check:public-hygiene`
- `bun test packages/runtime/test/channel-a.test.ts` (87 passed)
- `bun run lint -- packages/runtime/test/channel-a.test.ts`
- `bunx oxfmt --check packages/runtime/test/channel-a.test.ts`
- `git diff --check`

Agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/582205fb-3bfc-4e28-a2bf-e762cd7212f3

## Summary by Sourcery

Use portable generic fixtures in Connected Machine runtime tests and restore the public-repository hygiene check.

Enhancements:
- Replace machine-specific Connected Machine path examples with generic portable fixtures while preserving POSIX, Windows drive, UNC, sibling-worktree, relative-read, stale-route, and write-confinement coverage.

Tests:
- Update runtime filesystem tests to use repository-independent paths.

Chores:
- Restore the public-repository hygiene gate on current main.