### PR TITLE
fix(worker): stop retrying provider safety refusals

### DIFF
--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -725,7 +725,18 @@ export function isExactStatuslessUpstreamConnectivityMessage(message: string): b
   return message.trim().toLowerCase() === STATUSLESS_UPSTREAM_CONNECTIVITY_MESSAGE;
 }
 
+function isProviderSafetyRefusal(error: unknown): boolean {
+  return collectErrorStrings(error).some(
+    (value) =>
+      /^(?:content_policy_violation|content_filter|safety_violation|bio_policy|cyber_policy)$/.test(
+        value,
+      ) || /\bthis request was blocked by our safety systems\b/i.test(value),
+  );
+}
+
 export function isTransientProviderError(error: unknown): boolean {
+  // A semantic refusal can arrive inside a 5xx transport envelope.
+  if (isProviderSafetyRefusal(error)) return false;
   const status =
     typeof error === "object" && error !== null
       ? Number(
@@ -842,6 +853,15 @@ export function agentRunFailurePayload(
     return {
       ...underlying,
       historyPersistenceStage: error.stage,
+    };
+  }
+  if (isProviderSafetyRefusal(error)) {
+    return {
+      error:
+        "The model provider blocked this request through its safety systems. Automatic retries stopped.",
+      code: "provider_safety_refusal",
+      retryable: false,
+      detail: error instanceof Error ? error.message : collectErrorStrings(error).join(": "),
     };
   }
   const message = error instanceof Error ? error.message : String(error);
@@ -1106,6 +1126,8 @@ export function codexCredentialCooldownUntil(
  * progress and therefore MUST NOT walk the credential pool automatically.
  */
 export function classifyCodexCredentialFailure(error: unknown): CodexCredentialFailure | null {
+  // A request safety refusal is not evidence that another account should run it.
+  if (isProviderSafetyRefusal(error)) return null;
   // A permanent OAuth refresh failure is definitive and the shared resolver has
   // already fenced/stamped the exact credential version. The OpenAI client can
   // wrap a rejection from its custom fetch in APIConnectionError, so recognize

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -725,13 +725,17 @@ export function isExactStatuslessUpstreamConnectivityMessage(message: string): b
   return message.trim().toLowerCase() === STATUSLESS_UPSTREAM_CONNECTIVITY_MESSAGE;
 }
 
-function isProviderSafetyRefusal(error: unknown): boolean {
-  return collectErrorStrings(error).some(
+function providerSafetyRefusalDiagnostic(error: unknown): string | undefined {
+  return collectErrorStrings(error).find(
     (value) =>
       /^(?:content_policy_violation|content_filter|safety_violation|bio_policy|cyber_policy)$/.test(
         value,
       ) || /\bthis request was blocked by our safety systems\b/i.test(value),
   );
+}
+
+function isProviderSafetyRefusal(error: unknown): boolean {
+  return providerSafetyRefusalDiagnostic(error) !== undefined;
 }
 
 export function isTransientProviderError(error: unknown): boolean {
@@ -862,7 +866,7 @@ export function agentRunFailurePayload(
         "The model provider blocked this request through its safety systems. Automatic retries stopped.",
       code: "provider_safety_refusal",
       retryable: false,
-      detail: error instanceof Error ? error.message : collectErrorStrings(error).join(": "),
+      detail: providerSafetyRefusalDiagnostic(error),
     };
   }
   const message = error instanceof Error ? error.message : String(error);

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -780,6 +780,7 @@ export type XaiCredentialFailure = {
  * without an accepted model response; refresh relogin is equally definitive.
  */
 export function classifyXaiCredentialFailure(error: unknown): XaiCredentialFailure | null {
+  if (isProviderSafetyRefusal(error)) return null;
   let relogin: unknown = error;
   for (let depth = 0; depth < 6 && relogin && typeof relogin === "object"; depth += 1) {
     if (relogin instanceof XaiSubscriptionReloginRequired) {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -5289,6 +5289,14 @@ describe("transient provider error classifier", () => {
       });
       expect(isTransientProviderError(error)).toBe(false);
       expect(classifyCodexCredentialFailure(error)).toBeNull();
+      expect(
+        classifyXaiCredentialFailure(
+          Object.assign(new Error(message), {
+            status,
+            headers: new Headers({ [XAI_SUBSCRIPTION_TRANSPORT_ERROR_HEADER]: "1" }),
+          }),
+        ),
+      ).toBeNull();
       expect(agentRunFailurePayload(error)).toMatchObject({
         code: "provider_safety_refusal",
         retryable: false,

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -65,6 +65,7 @@ import {
   credentialSubjectIdForTurnInitiator,
   xaiCatalogReadinessAuthority,
   classifyMcpTransportTimeoutError,
+  classifyCodexCredentialFailure,
   clearAttemptCredentialsWithSettledFence,
   codexCredentialLeaseDeadlineExpired,
   completedToolCallFromSdkEvent,
@@ -5276,6 +5277,33 @@ describe("transient provider error classifier", () => {
     expect(JSON.stringify(payload)).not.toContain(syntheticValue);
     expect(JSON.stringify(payload)).not.toContain(source.query);
     expect((error as SessionEventPersistenceError).cause).toBe(source);
+  });
+
+  test("safety refusals outrank transient status and do not rotate credentials", () => {
+    const message =
+      "This request was blocked by our safety systems. Reason: Potentially unintended activity.";
+    for (const status of [403, 429, 500, 502, 503]) {
+      const error = Object.assign(new Error(message), {
+        status,
+        headers: new Headers({ "x-opengeni-codex-transport-error": "1" }),
+      });
+      expect(isTransientProviderError(error)).toBe(false);
+      expect(classifyCodexCredentialFailure(error)).toBeNull();
+      expect(agentRunFailurePayload(error)).toMatchObject({
+        code: "provider_safety_refusal",
+        retryable: false,
+        detail: message,
+      });
+    }
+    const wrapped = Object.assign(new Error("Service unavailable"), {
+      status: 503,
+      cause: { error: { code: "content_policy_violation" } },
+    });
+    expect(isTransientProviderError(wrapped)).toBe(false);
+    expect(agentRunFailurePayload(wrapped)).toMatchObject({
+      code: "provider_safety_refusal",
+      retryable: false,
+    });
   });
 
   test("classifies 5xx status codes as transient (status is authoritative)", () => {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -5311,6 +5311,7 @@ describe("transient provider error classifier", () => {
     expect(agentRunFailurePayload(wrapped)).toMatchObject({
       code: "provider_safety_refusal",
       retryable: false,
+      detail: "content_policy_violation",
     });
   });
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -30,6 +30,11 @@ one non-retryable Temporal `runAgentTurn` activity. Inside the activity the
 OpenAI Agents SDK loop makes as many model calls and tool calls as the work
 needs.
 
+Provider safety refusals terminate the turn with `provider_safety_refusal` and
+the original diagnostic. They are neither temporary provider unavailability
+nor credential failures, even when carried by a 5xx response. Same-turn recovery
+and account rotation must not replay them.
+
 Session display titles are durable session metadata, not a truncation of model
 history. Creation and migration use `New conversation` only as the durable
 marker that semantic naming is still pending. Human-facing clients render a


### PR DESCRIPTION
Provider safety refusals were classified as temporary outages when the transport supplied a 5xx status. A staging turn repeated the same refusal five times, then displayed an upstream-unavailable banner that hid the cause.

Classify explicit safety refusal diagnostics before transient HTTP status or account-failure handling. Emit a non-retryable `provider_safety_refusal` with the original diagnostic; do not rotate credentials for these refusals. Ordinary provider outages retain existing recovery behavior.

Validation: 225 worker/credential tests pass, worker typecheck passes, diff check clean. Regression covers 403/429/5xx refusal envelopes and nested policy codes.

## Summary by Sourcery

Classify provider safety refusals before transport and credential failure handling so blocked requests stop without retries or credential rotation.

Bug Fixes:
- Stop provider safety refusals from being retried or treated as credential failures, including when they are wrapped in transient HTTP responses.
- Report safety refusals as non-retryable `provider_safety_refusal` failures while preserving the provider diagnostic.

Enhancements:
- Keep ordinary transient provider outages and credential recovery behavior unchanged.

Documentation:
- Document that provider safety refusals terminate turns without same-turn recovery or account rotation.

Tests:
- Add regression coverage for safety refusals across 403, 429, and 5xx responses, including nested policy diagnostics.