### PR TITLE
fix(worker): narrow safety diagnostic before failure payload

### DIFF
--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -860,13 +860,14 @@ export function agentRunFailurePayload(
       historyPersistenceStage: error.stage,
     };
   }
-  if (isProviderSafetyRefusal(error)) {
+  const safetyRefusalDiagnostic = providerSafetyRefusalDiagnostic(error);
+  if (safetyRefusalDiagnostic !== undefined) {
     return {
       error:
         "The model provider blocked this request through its safety systems. Automatic retries stopped.",
       code: "provider_safety_refusal",
       retryable: false,
-      detail: providerSafetyRefusalDiagnostic(error),
+      detail: safetyRefusalDiagnostic,
     };
   }
   const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Fix the strict TypeScript error introduced by #2220: retain the safety diagnostic in a local variable and narrow it before assigning the optional string field. Runtime behavior is unchanged.

Validation: worker typecheck and safety-refusal regression pass. This fixes both source-contract and package declaration-build CI failures.

## Summary by Sourcery

Narrow the provider safety diagnostic before assigning it to the optional failure detail field.

Bug Fixes:
- Fix strict TypeScript errors when constructing provider safety-refusal failure payloads.

Build:
- Restore successful worker typechecking and package declaration builds.