### PR TITLE
Fix stale background-command tracking and slow session status reads

### DIFF
--- a/.changeset/connected-command-lifecycle.md
+++ b/.changeset/connected-command-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Retire background-command tracking after a connected agent instance is replaced, explicitly stopped, or revoked. Preserve historical records without waking old sessions, drain cleanup batches promptly, and scope session stopping counts to the requested trees.

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -1040,6 +1040,7 @@ export async function reconcileConnectedMachineBackgroundCommands(
   const dueBefore = new Date();
   const deadline = Date.now() + settings.sandboxLeaseReaperPeriodMs;
   const offlineConnections = new Set<string>();
+  const firstConnectionProbes = new Map<string, Promise<void>>();
   // Drain the fixed due frontier with the existing concurrency. Yield to the
   // remaining maintenance work each period; retries belong to a later sweep.
   do {
@@ -1072,11 +1073,23 @@ export async function reconcileConnectedMachineBackgroundCommands(
         claim.enrollmentId,
         claim.connectionInstanceId,
       ]);
-      if (!proof && offlineConnections.has(connectionKey)) {
-        await deferConnectedCommandClaim(db, settings, observability, claim, "provider_offline");
-        return;
-      }
       if (!proof) {
+        const firstProbe = firstConnectionProbes.get(connectionKey);
+        if (firstProbe) await firstProbe;
+        if (offlineConnections.has(connectionKey)) {
+          await deferConnectedCommandClaim(db, settings, observability, claim, "provider_offline");
+          return;
+        }
+        // Share only the initial connection observation, never another command's result.
+        let finishFirstProbe: (() => void) | undefined;
+        if (!firstProbe) {
+          firstConnectionProbes.set(
+            connectionKey,
+            new Promise<void>((resolve) => {
+              finishFirstProbe = resolve;
+            }),
+          );
+        }
         try {
           proof = await probeConnectedMachineBackgroundCommand(
             claim,
@@ -1117,6 +1130,8 @@ export async function reconcileConnectedMachineBackgroundCommands(
             offline ? "provider_offline" : "provider_error",
           );
           return;
+        } finally {
+          finishFirstProbe?.();
         }
 
         try {

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -1030,107 +1030,135 @@ async function adoptLegacyModalCheckpointReceipts(
 /** Reconcile commands only against the immutable physical locator copied at
  * adoption. A successor enrollment connection is intentionally irrelevant: no
  * query or cancellation is ever rebound to it. */
-async function reconcileConnectedMachineBackgroundCommands(
+export async function reconcileConnectedMachineBackgroundCommands(
   db: ActivityServices["db"],
   settings: ActivityServices["settings"],
   observability: ActivityServices["observability"],
   bus: ActivityServices["bus"],
+  controlRpcOverride?: ControlRpc,
 ): Promise<void> {
-  const claimId = crypto.randomUUID();
-  let claims: ConnectedMachineBackgroundCommandClaim[];
-  try {
-    claims = await claimConnectedMachineSessionBackgroundCommands(db, {
-      claimId,
-      limit: CONNECTED_COMMAND_RECONCILIATION_LIMIT,
-      claimTtlMs: CONNECTED_COMMAND_RECONCILIATION_CLAIM_TTL_MS,
-    });
-  } catch (error) {
-    recordConnectedCommandReconciliation(observability, "claim_failed");
-    observability.warn("sandbox reaper: connected-command claim failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return;
-  }
+  const dueBefore = new Date();
+  const deadline = Date.now() + settings.sandboxLeaseReaperPeriodMs;
+  const offlineConnections = new Set<string>();
+  // Drain the fixed due frontier with the existing concurrency. Yield to the
+  // remaining maintenance work each period; retries belong to a later sweep.
+  do {
+    const claimId = crypto.randomUUID();
+    let claims: ConnectedMachineBackgroundCommandClaim[];
+    try {
+      claims = await claimConnectedMachineSessionBackgroundCommands(db, {
+        claimId,
+        dueBefore,
+        limit: CONNECTED_COMMAND_RECONCILIATION_LIMIT,
+        claimTtlMs: CONNECTED_COMMAND_RECONCILIATION_CLAIM_TTL_MS,
+      });
+    } catch (error) {
+      recordConnectedCommandReconciliation(observability, "claim_failed");
+      observability.warn("sandbox reaper: connected-command claim failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
 
-  const controlRpc = new NatsControlRpc(
-    async (): Promise<NatsRequestConnection | null> => bus.getRequestConnection(),
-  );
-  await forEachWithConcurrency(claims, SANDBOX_MAINTENANCE_ITEM_CONCURRENCY, async (claim) => {
-    let proof = claim.proof;
-    if (!proof) {
-      try {
-        proof = await probeConnectedMachineBackgroundCommand(
-          claim,
-          controlRpc,
-          Math.min(
-            settings.sandboxSelfhostedControlTimeoutMs,
-            RETAINED_PROCESS_PROVIDER_PROBE_TIMEOUT_MS,
-          ),
-        );
-        if (!proof) {
-          await deferConnectedCommandClaim(db, settings, observability, claim, "provider_running");
+    const controlRpc =
+      controlRpcOverride ??
+      new NatsControlRpc(
+        async (): Promise<NatsRequestConnection | null> => bus.getRequestConnection(),
+      );
+    await forEachWithConcurrency(claims, SANDBOX_MAINTENANCE_ITEM_CONCURRENCY, async (claim) => {
+      let proof = claim.proof;
+      const connectionKey = JSON.stringify([
+        claim.controlWorkspaceId,
+        claim.enrollmentId,
+        claim.connectionInstanceId,
+      ]);
+      if (!proof && offlineConnections.has(connectionKey)) {
+        await deferConnectedCommandClaim(db, settings, observability, claim, "provider_offline");
+        return;
+      }
+      if (!proof) {
+        try {
+          proof = await probeConnectedMachineBackgroundCommand(
+            claim,
+            controlRpc,
+            Math.min(
+              settings.sandboxSelfhostedControlTimeoutMs,
+              RETAINED_PROCESS_PROVIDER_PROBE_TIMEOUT_MS,
+            ),
+          );
+          if (!proof) {
+            await deferConnectedCommandClaim(
+              db,
+              settings,
+              observability,
+              claim,
+              "provider_running",
+            );
+            return;
+          }
+        } catch (error) {
+          const offline =
+            error instanceof SelfhostedControlError &&
+            (error.agentOffline || error.reason === "agent_reconnecting" || error.draining);
+          if (offline) offlineConnections.add(connectionKey);
+          if (!offline) {
+            observability.warn("sandbox reaper: connected-command provider probe failed", {
+              commandId: claim.commandId,
+              enrollmentId: claim.enrollmentId,
+              connectionInstanceId: claim.connectionInstanceId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+          await deferConnectedCommandClaim(
+            db,
+            settings,
+            observability,
+            claim,
+            offline ? "provider_offline" : "provider_error",
+          );
           return;
         }
-      } catch (error) {
-        const offline =
-          error instanceof SelfhostedControlError &&
-          (error.agentOffline || error.reason === "agent_reconnecting" || error.draining);
-        if (!offline) {
-          observability.warn("sandbox reaper: connected-command provider probe failed", {
+
+        try {
+          await recordConnectedMachineBackgroundCommandProof(db, { claim, proof });
+          recordConnectedCommandReconciliation(observability, `proof_${proof.outcome}`);
+        } catch (error) {
+          recordConnectedCommandReconciliation(observability, "proof_checkpoint_failed");
+          observability.warn("sandbox reaper: connected-command proof checkpoint failed", {
             commandId: claim.commandId,
-            enrollmentId: claim.enrollmentId,
-            connectionInstanceId: claim.connectionInstanceId,
             error: error instanceof Error ? error.message : String(error),
           });
+          return;
         }
-        await deferConnectedCommandClaim(
-          db,
-          settings,
-          observability,
-          claim,
-          offline ? "provider_offline" : "provider_error",
-        );
-        return;
       }
 
       try {
-        await recordConnectedMachineBackgroundCommandProof(db, { claim, proof });
-        recordConnectedCommandReconciliation(observability, `proof_${proof.outcome}`);
+        const settlement = await settleClaimedConnectedMachineBackgroundCommand(db, { claim });
+        if (!settlement.settled) {
+          throw new Error("Connected command settlement lost its exact claim or proof");
+        }
+        if (settlement.events.length > 0) {
+          try {
+            await bus.publish(claim.workspaceId, claim.sessionId, settlement.events);
+          } catch (error) {
+            observability.warn("sandbox reaper: connected-command event fanout failed", {
+              commandId: claim.commandId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+        recordConnectedCommandReconciliation(observability, `settled_${proof.outcome}`);
       } catch (error) {
-        recordConnectedCommandReconciliation(observability, "proof_checkpoint_failed");
-        observability.warn("sandbox reaper: connected-command proof checkpoint failed", {
+        recordConnectedCommandReconciliation(observability, "settlement_failed");
+        observability.warn("sandbox reaper: connected-command settlement failed", {
           commandId: claim.commandId,
           error: error instanceof Error ? error.message : String(error),
         });
-        return;
+        await deferConnectedCommandClaim(db, settings, observability, claim, "settlement_failed");
       }
-    }
-
-    try {
-      const settlement = await settleClaimedConnectedMachineBackgroundCommand(db, { claim });
-      if (!settlement.settled) {
-        throw new Error("Connected command settlement lost its exact claim or proof");
-      }
-      if (settlement.events.length > 0) {
-        try {
-          await bus.publish(claim.workspaceId, claim.sessionId, settlement.events);
-        } catch (error) {
-          observability.warn("sandbox reaper: connected-command event fanout failed", {
-            commandId: claim.commandId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-      recordConnectedCommandReconciliation(observability, `settled_${proof.outcome}`);
-    } catch (error) {
-      recordConnectedCommandReconciliation(observability, "settlement_failed");
-      observability.warn("sandbox reaper: connected-command settlement failed", {
-        commandId: claim.commandId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await deferConnectedCommandClaim(db, settings, observability, claim, "settlement_failed");
-    }
-  });
+    });
+    if (claims.length < CONNECTED_COMMAND_RECONCILIATION_LIMIT) break;
+  } while (Date.now() < deadline);
 }
 
 export async function probeConnectedMachineBackgroundCommand(

--- a/apps/worker/test/connected-command-cleanup-integration.test.ts
+++ b/apps/worker/test/connected-command-cleanup-integration.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { bootstrapWorkspace, createDb, createEnrollment, createSession } from "@opengeni/db";
+import { ErrorCode, OpState } from "@opengeni/agent-proto";
+import { SelfhostedControlError, type ControlRpc } from "@opengeni/runtime/sandbox";
+import { reconcileConnectedMachineBackgroundCommands as reconcile } from "../src/activities/sandbox-lease";
+let shared: SharedTestDatabase;
+let client: ReturnType<typeof createDb>;
+beforeAll(async () => {
+  const db = await acquireSharedTestDatabase("connected-command-cleanup");
+  if (!db) throw new Error("PostgreSQL required");
+  shared = db;
+  client = createDb(db.appUrl);
+}, 180000);
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60000);
+
+async function seed() {
+  const id = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: id,
+    accountName: "Cleanup",
+    workspaceExternalSource: "test",
+    workspaceExternalId: id,
+    workspaceName: "Cleanup",
+    subjectId: `subject-${id}`,
+  });
+  const { accountId, workspaceId } = access.workspaceGrants[0]!;
+  const session = await createSession(client.db, {
+    accountId,
+    workspaceId: workspaceId!,
+    initialMessage: "Cleanup",
+    resources: [],
+    metadata: {},
+    model: "scripted-model",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  const enrollment = await createEnrollment(client.db, {
+    accountId,
+    workspaceId: workspaceId!,
+    pubkey: `ed25519:${id}`,
+  });
+  await shared.admin`update enrollments set connection_instance_id='launch',connection_lease_expires_at=now()+interval '1 hour' where id=${enrollment.id}`;
+  await shared.admin`insert into session_background_commands(account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id)
+ select ${accountId},${workspaceId!},${session.id},'connected_machine','running',${workspaceId!},${enrollment.id},'launch',gen_random_uuid()::text from generate_series(1,25)`;
+  return session.id;
+}
+const settings = {
+  sandboxLeaseReaperPeriodMs: 30000,
+  sandboxSelfhostedControlTimeoutMs: 1000,
+} as Parameters<typeof reconcile>[1];
+const warnings: unknown[] = [];
+const observability = {
+  incrementCounter: () => {},
+  warn: (...args: unknown[]) => warnings.push(args),
+} as unknown as Parameters<typeof reconcile>[2];
+const bus = {
+  getRequestConnection: async () => null,
+  publish: async () => {},
+} as unknown as Parameters<typeof reconcile>[3];
+
+test("one sweep settles more than one batch and emits each future completion only once", async () => {
+  const sessionId = await seed();
+  let queries = 0;
+  const rpc: ControlRpc = {
+    request: async (_subject, request) => {
+      queries++;
+      const op = request.op!;
+      if (op.$case !== "opQuery") throw new Error("Expected query");
+      return {
+        requestId: request.requestId,
+        error: undefined,
+        result: {
+          $case: "opStatus",
+          opStatus: {
+            opId: op.opQuery.opId,
+            state: OpState.OP_STATE_COMPLETE,
+            nextSeq: "1",
+            lostReason: 0,
+            exit: {
+              exitCode: 0,
+              cancelled: false,
+              timedOut: false,
+              durationMs: "1",
+              digests: {},
+              totals: {},
+              failureCode: "",
+              failureDetail: {},
+            },
+          },
+        },
+      };
+    },
+  };
+  await reconcile(client.db, settings, observability, bus, rpc);
+  expect(warnings).toEqual([]);
+  expect(queries).toBe(25);
+  const [row] =
+    await shared.admin`select count(*)::int n from session_background_commands where session_id=${sessionId} and state='exited'`;
+  expect(row!.n).toBe(25);
+  const [updates] =
+    await shared.admin`select count(*)::int n from session_system_updates where session_id=${sessionId} and kind='background_command_result'`;
+  expect(updates!.n).toBe(25);
+  await reconcile(client.db, settings, observability, bus, rpc);
+  expect(queries).toBe(25);
+});
+test("offline commands remain tracked while one sweep shares failed connection observations", async () => {
+  const sessionId = await seed();
+  let queries = 0;
+  const rpc: ControlRpc = {
+    request: async () => {
+      queries++;
+      throw new SelfhostedControlError({
+        message: "offline",
+        code: ErrorCode.ERROR_CODE_AGENT_OFFLINE,
+        agentOffline: true,
+        reason: null,
+        retryable: true,
+      });
+    },
+  };
+  await reconcile(client.db, settings, observability, bus, rpc);
+  expect(queries).toBeGreaterThan(0);
+  expect(queries).toBeLessThan(25);
+  const [row] =
+    await shared.admin`select count(*)::int n,min(reconcile_attempts)::int attempts from session_background_commands where session_id=${sessionId} and state='running'`;
+  expect(row!.n).toBe(25);
+  expect(row!.attempts).toBe(1);
+});

--- a/apps/worker/test/connected-command-cleanup-integration.test.ts
+++ b/apps/worker/test/connected-command-cleanup-integration.test.ts
@@ -126,7 +126,7 @@ test("offline commands remain tracked while one sweep shares failed connection o
   };
   await reconcile(client.db, settings, observability, bus, rpc);
   expect(queries).toBeGreaterThan(0);
-  expect(queries).toBeLessThan(25);
+  expect(queries).toBe(1);
   const [row] =
     await shared.admin`select count(*)::int n,min(reconcile_attempts)::int attempts from session_background_commands where session_id=${sessionId} and state='running'`;
   expect(row!.n).toBe(25);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,13 @@ A background command becomes session-owned only after its exact provider
 identity is durably adopted. Before adoption it remains attempt-owned. After
 adoption, ordinary turn completion and Steer detach from it, while explicit
 command cancellation, Pause, or terminal Cancel control its lifetime.
-Exact terminal proof settles the command row and appends its terminal session
+An explicitly stopped, revoked, or replaced Connected Machine instance ends
+command tracking as `lost`; this never asserts operating-system process death.
+A temporary transport outage alone preserves tracking. Reconciliation drains
+a fixed due-time frontier in batches, sharing offline observations per instance.
+The historical retirement migration preserves command records without creating
+model input or waking old sessions.
+Exact terminal proof (including confirmed tracking retirement) settles the command row and appends its terminal session
 event in one PostgreSQL transaction. A nonterminal session also receives one
 typed model input and any idle workflow wake in that commit; a failed or
 cancelled session remains terminal and keeps event-only audit rather than

--- a/packages/db/drizzle/0407_connected_command_tracking_retirement.sql
+++ b/packages/db/drizzle/0407_connected_command_tracking_retirement.sql
@@ -1,0 +1,245 @@
+-- deployment-mode: rolling
+-- Loss here means tracking ended, not proof that an operating-system process died.
+-- Preserve historical records without producing new model inputs or waking old sessions.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- Give this global cleanup the same owner-only, transaction-capability and
+-- workspace-fence policy used by the retained-process reaper. Runtime callers
+-- cannot mint these capabilities or inherit the migration owner's identity.
+DO $command_owner_policies$
+DECLARE data_schema text := current_schema(); owner_name text := current_user;
+        schema_oid oid := current_schema()::regnamespace;
+BEGIN
+  EXECUTE format('CREATE POLICY connected_command_inventory_read ON %1$I.session_background_commands
+    FOR SELECT USING (%1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,true))',
+    data_schema,owner_name,schema_oid);
+  EXECUTE format('CREATE POLICY connected_command_fenced_write ON %1$I.session_background_commands
+    FOR ALL USING (%1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,false))
+    WITH CHECK (%1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,false))',
+    data_schema,owner_name,schema_oid);
+  EXECUTE format('DROP POLICY session_visibility_isolation ON %I.session_background_commands',data_schema);
+  EXECUTE format('CREATE POLICY session_visibility_isolation ON %1$I.session_background_commands AS RESTRICTIVE
+    FOR ALL USING (
+      %1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,true)
+      OR %1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,false)
+      OR %1$I.session_reference_visible(account_id,workspace_id,session_id))
+    WITH CHECK (
+      %1$I.session_tenancy_fence_owner_policy_active(current_user,%2$L,%3$s::oid,workspace_id,false)
+      OR %1$I.session_reference_visible(account_id,workspace_id,session_id))',data_schema,owner_name,schema_oid);
+END
+$command_owner_policies$;
+
+DO $repair$
+DECLARE inventory_id uuid; workspace_ids uuid[]; workspace_value uuid;
+BEGIN
+  inventory_id := opengeni_private.open_session_tenancy_fence_inventory(session_tenancy_fence_target_schema());
+  SELECT array_agg(DISTINCT workspace_id ORDER BY workspace_id) INTO workspace_ids
+  FROM session_background_commands WHERE provider = 'connected_machine' AND state IN ('running','stopping');
+  FOREACH workspace_value IN ARRAY COALESCE(workspace_ids, ARRAY[]::uuid[]) LOOP
+    PERFORM acquire_session_tenancy_fence(workspace_value);
+  END LOOP;
+  PERFORM opengeni_private.close_session_tenancy_fence_inventory(inventory_id);
+ALTER TABLE session_background_commands NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE enrollments NO FORCE ROW LEVEL SECURITY;
+WITH retired AS MATERIALIZED (
+  SELECT command.id, CASE
+          WHEN enrollment.status = 'revoked' THEN 'op_enrollment_revoked'
+          WHEN enrollment.connection_instance_id IS NOT NULL
+            AND enrollment.connection_instance_id <> command.connection_instance_id
+            THEN 'op_connection_replaced'
+          WHEN enrollment.connection_instance_id IS NULL
+            AND enrollment.went_offline_reason IN (
+              'GOING_OFFLINE_REASON_USER_STOP', 'GOING_OFFLINE_REASON_UPDATE',
+              'GOING_OFFLINE_REASON_HOST_SHUTDOWN')
+            THEN 'op_connection_stopped'
+          ELSE NULL END AS reason
+  FROM session_background_commands command
+  JOIN enrollments enrollment ON enrollment.id = command.enrollment_id
+    AND enrollment.account_id = command.account_id
+    AND enrollment.workspace_id = command.control_workspace_id
+  WHERE command.provider = 'connected_machine' AND command.state IN ('running', 'stopping')
+    AND command.reconcile_proof_outcome IS NULL
+    AND command.workspace_id = ANY(workspace_ids)
+  FOR UPDATE OF command
+)
+UPDATE session_background_commands command SET
+  state = 'lost', settlement_reason = retired.reason, settled_at = clock_timestamp(),
+  reconcile_claim_id = NULL, reconcile_claimed_at = NULL,
+  reconcile_proof_outcome = 'lost', reconcile_proof_reason = retired.reason,
+  reconcile_proof_observed_at = clock_timestamp(),
+  last_reconcile_outcome = 'historical_tracking_retired', updated_at = clock_timestamp()
+FROM retired WHERE command.id = retired.id AND retired.reason IS NOT NULL
+  AND command.state IN ('running', 'stopping') AND command.reconcile_proof_outcome IS NULL;
+
+ALTER TABLE session_background_commands FORCE ROW LEVEL SECURITY;
+ALTER TABLE enrollments FORCE ROW LEVEL SECURITY;
+END
+$repair$;
+
+-- Keep the three-argument function for rolling compatibility. New workers use
+-- a fixed due-time frontier so one sweep cannot repeatedly reclaim its own retries.
+DO $connected_claim_function$
+DECLARE data_schema text := current_schema();
+BEGIN
+  EXECUTE format($create$
+    CREATE OR REPLACE FUNCTION opengeni_private.claim_connected_machine_background_commands(
+      p_claim_id uuid,
+      p_limit integer,
+      p_claim_ttl_ms bigint,
+      p_due_before timestamptz
+    )
+    RETURNS TABLE (
+      account_id uuid,
+      workspace_id uuid,
+      session_id uuid,
+      command_id uuid,
+      claim_id uuid,
+      command_state text,
+      control_workspace_id uuid,
+      enrollment_id uuid,
+      connection_instance_id text,
+      op_id text,
+      reconcile_attempts integer,
+      reconcile_proof_outcome text,
+      reconcile_proof_exit_code integer,
+      reconcile_proof_reason text,
+      reconcile_proof_observed_at timestamptz
+    )
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $function$
+    DECLARE
+      inventory_id uuid;
+      access_id uuid;
+      workspace_ids uuid[];
+      workspace_value uuid;
+      owns_compute_capability boolean := false;
+    BEGIN
+      IF p_limit < 1 OR p_limit > 100 THEN
+        RAISE EXCEPTION 'connected-command reconciliation limit must be between 1 and 100'
+          USING ERRCODE = '22023';
+      END IF;
+      IF p_claim_ttl_ms < 0 OR p_claim_ttl_ms > 3600000 THEN
+        RAISE EXCEPTION 'connected-command reconciliation claim TTL is invalid'
+          USING ERRCODE = '22023';
+      END IF;
+
+      inventory_id := opengeni_private.open_session_tenancy_fence_inventory(%1$I.session_tenancy_fence_target_schema());
+      SELECT array_agg(DISTINCT command.workspace_id ORDER BY command.workspace_id) INTO workspace_ids
+      FROM %1$I.session_background_commands command
+      WHERE command.provider = 'connected_machine' AND command.state IN ('running','stopping')
+        AND command.reconcile_after <= LEAST(p_due_before, pg_catalog.now());
+      FOREACH workspace_value IN ARRAY COALESCE(workspace_ids, ARRAY[]::uuid[]) LOOP
+        PERFORM %1$I.acquire_session_tenancy_fence(workspace_value);
+      END LOOP;
+      PERFORM opengeni_private.close_session_tenancy_fence_inventory(inventory_id);
+      access_id := opengeni_private.open_session_tenancy_fenced_access(%1$I.session_tenancy_fence_target_schema());
+      INSERT INTO opengeni_private.scoped_compute_capabilities(backend_pid, transaction_id, capability_kind)
+        VALUES(pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'read')
+        ON CONFLICT DO NOTHING;
+      owns_compute_capability := FOUND;
+      RETURN QUERY
+      WITH candidates AS MATERIALIZED (
+        SELECT command.id, command.reconcile_after, command.started_at,
+          CASE
+          WHEN enrollment.status = 'revoked' THEN 'op_enrollment_revoked'
+          WHEN enrollment.connection_instance_id IS NOT NULL
+            AND enrollment.connection_instance_id <> command.connection_instance_id
+            THEN 'op_connection_replaced'
+          WHEN enrollment.connection_instance_id IS NULL
+            AND enrollment.went_offline_reason IN (
+              'GOING_OFFLINE_REASON_USER_STOP', 'GOING_OFFLINE_REASON_UPDATE',
+              'GOING_OFFLINE_REASON_HOST_SHUTDOWN')
+            THEN 'op_connection_stopped'
+          ELSE NULL END AS retirement_reason
+        FROM %1$I.session_background_commands command
+        JOIN %1$I.enrollments enrollment ON enrollment.id = command.enrollment_id
+          AND enrollment.account_id = command.account_id
+          AND enrollment.workspace_id = command.control_workspace_id
+        WHERE command.provider = 'connected_machine'
+          AND command.workspace_id = ANY(workspace_ids)
+          AND command.state IN ('running', 'stopping')
+          AND command.reconcile_after <= LEAST(p_due_before, pg_catalog.now())
+          AND (
+            command.reconcile_claim_id IS NULL
+            OR command.reconcile_claimed_at <= pg_catalog.now()
+              - pg_catalog.make_interval(secs => p_claim_ttl_ms / 1000.0)
+          )
+        ORDER BY command.reconcile_after, command.started_at, command.id
+        FOR UPDATE OF command SKIP LOCKED
+        LIMIT p_limit
+      ), claimed AS (
+        UPDATE %1$I.session_background_commands command SET
+          reconcile_after = pg_catalog.now()
+            + pg_catalog.make_interval(secs => p_claim_ttl_ms / 1000.0),
+          reconcile_claim_id = p_claim_id,
+          reconcile_claimed_at = pg_catalog.now(),
+          reconcile_attempts = command.reconcile_attempts + 1,
+          last_reconcile_outcome = 'claimed',
+          reconcile_proof_outcome = COALESCE(command.reconcile_proof_outcome,
+            CASE WHEN candidates.retirement_reason IS NOT NULL THEN 'lost' END),
+          reconcile_proof_reason = COALESCE(command.reconcile_proof_reason, candidates.retirement_reason),
+          reconcile_proof_observed_at = COALESCE(command.reconcile_proof_observed_at,
+            CASE WHEN candidates.retirement_reason IS NOT NULL THEN pg_catalog.clock_timestamp() END),
+          updated_at = pg_catalog.clock_timestamp()
+        FROM candidates
+        WHERE command.id = candidates.id
+          AND command.provider = 'connected_machine'
+          AND command.state IN ('running', 'stopping')
+        RETURNING command.*, candidates.reconcile_after AS due_at,
+          candidates.started_at AS candidate_started_at
+      )
+      SELECT claimed.account_id,
+        claimed.workspace_id,
+        claimed.session_id,
+        claimed.id,
+        claimed.reconcile_claim_id,
+        claimed.state,
+        claimed.control_workspace_id,
+        claimed.enrollment_id,
+        claimed.connection_instance_id,
+        claimed.op_id,
+        claimed.reconcile_attempts,
+        claimed.reconcile_proof_outcome,
+        claimed.reconcile_proof_exit_code,
+        claimed.reconcile_proof_reason,
+        claimed.reconcile_proof_observed_at
+      FROM claimed
+      ORDER BY claimed.due_at, claimed.candidate_started_at, claimed.id;
+      IF owns_compute_capability THEN
+        DELETE FROM opengeni_private.scoped_compute_capabilities
+        WHERE backend_pid = pg_catalog.pg_backend_pid()
+          AND transaction_id = pg_catalog.pg_current_xact_id() AND capability_kind = 'read';
+      END IF;
+      PERFORM opengeni_private.close_session_tenancy_fenced_access(access_id);
+      PERFORM opengeni_private.close_session_tenancy_fence_inventory(inventory_id);
+    EXCEPTION WHEN OTHERS THEN
+      IF owns_compute_capability THEN
+        DELETE FROM opengeni_private.scoped_compute_capabilities
+        WHERE backend_pid = pg_catalog.pg_backend_pid()
+          AND transaction_id = pg_catalog.pg_current_xact_id() AND capability_kind = 'read';
+      END IF;
+      PERFORM opengeni_private.close_session_tenancy_fenced_access(access_id);
+      PERFORM opengeni_private.close_session_tenancy_fence_inventory(inventory_id);
+      RAISE;
+    END;
+    $function$;
+  $create$, data_schema);
+END
+$connected_claim_function$;
+
+REVOKE ALL ON FUNCTION opengeni_private.claim_connected_machine_background_commands(
+  uuid, integer, bigint, timestamptz
+) FROM PUBLIC;
+
+DO $connected_claim_grant$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.claim_connected_machine_background_commands(
+      uuid, integer, bigint, timestamptz
+    ) TO opengeni_app;
+  END IF;
+END
+$connected_claim_grant$;

--- a/packages/db/src/session-background-commands.ts
+++ b/packages/db/src/session-background-commands.ts
@@ -284,7 +284,7 @@ export async function insertConnectedMachineSessionBackgroundCommandInTransactio
  * claim expiry is coordination recovery only and never implies command loss. */
 export async function claimConnectedMachineSessionBackgroundCommands(
   db: Database,
-  input: { claimId: string; limit: number; claimTtlMs: number },
+  input: { claimId: string; limit: number; claimTtlMs: number; dueBefore?: Date },
 ): Promise<ConnectedMachineBackgroundCommandClaim[]> {
   if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > 100) {
     throw new Error("Connected command reconciliation limit must be between 1 and 100");
@@ -313,7 +313,8 @@ export async function claimConnectedMachineSessionBackgroundCommands(
       reconcile_proof_reason as "reconcileProofReason",
       reconcile_proof_observed_at as "reconcileProofObservedAt"
     from opengeni_private.claim_connected_machine_background_commands(
-      ${input.claimId}::uuid, ${input.limit}::integer, ${input.claimTtlMs}::bigint
+      ${input.claimId}::uuid, ${input.limit}::integer, ${input.claimTtlMs}::bigint,
+      ${(input.dueBefore ?? new Date()).toISOString()}::timestamptz
     )
   `);
   return rows.map((row: ConnectedMachineBackgroundCommandClaimRow) => {

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -1391,26 +1391,21 @@ async function stoppingBackgroundCommandCounts(
 ): Promise<Map<string, number>> {
   const rows = await db.execute<{ sessionId: string; commandCount: number | string }>(sql`
     with recursive targets(id) as (values ${targetValues(sessionIds)}),
-    command_ancestry(command_id, ancestor_id, depth, path) as (
-      select command.id, command.session_id, 0::integer, array[command.session_id]::uuid[]
-      from ${schema.sessionBackgroundCommands} command
-      where command.workspace_id = ${workspaceId}
-        and command.state = 'stopping'
+    descendants(target_id, session_id, depth, path) as (
+      select target.id, target.id, 0::integer, array[target.id]::uuid[] from targets target
       union all
-      select ancestry.command_id, current.parent_session_id,
-        ancestry.depth + 1, ancestry.path || current.parent_session_id
-      from command_ancestry ancestry
-      join ${schema.sessions} current
-        on current.workspace_id = ${workspaceId}
-       and current.id = ancestry.ancestor_id
-      where current.parent_session_id is not null
-        and not current.parent_session_id = any(ancestry.path)
-        and ancestry.depth < ${SESSION_ANCESTRY_LIMIT}
+      select parent.target_id, child.id, parent.depth + 1, parent.path || child.id
+      from descendants parent
+      join ${schema.sessions} child
+        on child.workspace_id = ${workspaceId} and child.parent_session_id = parent.session_id
+      where not child.id = any(parent.path) and parent.depth < ${SESSION_ANCESTRY_LIMIT}
     )
-    select target.id as "sessionId", count(distinct ancestry.command_id)::integer as "commandCount"
-    from targets target
-    join command_ancestry ancestry on ancestry.ancestor_id = target.id
-    group by target.id
+    select descendant.target_id as "sessionId", count(distinct command.id)::integer as "commandCount"
+    from descendants descendant
+    join ${schema.sessionBackgroundCommands} command
+      on command.workspace_id = ${workspaceId} and command.session_id = descendant.session_id
+      and command.state = 'stopping'
+    group by descendant.target_id
   `);
   return new Map(
     rows.map((row: { sessionId: string; commandCount: number | string }) => [

--- a/packages/db/test/migration-0184-sandbox-drain-teardown-fence.test.ts
+++ b/packages/db/test/migration-0184-sandbox-drain-teardown-fence.test.ts
@@ -25,6 +25,7 @@ const withheldMigrationNames = [
   "0391_sandbox_provider_deadline_interaction_followup.sql",
   "0397_sandbox_deadline_rotation_preemption.sql",
   "0402_session_input_wait_and_background_command_results.sql",
+  "0407_connected_command_tracking_retirement.sql",
 ];
 
 describe("migration 0184 sandbox drain teardown fence", () => {

--- a/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
+++ b/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
@@ -27,6 +27,7 @@ const sandboxProviderDeadlineInteractionFollowupMigrationName =
 const sandboxDeadlineRotationPreemptionMigrationName =
   "0397_sandbox_deadline_rotation_preemption.sql";
 const sessionInputWaitMigrationName = "0402_session_input_wait_and_background_command_results.sql";
+const commandTrackingRetirementMigrationName = "0407_connected_command_tracking_retirement.sql";
 const migrationUrl = new URL(`../drizzle/${migrationName}`, import.meta.url);
 const migration0241Url = new URL(
   "../drizzle/0241_atomic_personal_resource_delegation.sql",
@@ -191,7 +192,8 @@ describe("migration 0249 personal-resource delegation authority correction", () 
           (${sandboxProviderDeadlineInteractionMigrationName}),
           (${sandboxProviderDeadlineInteractionFollowupMigrationName}),
           (${sandboxDeadlineRotationPreemptionMigrationName}),
-          (${sessionInputWaitMigrationName})
+          (${sessionInputWaitMigrationName}),
+          (${commandTrackingRetirementMigrationName})
       `;
       await migrate(databaseUrl);
       // Current session adapters select the complete sessions row while this
@@ -221,7 +223,8 @@ describe("migration 0249 personal-resource delegation authority correction", () 
           ${sandboxProviderDeadlineInteractionMigrationName},
           ${sandboxProviderDeadlineInteractionFollowupMigrationName},
           ${sandboxDeadlineRotationPreemptionMigrationName},
-          ${sessionInputWaitMigrationName}
+          ${sessionInputWaitMigrationName},
+          ${commandTrackingRetirementMigrationName}
         )
       `;
 
@@ -275,7 +278,8 @@ describe("migration 0249 personal-resource delegation authority correction", () 
           ${sandboxProviderDeadlineInteractionMigrationName},
           ${sandboxProviderDeadlineInteractionFollowupMigrationName},
           ${sandboxDeadlineRotationPreemptionMigrationName},
-          ${sessionInputWaitMigrationName}
+          ${sessionInputWaitMigrationName},
+          ${commandTrackingRetirementMigrationName}
         )
         order by name
       `;
@@ -295,6 +299,7 @@ describe("migration 0249 personal-resource delegation authority correction", () 
         sandboxProviderDeadlineInteractionFollowupMigrationName,
         sandboxDeadlineRotationPreemptionMigrationName,
         sessionInputWaitMigrationName,
+        commandTrackingRetirementMigrationName,
       ]);
       expect(await countWorkspaceMemberships(sql, ids)).toBe(0);
       await insertAttempt(sql, ids, ids.attemptId);

--- a/packages/db/test/migration-0264-connection-authority-runtime-activation.test.ts
+++ b/packages/db/test/migration-0264-connection-authority-runtime-activation.test.ts
@@ -45,6 +45,7 @@ const sandboxProviderDeadlineInteractionFollowupMigrationName =
 const sandboxDeadlineRotationPreemptionMigrationName =
   "0397_sandbox_deadline_rotation_preemption.sql";
 const sessionInputWaitMigrationName = "0402_session_input_wait_and_background_command_results.sql";
+const commandTrackingRetirementMigrationName = "0407_connected_command_tracking_retirement.sql";
 
 describe("migration 0264 connection authority runtime activation", () => {
   test("is a drained exact-attempt cutover with canonical snapshots and idempotent audit", async () => {
@@ -100,7 +101,8 @@ describe("migration 0264 connection authority runtime activation", () => {
           (${sandboxProviderDeadlineInteractionMigrationName}),
           (${sandboxProviderDeadlineInteractionFollowupMigrationName}),
           (${sandboxDeadlineRotationPreemptionMigrationName}),
-          (${sessionInputWaitMigrationName})
+          (${sessionInputWaitMigrationName}),
+          (${commandTrackingRetirementMigrationName})
       `;
       await migrate(blank.databaseUrl);
       // Current session adapters select the complete sessions row while this
@@ -217,7 +219,8 @@ describe("migration 0264 connection authority runtime activation", () => {
           ${sandboxProviderDeadlineInteractionMigrationName},
           ${sandboxProviderDeadlineInteractionFollowupMigrationName},
           ${sandboxDeadlineRotationPreemptionMigrationName},
-          ${sessionInputWaitMigrationName}
+          ${sessionInputWaitMigrationName},
+          ${commandTrackingRetirementMigrationName}
         )
       `;
       await expect(migrate(blank.databaseUrl)).rejects.toMatchObject({ code: "55000" });
@@ -277,7 +280,8 @@ describe("migration 0264 connection authority runtime activation", () => {
           ${sandboxProviderDeadlineInteractionMigrationName},
           ${sandboxProviderDeadlineInteractionFollowupMigrationName},
           ${sandboxDeadlineRotationPreemptionMigrationName},
-          ${sessionInputWaitMigrationName}
+          ${sessionInputWaitMigrationName},
+          ${commandTrackingRetirementMigrationName}
         )
         order by name
       `;
@@ -293,6 +297,7 @@ describe("migration 0264 connection authority runtime activation", () => {
         sandboxProviderDeadlineInteractionFollowupMigrationName,
         sandboxDeadlineRotationPreemptionMigrationName,
         sessionInputWaitMigrationName,
+        commandTrackingRetirementMigrationName,
       ]);
     } finally {
       await sql.end({ timeout: 1 });

--- a/packages/db/test/migration-0345-tenant-scoped-session-tenancy-fence.test.ts
+++ b/packages/db/test/migration-0345-tenant-scoped-session-tenancy-fence.test.ts
@@ -260,7 +260,8 @@ describe("migration 0345 tenant-scoped session-tenancy fence", () => {
           ('0379_session_event_raw_lane_activation.sql'),
           ('0388_sandbox_provider_deadline_interactions.sql'),
           ('0391_sandbox_provider_deadline_interaction_followup.sql'),
-          ('0397_sandbox_deadline_rotation_preemption.sql')
+          ('0397_sandbox_deadline_rotation_preemption.sql'),
+          ('0407_connected_command_tracking_retirement.sql')
       `);
       await migrate(driftOwned.ownerUrl);
       const migration = await readFile(migrationUrl, "utf8");

--- a/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
+++ b/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
@@ -1,0 +1,162 @@
+// opengeni:test-shared-postgres-exclusive
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+import { migrate } from "../src/migrate";
+import { provisionRoles } from "../src/provision-roles";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import { bootstrapWorkspace, createDb, createEnrollment, createSession } from "../src/index";
+import { claimConnectedMachineSessionBackgroundCommands } from "../src/session-background-commands";
+
+let shared: OwnerMigratedTestDatabase;
+let client: ReturnType<typeof createDb>;
+let owner: ReturnType<typeof postgres>;
+beforeAll(async () => {
+  const acquired = await acquireOwnerMigratedTestDatabase("command-tracking-retirement");
+  if (!acquired) throw new Error("PostgreSQL required for command retirement tests");
+  shared = acquired;
+  await migrate(shared.ownerUrl);
+  await provisionRoles(shared.adminUrl, { appPassword: shared.appPassword, rlsStrategy: "force" });
+  const appUrl = new URL(shared.ownerUrl);
+  appUrl.username = "opengeni_app";
+  appUrl.password = shared.appPassword;
+  client = createDb(appUrl.toString(), { rlsStrategy: "force" });
+  owner = postgres(shared.ownerUrl, { max: 1 });
+}, 900_000);
+afterAll(async () => {
+  await owner?.end();
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+async function fixture(
+  kind: "replaced" | "stopped" | "offline" | "revoked" | "current",
+  proof = false,
+) {
+  const suffix = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: suffix,
+    accountName: "Command lifecycle",
+    workspaceExternalSource: "test",
+    workspaceExternalId: suffix,
+    workspaceName: "Command lifecycle",
+    subjectId: `subject-${suffix}`,
+  });
+  const { accountId, workspaceId } = access.workspaceGrants[0]!;
+  const session = await createSession(client.db, {
+    accountId,
+    workspaceId: workspaceId!,
+    initialMessage: "command lifecycle",
+    resources: [],
+    metadata: {},
+    model: "scripted-model",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  const enrollment = await createEnrollment(client.db, {
+    accountId,
+    workspaceId: workspaceId!,
+    pubkey: `ed25519:${suffix}`,
+  });
+  const connection = kind === "replaced" ? "successor" : kind === "stopped" ? null : "launch";
+  await shared.admin`update enrollments set connection_instance_id = ${connection},
+    connection_lease_expires_at = ${connection ? new Date(Date.now() - 60_000) : null},
+    went_offline_reason = ${kind === "stopped" ? "GOING_OFFLINE_REASON_USER_STOP" : null},
+    went_offline_at = ${kind === "stopped" ? new Date() : null},
+    status = ${kind === "revoked" ? "revoked" : "active"}
+    where id = ${enrollment.id}`;
+  const id = crypto.randomUUID();
+  await shared.admin`insert into session_background_commands
+    (id,account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,
+     connection_instance_id,op_id,cancel_requested_at,cancel_requested_by,
+     reconcile_proof_outcome,reconcile_proof_exit_code,reconcile_proof_reason,reconcile_proof_observed_at)
+    values (${id},${accountId},${workspaceId!},${session.id},'connected_machine','stopping',
+      ${workspaceId!},${enrollment.id},'launch',${id},now(),'test',
+      ${proof ? "exited" : null},${proof ? 0 : null},${proof ? "op_exit" : null},${proof ? new Date() : null})`;
+  return { id, sessionId: session.id, workspaceId: workspaceId! };
+}
+
+const source = await readFile(
+  new URL("../drizzle/0407_connected_command_tracking_retirement.sql", import.meta.url),
+  "utf8",
+);
+test("historical repair retires ended tracking without notifications, preserving offline commands and saved exits", async () => {
+  const replaced = await fixture("replaced");
+  const stopped = await fixture("stopped");
+  const revoked = await fixture("revoked");
+  const offline = await fixture("offline");
+  const proven = await fixture("replaced", true);
+  const [before] = await shared.admin`select count(*)::int n from session_system_updates`;
+  await owner.begin(async (tx) => {
+    await tx.unsafe(source.slice(source.indexOf("DO $repair$"), source.indexOf("-- Keep the three-argument")));
+  });
+  const rows =
+    await shared.admin`select id,state,settlement_reason from session_background_commands`;
+  for (const value of [replaced, stopped, revoked])
+    expect(rows.find((r) => r.id === value.id)?.state).toBe("lost");
+  for (const value of [offline, proven])
+    expect(rows.find((r) => r.id === value.id)?.state).toBe("stopping");
+  const [after] = await shared.admin`select count(*)::int n from session_system_updates`;
+  expect(after!.n).toBe(before!.n);
+  const [events] =
+    await shared.admin`select count(*)::int n from session_events where type='session.command.finished'`;
+  expect(events!.n).toBe(0);
+});
+
+test("runtime claims classify retirement, preserve exact exit proof, and never treat lease expiry as loss", async () => {
+  const replaced = await fixture("replaced");
+  const stopped = await fixture("stopped");
+  const revoked = await fixture("revoked");
+  const offline = await fixture("offline");
+  const proven = await fixture("replaced", true);
+  const claims = await claimConnectedMachineSessionBackgroundCommands(client.db, {
+    claimId: crypto.randomUUID(),
+    limit: 100,
+    claimTtlMs: 300_000,
+    dueBefore: new Date(),
+  });
+  const reason = (id: string) => claims.find((c) => c.commandId === id)?.proof?.reason;
+  expect(reason(replaced.id)).toBe("op_connection_replaced");
+  expect(reason(stopped.id)).toBe("op_connection_stopped");
+  expect(reason(revoked.id)).toBe("op_enrollment_revoked");
+  expect(claims.find((c) => c.commandId === offline.id)?.proof).toBeNull();
+  expect(claims.find((c) => c.commandId === proven.id)?.proof).toMatchObject({
+    outcome: "exited",
+    exitCode: 0,
+    reason: "op_exit",
+  });
+  const second = await claimConnectedMachineSessionBackgroundCommands(client.db, {
+    claimId: crypto.randomUUID(),
+    limit: 100,
+    claimTtlMs: 300_000,
+    dueBefore: new Date(),
+  });
+  expect(second).toHaveLength(0);
+});
+
+test("a fixed frontier drains multiple batches without revisiting claims even with zero claim TTL", async () => {
+  const value = await fixture("current");
+  await shared.admin`insert into session_background_commands
+    (account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id)
+    select account_id,workspace_id,session_id,provider,'running',control_workspace_id,enrollment_id,connection_instance_id,gen_random_uuid()::text
+    from session_background_commands cross join generate_series(1,24) where id=${value.id}`;
+  const dueBefore = new Date();
+  const claim = () =>
+    claimConnectedMachineSessionBackgroundCommands(client.db, {
+      claimId: crypto.randomUUID(),
+      limit: 20,
+      claimTtlMs: 0,
+      dueBefore,
+    });
+  const first = await claim();
+  const second = await claim();
+  expect(first).toHaveLength(20);
+  expect(second).toHaveLength(5);
+  expect(new Set([...first, ...second].map((c) => c.commandId)).size).toBe(25);
+  expect(await claim()).toHaveLength(0);
+});

--- a/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
+++ b/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
@@ -73,10 +73,10 @@ async function fixture(
   const id = crypto.randomUUID();
   await shared.admin`insert into session_background_commands
     (id,account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,
-     connection_instance_id,op_id,cancel_requested_at,cancel_requested_by,
+     connection_instance_id,op_id,cancel_requested_at,cancel_requested_by,reconcile_after,
      reconcile_proof_outcome,reconcile_proof_exit_code,reconcile_proof_reason,reconcile_proof_observed_at)
     values (${id},${accountId},${workspaceId!},${session.id},'connected_machine','stopping',
-      ${workspaceId!},${enrollment.id},'launch',${id},now(),'test',
+      ${workspaceId!},${enrollment.id},'launch',${id},now(),'test',now() - interval '1 minute',
       ${proof ? "exited" : null},${proof ? 0 : null},${proof ? "op_exit" : null},${proof ? new Date() : null})`;
   return { id, sessionId: session.id, workspaceId: workspaceId! };
 }
@@ -144,8 +144,8 @@ test("runtime claims classify retirement, preserve exact exit proof, and never t
 test("a fixed frontier drains multiple batches without revisiting claims even with zero claim TTL", async () => {
   const value = await fixture("current");
   await shared.admin`insert into session_background_commands
-    (account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id)
-    select account_id,workspace_id,session_id,provider,'running',control_workspace_id,enrollment_id,connection_instance_id,gen_random_uuid()::text
+    (account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id,reconcile_after)
+    select account_id,workspace_id,session_id,provider,'running',control_workspace_id,enrollment_id,connection_instance_id,gen_random_uuid()::text,now() - interval '1 minute'
     from session_background_commands cross join generate_series(1,24) where id=${value.id}`;
   const dueBefore = new Date();
   const claim = () =>

--- a/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
+++ b/packages/db/test/migration-0407-connected-command-tracking-retirement.test.ts
@@ -93,7 +93,9 @@ test("historical repair retires ended tracking without notifications, preserving
   const proven = await fixture("replaced", true);
   const [before] = await shared.admin`select count(*)::int n from session_system_updates`;
   await owner.begin(async (tx) => {
-    await tx.unsafe(source.slice(source.indexOf("DO $repair$"), source.indexOf("-- Keep the three-argument")));
+    await tx.unsafe(
+      source.slice(source.indexOf("DO $repair$"), source.indexOf("-- Keep the three-argument")),
+    );
   });
   const rows =
     await shared.admin`select id,state,settlement_reason from session_background_commands`;

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,7 +131,9 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe("0406_workspace_html_site_sources.sql");
+    expect(completeSourceContract.latestMigration).toBe(
+      "0407_connected_command_tracking_retirement.sql",
+    );
     const sandboxDeadlineIndex = completeSourceContract.migrations.findIndex(
       (migration) => migration.path === "0397_sandbox_deadline_rotation_preemption.sql",
     );
@@ -228,6 +230,23 @@ describe("release schema contract", () => {
 
   test("registers forward migrations without repinning host-export history", async () => {
     let completeSourceContract = await buildSchemaContract();
+    const connectedCommandTrackingRetirement = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0407_connected_command_tracking_retirement.sql",
+    );
+    const completeSourceContractWithConnectedCommandTrackingRetirement = completeSourceContract;
+    const connectedCommandTrackingRetirementMigrationIndex =
+      completeSourceContractWithConnectedCommandTrackingRetirement.migrations.findIndex(
+        (migration) => migration.path === "0407_connected_command_tracking_retirement.sql",
+      );
+    completeSourceContract = connectedCommandTrackingRetirement
+      ? {
+          ...completeSourceContractWithConnectedCommandTrackingRetirement,
+          latestMigration:
+            completeSourceContractWithConnectedCommandTrackingRetirement.migrations[
+              connectedCommandTrackingRetirementMigrationIndex - 1
+            ]?.path ?? completeSourceContractWithConnectedCommandTrackingRetirement.latestMigration,
+        }
+      : completeSourceContractWithConnectedCommandTrackingRetirement;
     const workspaceHtmlSiteSources = completeSourceContract.migrations.some(
       (migration) => migration.path === "0406_workspace_html_site_sources.sql",
     );
@@ -568,6 +587,12 @@ describe("release schema contract", () => {
         latestMigration: "0406_workspace_html_site_sources.sql",
       };
     }
+    if (connectedCommandTrackingRetirement) {
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0407_connected_command_tracking_retirement.sql",
+      };
+    }
     const automaticSessionTitleMigrationPaths = new Set([
       "0398_organization_workspace_management_entry.sql",
       "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
@@ -617,6 +642,7 @@ describe("release schema contract", () => {
       "0404_mcp_oauth_authorization_server.sql",
       "0405_tool_gateway_approval_capabilities.sql",
       "0406_workspace_html_site_sources.sql",
+      "0407_connected_command_tracking_retirement.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -635,6 +661,7 @@ describe("release schema contract", () => {
         ? { latestMigration: "0397_sandbox_deadline_rotation_preemption.sql" }
         : {}),
       fileCount:
+        (connectedCommandTrackingRetirement ? 1 : 0) +
         (sessionAttemptModelContextSnapshots ? 1 : 0) +
         (organizationUserSetupTokenTransport ? 1 : 0) +
         (sessionInputWaitAndBackgroundCommandResults ? 1 : 0) +
@@ -694,89 +721,91 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: sandboxProviderDeadlineInteractionFollowup
-        ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-        : organizationModelProviderConnections
-          ? "0390_organization_model_provider_connections.sql"
-          : modelCatalogAndGatewayCustomModels
-            ? "0389_model_catalog_and_gateway_custom_models.sql"
-            : sandboxProviderDeadlineInteractions
-              ? "0388_sandbox_provider_deadline_interactions.sql"
-              : boundHostExportSessionPayloads
-                ? "0387_bound_host_export_session_payloads.sql"
-                : localOrganizationAdministration
-                  ? "0386_local_organization_administration.sql"
-                  : connectedMachineLegacyTildeWorkdirs
-                    ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                    : codexCooldownRevisionGuardPrivileges
-                      ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                      : codexCooldownReconciliation
-                        ? "0383_codex_cooldown_reconciliation.sql"
-                        : organizationApiKeyProvenance
-                          ? "0382_organization_api_key_provenance.sql"
-                          : organizationCodexSubscriptionInheritance
-                            ? "0381_organization_codex_subscription_inheritance.sql"
-                            : autonomousCompanyProfileAgentPolicy
-                              ? "0380_autonomous_company_profile_agent_policy.sql"
-                              : sessionEventRawLaneActivation
-                                ? "0379_session_event_raw_lane_activation.sql"
-                                : scopedRigHealthAuditTimestamp
-                                  ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                  : scopedRigHealthProjection
-                                    ? "0377_scoped_rig_health_projection.sql"
-                                    : organizationWorkspaceInventory
-                                      ? "0376_organization_workspace_inventory.sql"
-                                      : sessionRecoveryObservability
-                                        ? "0375_session_recovery_observability.sql"
-                                        : sessionEventCursors
-                                          ? "0374_session_event_cursors.sql"
-                                          : sandboxSharedPreparation
-                                            ? "0373_sandbox_shared_preparation.sql"
-                                            : orderedVariableSetRuntimeAuthority
-                                              ? "0372_ordered_variable_set_runtime_authority.sql"
-                                              : workspaceMemberCandidateInventory
-                                                ? "0371_workspace_member_candidate_inventory.sql"
-                                                : workspaceMemberManagementScope
-                                                  ? "0370_workspace_member_management_scope.sql"
-                                                  : localHumanPersonalAuthority
-                                                    ? "0369_local_human_personal_authority.sql"
-                                                    : sessionDiscoveryClaimSearchIndex
-                                                      ? "0368_session_discovery_claim_search_index.sql"
-                                                      : sessionDiscoveryGoalSearchIndex
-                                                        ? "0367_session_discovery_goal_search_index.sql"
-                                                        : sessionDiscoveryTitleSearchIndex
-                                                          ? "0366_session_discovery_title_search_index.sql"
-                                                          : permissionScopedWorkClaims
-                                                            ? "0365_permission_scoped_work_claims.sql"
-                                                            : workspaceLearningPolicySnapshotLockOrder
-                                                              ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                              : organizationRecoveryCustody
-                                                                ? "0363_organization_recovery_custody.sql"
-                                                                : managedAuthSessionSets
-                                                                  ? "0362_managed_auth_session_sets.sql"
-                                                                  : rememberKnowledgeMemoryMaterialization
-                                                                    ? "0361_remember_knowledge_memory_materialization.sql"
-                                                                    : organizationIdentityConfirmationPrompt
-                                                                      ? "0360_organization_identity_confirmation_prompt.sql"
-                                                                      : insightsForceRlsReadCapability
-                                                                        ? "0359_insights_force_rls_read_capability.sql"
-                                                                        : prReviewManagedGithubApp
-                                                                          ? "0358_pr_review_managed_github_app.sql"
-                                                                          : rigPlatformBaseOnly
-                                                                            ? "0357_rig_platform_base_only.sql"
-                                                                            : setBasedInsightsSessionVisibility
-                                                                              ? "0356_set_based_insights_session_visibility.sql"
-                                                                              : automaticSessionTitleQuarantine
-                                                                                ? "0355_automatic_session_title_quarantine.sql"
-                                                                                : automaticSessionTitleQuarantineIndex
-                                                                                  ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                                  : automaticSessionTitlePolicyFence
-                                                                                    ? "0353_automatic_session_title_policy_fence.sql"
-                                                                                    : sessionVariableSetAttachments
-                                                                                      ? "0352_session_variable_set_attachments.sql"
-                                                                                      : migrationsBeforeAutomaticSessionTitles.at(
-                                                                                          -1,
-                                                                                        )?.path,
+      latestMigration: connectedCommandTrackingRetirement
+        ? "0407_connected_command_tracking_retirement.sql"
+        : sandboxProviderDeadlineInteractionFollowup
+          ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+          : organizationModelProviderConnections
+            ? "0390_organization_model_provider_connections.sql"
+            : modelCatalogAndGatewayCustomModels
+              ? "0389_model_catalog_and_gateway_custom_models.sql"
+              : sandboxProviderDeadlineInteractions
+                ? "0388_sandbox_provider_deadline_interactions.sql"
+                : boundHostExportSessionPayloads
+                  ? "0387_bound_host_export_session_payloads.sql"
+                  : localOrganizationAdministration
+                    ? "0386_local_organization_administration.sql"
+                    : connectedMachineLegacyTildeWorkdirs
+                      ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                      : codexCooldownRevisionGuardPrivileges
+                        ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                        : codexCooldownReconciliation
+                          ? "0383_codex_cooldown_reconciliation.sql"
+                          : organizationApiKeyProvenance
+                            ? "0382_organization_api_key_provenance.sql"
+                            : organizationCodexSubscriptionInheritance
+                              ? "0381_organization_codex_subscription_inheritance.sql"
+                              : autonomousCompanyProfileAgentPolicy
+                                ? "0380_autonomous_company_profile_agent_policy.sql"
+                                : sessionEventRawLaneActivation
+                                  ? "0379_session_event_raw_lane_activation.sql"
+                                  : scopedRigHealthAuditTimestamp
+                                    ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                    : scopedRigHealthProjection
+                                      ? "0377_scoped_rig_health_projection.sql"
+                                      : organizationWorkspaceInventory
+                                        ? "0376_organization_workspace_inventory.sql"
+                                        : sessionRecoveryObservability
+                                          ? "0375_session_recovery_observability.sql"
+                                          : sessionEventCursors
+                                            ? "0374_session_event_cursors.sql"
+                                            : sandboxSharedPreparation
+                                              ? "0373_sandbox_shared_preparation.sql"
+                                              : orderedVariableSetRuntimeAuthority
+                                                ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                : workspaceMemberCandidateInventory
+                                                  ? "0371_workspace_member_candidate_inventory.sql"
+                                                  : workspaceMemberManagementScope
+                                                    ? "0370_workspace_member_management_scope.sql"
+                                                    : localHumanPersonalAuthority
+                                                      ? "0369_local_human_personal_authority.sql"
+                                                      : sessionDiscoveryClaimSearchIndex
+                                                        ? "0368_session_discovery_claim_search_index.sql"
+                                                        : sessionDiscoveryGoalSearchIndex
+                                                          ? "0367_session_discovery_goal_search_index.sql"
+                                                          : sessionDiscoveryTitleSearchIndex
+                                                            ? "0366_session_discovery_title_search_index.sql"
+                                                            : permissionScopedWorkClaims
+                                                              ? "0365_permission_scoped_work_claims.sql"
+                                                              : workspaceLearningPolicySnapshotLockOrder
+                                                                ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                : organizationRecoveryCustody
+                                                                  ? "0363_organization_recovery_custody.sql"
+                                                                  : managedAuthSessionSets
+                                                                    ? "0362_managed_auth_session_sets.sql"
+                                                                    : rememberKnowledgeMemoryMaterialization
+                                                                      ? "0361_remember_knowledge_memory_materialization.sql"
+                                                                      : organizationIdentityConfirmationPrompt
+                                                                        ? "0360_organization_identity_confirmation_prompt.sql"
+                                                                        : insightsForceRlsReadCapability
+                                                                          ? "0359_insights_force_rls_read_capability.sql"
+                                                                          : prReviewManagedGithubApp
+                                                                            ? "0358_pr_review_managed_github_app.sql"
+                                                                            : rigPlatformBaseOnly
+                                                                              ? "0357_rig_platform_base_only.sql"
+                                                                              : setBasedInsightsSessionVisibility
+                                                                                ? "0356_set_based_insights_session_visibility.sql"
+                                                                                : automaticSessionTitleQuarantine
+                                                                                  ? "0355_automatic_session_title_quarantine.sql"
+                                                                                  : automaticSessionTitleQuarantineIndex
+                                                                                    ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                                    : automaticSessionTitlePolicyFence
+                                                                                      ? "0353_automatic_session_title_policy_fence.sql"
+                                                                                      : sessionVariableSetAttachments
+                                                                                        ? "0352_session_variable_set_attachments.sql"
+                                                                                        : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                            -1,
+                                                                                          )?.path,
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -812,6 +841,9 @@ describe("release schema contract", () => {
         : {}),
       ...(workspaceHtmlSiteSources
         ? { latestMigration: "0406_workspace_html_site_sources.sql" }
+        : {}),
+      ...(connectedCommandTrackingRetirement
+        ? { latestMigration: "0407_connected_command_tracking_retirement.sql" }
         : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
@@ -873,6 +905,23 @@ describe("release schema contract", () => {
       "0360_organization_identity_confirmation_prompt.sql",
       "0361_remember_knowledge_memory_materialization.sql",
     ]);
+    const connectedCommandTrackingRetirement = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0407_connected_command_tracking_retirement.sql",
+    );
+    const completeSourceContractWithConnectedCommandTrackingRetirement = completeSourceContract;
+    const connectedCommandTrackingRetirementMigrationIndex =
+      completeSourceContractWithConnectedCommandTrackingRetirement.migrations.findIndex(
+        (migration) => migration.path === "0407_connected_command_tracking_retirement.sql",
+      );
+    completeSourceContract = connectedCommandTrackingRetirement
+      ? {
+          ...completeSourceContractWithConnectedCommandTrackingRetirement,
+          latestMigration:
+            completeSourceContractWithConnectedCommandTrackingRetirement.migrations[
+              connectedCommandTrackingRetirementMigrationIndex - 1
+            ]?.path ?? completeSourceContractWithConnectedCommandTrackingRetirement.latestMigration,
+        }
+      : completeSourceContractWithConnectedCommandTrackingRetirement;
     const workspaceHtmlSiteSources = completeSourceContract.migrations.some(
       (migration) => migration.path === "0406_workspace_html_site_sources.sql",
     );
@@ -1145,6 +1194,7 @@ describe("release schema contract", () => {
       "0404_mcp_oauth_authorization_server.sql",
       "0405_tool_gateway_approval_capabilities.sql",
       "0406_workspace_html_site_sources.sql",
+      "0407_connected_command_tracking_retirement.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -1388,8 +1438,15 @@ describe("release schema contract", () => {
         latestMigration: "0406_workspace_html_site_sources.sql",
       };
     }
+    if (connectedCommandTrackingRetirement) {
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0407_connected_command_tracking_retirement.sql",
+      };
+    }
     expect(completeSourceContract).toMatchObject({
       fileCount:
+        (connectedCommandTrackingRetirement ? 1 : 0) +
         (sessionInputWaitAndBackgroundCommandResults ? 1 : 0) +
         (organizationUserSetupTokenTransport ? 1 : 0) +
         (codexUnconditionalCredentialLeasing ? 1 : 0) +
@@ -1454,99 +1511,101 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: sandboxProviderDeadlineInteractionFollowup
-        ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-        : organizationModelProviderConnections
-          ? "0390_organization_model_provider_connections.sql"
-          : modelCatalogAndGatewayCustomModels
-            ? "0389_model_catalog_and_gateway_custom_models.sql"
-            : sandboxProviderDeadlineInteractions
-              ? "0388_sandbox_provider_deadline_interactions.sql"
-              : boundHostExportSessionPayloads
-                ? "0387_bound_host_export_session_payloads.sql"
-                : localOrganizationAdministration
-                  ? "0386_local_organization_administration.sql"
-                  : connectedMachineLegacyTildeWorkdirs
-                    ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                    : codexCooldownRevisionGuardPrivileges
-                      ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                      : codexCooldownReconciliation
-                        ? "0383_codex_cooldown_reconciliation.sql"
-                        : organizationApiKeyProvenance
-                          ? "0382_organization_api_key_provenance.sql"
-                          : organizationCodexSubscriptionInheritance
-                            ? "0381_organization_codex_subscription_inheritance.sql"
-                            : autonomousCompanyProfileAgentPolicy
-                              ? "0380_autonomous_company_profile_agent_policy.sql"
-                              : sessionEventRawLaneActivation
-                                ? "0379_session_event_raw_lane_activation.sql"
-                                : scopedRigHealthAuditTimestamp
-                                  ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                  : scopedRigHealthProjection
-                                    ? "0377_scoped_rig_health_projection.sql"
-                                    : organizationWorkspaceInventory
-                                      ? "0376_organization_workspace_inventory.sql"
-                                      : sessionRecoveryObservability
-                                        ? "0375_session_recovery_observability.sql"
-                                        : sessionEventCursors
-                                          ? "0374_session_event_cursors.sql"
-                                          : sandboxSharedPreparation
-                                            ? "0373_sandbox_shared_preparation.sql"
-                                            : orderedVariableSetRuntimeAuthority
-                                              ? "0372_ordered_variable_set_runtime_authority.sql"
-                                              : workspaceMemberCandidateInventory
-                                                ? "0371_workspace_member_candidate_inventory.sql"
-                                                : workspaceMemberManagementScope
-                                                  ? "0370_workspace_member_management_scope.sql"
-                                                  : localHumanPersonalAuthority
-                                                    ? "0369_local_human_personal_authority.sql"
-                                                    : sessionDiscoveryClaimSearchIndex
-                                                      ? "0368_session_discovery_claim_search_index.sql"
-                                                      : sessionDiscoveryGoalSearchIndex
-                                                        ? "0367_session_discovery_goal_search_index.sql"
-                                                        : sessionDiscoveryTitleSearchIndex
-                                                          ? "0366_session_discovery_title_search_index.sql"
-                                                          : permissionScopedWorkClaims
-                                                            ? "0365_permission_scoped_work_claims.sql"
-                                                            : workspaceLearningPolicySnapshotLockOrder
-                                                              ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                              : organizationRecoveryCustody
-                                                                ? "0363_organization_recovery_custody.sql"
-                                                                : managedAuthSessionSets
-                                                                  ? "0362_managed_auth_session_sets.sql"
-                                                                  : sessionVariableSetAttachments
-                                                                    ? "0352_session_variable_set_attachments.sql"
-                                                                    : organizationUserSetupDelivery
-                                                                      ? "0351_organization_user_setup_delivery.sql"
-                                                                      : organizationSharedWorkspaceAdministration
-                                                                        ? "0350_organization_shared_workspace_administration.sql"
-                                                                        : greenfieldSessionTenancyActivation
-                                                                          ? "0349_greenfield_session_tenancy_activation.sql"
-                                                                          : namedSignupAndUserSetup
-                                                                            ? "0348_named_signup_and_user_setup.sql"
-                                                                            : connectionAuthorityConvergenceEvidence
-                                                                              ? "0347_connection_authority_convergence_evidence.sql"
-                                                                              : documentMigrationAuditSurface
-                                                                                ? "0346_document_migration_audit_surface.sql"
-                                                                                : tenantScopedSessionTenancyFence
-                                                                                  ? "0345_tenant_scoped_session_tenancy_fence.sql"
-                                                                                  : privateSessionVisibilityTransitionGate
-                                                                                    ? "0344_private_session_visibility_transition_gate.sql"
-                                                                                    : personalDocumentForceRlsRepair
-                                                                                      ? "0343_personal_document_force_rls_lock_repair.sql"
-                                                                                      : slackRoutePromptSinglePending
-                                                                                        ? "0342_slack_route_prompt_single_pending.sql"
-                                                                                        : slackRoutingProbeFence
-                                                                                          ? "0341_slack_routing_probe_organization_fence.sql"
-                                                                                          : tenancyBackfillActivationEvidence
-                                                                                            ? "0340_tenancy_backfill_activation_evidence.sql"
-                                                                                            : documentAuthorityReclassification
-                                                                                              ? "0339_document_authority_reclassification.sql"
-                                                                                              : atomicConnectedMachineAttachments
-                                                                                                ? "0338_atomic_connected_machine_attachments.sql"
-                                                                                                : routedSlackHandles
-                                                                                                  ? "0337_slack_routed_action_handles.sql"
-                                                                                                  : "0336_atomic_session_fork_visibility.sql",
+      latestMigration: connectedCommandTrackingRetirement
+        ? "0407_connected_command_tracking_retirement.sql"
+        : sandboxProviderDeadlineInteractionFollowup
+          ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+          : organizationModelProviderConnections
+            ? "0390_organization_model_provider_connections.sql"
+            : modelCatalogAndGatewayCustomModels
+              ? "0389_model_catalog_and_gateway_custom_models.sql"
+              : sandboxProviderDeadlineInteractions
+                ? "0388_sandbox_provider_deadline_interactions.sql"
+                : boundHostExportSessionPayloads
+                  ? "0387_bound_host_export_session_payloads.sql"
+                  : localOrganizationAdministration
+                    ? "0386_local_organization_administration.sql"
+                    : connectedMachineLegacyTildeWorkdirs
+                      ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                      : codexCooldownRevisionGuardPrivileges
+                        ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                        : codexCooldownReconciliation
+                          ? "0383_codex_cooldown_reconciliation.sql"
+                          : organizationApiKeyProvenance
+                            ? "0382_organization_api_key_provenance.sql"
+                            : organizationCodexSubscriptionInheritance
+                              ? "0381_organization_codex_subscription_inheritance.sql"
+                              : autonomousCompanyProfileAgentPolicy
+                                ? "0380_autonomous_company_profile_agent_policy.sql"
+                                : sessionEventRawLaneActivation
+                                  ? "0379_session_event_raw_lane_activation.sql"
+                                  : scopedRigHealthAuditTimestamp
+                                    ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                    : scopedRigHealthProjection
+                                      ? "0377_scoped_rig_health_projection.sql"
+                                      : organizationWorkspaceInventory
+                                        ? "0376_organization_workspace_inventory.sql"
+                                        : sessionRecoveryObservability
+                                          ? "0375_session_recovery_observability.sql"
+                                          : sessionEventCursors
+                                            ? "0374_session_event_cursors.sql"
+                                            : sandboxSharedPreparation
+                                              ? "0373_sandbox_shared_preparation.sql"
+                                              : orderedVariableSetRuntimeAuthority
+                                                ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                : workspaceMemberCandidateInventory
+                                                  ? "0371_workspace_member_candidate_inventory.sql"
+                                                  : workspaceMemberManagementScope
+                                                    ? "0370_workspace_member_management_scope.sql"
+                                                    : localHumanPersonalAuthority
+                                                      ? "0369_local_human_personal_authority.sql"
+                                                      : sessionDiscoveryClaimSearchIndex
+                                                        ? "0368_session_discovery_claim_search_index.sql"
+                                                        : sessionDiscoveryGoalSearchIndex
+                                                          ? "0367_session_discovery_goal_search_index.sql"
+                                                          : sessionDiscoveryTitleSearchIndex
+                                                            ? "0366_session_discovery_title_search_index.sql"
+                                                            : permissionScopedWorkClaims
+                                                              ? "0365_permission_scoped_work_claims.sql"
+                                                              : workspaceLearningPolicySnapshotLockOrder
+                                                                ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                : organizationRecoveryCustody
+                                                                  ? "0363_organization_recovery_custody.sql"
+                                                                  : managedAuthSessionSets
+                                                                    ? "0362_managed_auth_session_sets.sql"
+                                                                    : sessionVariableSetAttachments
+                                                                      ? "0352_session_variable_set_attachments.sql"
+                                                                      : organizationUserSetupDelivery
+                                                                        ? "0351_organization_user_setup_delivery.sql"
+                                                                        : organizationSharedWorkspaceAdministration
+                                                                          ? "0350_organization_shared_workspace_administration.sql"
+                                                                          : greenfieldSessionTenancyActivation
+                                                                            ? "0349_greenfield_session_tenancy_activation.sql"
+                                                                            : namedSignupAndUserSetup
+                                                                              ? "0348_named_signup_and_user_setup.sql"
+                                                                              : connectionAuthorityConvergenceEvidence
+                                                                                ? "0347_connection_authority_convergence_evidence.sql"
+                                                                                : documentMigrationAuditSurface
+                                                                                  ? "0346_document_migration_audit_surface.sql"
+                                                                                  : tenantScopedSessionTenancyFence
+                                                                                    ? "0345_tenant_scoped_session_tenancy_fence.sql"
+                                                                                    : privateSessionVisibilityTransitionGate
+                                                                                      ? "0344_private_session_visibility_transition_gate.sql"
+                                                                                      : personalDocumentForceRlsRepair
+                                                                                        ? "0343_personal_document_force_rls_lock_repair.sql"
+                                                                                        : slackRoutePromptSinglePending
+                                                                                          ? "0342_slack_route_prompt_single_pending.sql"
+                                                                                          : slackRoutingProbeFence
+                                                                                            ? "0341_slack_routing_probe_organization_fence.sql"
+                                                                                            : tenancyBackfillActivationEvidence
+                                                                                              ? "0340_tenancy_backfill_activation_evidence.sql"
+                                                                                              : documentAuthorityReclassification
+                                                                                                ? "0339_document_authority_reclassification.sql"
+                                                                                                : atomicConnectedMachineAttachments
+                                                                                                  ? "0338_atomic_connected_machine_attachments.sql"
+                                                                                                  : routedSlackHandles
+                                                                                                    ? "0337_slack_routed_action_handles.sql"
+                                                                                                    : "0336_atomic_session_fork_visibility.sql",
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -1576,6 +1635,9 @@ describe("release schema contract", () => {
         : {}),
       ...(workspaceHtmlSiteSources
         ? { latestMigration: "0406_workspace_html_site_sources.sql" }
+        : {}),
+      ...(connectedCommandTrackingRetirement
+        ? { latestMigration: "0407_connected_command_tracking_retirement.sql" }
         : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -1147,6 +1147,8 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     const resetEmail = await takeEmail("password_reset", registeredEmail);
     const resetUrl = new URL(firstUrl(resetEmail));
     expect(resetUrl.pathname.startsWith("/v1/auth/reset-password/")).toBe(true);
+    // Stop authenticated background reads before removing their credentials.
+    await registeredPage.goto("about:blank");
     await registeredContext.clearCookies();
     await registeredPage.goto(resetUrl.toString(), {
       waitUntil: "domcontentloaded",


### PR DESCRIPTION
Background commands tied to an ended Connected Machine instance kept retrying indefinitely, delaying current command completion and making session status reads scan growing workspace-wide backlogs. Retire tracking on replacement, explicit shutdown, or revocation; preserve temporarily offline instances and saved completion proofs. Drain a fixed due frontier across batches and share offline observations per instance. Scope stopping counts to the requested session trees.

The rolling migration retains historical command records as lost tracking without generating model inputs or waking old sessions. The new global claim path uses the existing owner-only capabilities and ordered workspace tenancy fences. Lost tracking does not assert operating-system process termination.

Validation: full TypeScript check; lint; migration ledger/schema checks; release-schema and reconciliation tests; real PostgreSQL control-algebra tests; non-superuser migration-owner tests covering retirement, offline instances, saved exits, and multiple batches; worker integration tests covering completion notifications and shared offline observations. Independent review completed.

## Summary by Sourcery

Fix Connected Machine background-command lifecycle cleanup and make session status reconciliation efficient and correctly scoped.

Bug Fixes:
- Retire stale Connected Machine background-command tracking when instances are replaced, stopped, or revoked while preserving temporarily offline commands and saved completion proofs.
- Prevent repeated reconciliation retries from delaying cleanup by draining a fixed due frontier across batches and sharing offline observations per connection instance.
- Scope stopping-command counts to the requested session trees.

Enhancements:
- Preserve historically retired command records without generating model inputs, session wakeups, or implying operating-system process termination.
- Enforce migration-owner capabilities and workspace tenancy fences for the global connected-command cleanup path.

Documentation:
- Document Connected Machine tracking retirement semantics, offline preservation, fixed-frontier reconciliation, and historical cleanup behavior.

Tests:
- Add PostgreSQL integration coverage for multi-batch reconciliation, completion notifications, shared offline observations, retirement reasons, saved proofs, tenancy controls, and migration behavior.