### PR TITLE
fix(ui): show underlying session failure reasons

### DIFF
--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -131,8 +131,9 @@ export function FailedSessionBanner({
             {failure.failedTurnCount > 1 ? (
               <>{failure.failedTurnCount} turns have failed in this session. </>
             ) : null}
-            The conversation history is preserved — send a message to revive the session and keep
-            working.
+            {failure.safetyRefusal
+              ? "The conversation history is preserved. Automatic retries are stopped."
+              : "The conversation history is preserved — send a message to revive the session and keep working."}
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,4 +1,4 @@
-import { buildTimeline, humanizeFailureReason, type TimelineItem } from "@opengeni/react";
+import { buildTimeline, presentFailure, type TimelineItem } from "@opengeni/react";
 
 import type { Session, SessionEvent, SessionStatus } from "@/types";
 
@@ -62,6 +62,7 @@ export function projectSessionTimeline(
 export type SessionFailureSummary = {
   /** Human-readable reason from the most recent turn.failed event, if any. */
   reason: string | null;
+  safetyRefusal?: boolean;
   /** When the most recent failure happened. */
   failedAt: string | null;
   /** Same-turn recovery attempts recorded by the control plane. */
@@ -79,6 +80,7 @@ export function summarizeSessionFailure(
   _sessionStatus: SessionStatus,
 ): SessionFailureSummary {
   let reason: string | null = null;
+  let safetyRefusal = false;
   let failedAt: string | null = null;
   let recoveryCount = 0;
   let failedTurnCount = 0;
@@ -92,11 +94,13 @@ export function summarizeSessionFailure(
         event.payload && typeof event.payload === "object" && !Array.isArray(event.payload)
           ? (event.payload as Record<string, unknown>)
           : {};
-      reason = humanizeFailureReason(failurePayloadMessage(payload) ?? null) ?? reason;
+      const presentation = presentFailure(payload);
+      reason = presentation.reason;
+      safetyRefusal = presentation.safetyRefusal;
       failedAt = event.occurredAt;
     }
   }
-  return { reason, failedAt, recoveryCount, failedTurnCount };
+  return { reason, safetyRefusal, failedAt, recoveryCount, failedTurnCount };
 }
 
 export function reasoningSummaryText(payload: unknown): string {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -2074,7 +2074,9 @@ function SessionChatPane(props: {
                     // the reply turn dies the same budget death.
                     "Out of OpenGeni credits — add credits to continue."
                   : props.session.status === "failed"
-                    ? "This session failed — send a message to revive it."
+                    ? props.failure?.safetyRefusal
+                      ? "The model provider blocked the previous request."
+                      : "This session failed — send a message to revive it."
                     : "Send a follow-up…"
             }
             controls={

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -600,6 +600,7 @@ export {
   formatClockTime,
   formatRelativeTime,
   humanizeFailureReason,
+  presentFailure,
   isCreditExhaustion,
   stringifyPayload,
   truncate,

--- a/packages/react/src/lib/format.ts
+++ b/packages/react/src/lib/format.ts
@@ -186,3 +186,35 @@ export function humanizeFailureReason(reason: string | null): string | null {
   }
   return reason;
 }
+
+/** Project failure diagnostics without changing the stored event, including legacy retry wrappers. */
+export function presentFailure(payload: Record<string, unknown>): {
+  reason: string | null;
+  safetyRefusal: boolean;
+} {
+  const text = (key: string): string | null => {
+    const value = payload[key];
+    return typeof value === "string" && value.trim() ? value : null;
+  };
+  const message = text("error") ?? text("message");
+  const detail = text("lastRetryableError") ?? text("detail");
+  const safetyRefusal =
+    payload.code === "provider_safety_refusal" ||
+    [message, detail].some(
+      (value) =>
+        value !== null && /\bthis request was blocked by our safety systems\b/i.test(value),
+    );
+  if (safetyRefusal) {
+    return {
+      reason: `The model provider blocked this request.${detail || message ? ` ${detail ?? message}` : ""}`,
+      safetyRefusal: true,
+    };
+  }
+  return {
+    reason:
+      detail && detail !== message
+        ? [humanizeFailureReason(message), humanizeFailureReason(detail)].filter(Boolean).join(" ")
+        : humanizeFailureReason(message),
+    safetyRefusal: false,
+  };
+}

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -10,7 +10,7 @@ import {
 import fleetDecisionItem from "./fleet-decision-projection";
 import {
   CREDIT_EXHAUSTION_MESSAGE,
-  humanizeFailureReason,
+  presentFailure,
   isCreditExhaustion,
   tryParseJson,
 } from "../lib/format";
@@ -2273,15 +2273,7 @@ function elapsedDurationMs(startedAt: string, completedAt: string): number | nul
 }
 
 function failureMessage(payload: Record<string, unknown>): string | null {
-  for (const key of ["error", "message"] as const) {
-    const value = payload[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      // Auth/quota provider errors are rewritten for the right audience
-      // (raw text remains in the event payload for debug surfaces).
-      return humanizeFailureReason(value);
-    }
-  }
-  return null;
+  return presentFailure(payload).reason;
 }
 
 function goalText(payload: Record<string, unknown>): string | null {

--- a/packages/react/test/format.test.ts
+++ b/packages/react/test/format.test.ts
@@ -6,12 +6,49 @@ import {
   formatClockTime,
   formatRelativeTime,
   humanizeFailureReason,
+  presentFailure,
   isCreditExhaustion,
   stringifyPayload,
   truncate,
   tryParseJson,
 } from "../src/lib/format";
 import { OpenGeniApiError } from "@opengeni/sdk";
+
+describe("failure presentation", () => {
+  const refusal =
+    "This request was blocked by our safety systems. Reason: Potentially unintended activity.";
+  test("exposes the actual reason in legacy exhausted-retry failures", () => {
+    expect(
+      presentFailure({
+        error: "Upstream unavailable. Send a message to retry.",
+        lastRetryableError: refusal,
+      }),
+    ).toEqual({
+      reason: `The model provider blocked this request. ${refusal}`,
+      safetyRefusal: true,
+    });
+  });
+  test("retains the exact diagnostic on new safety failures", () => {
+    expect(
+      presentFailure({
+        code: "provider_safety_refusal",
+        error: "Automatic retries stopped.",
+        detail: refusal,
+      }),
+    ).toEqual({
+      reason: `The model provider blocked this request. ${refusal}`,
+      safetyRefusal: true,
+    });
+  });
+  test("keeps other underlying failures and ignores nontext details", () => {
+    expect(
+      presentFailure({ error: "Retries exhausted.", lastRetryableError: "Connection reset." })
+        .reason,
+    ).toBe("Retries exhausted. Connection reset.");
+    expect(presentFailure({ error: "Failed.", detail: { nested: true } }).reason).toBe("Failed.");
+    expect(presentFailure({})).toEqual({ reason: null, safetyRefusal: false });
+  });
+});
 
 describe("formatClockTime", () => {
   test("formats date + time and rejects invalid input", () => {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -3793,6 +3793,26 @@ describe("credit exhaustion", () => {
     });
   });
 
+  test("legacy safety refusal is visible in both turn summary and notice", () => {
+    reset();
+    const detail =
+      "This request was blocked by our safety systems. Reason: Potentially unintended activity.";
+    const items = buildTimeline([
+      event("turn.failed", {
+        error: "Upstream unavailable. Send a message to retry.",
+        lastRetryableError: detail,
+      }),
+    ]);
+    expect(items[0]).toMatchObject({
+      kind: "turn-end",
+      failureText: `The model provider blocked this request. ${detail}`,
+    });
+    expect(items[1]).toMatchObject({
+      kind: "notice",
+      text: `The model provider blocked this request. ${detail}`,
+    });
+  });
+
   test("groupTimeline folds a credit-exhausted turn as failed", () => {
     reset();
     const groups = groupTimeline(


### PR DESCRIPTION
Failure banners and timeline summaries hid the underlying provider diagnostic behind the generic exhausted-retry error. Project the same failure reason across both surfaces, including existing events with `lastRetryableError` and new events with `detail`.

Safety refusals explicitly say the model provider blocked the request and show its recorded explanation. The banner and composer no longer suggest sending another message will revive these failures. Stored history stays unchanged.

Validation: format and timeline regression tests, existing timeline/render tests, web and React typechecks pass. Independent review found no actionable issues. Live staging UI verification follows deployment.

## Summary by Sourcery

Project accurate provider failure reasons consistently across session and timeline surfaces, with explicit handling for safety refusals.

Bug Fixes:
- Surface underlying provider diagnostics in session failure banners, composer guidance, turn summaries, and timeline notices instead of generic exhausted-retry messages.
- Clearly identify provider safety refusals and explain that automatic retries are stopped without suggesting that another message will revive the failure.

Enhancements:
- Centralize failure presentation for legacy retry errors and newer detailed failure payloads while preserving stored event history.

Tests:
- Add regression coverage for legacy and new safety refusal diagnostics, other underlying failures, and timeline presentation.