### PR TITLE
test(web): align clean-session summary assertion

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1588,6 +1588,7 @@ describe("summarizeSessionFailure", () => {
       failedAt: null,
       recoveryCount: 0,
       failedTurnCount: 0,
+      safetyRefusal: false,
     });
   });
 });


### PR DESCRIPTION
The clean-session summary now includes `safetyRefusal: false`. Update the strict expected object to match that contract and restore the failing main-branch unit test.

Validation: `bun test apps/web/src/App.test.ts` and formatting check pass. No production behavior changes.

## Summary by Sourcery

Align the clean-session summary test with the current summary contract.

Bug Fixes:
- Update the clean-session summary test expectation to include the default safety-refusal status and restore the unit test to the current contract.

Tests:
- Align the strict clean-session summary assertion with the returned session summary.