### PR TITLE
test(web): cover safety refusal summary contract

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1585,9 +1585,31 @@ describe("summarizeSessionFailure", () => {
   test("reports nothing for a clean session", () => {
     expect(summarizeSessionFailure([event(1, "user.message", { text: "hi" })], "failed")).toEqual({
       reason: null,
+      safetyRefusal: false,
       failedAt: null,
       recoveryCount: 0,
       failedTurnCount: 0,
+    });
+  });
+  test("exposes a legacy safety rejection and clears it on a later unrelated failure", () => {
+    const refusal = event(1, "turn.failed", {
+      error: "Retries exhausted.",
+      lastRetryableError:
+        "This request was blocked by our safety systems. Reason: Potentially unintended activity.",
+    });
+    expect(summarizeSessionFailure([refusal], "failed")).toMatchObject({
+      safetyRefusal: true,
+      reason:
+        "The model provider blocked this request. This request was blocked by our safety systems. Reason: Potentially unintended activity.",
+    });
+    expect(
+      summarizeSessionFailure(
+        [refusal, event(2, "turn.failed", { error: "Connection reset." })],
+        "failed",
+      ),
+    ).toMatchObject({
+      safetyRefusal: false,
+      reason: "Connection reset.",
     });
   });
 });


### PR DESCRIPTION
Update the existing clean-session summary assertion for the safety-refusal field added in #2224. Add coverage that historical provider rejections expose the actual reason and a later unrelated failure clears the safety-specific UI guidance.

Validation: all 125 App.test.ts tests pass. Test-only change; no runtime behavior changes.

## Summary by Sourcery

Tests:
- Expand web session-failure summary coverage to verify clean sessions report no safety refusal, legacy provider safety rejections expose their reason, and later unrelated failures clear safety-specific guidance.