### PR TITLE
test(web): remove duplicate session summary assertion

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1589,7 +1589,6 @@ describe("summarizeSessionFailure", () => {
       failedAt: null,
       recoveryCount: 0,
       failedTurnCount: 0,
-      safetyRefusal: false,
     });
   });
   test("exposes a legacy safety rejection and clears it on a later unrelated failure", () => {


### PR DESCRIPTION
Two concurrent test updates added the same `safetyRefusal: false` property at different positions. Remove the duplicate while retaining the strict clean-session assertion and the new refusal regression tests.

Validation: `bun test apps/web/src/App.test.ts` and formatting pass. No production code changes.

## Summary by Sourcery

Remove the redundant session summary assertion while preserving safety refusal regression coverage.

Enhancements:
- Remove a duplicate clean-session safety refusal assertion while preserving strict session summary coverage.

Tests:
- Retain regression coverage for legacy safety rejections and their subsequent clearing.