### PR TITLE
fix(api): restore workspace archives from object storage

### DIFF
--- a/.changeset/archive-ref-recovery.md
+++ b/.changeset/archive-ref-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Restore API-direct sandboxes from workspace archives stored behind durable object-storage references.

--- a/.changeset/archive-ref-recovery.md
+++ b/.changeset/archive-ref-recovery.md
@@ -2,4 +2,4 @@
 "@opengeni/api-router": patch
 ---
 
-Restore API-direct sandboxes from workspace archives stored behind durable object-storage references.
+Restore API-direct sandboxes from workspace archives stored behind durable object-storage references. Reject malformed archive locators before creating a replacement workspace.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -335,6 +335,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     db,
     settings,
     bus,
+    objectStorage,
     observability: deps.observability,
   };
   const workspaceCaptureManifestCache = new WorkspaceCaptureManifestCache();
@@ -516,6 +517,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     db,
     settings,
     bus,
+    objectStorage,
     ...(deps.establishSandboxSession
       ? { establishSandboxSession: deps.establishSandboxSession }
       : {}),

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -55,6 +55,7 @@ import {
 } from "@opengeni/observability";
 import { HTTPException } from "hono/http-exception";
 import { ApiHttpError } from "../http/api-error";
+import type { ObjectStorage } from "@opengeni/storage";
 
 import {
   buildSelfhostedBackendSession,
@@ -101,6 +102,7 @@ export type ChannelAServices = {
   db: Database;
   settings: Settings;
   bus: EventBus;
+  objectStorage?: ObjectStorage | null;
   observability?: Observability | undefined;
 };
 
@@ -1012,6 +1014,9 @@ async function withChannelAOperation<T>(
           acquiredLease: acquired.lease,
           fallbackEnvelope: envelope,
           dataPlaneUrl: acquired.lease.dataPlaneUrl,
+          ...(services.objectStorage !== undefined
+            ? { objectStorage: services.objectStorage }
+            : {}),
         });
         established = result.established;
         leaseSnapshot = result.lease;

--- a/apps/api/src/sandbox/rematerialize.ts
+++ b/apps/api/src/sandbox/rematerialize.ts
@@ -1,4 +1,5 @@
 import type { Settings } from "@opengeni/config";
+import { parseWorkspaceArchiveObjectRef } from "@opengeni/contracts";
 import {
   adoptLegacyModalCheckpointArtifact,
   beginSandboxRematerialization,
@@ -13,6 +14,7 @@ import {
   type LeaseSnapshot,
 } from "@opengeni/db";
 import {
+  inlineWorkspaceArchiveForRestore,
   describeLegacyNativeSnapshotArchive,
   establishSandboxSessionFromEnvelope,
   isProviderSandboxNotFoundError,
@@ -30,15 +32,47 @@ import {
   type EstablishedSandboxSession,
   type WorkspaceArchiveDescriptor,
 } from "@opengeni/runtime/sandbox";
+import type { ObjectStorage } from "@opengeni/storage";
 
 function hasWorkspaceArchive(envelope: Record<string, unknown> | null): boolean {
   const sessionState =
-    envelope?.sessionState && typeof envelope.sessionState === "object"
+    envelope?.sessionState &&
+    typeof envelope.sessionState === "object" &&
+    !Array.isArray(envelope.sessionState)
       ? (envelope.sessionState as Record<string, unknown>)
       : null;
   return (
-    typeof sessionState?.workspaceArchive === "string" && sessionState.workspaceArchive.length > 0
+    (typeof sessionState?.workspaceArchive === "string" &&
+      sessionState.workspaceArchive.length > 0) ||
+    parseWorkspaceArchiveObjectRef(sessionState?.workspaceArchiveRef) !== null
   );
+}
+
+async function materializeArchiveObjectRef(
+  envelope: Record<string, unknown> | null,
+  objectStorage: ObjectStorage | null | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (!envelope) return null;
+  const sessionState =
+    envelope.sessionState &&
+    typeof envelope.sessionState === "object" &&
+    !Array.isArray(envelope.sessionState)
+      ? (envelope.sessionState as Record<string, unknown>)
+      : null;
+  if (!sessionState) return envelope;
+  if (!parseWorkspaceArchiveObjectRef(sessionState.workspaceArchiveRef)) return envelope;
+  if (!objectStorage) {
+    throw new WorkspaceArchiveIntegrityError(
+      "archive_base64_invalid",
+      "workspace archive object storage is not configured",
+    );
+  }
+  return {
+    ...envelope,
+    sessionState: await inlineWorkspaceArchiveForRestore(sessionState, (key) =>
+      objectStorage.getObjectBytes(key),
+    ),
+  };
 }
 
 function legacyNativeArchiveFromEnvelope(envelope: Record<string, unknown> | null) {
@@ -82,6 +116,7 @@ export async function establishApiSandboxSpawner(input: {
   acquiredLease: LeaseSnapshot;
   fallbackEnvelope: Record<string, unknown> | null;
   dataPlaneUrl: string | null;
+  objectStorage?: ObjectStorage | null;
 }): Promise<{ established: EstablishedSandboxSession; lease: LeaseSnapshot }> {
   const fallbackArchiveEnvelope =
     input.acquiredLease.recovery.archive.status === "none" &&
@@ -162,8 +197,10 @@ export async function establishApiSandboxSpawner(input: {
       );
     }
 
+    const hydrateEnvelope = await materializeArchiveObjectRef(spawnEnvelope, input.objectStorage);
+
     const providerCreateStartedAt = new Date();
-    established = await establishSandboxSessionFromEnvelope(input.settings, spawnEnvelope, {
+    established = await establishSandboxSessionFromEnvelope(input.settings, hydrateEnvelope, {
       sessionId: input.sessionId,
       recovery: "create-or-restore",
       backendOverride: input.backend as never,

--- a/apps/api/src/sandbox/rematerialize.ts
+++ b/apps/api/src/sandbox/rematerialize.ts
@@ -60,7 +60,13 @@ async function materializeArchiveObjectRef(
       ? (envelope.sessionState as Record<string, unknown>)
       : null;
   if (!sessionState) return envelope;
-  if (!parseWorkspaceArchiveObjectRef(sessionState.workspaceArchiveRef)) return envelope;
+  if (sessionState.workspaceArchiveRef == null) return envelope;
+  if (!parseWorkspaceArchiveObjectRef(sessionState.workspaceArchiveRef)) {
+    throw new WorkspaceArchiveIntegrityError(
+      "archive_metadata_invalid",
+      "workspace archive object reference is malformed",
+    );
+  }
   if (!objectStorage) {
     throw new WorkspaceArchiveIntegrityError(
       "archive_base64_invalid",

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -55,6 +55,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
+import type { ObjectStorage } from "@opengeni/storage";
 
 // The leaf — agent-loop-free. apps/api imports sandbox symbols ONLY from here
 // (enforced by sandbox-access-import-guard.test.ts).
@@ -98,6 +99,7 @@ export type ViewerServices = {
   db: Database;
   settings: Settings;
   bus?: EventBus;
+  objectStorage?: ObjectStorage | null;
   /** Provider-establish dependency used by API-direct readiness and stream
    *  operations. Production uses the runtime leaf; isolated tests may supply a
    *  deterministic provider without replacing a process-global module. */
@@ -381,6 +383,9 @@ export async function attachViewer(
         acquiredLease: acquired.lease,
         fallbackEnvelope: envelope,
         dataPlaneUrl: null,
+        ...(services.objectStorage !== undefined
+          ? { objectStorage: services.objectStorage }
+          : {}),
       });
       established = result.established;
       return {

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -383,9 +383,7 @@ export async function attachViewer(
         acquiredLease: acquired.lease,
         fallbackEnvelope: envelope,
         dataPlaneUrl: null,
-        ...(services.objectStorage !== undefined
-          ? { objectStorage: services.objectStorage }
-          : {}),
+        ...(services.objectStorage !== undefined ? { objectStorage: services.objectStorage } : {}),
       });
       established = result.established;
       return {

--- a/apps/api/test/rematerialize-archive-ref.test.ts
+++ b/apps/api/test/rematerialize-archive-ref.test.ts
@@ -1,0 +1,342 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import postgres from "postgres";
+import { parseWorkspaceArchiveObjectRef, workspaceArchiveObjectKey } from "@opengeni/contracts";
+import {
+  acquireLease,
+  createDb,
+  createSession,
+  failWarmingToCold,
+  readLease,
+  type Database,
+  type DbClient,
+} from "@opengeni/db";
+import {
+  acquireSharedTestDatabase,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import {
+  captureVerifiedWorkspaceArchive,
+  establishSandboxSessionFromEnvelope,
+  type EstablishedSandboxSession,
+} from "@opengeni/runtime";
+import type { ObjectStorage } from "@opengeni/storage";
+import { establishApiSandboxSpawner } from "../src/sandbox/rematerialize";
+import { attachViewer, detachViewer } from "../src/sandbox/viewer";
+
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql | undefined;
+let client: DbClient | undefined;
+let db: Database | undefined;
+const seeded: EstablishedSandboxSession[] = [];
+
+const backend = process.platform === "linux" ? ("local" as const) : ("docker" as const);
+const settings = testSettings({
+  sandboxBackend: backend,
+  ...(backend === "docker" ? { dockerImage: "opengeni-sandbox:local" } : {}),
+  sandboxOwnershipEnabled: true,
+  sandboxLeaseTtlMs: 60_000,
+  sandboxLeaseWarmingTtlMs: 60_000,
+});
+
+async function freshWorkspace(): Promise<{
+  accountId: string;
+  workspaceId: string;
+  groupId: string;
+}> {
+  const [account] = await admin!<{ id: string }[]>`
+    insert into managed_accounts (name) values ('api-rematerialize-ref') returning id`;
+  const [workspace] = await admin!<{ id: string }[]>`
+    insert into workspaces (account_id, name) values (${account!.id}, 'api-rematerialize-ref') returning id`;
+  await admin!`insert into workspace_inference_controls (workspace_id, account_id) values (${workspace!.id}, ${account!.id})`;
+  return { accountId: account!.id, workspaceId: workspace!.id, groupId: crypto.randomUUID() };
+}
+
+async function closeSandbox(value: EstablishedSandboxSession | null): Promise<void> {
+  if (!value) return;
+  await value.session.close().catch(() => undefined);
+}
+
+async function closeLeaseProvider(
+  fixture: ArchiveFixture,
+  lease: Awaited<ReturnType<typeof readLease>>,
+): Promise<void> {
+  if (!lease?.resumeState) return;
+  let resumed: EstablishedSandboxSession | null = null;
+  try {
+    resumed = await establishSandboxSessionFromEnvelope(settings, lease.resumeState, {
+      sessionId: fixture.groupId,
+      recovery: "resume-only",
+      backendOverride: backend,
+    });
+  } catch {
+    return;
+  }
+  await closeSandbox(resumed);
+}
+
+type ArchiveFixture = Awaited<ReturnType<typeof setupColdArchiveLease>>;
+
+function objectStorageFor(
+  ref: ArchiveFixture["ref"],
+  reply: Uint8Array | null,
+): { objectStorage: ObjectStorage; reads: () => number } {
+  let readCount = 0;
+  return {
+    reads: () => readCount,
+    objectStorage: {
+      bucket: "test",
+      backend: "s3-compatible" as const,
+      maxSinglePutSizeBytes: 5_000_000_000,
+      createPutUrl: async () => {
+        throw new Error("not used");
+      },
+      createGetUrl: async () => {
+        throw new Error("not used");
+      },
+      headFile: async () => {
+        throw new Error("not used");
+      },
+      fileExists: async () => false,
+      getFileBytes: async () => {
+        throw new Error("not used");
+      },
+      getFileRange: async () => null,
+      async getObjectBytes(key: string) {
+        readCount += 1;
+        expect(key).toBe(ref.key);
+        return reply === null ? null : { bytes: reply };
+      },
+      putObject: async () => undefined,
+      deleteObject: async () => undefined,
+    },
+  };
+}
+
+async function setupColdArchiveLease() {
+  const { accountId, workspaceId, groupId } = await freshWorkspace();
+  const seed = await establishSandboxSessionFromEnvelope(settings, null, {
+    sessionId: groupId,
+    recovery: "create-or-restore",
+    backendOverride: backend,
+  });
+  const backendId = seed.backendId;
+  seeded.push(seed);
+  let archive;
+  try {
+    const write = await seed.session.exec({
+      cmd: "printf 'api-object-ref-proof' > /workspace/api-object-ref-proof.txt",
+    });
+    expect(write.exitCode).toBe(0);
+    archive = await captureVerifiedWorkspaceArchive(seed.session);
+  } finally {
+    await closeSandbox(seed);
+    const index = seeded.indexOf(seed);
+    if (index >= 0) seeded.splice(index, 1);
+  }
+
+  const ref = {
+    schema: "sandbox_archive_object_v1" as const,
+    key: workspaceArchiveObjectKey({
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      revision: archive.descriptor.revision,
+    }),
+    sha256: archive.descriptor.archiveSha256,
+    bytes: archive.descriptor.archiveBytes,
+    backend: "s3-compatible" as const,
+  };
+  const envelope = {
+    backendId,
+    sessionState: {
+      workspaceArchiveRef: ref,
+      workspaceArchiveMeta: archive.descriptor,
+    },
+  };
+  await admin!.unsafe(
+    `
+      insert into sandbox_leases (
+        account_id, workspace_id, sandbox_group_id, liveness, refcount,
+        turn_holders, viewer_holders, backend, lease_epoch,
+        workspace_generation, archive_generation,
+        resume_backend_id, resume_state, expires_at
+      ) values (
+        $1, $2, $3, 'cold', 0, 0, 0,
+        $5, 1, 0, 0, $6, $4::text::jsonb, now() + interval '60s'
+      )`,
+    [accountId, workspaceId, groupId, JSON.stringify(envelope), backend, backendId],
+  );
+  const acquired = await acquireLease(db!, {
+    accountId,
+    workspaceId,
+    sandboxGroupId: groupId,
+    kind: "turn",
+    holderId: `api-ref-${groupId}`,
+    subjectId: groupId,
+    backend,
+    leaseTtlMs: settings.sandboxLeaseTtlMs,
+    warmingLeaseTtlMs: settings.sandboxLeaseWarmingTtlMs,
+  });
+  expect(acquired.role).toBe("spawner");
+  if (acquired.role !== "spawner") throw new Error(`expected spawner, got ${acquired.role}`);
+  if (!acquired.lease.archiveComplete) {
+    throw new Error(
+      `archive fixture was not complete: ${JSON.stringify({
+        archive: acquired.lease.recovery.archive,
+        workspaceGeneration: acquired.lease.workspaceGeneration,
+        archiveGeneration: acquired.lease.archiveGeneration,
+        descriptor: archive.descriptor,
+        ref,
+      })}`,
+    );
+  }
+  return { accountId, workspaceId, groupId, archive, ref, acquired };
+}
+
+async function establishArchiveFixture(fixture: ArchiveFixture, objectStorage: ObjectStorage) {
+  return await establishApiSandboxSpawner({
+    db: db!,
+    settings,
+    accountId: fixture.accountId,
+    workspaceId: fixture.workspaceId,
+    sandboxGroupId: fixture.groupId,
+    sessionId: fixture.groupId,
+    backend,
+    environment: {},
+    expectedEpoch: fixture.acquired.lease.leaseEpoch,
+    acquiredLease: fixture.acquired.lease,
+    fallbackEnvelope: null,
+    dataPlaneUrl: null,
+    objectStorage,
+  });
+}
+
+function expectFailedArchiveRestore(
+  lease: Awaited<ReturnType<typeof readLease>>,
+  failureCode: string,
+): void {
+  expect(lease).not.toBeNull();
+  expect(lease?.liveness).toBe("cold");
+  expect(lease?.instanceId).toBeNull();
+  expect(lease?.recovery.provider).toMatchObject({
+    status: "missing",
+    instanceId: null,
+  });
+  expect(lease?.recovery.restore).toMatchObject({
+    status: "unrecoverable",
+    failureCode,
+    retryable: false,
+  });
+  expect(lease?.recovery.workspace.status).toBe("unrecoverable");
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("api-rematerialize-archive-ref");
+  if (!shared) throw new Error("shared test database unavailable");
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  for (const session of seeded.splice(0)) await closeSandbox(session);
+  await client?.close();
+  await shared?.release();
+}, 180_000);
+
+test("API cold spawner restores a valid object-storage archive ref", async () => {
+  const fixture = await setupColdArchiveLease();
+  const { archive, ref } = fixture;
+  const storage = objectStorageFor(ref, archive.bytes);
+  const result = await establishArchiveFixture(fixture, storage.objectStorage);
+  seeded.push(result.established);
+  const proof = await result.established.session.exec({
+    cmd: "cat /workspace/api-object-ref-proof.txt",
+  });
+  expect(proof.exitCode).toBe(0);
+  expect(proof.stdout).toContain("api-object-ref-proof");
+  expect(storage.reads()).toBe(1);
+  expect(result.established.restoredArchive?.revision).toBe(archive.descriptor.revision);
+  const persistedState =
+    result.lease.resumeState && typeof result.lease.resumeState === "object"
+      ? result.lease.resumeState.sessionState
+      : null;
+  expect(persistedState && typeof persistedState === "object" ? persistedState : null).toBeTruthy();
+  if (!persistedState || typeof persistedState !== "object")
+    throw new Error("missing persisted state");
+  expect(parseWorkspaceArchiveObjectRef(persistedState.workspaceArchiveRef)).not.toBeNull();
+  expect(persistedState.workspaceArchive).toBeUndefined();
+}, 120_000);
+
+test("viewer attach forwards object storage and restores a cold archive ref", async () => {
+  const fixture = await setupColdArchiveLease();
+  const session = await createSession(db!, {
+    requestedSessionId: fixture.groupId,
+    accountId: fixture.accountId,
+    workspaceId: fixture.workspaceId,
+    initialMessage: "viewer archive ref",
+    resources: [],
+    metadata: {},
+    model: "m",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: backend,
+  });
+  await failWarmingToCold(db!, {
+    accountId: fixture.accountId,
+    workspaceId: fixture.workspaceId,
+    sandboxGroupId: fixture.groupId,
+    expectedEpoch: fixture.acquired.lease.leaseEpoch,
+  });
+  const storage = objectStorageFor(fixture.ref, fixture.archive.bytes);
+  const attached = await attachViewer(
+    { db: db!, settings, objectStorage: storage.objectStorage },
+    { accountId: fixture.accountId, workspaceId: fixture.workspaceId, session },
+  );
+  try {
+    expect(attached.liveness).toBe("warm");
+    expect(storage.reads()).toBe(1);
+    expect((await readLease(db!, fixture.workspaceId, fixture.groupId))?.archiveComplete).toBe(
+      true,
+    );
+  } finally {
+    const leaseBeforeDetach = await readLease(db!, fixture.workspaceId, fixture.groupId);
+    await detachViewer(
+      { db: db!, settings },
+      {
+        accountId: fixture.accountId,
+        workspaceId: fixture.workspaceId,
+        sandboxGroupId: fixture.groupId,
+        viewerId: attached.viewerId,
+      },
+    );
+    await closeLeaseProvider(fixture, leaseBeforeDetach);
+  }
+}, 120_000);
+
+test("API cold spawner records a missing object archive restore failure", async () => {
+  const fixture = await setupColdArchiveLease();
+  const storage = objectStorageFor(fixture.ref, null);
+  await expect(establishArchiveFixture(fixture, storage.objectStorage)).rejects.toMatchObject({
+    code: "archive_base64_invalid",
+  });
+  expect(storage.reads()).toBe(1);
+  expectFailedArchiveRestore(
+    await readLease(db!, fixture.workspaceId, fixture.groupId),
+    "archive_base64_invalid",
+  );
+}, 120_000);
+
+test("API cold spawner records a corrupt object archive restore failure", async () => {
+  const fixture = await setupColdArchiveLease();
+  const storage = objectStorageFor(fixture.ref, new Uint8Array([7]));
+  await expect(establishArchiveFixture(fixture, storage.objectStorage)).rejects.toMatchObject({
+    code: "archive_hash_mismatch",
+  });
+  expect(storage.reads()).toBe(1);
+  expectFailedArchiveRestore(
+    await readLease(db!, fixture.workspaceId, fixture.groupId),
+    "archive_hash_mismatch",
+  );
+}, 120_000);

--- a/apps/api/test/rematerialize-archive-ref.test.ts
+++ b/apps/api/test/rematerialize-archive-ref.test.ts
@@ -340,3 +340,27 @@ test("API cold spawner records a corrupt object archive restore failure", async 
     "archive_hash_mismatch",
   );
 }, 120_000);
+
+test("API cold spawner refuses a malformed durable archive locator", async () => {
+  const fixture = await setupColdArchiveLease();
+  await admin!`update sandbox_leases set resume_state = jsonb_set(
+    resume_state, '{sessionState,workspaceArchiveRef,key}', '"malformed-key"'::jsonb
+  ) where sandbox_group_id = ${fixture.groupId}`;
+  fixture.acquired.lease = (await readLease(db!, fixture.workspaceId, fixture.groupId))!;
+  const storage = objectStorageFor(fixture.ref, fixture.archive.bytes);
+  let failure: unknown;
+  try {
+    const result = await establishArchiveFixture(fixture, storage.objectStorage);
+    seeded.push(result.established);
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toMatchObject({
+    name: "WorkspaceArchiveIntegrityError",
+    code: "archive_metadata_invalid",
+  });
+  expect(storage.reads()).toBe(0);
+  const after = await readLease(db!, fixture.workspaceId, fixture.groupId);
+  expect(after?.liveness).toBe("cold");
+  expect(after?.instanceId).toBeNull();
+});


### PR DESCRIPTION
Attaching a viewer or using Channel A against a cold sandbox could fail with `workspace_fingerprint_mismatch` even when its durable workspace archive existed in object storage. The API passed the archive reference into provider restoration without loading its bytes, while the worker path already materialized those references.

The API now uses the existing archive verifier before restoring the selected revision, and passes object storage through both callers. The hydrated bytes stay transient; the persisted replacement envelope retains the object reference. Missing or corrupt objects leave the lease cold with the recorded restore failure.

## Verification

- The same desired-success test fails on upstream `b4575cc` and passes on `bd51aa5`.
- Four regression cases pass with 38 assertions: restored file contents and revision, ref-only persistence, viewer attach, and missing/corrupt archive failure state. The viewer fixture closes its restored provider after detaching.
- 38 existing archive/contract tests pass with 123 assertions. Lint and formatting pass.
- 149 integration tests passed across API, uploads, database, NATS, and control transport before the bounded run stopped during NATS auth-callout failures.

Full local checks are not green. `bun run check` fails on dependency/type issues in the reused worktree setup. An independent API typecheck using one coherent dependency graph produces the same two `fatal-process-boundary.ts` diagnostics on baseline and patch. The integration run reached its 120-second bound after `AUTHORIZATION_VIOLATION`; browser e2e passed the first Chromium case, then stopped because the Firefox executable is absent.

## Before and after

These captures show the same real Docker/PostgreSQL test with an in-memory ObjectStorage stub. They show test output, not browser UI or live S3 coverage.

| Before | After |
| --- | --- |
| ![Baseline archive restoration fails](https://raw.githubusercontent.com/VasuBansal7576/opengeni/ace7beef9675e97343a020d533e9e56ffa11f698/before.png) | ![Patched archive restoration succeeds](https://raw.githubusercontent.com/VasuBansal7576/opengeni/ace7beef9675e97343a020d533e9e56ffa11f698/after.png) |

## Summary by Sourcery

Restore cold API sandboxes from durable workspace archive references while validating archive integrity and preserving failure state.

Bug Fixes:
- Restore API-direct and viewer-attached cold sandboxes from valid workspace archives stored in object storage.
- Record unrecoverable cold lease state when archive objects are missing, corrupt, or malformed instead of creating a replacement workspace.

Enhancements:
- Preserve durable object-storage archive references after temporarily materializing archive bytes for restoration.

Tests:
- Add regression coverage for API spawner restoration, viewer attachment, durable reference persistence, and archive integrity failures.