### PR TITLE
Fix session history scrolling, anchoring, and false retries

### DIFF
--- a/.changeset/goal-resume-tool.md
+++ b/.changeset/goal-resume-tool.md
@@ -1,5 +1,5 @@
 ---
-"@opengeni/api": patch
+"@opengeni/api-router": patch
 "@opengeni/db": patch
 "@opengeni/contracts": patch
 "@opengeni/config": patch

--- a/.changeset/quiescence-reconciliation-wake.md
+++ b/.changeset/quiescence-reconciliation-wake.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Preserve receipt wakeups received during quiescence reconciliation so an interrupted session admits its queued replacement. Retain historical workflow behavior behind a Temporal patch marker.

--- a/.changeset/session-history-scroll.md
+++ b/.changeset/session-history-scroll.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve reading position during session history pagination, keep folded history loading, and prevent false retries across stream reconnects.

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1824,6 +1824,7 @@ function SessionChatPane(props: {
           ) : null}
           <div data-testid="session-timeline" className="min-h-0 min-w-0 flex-1">
             <MessageTimeline
+              key={props.session.id}
               className="h-full"
               items={timelineWithOptimisticSends}
               events={props.events}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1825,6 +1825,7 @@ function SessionChatPane(props: {
             <MessageTimeline
               className="h-full"
               items={timelineWithOptimisticSends}
+              events={props.events}
               status={props.session.status}
               computeLabel={computeLabel}
               renderMessageText={renderMessageText}

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -348,6 +348,7 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
   // every new run records v2 and uses the activity-owned receipt contract.
   const receiptGatedCancellation = patched("session-attempt-quiescence-v2");
   const writerSetQuiescenceRecovery = patched("session-attempt-writer-set-quiescence-v1");
+  const preserveQuiescenceWake = patched("session-quiescence-reconciliation-wake-v1");
   const staleControlSignalIsOnlyWakeHint = patched("session-control-stale-wake-v1");
   const unclaimedAttemptRecovery = patched("session-unclaimed-attempt-recovery-v1");
   // PR #2208 changed a typed-cancelled result from a plain re-peek into a
@@ -584,6 +585,8 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       continue;
     }
     if (peek.kind === "cancellation-wait") {
+      // The receipt wake can arrive while reconciliation returns an older pending result.
+      const beforeReconciliationSignalVersion = signalVersion;
       if (writerSetQuiescenceRecovery) {
         const reconciliation = await activity.reconcileSessionAttemptQuiescence({
           accountId: input.accountId,
@@ -600,7 +603,9 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       // genuinely slow, close this workflow run rather than consuming a turn
       // slot or churning control activities; the outbox uses signalWithStart to
       // restart this exact workflow after the receipt commits.
-      const seenSignalVersion = signalVersion;
+      const seenSignalVersion = preserveQuiescenceWake
+        ? beforeReconciliationSignalVersion
+        : signalVersion;
       const woke = await condition(() => signalVersion !== seenSignalVersion, "5s");
       if (woke) continue;
       // Close only against the same signal snapshot. A proof signal accepted

--- a/apps/worker/test/scheduled-task-model-catalog.test.ts
+++ b/apps/worker/test/scheduled-task-model-catalog.test.ts
@@ -508,12 +508,17 @@ describe("scheduled-task model catalog retention (real PostgreSQL)", () => {
       retryPromise,
     ]);
     expect(retired).toMatchObject({ outcome: "success" });
-    expect(winner.action).toBe("start");
-    if (winner.action !== "start") throw new Error("producer winner did not start a session");
+    // Admission commits before idempotent session creation. Either overlapping
+    // caller may create the session; the other must signal that same session.
+    expect(["start", "signal"]).toContain(winner.action);
+    if (winner.action !== "start" && winner.action !== "signal") {
+      throw new Error("producer winner did not converge on the accepted session");
+    }
     expect(["start", "signal"]).toContain(replay.action);
     if (replay.action !== "start" && replay.action !== "signal") {
       throw new Error("producer replay did not converge on the accepted session");
     }
+    expect([winner.action, replay.action]).toContain("start");
     expect(replay.sessionId).toBe(winner.sessionId);
     expect(replay.triggerEventId).toBe(winner.triggerEventId);
     const persistedRun = await getScheduledTaskRunByProducerKey(client.db, {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1268,7 +1268,9 @@ become a hidden source of domain semantics.
 Timeline history ownership stays in `packages/react`: `use-session-events.ts`
 fences history navigation by session/client lifetime, independently of SSE
 reconnects. The web route supplies source events alongside projected rows;
-retained event identity determines window overlap because partial-message row
+it keys the timeline by session so pagination ownership and reading state cannot
+survive navigation to another session.
+Retained event identity determines window overlap because partial-message row
 IDs can change on prepend. `timeline-anchor.tsx` captures the reading position
 immediately before React mutates the DOM; `message-timeline.tsx` applies only
 the residual correction after browser anchoring. Corrections cannot resume

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1265,6 +1265,16 @@ Canonical: [`artifact-engine.md`](artifact-engine.md),
 adds hooks and UI. `apps/web` is a consumer of those packages and should not
 become a hidden source of domain semantics.
 
+Timeline history ownership stays in `packages/react`: `use-session-events.ts`
+fences history navigation by session/client lifetime, independently of SSE
+reconnects. The web route supplies source events alongside projected rows;
+retained event identity determines window overlap because partial-message row
+IDs can change on prepend. `timeline-anchor.tsx` captures the reading position
+immediately before React mutates the DOM; `message-timeline.tsx` applies only
+the residual correction after browser anchoring. Corrections cannot resume
+tip-follow, and continued upward input permits bounded sequential older-page
+loads even when collapsed content adds no scroll range.
+
 The stock web console imports the browser-focused `@opengeni/sdk/browser`
 entry. Operator-only Document-authority and tenancy-backfill methods live in
 the optional `@opengeni/sdk/document-authority` entry, while the root and

--- a/packages/db/test/session-event-writer-audit.test.ts
+++ b/packages/db/test/session-event-writer-audit.test.ts
@@ -441,7 +441,8 @@ function productionTypeScriptFiles(): string[] {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       if (
         entry.isDirectory() &&
-        ["node_modules", "dist", "coverage", "test", "tests", "__tests__"].includes(entry.name)
+        (["node_modules", "dist", "coverage", "test", "tests", "__tests__"].includes(entry.name) ||
+          entry.name.startsWith(".native-closure-"))
       ) {
         continue;
       }

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -50,6 +50,12 @@ import {
 } from "../older-history";
 import { Markdown } from "./markdown";
 import {
+  TimelineBeforeLayout,
+  captureTimelineAnchor,
+  timelineAnchorCorrection,
+  type TimelineAnchor,
+} from "./timeline-anchor";
+import {
   UserMessageBody,
   UserMessageDisclosureProvider,
   type UserMessageDisclosureContextValue,
@@ -418,8 +424,15 @@ export function MessageTimeline({
       (item) => item.kind !== "auth-needed" || shouldRenderAuthNeeded(item),
     );
   }, [items, events, shouldRenderAuthNeeded]);
-  const sourceItems = items || events;
+  // Event-window identity is independent of projected rows (partial messages
+  // can acquire a different first-delta id when older text arrives).
+  const sourceItems = events ?? items;
   const olderBoundaryKey = sourceItems?.[0]?.id;
+  const previousSourceIdsRef = useRef(new Set<string>());
+  const previousSourceBoundaryRef = useRef<string | undefined>(undefined);
+  const readingAnchorRef = useRef<TimelineAnchor | null>(null);
+  const olderPageBudgetRef = useRef(0);
+  const [olderDemand, setOlderDemand] = useState(0);
   const allGroups = useMemo(() => groupTimeline(resolvedItems), [resolvedItems]);
   const annotationSources = useMemo(() => {
     const sources = new Map<string, TimelineAnnotationSourceDescriptor>();
@@ -648,29 +661,22 @@ export function MessageTimeline({
   }, []);
 
   /** Reader left the tip — wheel, keyboard, pointer-armed scroll-up, or scrollend. */
-  const releasePinFromReader = useCallback(
-    (node?: HTMLElement | null) => {
-      if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
-        return;
-      }
-      // Unscrollable window: unpin strands Jump-to-latest with no way back.
-      if (node && maxScrollOf(node) <= 1) {
-        return;
-      }
-      clearReaderIntent();
-      clearPendingReaderLeave();
-      stopFollow();
-      applyPinned(false);
-      if (wantPinRef.current) {
-        wantPinRef.current = false;
-      }
-      if (!olderPrefetchArmedRef.current) {
-        olderPrefetchArmedRef.current = true;
-        setOlderPrefetchArmed(true);
-      }
-    },
-    [autoFollow, applyPinned, clearPendingReaderLeave, clearReaderIntent, stopFollow],
-  );
+  const releasePinFromReader = useCallback(() => {
+    if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
+      return;
+    }
+    clearReaderIntent();
+    clearPendingReaderLeave();
+    stopFollow();
+    applyPinned(false);
+    if (wantPinRef.current) {
+      wantPinRef.current = false;
+    }
+    if (!olderPrefetchArmedRef.current) {
+      olderPrefetchArmedRef.current = true;
+      setOlderPrefetchArmed(true);
+    }
+  }, [autoFollow, applyPinned, clearPendingReaderLeave, clearReaderIntent, stopFollow]);
 
   /**
    * Settled away from the tip while the camera is idle — Vimium / unfocused
@@ -691,7 +697,7 @@ export function MessageTimeline({
         clearPendingReaderLeave();
         return;
       }
-      releasePinFromReader(node);
+      releasePinFromReader();
       rearmOlderPrefetchAfterLeavingTop(node);
     },
     [autoFollow, clearPendingReaderLeave, rearmOlderPrefetchAfterLeavingTop, releasePinFromReader],
@@ -729,12 +735,19 @@ export function MessageTimeline({
       return;
     }
     disclosureKeepsUnpinnedRef.current = false;
+    programmaticScrollRef.current = 0;
     if (event.deltaY >= 0) {
       return;
     }
-    const node =
-      event.currentTarget instanceof HTMLElement ? event.currentTarget : scrollRef.current;
-    releasePinFromReader(node);
+    releasePinFromReader();
+    wantPinRef.current = false;
+    // A stationary upward gesture is still demand. Successful short/folded
+    // pages may never create enough range to leave the prefetch band.
+    olderPageBudgetRef.current = 8;
+    if (olderLoadAttemptRef.current?.[1] === 2) {
+      olderLoadAttemptRef.current = null;
+      setOlderDemand((value) => value + 1);
+    }
   };
 
   /** Touch / stylus / mouse drag on the scroller — explicit leave (not layout). */
@@ -779,9 +792,7 @@ export function MessageTimeline({
     if (event.key !== "ArrowUp" && event.key !== "PageUp" && event.key !== "Home") {
       return;
     }
-    const node =
-      event.currentTarget instanceof HTMLElement ? event.currentTarget : scrollRef.current;
-    releasePinFromReader(node);
+    releasePinFromReader();
   };
 
   const snapToBottom = useCallback(
@@ -1103,15 +1114,26 @@ export function MessageTimeline({
       previousMaxScroll <= 1 ||
       previousMaxScroll - previousScrollTop < Math.min(PIN_THRESHOLD_PX, previousMaxScroll);
     const firstItemChanged = !!previousFirstItemId && firstItemId !== previousFirstItemId;
-    const prepended =
-      firstItemChanged && resolvedItems.some((item) => item.id === previousFirstItemId);
+    const sourceChanged = olderBoundaryKey !== previousSourceBoundaryRef.current;
+    const retainedSource =
+      sourceItems?.some((item) => previousSourceIdsRef.current.has(item.id)) ?? false;
+    const prepended = sourceChanged && retainedSource;
+    previousSourceBoundaryRef.current = olderBoundaryKey;
+    previousSourceIdsRef.current = new Set(sourceItems?.map((item) => item.id));
+    const readingAnchor = readingAnchorRef.current;
+    readingAnchorRef.current = null;
     const attempt = olderLoadAttemptRef.current;
     const committedZeroOverlapOlderReplacement = !!(
       attempt?.[2]?.committed &&
-      firstItemChanged &&
-      !prepended
+      sourceChanged &&
+      !retainedSource
     );
     const restorePrependAnchor = () => {
+      const correction = readingAnchor && timelineAnchorCorrection(node, readingAnchor);
+      if (correction != null) {
+        if (Math.abs(correction) > 1) writeScrollTop(node, node.scrollTop + correction);
+        return;
+      }
       // Keep the reader on the same retained rows. Prefer the exact first-item
       // content coordinate (needed when a prepend merges inside one group),
       // then the retained group offset, then scrollHeight as a final fallback.
@@ -1289,6 +1311,19 @@ export function MessageTimeline({
     // Boundary progress retires the request owner. A late settlement from
     // that completed prefetch cannot mutate the new window's cooldown owner.
     olderLoadAttemptRef.current = [olderBoundaryKey, 2];
+    // Bound automatic work, but let continued upward input replenish demand.
+    // Only a committed first-party receipt proves that another page is safe.
+    if (
+      attempt[2]?.committed &&
+      !pinnedRef.current &&
+      hasOlder &&
+      node.scrollTop <= OLDER_PREFETCH_MARGIN_PX &&
+      olderPageBudgetRef.current > 0
+    ) {
+      olderPageBudgetRef.current -= 1;
+      olderLoadAttemptRef.current = null;
+      setOlderDemand((value) => value + 1);
+    }
     rearmOlderPrefetchAfterLeavingTop(node);
     requestOlderIfUnderfilled(node);
   });
@@ -1459,6 +1494,7 @@ export function MessageTimeline({
     loadingOlder,
     olderBoundaryKey,
     olderPrefetchArmed,
+    olderDemand,
     onLoadOlder,
     requestOlderIfUnderfilled,
   ]);
@@ -1651,7 +1687,7 @@ export function MessageTimeline({
       // Pointer-dragged scroll-up away from tip. Layout churn never arms this.
       if (readerArmed && cumulativeReaderUp > TIP_FOLLOW_READER_UP_EPS_PX && !nearBottomPinned) {
         clearReaderIntent();
-        releasePinFromReader(node);
+        releasePinFromReader();
         rearmOlderPrefetchAfterLeavingTop(node);
         return;
       }
@@ -1676,6 +1712,10 @@ export function MessageTimeline({
     }
 
     syncScrollBaseline(node);
+    if (programmatic) {
+      // Anchor restoration is never permission to resume tip-follow.
+      return;
+    }
     const nearBottom = isNearBottom(node);
 
     // Re-pin only when the reader moved toward/at the tip without a content
@@ -1759,148 +1799,170 @@ export function MessageTimeline({
                     onScroll={onScroll}
                     onScrollEnd={onScrollEnd}
                     onWheel={onWheel}
+                    onClickCapture={(event) => {
+                      const target =
+                        event.target instanceof Element
+                          ? event.target.closest("button[aria-expanded]")
+                          : null;
+                      if (target) {
+                        releasePinFromReader();
+                        disclosureKeepsUnpinnedRef.current = true;
+                      }
+                    }}
                     onPointerDown={onPointerDown}
                     onKeyDown={onKeyDown}
                     style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
                     className={cn(
                       // tabIndex=-1 is programmatic only — never paint a focus ring on
                       // the whole scroller (click + Shift used to flash a blue outline).
-                      "min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 outline-hidden",
+                      "min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pt-16 pb-6 sm:px-6 outline-hidden",
                       autoFollow && pinned && !hasNewer
                         ? "[overflow-anchor:none]"
                         : "[overflow-anchor:auto]",
                     )}
                   >
-                    <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
-                      {!groups.length
-                        ? (emptyState ?? (
-                            <p className="py-10 text-center text-og-menu text-og-fg-subtle">
-                              No activity yet.
-                            </p>
-                          ))
-                        : null}
-                      {hasOlder && olderPrefetchArmed ? (
-                        // Overlaid, not a layout row: mounting/unmounting the sentinel
-                        // must never shift content (that shift was itself a wobble).
-                        <div
-                          ref={topSentinelRef}
-                          data-og-top-sentinel=""
-                          data-og-timeline-chrome=""
-                          aria-hidden="true"
-                          className="pointer-events-none absolute inset-x-0 top-0 h-px"
-                        />
-                      ) : null}
-                      {groups.map(({ group, key, entranceEnabled }, index) => {
-                        return (
-                          <TimelineGroupEntry
-                            key={key}
-                            groupKey={key}
-                            group={group}
-                            nextGroup={groups[index + 1]?.group}
-                            entranceEnabled={entranceEnabled}
-                            liveEntranceEnabled={
-                              group.kind === "activity" ? !bulkRender : undefined
-                            }
-                            context={timelineGroupEntryContext}
-                          />
-                        );
-                      })}
-                      {groups.length > 0 && trailingState ? (
-                        <div data-og-timeline-trailing-state="">{trailingState}</div>
-                      ) : null}
-                      {hasNewer ? (
-                        <div
-                          ref={bottomSentinelRef}
-                          data-og-bottom-sentinel=""
-                          data-og-timeline-chrome=""
-                          aria-hidden="true"
-                          className="h-px w-full"
-                        />
-                      ) : null}
-                    </div>
-                  </div>
-                  <AnimatePresence>
-                    {loadingOlder ||
-                    loadingOldest ||
-                    (hasOlder && onJumpToStart && olderPrefetchArmed) ||
-                    underfillRetryReady ? (
-                      // Floating over the scroller (not a timeline row) so showing and
-                      // hiding it never reflows history under the reader.
-                      <motion.div
-                        initial={{ opacity: 0, y: -6 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -6 }}
-                        transition={{ duration: 0.15, ease: "easeOut" }}
-                        data-og-loading-older=""
-                        aria-live="polite"
-                        className="absolute inset-x-0 top-3 z-10 flex justify-center"
-                      >
-                        {loadingOlder || loadingOldest ? (
-                          <span className={LOADING_CHIP_CLASS}>
-                            <span className="og-shimmer-text">
-                              {loadingOldest ? "Jumping to start…" : "Loading earlier activity…"}
-                            </span>
-                          </span>
-                        ) : null}
-                        {hasOlder &&
-                        !loadingOlder &&
-                        !loadingOldest &&
-                        (underfillRetryReady || onJumpToStart) ? (
-                          <button
-                            type="button"
-                            data-og-retry={underfillRetryReady || undefined}
-                            data-og-jump-to-start={!underfillRetryReady || undefined}
-                            onClick={() => {
-                              const node = scrollRef.current;
-                              if (underfillRetryReady) {
-                                if (node && underfillRetryReadyRef.current) {
-                                  // AnimatePresence retains this handler during
-                                  // exit. Current authorization plus the exact
-                                  // attempt check prevent stale dispatch.
-                                  requestOlderIfUnderfilled(node, underfillSettledAttempt!);
-                                }
-                                return;
-                              }
-                              applyPinned(false);
-                              pendingJumpToStartRef.current = true;
-                              const seq = ++jumpToStartSeqRef.current;
-                              void Promise.resolve(onJumpToStart!()).then(
-                                () => {
-                                  // The commit that swaps in the oldest window consumes
-                                  // the flag against the new DOM; this write covers the
-                                  // already-committed order and the no-window-change
-                                  // case (jumping within the current window).
-                                  const scroller = scrollRef.current ?? node;
-                                  if (scroller) {
-                                    scroller.scrollTop = 0;
-                                  }
-                                  // A host may resolve without ever changing the
-                                  // window (already on the oldest page). Any swap
-                                  // commit runs its layout effect before the next
-                                  // frame, so a flag still armed by then is the
-                                  // no-change case — clear it, or a LATER prepend
-                                  // would spuriously jump the reader to the top.
-                                  requestFrame(() => {
-                                    if (jumpToStartSeqRef.current === seq) {
-                                      pendingJumpToStartRef.current = false;
+                    <TimelineBeforeLayout
+                      capture={() => {
+                        readingAnchorRef.current =
+                          !pinnedRef.current && scrollRef.current
+                            ? captureTimelineAnchor(scrollRef.current)
+                            : null;
+                      }}
+                    >
+                      <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
+                        <AnimatePresence>
+                          {loadingOlder ||
+                          loadingOldest ||
+                          (hasOlder && onJumpToStart && olderPrefetchArmed) ||
+                          underfillRetryReady ? (
+                            // Reserved top gutter: controls scroll with history and cannot
+                            // cover a disclosure. Visibility never changes content height.
+                            <motion.div
+                              initial={{ opacity: 0, y: -6 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              exit={{ opacity: 0, y: -6 }}
+                              transition={{ duration: 0.15, ease: "easeOut" }}
+                              data-og-loading-older=""
+                              aria-live="polite"
+                              className="pointer-events-none absolute inset-x-0 -top-11 z-10 flex justify-center"
+                            >
+                              {loadingOlder || loadingOldest ? (
+                                <span className={LOADING_CHIP_CLASS}>
+                                  <span className="og-shimmer-text">
+                                    {loadingOldest
+                                      ? "Jumping to start…"
+                                      : "Loading earlier activity…"}
+                                  </span>
+                                </span>
+                              ) : null}
+                              {hasOlder &&
+                              !loadingOlder &&
+                              !loadingOldest &&
+                              (underfillRetryReady || onJumpToStart) ? (
+                                <button
+                                  type="button"
+                                  data-og-retry={underfillRetryReady || undefined}
+                                  data-og-jump-to-start={!underfillRetryReady || undefined}
+                                  onClick={() => {
+                                    const node = scrollRef.current;
+                                    if (underfillRetryReady) {
+                                      if (node && underfillRetryReadyRef.current) {
+                                        // AnimatePresence retains this handler during
+                                        // exit. Current authorization plus the exact
+                                        // attempt check prevent stale dispatch.
+                                        requestOlderIfUnderfilled(node, underfillSettledAttempt!);
+                                      }
+                                      return;
                                     }
-                                  });
-                                },
-                                () => {
-                                  if (jumpToStartSeqRef.current === seq) {
-                                    pendingJumpToStartRef.current = false;
-                                  }
-                                },
-                              );
-                            }}
-                            className="rounded-full border border-og-border px-3 py-1.5 text-og-control"
-                          >
-                            {underfillRetryReady ? "Retry earlier activity" : "Jump to start"}
-                          </button>
+                                    applyPinned(false);
+                                    pendingJumpToStartRef.current = true;
+                                    const seq = ++jumpToStartSeqRef.current;
+                                    void Promise.resolve(onJumpToStart!()).then(
+                                      () => {
+                                        // The commit that swaps in the oldest window consumes
+                                        // the flag against the new DOM; this write covers the
+                                        // already-committed order and the no-window-change
+                                        // case (jumping within the current window).
+                                        const scroller = scrollRef.current ?? node;
+                                        if (scroller) {
+                                          scroller.scrollTop = 0;
+                                        }
+                                        // A host may resolve without ever changing the
+                                        // window (already on the oldest page). Any swap
+                                        // commit runs its layout effect before the next
+                                        // frame, so a flag still armed by then is the
+                                        // no-change case — clear it, or a LATER prepend
+                                        // would spuriously jump the reader to the top.
+                                        requestFrame(() => {
+                                          if (jumpToStartSeqRef.current === seq) {
+                                            pendingJumpToStartRef.current = false;
+                                          }
+                                        });
+                                      },
+                                      () => {
+                                        if (jumpToStartSeqRef.current === seq) {
+                                          pendingJumpToStartRef.current = false;
+                                        }
+                                      },
+                                    );
+                                  }}
+                                  className="pointer-events-auto rounded-full border border-og-border px-3 py-1.5 text-og-control"
+                                >
+                                  {underfillRetryReady ? "Retry earlier activity" : "Jump to start"}
+                                </button>
+                              ) : null}
+                            </motion.div>
+                          ) : null}
+                        </AnimatePresence>
+                        {!groups.length
+                          ? (emptyState ?? (
+                              <p className="py-10 text-center text-og-menu text-og-fg-subtle">
+                                No activity yet.
+                              </p>
+                            ))
+                          : null}
+                        {hasOlder && olderPrefetchArmed ? (
+                          // Overlaid, not a layout row: mounting/unmounting the sentinel
+                          // must never shift content (that shift was itself a wobble).
+                          <div
+                            ref={topSentinelRef}
+                            data-og-top-sentinel=""
+                            data-og-timeline-chrome=""
+                            aria-hidden="true"
+                            className="pointer-events-none absolute inset-x-0 top-0 h-px"
+                          />
                         ) : null}
-                      </motion.div>
-                    ) : null}
-                  </AnimatePresence>
+                        {groups.map(({ group, key, entranceEnabled }, index) => {
+                          return (
+                            <TimelineGroupEntry
+                              key={key}
+                              groupKey={key}
+                              group={group}
+                              nextGroup={groups[index + 1]?.group}
+                              entranceEnabled={entranceEnabled}
+                              liveEntranceEnabled={
+                                group.kind === "activity" ? !bulkRender : undefined
+                              }
+                              context={timelineGroupEntryContext}
+                            />
+                          );
+                        })}
+                        {groups.length > 0 && trailingState ? (
+                          <div data-og-timeline-trailing-state="">{trailingState}</div>
+                        ) : null}
+                        {hasNewer ? (
+                          <div
+                            ref={bottomSentinelRef}
+                            data-og-bottom-sentinel=""
+                            data-og-timeline-chrome=""
+                            aria-hidden="true"
+                            className="h-px w-full"
+                          />
+                        ) : null}
+                      </div>
+                    </TimelineBeforeLayout>
+                  </div>
+
                   <AnimatePresence>
                     {loadingNewer ? (
                       <motion.div

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1731,8 +1731,7 @@ export function MessageTimeline({
     // inside PIN_THRESHOLD once the window is tall) and snapped them back.
     const inserted = Math.max(0, nextMaxScroll - previousMaxScroll);
     const towardTip = nextTop - previousTop - inserted;
-    const nextPinned =
-      !hasNewer && nearBottom && towardTip >= -TIP_FOLLOW_READER_UP_EPS_PX && inserted <= 1;
+    const nextPinned = !hasNewer && nearBottom && towardTip > 0.5 && inserted <= 1;
     if (!nextPinned) {
       stopFollow();
     }

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1806,7 +1806,7 @@ export function MessageTimeline({
                     onScrollEnd={onScrollEnd}
                     onWheel={onWheel}
                     onTouchStart={(event) => {
-                      const touch = event.touches[0];
+                      const touch = event.touches.length === 1 ? event.touches[0] : undefined;
                       touchPositionRef.current = touch
                         ? { x: touch.clientX, y: touch.clientY }
                         : null;
@@ -1814,7 +1814,10 @@ export function MessageTimeline({
                     onTouchMove={(event) => {
                       const touch = event.touches[0];
                       const previous = touchPositionRef.current;
-                      if (!touch || !previous) return;
+                      if (!touch || !previous || event.touches.length !== 1) {
+                        touchPositionRef.current = null;
+                        return;
+                      }
                       const deltaX = previous.x - touch.clientX;
                       const deltaY = previous.y - touch.clientY;
                       if (Math.max(Math.abs(deltaX), Math.abs(deltaY)) < 4) return;

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -718,6 +718,19 @@ export function MessageTimeline({
     });
   }, [cancelLeaveFallback, releasePinAfterScrollSettled]);
 
+  const requestEarlierFromReader = () => {
+    releasePinFromReader();
+    wantPinRef.current = false;
+    // A stationary upward gesture is still demand. Successful short/folded
+    // pages may never create enough range to leave the prefetch band.
+    olderPageBudgetRef.current = 8;
+    if (olderLoadAttemptRef.current?.[1] === 2) {
+      olderLoadAttemptRef.current = null;
+      setOlderDemand((value) => value + 1);
+    }
+  };
+  const touchPositionRef = useRef<{ x: number; y: number } | null>(null);
+
   const onWheel = (event: {
     deltaY: number;
     deltaX: number;
@@ -739,15 +752,7 @@ export function MessageTimeline({
     if (event.deltaY >= 0) {
       return;
     }
-    releasePinFromReader();
-    wantPinRef.current = false;
-    // A stationary upward gesture is still demand. Successful short/folded
-    // pages may never create enough range to leave the prefetch band.
-    olderPageBudgetRef.current = 8;
-    if (olderLoadAttemptRef.current?.[1] === 2) {
-      olderLoadAttemptRef.current = null;
-      setOlderDemand((value) => value + 1);
-    }
+    requestEarlierFromReader();
   };
 
   /** Touch / stylus / mouse drag on the scroller — explicit leave (not layout). */
@@ -792,7 +797,8 @@ export function MessageTimeline({
     if (event.key !== "ArrowUp" && event.key !== "PageUp" && event.key !== "Home") {
       return;
     }
-    releasePinFromReader();
+    programmaticScrollRef.current = 0;
+    requestEarlierFromReader();
   };
 
   const snapToBottom = useCallback(
@@ -1687,7 +1693,7 @@ export function MessageTimeline({
       // Pointer-dragged scroll-up away from tip. Layout churn never arms this.
       if (readerArmed && cumulativeReaderUp > TIP_FOLLOW_READER_UP_EPS_PX && !nearBottomPinned) {
         clearReaderIntent();
-        releasePinFromReader();
+        requestEarlierFromReader();
         rearmOlderPrefetchAfterLeavingTop(node);
         return;
       }
@@ -1799,6 +1805,33 @@ export function MessageTimeline({
                     onScroll={onScroll}
                     onScrollEnd={onScrollEnd}
                     onWheel={onWheel}
+                    onTouchStart={(event) => {
+                      const touch = event.touches[0];
+                      touchPositionRef.current = touch
+                        ? { x: touch.clientX, y: touch.clientY }
+                        : null;
+                    }}
+                    onTouchMove={(event) => {
+                      const touch = event.touches[0];
+                      const previous = touchPositionRef.current;
+                      if (!touch || !previous) return;
+                      const deltaX = previous.x - touch.clientX;
+                      const deltaY = previous.y - touch.clientY;
+                      if (Math.max(Math.abs(deltaX), Math.abs(deltaY)) < 4) return;
+                      touchPositionRef.current = { x: touch.clientX, y: touch.clientY };
+                      onWheel({
+                        deltaX,
+                        deltaY,
+                        target: event.target,
+                        currentTarget: event.currentTarget,
+                      });
+                    }}
+                    onTouchEnd={() => {
+                      touchPositionRef.current = null;
+                    }}
+                    onTouchCancel={() => {
+                      touchPositionRef.current = null;
+                    }}
                     onClickCapture={(event) => {
                       const target =
                         event.target instanceof Element

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1960,12 +1960,14 @@ export function MessageTimeline({
                         {hasOlder && olderPrefetchArmed ? (
                           // Overlaid, not a layout row: mounting/unmounting the sentinel
                           // must never shift content (that shift was itself a wobble).
+                          // End at the scroll origin above the pt-16 gutter so the
+                          // observer and scrollTop cooldown share the same 400px band.
                           <div
                             ref={topSentinelRef}
                             data-og-top-sentinel=""
                             data-og-timeline-chrome=""
                             aria-hidden="true"
-                            className="pointer-events-none absolute inset-x-0 top-0 h-px"
+                            className="pointer-events-none absolute inset-x-0 -top-16 h-px -translate-y-full"
                           />
                         ) : null}
                         {groups.map(({ group, key, entranceEnabled }, index) => {

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -935,7 +935,7 @@ export function SessionChrome({
                     );
                   }}
                   className={cn(
-                    "ml-auto inline-flex min-h-8 shrink-0 items-center gap-1.5 rounded-og-md px-2 text-og-xs transition-colors outline-hidden focus-visible:ring-2 focus-visible:ring-og-accent/40 pointer-coarse:min-h-11",
+                    "ml-auto inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-og-md px-2 text-og-xs transition-colors outline-hidden focus-visible:ring-2 focus-visible:ring-og-accent/40 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
                     activityOpen
                       ? "bg-og-surface-3 text-og-fg"
                       : "text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg",

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -1543,9 +1543,10 @@ function IconAction({
           disabled={disabled}
           onClick={onClick}
           className={cn(
-            "inline-flex size-6 items-center justify-center rounded-og-sm text-og-fg-subtle outline-hidden transition-colors",
+            "inline-flex size-6 items-center justify-center rounded-og-sm outline-hidden transition-colors",
             "hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40",
             "disabled:pointer-events-none disabled:opacity-40 pointer-coarse:size-9",
+            text ? "text-og-fg" : "text-og-fg-subtle",
             text && "w-auto gap-1 px-1.5 text-og-xs pointer-coarse:w-auto",
             danger && "hover:text-og-danger",
           )}

--- a/packages/react/src/components/timeline-anchor.tsx
+++ b/packages/react/src/components/timeline-anchor.tsx
@@ -21,7 +21,9 @@ export class TimelineBeforeLayout extends Component<{
 export function captureTimelineAnchor(scroller: HTMLElement): TimelineAnchor | null {
   const viewport = scroller.getBoundingClientRect();
   if (viewport.height <= 0) return null;
-  const groups = Array.from(scroller.querySelectorAll<HTMLElement>("[data-og-group-key]"));
+  const groups = Array.from(scroller.querySelectorAll<HTMLElement>("[data-og-group-key]")).filter(
+    (group) => group.getBoundingClientRect().height > 0,
+  );
   const anchors: TimelineAnchor = [];
   // A disclosure is the reader's explicit point of interaction. In particular,
   // anchoring a paragraph below an expanding disclosure would move its button.

--- a/packages/react/src/components/timeline-anchor.tsx
+++ b/packages/react/src/components/timeline-anchor.tsx
@@ -1,0 +1,89 @@
+import { Component, type ReactNode } from "react";
+
+type Anchor = { element: HTMLElement; key: string | null; text: string | null; top: number };
+export type TimelineAnchor = Anchor[];
+
+/** Read the old DOM immediately before React changes it, not when a fetch starts. */
+export class TimelineBeforeLayout extends Component<{
+  capture: () => void;
+  children: ReactNode;
+}> {
+  getSnapshotBeforeUpdate() {
+    this.props.capture();
+    return null;
+  }
+  componentDidUpdate() {}
+  render() {
+    return this.props.children;
+  }
+}
+
+export function captureTimelineAnchor(scroller: HTMLElement): TimelineAnchor | null {
+  const viewport = scroller.getBoundingClientRect();
+  if (viewport.height <= 0) return null;
+  const groups = Array.from(scroller.querySelectorAll<HTMLElement>("[data-og-group-key]"));
+  const anchors: TimelineAnchor = [];
+  // A disclosure is the reader's explicit point of interaction. In particular,
+  // anchoring a paragraph below an expanding disclosure would move its button.
+  const focused = scroller.ownerDocument.activeElement;
+  if (
+    focused instanceof HTMLElement &&
+    scroller.contains(focused) &&
+    focused.matches("button[aria-expanded]")
+  ) {
+    const box = focused.getBoundingClientRect();
+    if (box.bottom > viewport.top && box.top < viewport.bottom) {
+      anchors.push({ element: focused, key: null, text: null, top: box.top });
+    }
+  }
+  // A paragraph survives even when earlier deltas reconstruct its containing message.
+  for (const group of groups) {
+    const rect = group.getBoundingClientRect();
+    if (rect.bottom <= viewport.top || rect.top >= viewport.bottom) continue;
+    for (const element of group.querySelectorAll<HTMLElement>("p, li, pre, h1, h2, h3, h4")) {
+      const box = element.getBoundingClientRect();
+      const text = element.textContent;
+      if (box.bottom > viewport.top && box.top < viewport.bottom && text && text.length >= 12) {
+        anchors.push({ element, key: null, text, top: box.top });
+      }
+    }
+  }
+  // Prefer a retained visible row, then a following row. A following row also
+  // anchors the unchanged suffix of a partially loaded message above it.
+  const rows = groups.map((element) => ({
+    element,
+    key: element.getAttribute("data-og-group-key"),
+    text: null,
+    top: element.getBoundingClientRect().top,
+  }));
+  anchors.push(...rows.filter((row) => row.top >= viewport.top));
+  anchors.push(...rows.filter((row) => row.top < viewport.top).reverse());
+  return anchors;
+}
+
+/** Return only the correction native browser anchoring has not already made. */
+export function timelineAnchorCorrection(
+  scroller: HTMLElement,
+  anchors: TimelineAnchor,
+): number | null {
+  let blocks: HTMLElement[] | undefined;
+  const groups = Array.from(scroller.querySelectorAll<HTMLElement>("[data-og-group-key]"));
+  for (const anchor of anchors) {
+    let element: HTMLElement | undefined;
+    if (
+      scroller.contains(anchor.element) &&
+      (!anchor.text || anchor.element.textContent === anchor.text)
+    ) {
+      element = anchor.element;
+    } else if (anchor.key) {
+      element = groups.find((group) => group.getAttribute("data-og-group-key") === anchor.key);
+    } else if (anchor.text) {
+      blocks ??= Array.from(scroller.querySelectorAll<HTMLElement>("p, li, pre, h1, h2, h3, h4"));
+      const matches = blocks.filter((block) => block.textContent === anchor.text);
+      // Repeated boilerplate is not sufficient evidence of retained content.
+      if (matches.length === 1) element = matches[0];
+    }
+    if (element) return element.getBoundingClientRect().top - anchor.top;
+  }
+  return null;
+}

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -427,6 +427,16 @@ export function useSessionEvents(
           }
           const status = observeSessionStatus(window.events, sessionStatusRef);
           const retained = boundBrowserSessionEventWindow(window.events);
+          // A replacement tail retires requests against the discarded window.
+          // Ordinary SSE reconnects preserve navigation, but splicing an old
+          // page into this new tail could leave an inaccessible history gap.
+          navigationGenerationRef.current += 1;
+          loadingOlderRef.current = false;
+          loadingNewerRef.current = false;
+          loadingOldestRef.current = false;
+          setLoadingOlder(false);
+          setLoadingNewer(false);
+          setLoadingOldest(false);
           eventWindowRef.current = retained;
           oldestSequenceRef.current = retained.events[0]?.sequence ?? window.oldestSequence;
           newestSequenceRef.current =

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -193,6 +193,7 @@ export function useSessionEvents(
   const streamAbortRef = useRef<AbortController | null>(null);
   const streamKeyRef = useRef<string | null>(null);
   const generationRef = useRef(0);
+  const navigationGenerationRef = useRef(0);
   const eventWindowRef = useRef<BrowserSessionEventWindow>(EMPTY_EVENT_WINDOW);
   const sessionStatusRef = useRef<{
     sequence: number;
@@ -204,6 +205,21 @@ export function useSessionEvents(
   // Effects reset state after commit. Tag the state so the first render for a
   // new stream identity cannot expose the previous session's event log.
   const [stateStreamKey, setStateStreamKey] = useState(streamKey);
+
+  // Reopening SSE after a prepend must not cancel the next history page.
+  // Navigation belongs to the session/client lifetime, not the transport.
+  useEffect(() => {
+    navigationGenerationRef.current += 1;
+    loadingOlderRef.current = false;
+    loadingNewerRef.current = false;
+    loadingOldestRef.current = false;
+    setLoadingOlder(false);
+    setLoadingNewer(false);
+    setLoadingOldest(false);
+    return () => {
+      navigationGenerationRef.current += 1;
+    };
+  }, [client, workspaceId, sessionId, after, enabled, fullReplay]);
 
   useEffect(() => {
     // Reset the accumulated log only when the stream identity changes —
@@ -243,10 +259,6 @@ export function useSessionEvents(
     // only the newest dependency generation can mutate refs or React state.
     const generation = generationRef.current + 1;
     generationRef.current = generation;
-    if (loadingOlderRef.current) {
-      loadingOlderRef.current = false;
-      setLoadingOlder(false);
-    }
     if (!sessionId || !streamEnabled) {
       // A page that stayed hidden beyond the live-activity grace deliberately
       // closed its SSE connection. Replaying from the old cursor on return can
@@ -543,7 +555,7 @@ export function useSessionEvents(
           setHasOlder(false);
           return false;
         }
-        const generation = generationRef.current;
+        const generation = navigationGenerationRef.current;
         loadingOlderRef.current = true;
         setLoadingOlder(true);
         let published = false;
@@ -554,7 +566,7 @@ export function useSessionEvents(
             targetGroups: OLDER_GROUP_TARGET,
             maxFetches: OLDER_FETCH_CAP,
           });
-          if (generationRef.current !== generation) {
+          if (navigationGenerationRef.current !== generation) {
             return false;
           }
           if (window.events.length === 0) {
@@ -635,7 +647,7 @@ export function useSessionEvents(
           published = true;
           return olderStillAvailable;
         } finally {
-          if (!published) {
+          if (!published && navigationGenerationRef.current === generation) {
             loadingOlderRef.current = false;
             setLoadingOlder(false);
           }
@@ -648,7 +660,7 @@ export function useSessionEvents(
     if (!sessionId || navigationBusy() || !hasOlderRef.current) {
       return false;
     }
-    const generation = generationRef.current;
+    const generation = navigationGenerationRef.current;
     loadingOldestRef.current = true;
     setLoadingOldest(true);
     let published = false;
@@ -659,7 +671,7 @@ export function useSessionEvents(
         targetGroups: OLDEST_GROUP_TARGET,
         maxFetches: OLDEST_FETCH_CAP,
       });
-      if (generationRef.current !== generation) {
+      if (navigationGenerationRef.current !== generation) {
         return false;
       }
       if (window.events.length === 0) {
@@ -700,7 +712,7 @@ export function useSessionEvents(
       published = true;
       return newer;
     } finally {
-      if (!published) {
+      if (!published && navigationGenerationRef.current === generation) {
         loadingOldestRef.current = false;
         setLoadingOldest(false);
       }
@@ -717,7 +729,7 @@ export function useSessionEvents(
       setHasNewer(false);
       return false;
     }
-    const generation = generationRef.current;
+    const generation = navigationGenerationRef.current;
     loadingNewerRef.current = true;
     setLoadingNewer(true);
     let published = false;
@@ -728,7 +740,7 @@ export function useSessionEvents(
         targetGroups: NEWER_GROUP_TARGET,
         maxFetches: NEWER_FETCH_CAP,
       });
-      if (generationRef.current !== generation) {
+      if (navigationGenerationRef.current !== generation) {
         return false;
       }
       if (window.events.length === 0) {
@@ -800,7 +812,7 @@ export function useSessionEvents(
       published = true;
       return newer;
     } finally {
-      if (!published) {
+      if (!published && navigationGenerationRef.current === generation) {
         loadingNewerRef.current = false;
         setLoadingNewer(false);
       }

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -550,6 +550,9 @@
 :where(.og-root).-top-3,:where(.og-root) .-top-3 {
     top: calc(var(--spacing) * -3);
   }
+:where(.og-root).-top-11,:where(.og-root) .-top-11 {
+    top: calc(var(--spacing) * -11);
+  }
 :where(.og-root).top-0,:where(.og-root) .top-0 {
     top: calc(var(--spacing) * 0);
   }
@@ -2468,6 +2471,9 @@
 :where(.og-root).pt-3,:where(.og-root) .pt-3 {
     padding-top: calc(var(--spacing) * 3);
   }
+:where(.og-root).pt-16,:where(.og-root) .pt-16 {
+    padding-top: calc(var(--spacing) * 16);
+  }
 :where(.og-root).pr-1,:where(.og-root) .pr-1 {
     padding-right: calc(var(--spacing) * 1);
   }
@@ -2497,6 +2503,9 @@
   }
 :where(.og-root).pb-3,:where(.og-root) .pb-3 {
     padding-bottom: calc(var(--spacing) * 3);
+  }
+:where(.og-root).pb-6,:where(.og-root) .pb-6 {
+    padding-bottom: calc(var(--spacing) * 6);
   }
 :where(.og-root).pb-\[8\%\],:where(.og-root) .pb-\[8\%\] {
     padding-bottom: 8%;

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -1418,6 +1418,9 @@
 :where(.og-root).flex-row,:where(.og-root) .flex-row {
     flex-direction: row;
   }
+:where(.og-root).flex-nowrap,:where(.og-root) .flex-nowrap {
+    flex-wrap: nowrap;
+  }
 :where(.og-root).flex-wrap,:where(.og-root) .flex-wrap {
     flex-wrap: wrap;
   }
@@ -1567,6 +1570,14 @@
       border-color: var(--og-color-border);
     }
   }
+:where(.og-root).divide-og-border\/40,:where(.og-root) .divide-og-border\/40 {
+    :where(& > :not(:last-child)) {
+      border-color: var(--og-color-border);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--og-color-border) 40%, transparent);
+      }
+    }
+  }
 :where(.og-root).self-center,:where(.og-root) .self-center {
     align-self: center;
   }
@@ -1638,6 +1649,10 @@
 :where(.og-root).rounded-xl,:where(.og-root) .rounded-xl {
     border-radius: var(--og-radius-xl);
   }
+:where(.og-root).rounded-t-og-lg,:where(.og-root) .rounded-t-og-lg {
+    border-top-left-radius: var(--og-radius-lg);
+    border-top-right-radius: var(--og-radius-lg);
+  }
 :where(.og-root).rounded-t-og-sm,:where(.og-root) .rounded-t-og-sm {
     border-top-left-radius: var(--og-radius-sm);
     border-top-right-radius: var(--og-radius-sm);
@@ -1653,6 +1668,10 @@
 :where(.og-root).rounded-r-og-md,:where(.og-root) .rounded-r-og-md {
     border-top-right-radius: var(--og-radius-md);
     border-bottom-right-radius: var(--og-radius-md);
+  }
+:where(.og-root).rounded-b-og-lg,:where(.og-root) .rounded-b-og-lg {
+    border-bottom-right-radius: var(--og-radius-lg);
+    border-bottom-left-radius: var(--og-radius-lg);
   }
 :where(.og-root).rounded-br-og-xs,:where(.og-root) .rounded-br-og-xs {
     border-bottom-right-radius: var(--og-radius-xs);
@@ -2196,6 +2215,12 @@
       background-color: color-mix(in oklab, var(--og-color-surface-2) 40%, transparent);
     }
   }
+:where(.og-root).bg-og-surface-2\/50,:where(.og-root) .bg-og-surface-2\/50 {
+    background-color: var(--og-color-surface-2);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--og-color-surface-2) 50%, transparent);
+    }
+  }
 :where(.og-root).bg-og-surface-2\/60,:where(.og-root) .bg-og-surface-2\/60 {
     background-color: var(--og-color-surface-2);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2509,6 +2534,9 @@
   }
 :where(.og-root).pb-\[8\%\],:where(.og-root) .pb-\[8\%\] {
     padding-bottom: 8%;
+  }
+:where(.og-root).pl-0\.5,:where(.og-root) .pl-0\.5 {
+    padding-left: calc(var(--spacing) * 0.5);
   }
 :where(.og-root).pl-1,:where(.og-root) .pl-1 {
     padding-left: calc(var(--spacing) * 1);
@@ -3216,6 +3244,11 @@
       rotate: 90deg;
     }
   }
+:where(.og-root).group-open\/command\:rotate-90,:where(.og-root) .group-open\/command\:rotate-90 {
+    &:is(:where(.group\/command):is([open], :popover-open, :open) *) {
+      rotate: 90deg;
+    }
+  }
 :where(.og-root).group-focus-within\/copy\:opacity-100,:where(.og-root) .group-focus-within\/copy\:opacity-100 {
     &:is(:where(.group\/copy):focus-within *) {
       opacity: 100%;
@@ -3504,6 +3537,11 @@
       margin-top: calc(var(--spacing) * 0);
     }
   }
+:where(.og-root).first\:pt-0,:where(.og-root) .first\:pt-0 {
+    &:first-child {
+      padding-top: calc(var(--spacing) * 0);
+    }
+  }
 :where(.og-root).first\:pl-0,:where(.og-root) .first\:pl-0 {
     &:first-child {
       padding-left: calc(var(--spacing) * 0);
@@ -3512,6 +3550,11 @@
 :where(.og-root).last\:mb-0,:where(.og-root) .last\:mb-0 {
     &:last-child {
       margin-bottom: calc(var(--spacing) * 0);
+    }
+  }
+:where(.og-root).last\:pb-0,:where(.og-root) .last\:pb-0 {
+    &:last-child {
+      padding-bottom: calc(var(--spacing) * 0);
     }
   }
 :where(.og-root).focus-within\:border-og-accent\/50,:where(.og-root) .focus-within\:border-og-accent\/50 {
@@ -4746,6 +4789,11 @@
 :where(.og-root).pointer-coarse\:w-11,:where(.og-root) .pointer-coarse\:w-11 {
     @media (pointer: coarse) {
       width: calc(var(--spacing) * 11);
+    }
+  }
+:where(.og-root).pointer-coarse\:w-auto,:where(.og-root) .pointer-coarse\:w-auto {
+    @media (pointer: coarse) {
+      width: auto;
     }
   }
 :where(.og-root).pointer-coarse\:min-w-11,:where(.og-root) .pointer-coarse\:min-w-11 {

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -553,6 +553,9 @@
 :where(.og-root).-top-11,:where(.og-root) .-top-11 {
     top: calc(var(--spacing) * -11);
   }
+:where(.og-root).-top-16,:where(.og-root) .-top-16 {
+    top: calc(var(--spacing) * -16);
+  }
 :where(.og-root).top-0,:where(.og-root) .top-0 {
     top: calc(var(--spacing) * 0);
   }
@@ -1294,6 +1297,10 @@
   }
 :where(.og-root).-translate-y-1\/2,:where(.og-root) .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+:where(.og-root).-translate-y-full,:where(.og-root) .-translate-y-full {
+    --tw-translate-y: -100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
 :where(.og-root).translate-y-\[2px\],:where(.og-root) .translate-y-\[2px\] {

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -2148,9 +2148,9 @@ describe("MessageTimeline pagination affordances", () => {
           scroller.dispatchEvent(new KeyboardEvent("keydown", { key: "PageUp", bubbles: true }));
         } else {
           const touchEvent = (name: string, y: number) => {
-            const event = new Event(name, { bubbles: true });
-            Object.defineProperty(event, "touches", { value: [{ clientX: 200, clientY: y }] });
-            scroller.dispatchEvent(event);
+            const gesture = new Event(name, { bubbles: true });
+            Object.defineProperty(gesture, "touches", { value: [{ clientX: 200, clientY: y }] });
+            scroller.dispatchEvent(gesture);
           };
           touchEvent("touchstart", 200);
           touchEvent("touchmove", 240);

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -650,6 +650,15 @@ describe("MessageTimeline pagination affordances", () => {
     expect(scroller.scrollTop).toBe(2_000);
     expect(distanceFromBottom(scroller)).toBe(40);
 
+    // Browsers may emit more than one scroll event for the same restoration.
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    expect(scroller.getAttribute("data-og-bottom-follow")).toBe("false");
+    expect(scroller.scrollTop).toBe(2_000);
+
     // An actual reader move toward the now-distant live tip still re-pins.
     await actRun(() => {
       scroller.scrollTop = 2_040;

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -2128,7 +2128,7 @@ describe("MessageTimeline pagination affordances", () => {
           return [];
         }
       };
-      const pending = [deferred<boolean>(), deferred<boolean>()];
+      const pending = [deferred<boolean>(), deferred<boolean>(), deferred<boolean>()];
       const receipts = pending.map((load) => controlledOlderReceipt(load.promise));
       let calls = 0;
       const loadOlder: OlderHistoryLoader = () => receipts[calls++]!.receipt;
@@ -2171,7 +2171,22 @@ describe("MessageTimeline pagination affordances", () => {
       expect(calls).toBe(2);
       await actRun(() => intersect());
       expect(calls).toBe(2);
+      // The web route keys this component by session ID. A pending old page
+      // must neither block the new session nor publish its retry UI there.
+      await view.rerender(
+        <PublicMessageTimeline
+          key="next-session"
+          events={events}
+          hasOlder
+          onLoadOlder={loadOlder}
+        />,
+      );
+      await armOlderPrefetch(view.container);
+      await actRun(() => intersect());
+      expect(calls).toBe(3);
       await actRun(() => pending[1]!.resolve(false));
+      expect(view.container.querySelector("[data-og-retry]")).toBeNull();
+      await actRun(() => pending[2]!.resolve(true));
       layout.restore();
       await view.unmount();
     },

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -641,7 +641,7 @@ describe("MessageTimeline pagination affordances", () => {
     await flush();
     expect(scroller.scrollTop).toBe(0);
 
-    layout.setContentHeight(2_440);
+    layout.setContentHeightOnPrepend(2_440);
     await r.rerender(<MessageTimeline events={manyEvents(20)} hasOlder loadingOlder={false} />);
     await flush();
     await drainFrames(frames);
@@ -730,7 +730,7 @@ describe("MessageTimeline pagination affordances", () => {
     expect(scroller.scrollTop).toBe(0);
 
     controlled.commit();
-    layout.setContentHeight(2_440);
+    layout.setContentHeightOnPrepend(2_440);
     await r.rerender(
       <PublicMessageTimeline events={manyEvents(20)} hasOlder onLoadOlder={onLoadOlder} />,
     );
@@ -4225,6 +4225,17 @@ function mockScrollerLayout(
   let tipTopInScroller = contentHeight - options.paddingBottom - options.tipHeight;
   let currentScrollTop = Math.max(0, contentHeight - options.clientHeight);
   const scrollerTop = 100;
+  let pendingHeight: { height: number; rows: number } | null = null;
+  const refreshLayout = () => {
+    if (
+      pendingHeight &&
+      scroller.querySelectorAll("[data-og-group-key]").length !== pendingHeight.rows
+    ) {
+      contentHeight = pendingHeight.height;
+      tipTopInScroller = contentHeight - options.paddingBottom - options.tipHeight;
+      pendingHeight = null;
+    }
+  };
 
   const findTip = (): HTMLElement | null => {
     const inner = scroller.firstElementChild;
@@ -4245,7 +4256,10 @@ function mockScrollerLayout(
   });
   Object.defineProperty(scroller, "scrollHeight", {
     configurable: true,
-    get: () => contentHeight,
+    get: () => {
+      refreshLayout();
+      return contentHeight;
+    },
   });
   Object.defineProperty(scroller, "scrollTop", {
     configurable: true,
@@ -4266,6 +4280,7 @@ function mockScrollerLayout(
 
   const scrollerElementRect = Element.prototype.getBoundingClientRect;
   Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    refreshLayout();
     if (this === scroller) {
       return {
         top: scrollerTop,
@@ -4317,6 +4332,14 @@ function mockScrollerLayout(
   };
 
   return {
+    // Pre-commit snapshots must see the old DOM's geometry. Growing the mock
+    // before React mutates rows would simulate an unrelated prior resize.
+    setContentHeightOnPrepend(next: number) {
+      pendingHeight = {
+        height: next,
+        rows: scroller.querySelectorAll("[data-og-group-key]").length,
+      };
+    },
     setContentHeight(next: number) {
       contentHeight = next;
       tipTopInScroller = contentHeight - options.paddingBottom - options.tipHeight;

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -2106,6 +2106,110 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test("a reconstructed first display item does not turn retained events into a replacement", async () => {
+    let intersectionCallback: IntersectionObserverCallback = () => undefined;
+    let intersectionObserver: IntersectionObserver | null = null;
+    const observed: Element[] = [];
+    globalThis.IntersectionObserver = class implements IntersectionObserver {
+      readonly root: Element | Document | null = null;
+      readonly rootMargin = "400px 0px 0px 0px";
+      readonly scrollMargin = "0px 0px 0px 0px";
+      readonly thresholds = [0];
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+        intersectionObserver = this;
+      }
+      observe(target: Element): void {
+        observed.push(target);
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    };
+
+    const load = deferred<boolean>();
+    const controlled = controlledOlderReceipt(load.promise);
+    let calls = 0;
+    const loadOlder: OlderHistoryLoader = () => {
+      calls += 1;
+      return controlled.receipt;
+    };
+    const forwardingLoadOlder: OlderHistoryLoader = () => loadOlder();
+    const source = Array.from({ length: 40 }, (_, i) => event(i + 2));
+    const initialItems = Array.from({ length: 40 }, (_, index) =>
+      userItem(`tail-${index}`, `tail ${index}`),
+    );
+    const replacement = Array.from({ length: 40 }, (_, index) =>
+      userItem(`older-${index}`, `older ${index}`),
+    );
+    const r = await renderComponent(
+      <PublicMessageTimeline
+        items={initialItems}
+        events={source}
+        hasOlder
+        onLoadOlder={forwardingLoadOlder}
+      />,
+    );
+    const scroller = r.container.querySelector("[data-og-timeline-scroller]");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 1_600,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+
+    await r.rerender(
+      <PublicMessageTimeline
+        items={initialItems}
+        events={source}
+        status="idle"
+        hasOlder
+        onLoadOlder={forwardingLoadOlder}
+      />,
+    );
+    await readerScrollUp(scroller, 80);
+    const target = observed.at(-1);
+    if (!target) {
+      throw new Error("expected observed top sentinel");
+    }
+    await actRun(() =>
+      intersectionCallback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        intersectionObserver!,
+      ),
+    );
+    expect(calls).toBe(1);
+    expect(scroller.scrollTop).toBe(80);
+
+    controlled.commit();
+    layout.setContentHeight(2_000);
+    await r.rerender(
+      <PublicMessageTimeline
+        items={replacement}
+        events={[event(1), ...source]}
+        status="idle"
+        hasOlder
+        onLoadOlder={forwardingLoadOlder}
+      />,
+    );
+
+    expect(scroller.scrollTop).toBe(480);
+    await actRun(() => scroller.dispatchEvent(new Event("scroll")));
+    expect(scroller.getAttribute("data-og-bottom-follow")).toBe("false");
+    expect(r.container.textContent).toContain("Jump to latest");
+
+    await actRun(() => load.resolve(true));
+    await flush();
+    expect(calls).toBe(1);
+    layout.restore();
+    await r.unmount();
+  });
+
   test("a declined older load during newer navigation exposes one bounded retry", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -2106,6 +2106,77 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test.each(["keyboard", "touch"] as const)(
+    "%s demand continues through a short committed page",
+    async (input) => {
+      let intersect: () => void = () => {
+        throw new Error("sentinel not observed");
+      };
+      globalThis.IntersectionObserver = class implements IntersectionObserver {
+        readonly root = null;
+        readonly rootMargin = "400px";
+        readonly scrollMargin = "0px";
+        readonly thresholds = [0];
+        constructor(private callback: IntersectionObserverCallback) {}
+        observe(target: Element) {
+          intersect = () =>
+            this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+        }
+        unobserve() {}
+        disconnect() {}
+        takeRecords(): IntersectionObserverEntry[] {
+          return [];
+        }
+      };
+      const pending = [deferred<boolean>(), deferred<boolean>()];
+      const receipts = pending.map((load) => controlledOlderReceipt(load.promise));
+      let calls = 0;
+      const loadOlder: OlderHistoryLoader = () => receipts[calls++]!.receipt;
+      const events = Array.from({ length: 20 }, (_, i) => event(i + 2));
+      const view = await renderComponent(
+        <PublicMessageTimeline events={events} hasOlder onLoadOlder={loadOlder} />,
+      );
+      const scroller = view.container.querySelector<HTMLElement>("[data-og-timeline-scroller]")!;
+      const layout = mockScrollerLayout(scroller, {
+        clientHeight: 400,
+        contentHeight: 500,
+        tipHeight: 80,
+        paddingBottom: 24,
+      });
+      await actRun(() => {
+        if (input === "keyboard") {
+          scroller.dispatchEvent(new KeyboardEvent("keydown", { key: "PageUp", bubbles: true }));
+        } else {
+          const touchEvent = (name: string, y: number) => {
+            const event = new Event(name, { bubbles: true });
+            Object.defineProperty(event, "touches", { value: [{ clientX: 200, clientY: y }] });
+            scroller.dispatchEvent(event);
+          };
+          touchEvent("touchstart", 200);
+          touchEvent("touchmove", 240);
+        }
+        scroller.scrollTop = 0;
+        scroller.dispatchEvent(new Event("scroll"));
+      });
+      await actRun(() => intersect());
+      expect(calls).toBe(1);
+      receipts[0]!.commit();
+      await view.rerender(
+        <PublicMessageTimeline events={[event(1), ...events]} hasOlder onLoadOlder={loadOlder} />,
+      );
+      await actRun(() => pending[0]!.resolve(true));
+      // No leave/re-enter gesture and no new scroll range: next accepted page
+      // must still be reachable for both inputs, just as for wheel input.
+      await actRun(() => intersect());
+      expect(calls).toBe(2);
+      await actRun(() => intersect());
+      expect(calls).toBe(2);
+      await actRun(() => pending[1]!.resolve(false));
+      layout.restore();
+      await view.unmount();
+    },
+  );
+
   test("a reconstructed first display item does not turn retained events into a replacement", async () => {
     let intersectionCallback: IntersectionObserverCallback = () => undefined;
     let intersectionObserver: IntersectionObserver | null = null;

--- a/packages/react/test/timeline-anchor.test.tsx
+++ b/packages/react/test/timeline-anchor.test.tsx
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import {
+  TimelineBeforeLayout,
+  captureTimelineAnchor,
+  timelineAnchorCorrection,
+} from "../src/components/timeline-anchor";
+import { registerDom, renderComponent } from "./render-hook";
+
+registerDom();
+
+function position(element: HTMLElement, top: number, height = 40) {
+  element.getBoundingClientRect = () => ({
+    top,
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 600,
+    width: 600,
+    x: 0,
+    y: top,
+    toJSON() {},
+  });
+}
+
+test("capture runs against the old DOM immediately before the replacement commit", async () => {
+  const seen: string[] = [];
+  let text: HTMLElement | null = null;
+  const render = (value: string) => (
+    <TimelineBeforeLayout capture={() => seen.push(text?.textContent ?? "missing")}>
+      <p
+        ref={(node) => {
+          text = node;
+        }}
+      >
+        {value}
+      </p>
+    </TimelineBeforeLayout>
+  );
+  const view = await renderComponent(render("old content"));
+  await view.rerender(render("new content"));
+  expect(seen).toEqual(["old content"]);
+  await view.unmount();
+});
+
+test("retained paragraph anchors reconstructed rows and subtracts native anchoring", () => {
+  const scroller = document.createElement("div");
+  scroller.innerHTML = '<div data-og-group-key="old"><p>Retained paragraph being read.</p></div>';
+  const group = scroller.firstElementChild as HTMLElement;
+  const paragraph = group.firstElementChild as HTMLElement;
+  position(scroller, 50, 400);
+  position(group, 80, 200);
+  position(paragraph, 100);
+  const anchors = captureTimelineAnchor(scroller)!;
+  group.remove();
+  scroller.innerHTML =
+    '<div data-og-group-key="new"><p>Earlier text newly loaded.</p><p>Retained paragraph being read.</p></div>';
+  const replacement = scroller.querySelectorAll("p")[1]!;
+  position(replacement, 180);
+  expect(timelineAnchorCorrection(scroller, anchors)).toBe(80);
+  position(replacement, 100);
+  expect(timelineAnchorCorrection(scroller, anchors)).toBe(0);
+});
+
+test("focused disclosure takes priority over the paragraph moving below it", () => {
+  const scroller = document.createElement("div");
+  scroller.innerHTML =
+    '<div data-og-group-key="turn"><button aria-expanded="false">4 steps</button><p>Paragraph below expanded activity.</p></div>';
+  document.body.append(scroller);
+  const button = scroller.querySelector("button")!;
+  const paragraph = scroller.querySelector("p")!;
+  position(scroller, 50, 400);
+  position(scroller.firstElementChild as HTMLElement, 80, 250);
+  position(button, 100);
+  position(paragraph, 150);
+  button.focus();
+  const anchors = captureTimelineAnchor(scroller)!;
+  position(button, 160);
+  position(paragraph, 400);
+  expect(timelineAnchorCorrection(scroller, anchors)).toBe(60);
+  scroller.remove();
+});

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -224,6 +224,7 @@ describe("useSessionEvents", () => {
     let durableHead = 2;
     let failHeadRead = false;
     let delayedTail: Promise<SessionEvent[]> | null = null;
+    let delayedOlder: Promise<void> | null = null;
     const headReadCalls: GetSessionOptions[] = [];
     const listCalls: ListOptions[] = [];
     const streamCalls: number[] = [];
@@ -235,6 +236,11 @@ describe("useSessionEvents", () => {
       },
       listEvents: async (_workspaceId, _sessionId, options = {}) => {
         listCalls.push(options);
+        if (delayedOlder && options.before === 146) {
+          const page = listPage(store, options);
+          await delayedOlder;
+          return page;
+        }
         if (delayedTail && options.before === Number.MAX_SAFE_INTEGER) {
           return await delayedTail;
         }
@@ -372,6 +378,16 @@ describe("useSessionEvents", () => {
       expect(hook.result.current.events[0]?.sequence).toBe(146);
       expect(hook.result.current.events.at(-1)?.sequence).toBe(400);
 
+      let releaseOlder!: () => void;
+      delayedOlder = new Promise<void>((resolve) => {
+        releaseOlder = resolve;
+      });
+      let pendingOlder!: ReturnType<typeof hook.result.current.loadOlder>;
+      await actRun(() => {
+        pendingOlder = hook.result.current.loadOlder();
+      });
+      expect(hook.result.current.loadingOlder).toBe(true);
+
       // A gap beyond the bounded one-page probe budget skips the forward
       // read entirely and goes straight to the latest compact tail.
       store = Array.from({ length: 6_000 }, (_, index) => event(index + 1));
@@ -403,6 +419,16 @@ describe("useSessionEvents", () => {
       expect(hook.result.current.events).toHaveLength(SESSION_HISTORY_PAGE_SIZE);
       expect(hook.result.current.events[0]?.sequence).toBe(5_746);
       expect(hook.result.current.events.at(-1)?.sequence).toBe(6_000);
+
+      // Replacement retires navigation against the discarded window. The old
+      // page must not splice 1–145 onto 5746–6000, leaving an inaccessible gap.
+      expect(hook.result.current.loadingOlder).toBe(false);
+      releaseOlder();
+      await actRun(() => pendingOlder);
+      expect(pendingOlder.committed).toBe(false);
+      expect(hook.result.current.events[0]?.sequence).toBe(5_746);
+      expect(hook.result.current.events.at(-1)?.sequence).toBe(6_000);
+      expect(hook.result.current.hasOlder).toBe(true);
 
       // The head read is only an optimization. A transient failure falls back
       // to the SDK's exact cursor replay and keeps the existing timeline.

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -96,6 +96,44 @@ function scriptedClient(input: {
 }
 
 describe("useSessionEvents", () => {
+  test("a second older page survives the stream reconnect caused by the first", async () => {
+    const store = Array.from({ length: 4000 }, (_, i) => event(i + 1));
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let holdNext = false;
+    const { client, streamCalls } = scriptedClient({
+      store,
+      listEvents: async (options) => {
+        if (holdNext) await held;
+        return listPage(store, options);
+      },
+    });
+    const hook = await renderHook(
+      () => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush(20);
+    const initialStreams = streamCalls.length;
+    let second!: ReturnType<typeof hook.result.current.loadOlder>;
+    await actRun(async () => {
+      await hook.result.current.loadOlder();
+      holdNext = true;
+      second = hook.result.current.loadOlder();
+    });
+    await flush(20);
+    expect(streamCalls.length).toBeGreaterThan(initialStreams);
+    expect(hook.result.current.loadingOlder).toBe(true);
+    const previousOldest = hook.result.current.events[0]!.sequence;
+    release();
+    await actRun(() => second);
+    await flush(20);
+    expect(second.committed).toBe(true);
+    expect(hook.result.current.events[0]!.sequence).toBeLessThan(previousOldest);
+    await hook.unmount();
+  });
+
   test("projects authoritative capacity arm and resume statuses from the live stream", async () => {
     let resume: () => void = () => undefined;
     const resumeGate = new Promise<void>((resolve) => {

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import {
   EFFECTIVE_DIRECT_SESSION_RAW_BUDGET,
+  wholeKibEnvelope,
   KIB as kib,
   PR_REVIEW_EXECUTION_CURRENT_MAIN_BROWSER_FILE_COUNT,
   PR_REVIEW_EXECUTION_CURRENT_MAIN_BROWSER_GZIP_BUDGET,
@@ -427,7 +428,9 @@ const budgets = {
   lazyChunkGzip: 240 * kib,
   // Member roster and permission-editor selectors bring the single compiled
   // stylesheet to 32,221 gzip bytes. Keep the next whole-KiB envelope.
-  cssGzip: 32 * kib,
+  // Main 52ff56a94 is already 33,660 gzip bytes; the scroll-control gutter
+  // adds 14. Preserve the measured whole-KiB envelope and 1-KiB headroom.
+  cssGzip: wholeKibEnvelope(33_674),
 } as const;
 
 // The canonical sensitive-preview policy measures 626,021 gzip bytes across
@@ -445,6 +448,9 @@ const effectiveBudgets = {
     // configured Linux/x64 acceptance build. Use the established whole-KiB
     // envelope with at least 1 KiB headroom; all other limits stay fixed.
     627 * kib,
+    // Same September 6 Bun 1.4 graph: untouched main is 643,869 gzip bytes;
+    // history anchoring + keyboard/touch demand adds 964, with no new chunk.
+    wholeKibEnvelope(644_833, 1.5 * kib),
   ),
   directSessionFiles: Math.max(
     budgets.directSessionFiles,

--- a/scripts/web-bundle-budget-unified-tool-gateway.test.ts
+++ b/scripts/web-bundle-budget-unified-tool-gateway.test.ts
@@ -14,6 +14,12 @@ describe("unified tool gateway web bundle budget", () => {
     expect(
       UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET - UNIFIED_TOOL_GATEWAY_BROWSER_RAW_MEASUREMENT,
     ).toBe(1_035);
-    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBe(UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET);
+    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBeGreaterThanOrEqual(
+      UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET,
+    );
+  });
+  test("fits the measured session-history graph with bounded headroom", () => {
+    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBe(2260 * KIB);
+    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET - 2_312_535).toBe(1_705);
   });
 });

--- a/scripts/web-bundle-budget-unified-tool-gateway.ts
+++ b/scripts/web-bundle-budget-unified-tool-gateway.ts
@@ -5,6 +5,7 @@ import {
 
 export {
   KIB,
+  wholeKibEnvelope,
   PR_REVIEW_EXECUTION_CURRENT_MAIN_BROWSER_FILE_COUNT,
   PR_REVIEW_EXECUTION_CURRENT_MAIN_BROWSER_GZIP_BUDGET,
 } from "./web-bundle-budget-policy";
@@ -22,4 +23,7 @@ export const UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET = wholeKibEnvelope(
 export const EFFECTIVE_DIRECT_SESSION_RAW_BUDGET = Math.max(
   BASE_DIRECT_SESSION_RAW_BUDGET,
   UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET,
+  // September 6, Bun 1.4 macOS/arm64: main 52ff56a94 measures 2,309,542
+  // raw bytes; history anchoring and input handling measure 2,312,535.
+  wholeKibEnvelope(2_312_535),
 );

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1320,7 +1320,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         manager.id,
         "A first prompt queued from the composer",
       );
-      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor({ timeout: 20_000 });
+      await queueChip.getByText("1 queued", { exact: true }).waitFor({ timeout: 20_000 });
       await composer.fill("A second prompt queued from the composer");
       await submitQueuedComposerPrompt(
         desktopPage,
@@ -1329,10 +1329,8 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         manager.id,
         "A second prompt queued from the composer",
       );
-      await queueChip.getByText("2 queued prompts", { exact: true }).waitFor({ timeout: 20_000 });
-      // A freshly queued prompt intentionally opens the queue for the transfer
-      // animation. Preserve that open state; only click when an older client
-      // or reduced host did not open it.
+      await queueChip.getByText("2 queued", { exact: true }).waitFor({ timeout: 20_000 });
+      // Queue receipts pulse the compact control; open it to inspect the prompts.
       if ((await queueChip.getAttribute("aria-expanded")) !== "true") {
         await queueChip.click();
       }
@@ -1400,7 +1398,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         async () => (await composer.inputValue()) === "A second prompt queued from the composer",
         { timeoutMs: 10_000 },
       );
-      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
+      await queueChip.getByText("1 queued", { exact: true }).waitFor();
       await composer.fill("A second prompt queued from the composer (edited)");
       await submitQueuedComposerPrompt(
         desktopPage,
@@ -1409,7 +1407,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         manager.id,
         "A second prompt queued from the composer (edited)",
       );
-      await queueChip.getByText("2 queued prompts", { exact: true }).waitFor();
+      await queueChip.getByText("2 queued", { exact: true }).waitFor();
 
       // Pause is a durable workstream barrier. Row Steer is one atomic action:
       // it moves that row to the head and resumes the branch. The accepted row
@@ -1434,7 +1432,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         );
       }
       expect(await chrome.getByText("Changing direction…", { exact: true }).count()).toBe(0);
-      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
+      await queueChip.getByText("1 queued", { exact: true }).waitFor();
       await expectRowPrompt(queuedRows, 0, "A first prompt queued from the composer");
 
       // Remove deletes only the selected waiting prompt. Add one final prompt so
@@ -1449,7 +1447,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         manager.id,
         "A replacement prompt after delete",
       );
-      await queueChip.getByText("1 queued prompt", { exact: true }).waitFor();
+      await queueChip.getByText("1 queued", { exact: true }).waitFor();
       expect(
         await timeline
           .getByText("Inspect the full session-control surface", { exact: true })
@@ -1503,7 +1501,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await desktopPage.getByRole("button", { name: "Resume this workstream" }).waitFor();
       await desktopPage
         .getByTestId("session-chrome-queue")
-        .getByText("1 queued prompt", { exact: true })
+        .getByText("1 queued", { exact: true })
         .waitFor();
 
       // The manager remains paused: queueing in a descendant is never a hidden

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1355,6 +1355,20 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       // where users reorder, edit, steer, or delete a waiting prompt.
       for (const theme of ["light", "dark"] as const) {
         await setTheme(desktopPage, theme);
+        // Keep the hover-revealed actions visible while Axe inspects their text.
+        const steerAction = chrome.getByRole("button", {
+          name: "Steer queued prompt 2",
+          exact: true,
+        });
+        await steerAction.focus();
+        await steerAction.evaluate(async (node) => {
+          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+          await Promise.all(
+            node
+              .parentElement!.getAnimations()
+              .map((animation) => animation.finished.catch(() => undefined)),
+          );
+        });
         await expectNoPageOverflow(desktopPage);
         await expectNoAxeViolations(desktopPage, ["[data-testid=session-chrome]"]);
         await desktopPage.screenshot({
@@ -2364,6 +2378,7 @@ async function expectNoAxeViolations(page: Page, includes: string[]): Promise<vo
   let scan = new AxeBuilder({ page });
   for (const include of includes) scan = scan.include(include);
   const results = await scan.analyze();
+
   expect(
     results.violations.map((violation) => ({
       id: violation.id,

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1278,7 +1278,10 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       const chrome = desktopPage.getByTestId("session-chrome");
       const queueChip = desktopPage.getByTestId("session-chrome-queue");
       const goalChip = desktopPage.getByTestId("session-chrome-goal");
-      const agentsChip = desktopPage.getByTestId("session-chrome-agents");
+      const activityButton = desktopPage.getByRole("button", {
+        name: "Session activity",
+        exact: true,
+      });
       const composer = desktopPage.getByLabel("Message the agent");
       const timeline = desktopPage.getByTestId("session-timeline");
       await timeline
@@ -1286,10 +1289,15 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         .waitFor();
       expect(await queueChip.count()).toBe(0);
       await goalChip.waitFor();
-      await agentsChip.waitFor();
+      await activityButton.waitFor();
+      await activityButton.click();
+      await chrome.getByRole("button", { name: /^\d+ agents?$/ }).waitFor();
+      await activityButton.click();
       await composer.waitFor();
       expect(await desktopPage.getByTestId("session-chrome").count()).toBe(1);
-      expect(await desktopPage.getByTestId("session-chrome-agents").count()).toBe(1);
+      expect(
+        await desktopPage.getByRole("button", { name: "Session activity", exact: true }).count(),
+      ).toBe(1);
       const [chromeBounds, composerBounds] = await Promise.all([
         chrome.boundingBox(),
         composer.locator("xpath=ancestor::*[@data-og-composer-id][1]").boundingBox(),
@@ -1508,13 +1516,13 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       // must not require one to block the other, so await both independently
       // owned chips before asserting the settled control stack.
       await goalChip.waitFor();
-      await agentsChip.waitFor();
+      await activityButton.waitFor();
 
       const boxes = await Promise.all([chrome.boundingBox(), composer.boundingBox()]);
       for (const box of boxes) expect(box).not.toBeNull();
       expect(boxes[0]!.y).toBeLessThan(boxes[1]!.y);
       expect(await goalChip.count()).toBe(1);
-      expect(await agentsChip.count()).toBe(1);
+      expect(await activityButton.count()).toBe(1);
 
       for (const theme of ["light", "dark"] as const) {
         await setTheme(desktopPage, theme);
@@ -1547,10 +1555,12 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await mobilePage.goto(managerUrl);
       await mobilePage.getByTestId("session-chrome").waitFor();
       await mobilePage.getByTestId("session-chrome-goal").waitFor();
-      await mobilePage.getByTestId("session-chrome-agents").waitFor();
+      await mobilePage.getByRole("button", { name: "Session activity", exact: true }).waitFor();
       await expectNoPageOverflow(mobilePage);
       await expectTouchTarget(mobilePage.getByTestId("session-chrome-queue"));
-      await expectTouchTarget(mobilePage.getByTestId("session-chrome-agents"));
+      await expectTouchTarget(
+        mobilePage.getByRole("button", { name: "Session activity", exact: true }),
+      );
       await mobilePage.screenshot({
         path: "/tmp/opengeni-session-control-stack-mobile.png",
         fullPage: true,

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -468,12 +468,16 @@ describe("timeline scroll ownership browser regression", () => {
     expect(beforeWheel.gap).toBeLessThan(2);
 
     await scroller.hover();
-    for (let index = 0; index < 8; index += 1) {
-      await page.mouse.wheel(0, -120);
-      if ((await scroller.evaluate((node) => node.scrollTop)) < 2) {
-        break;
-      }
-    }
+    // Finish native wheel momentum before measuring a stationary prepend.
+    await Promise.all([
+      scroller.evaluate(
+        (node) =>
+          new Promise<void>((resolve) =>
+            node.addEventListener("scrollend", () => resolve(), { once: true }),
+          ),
+      ),
+      page.mouse.wheel(0, -120),
+    ]);
     await page.waitForFunction(
       () => {
         const node = document.querySelector<HTMLElement>(
@@ -569,15 +573,15 @@ describe("timeline scroll ownership browser regression", () => {
     expect(beforeScroll.maxScroll).toBeGreaterThan(0);
 
     await scroller.hover();
-    for (let index = 0; index < 12; index += 1) {
-      await page.mouse.wheel(0, -1_200);
-      if (
-        (await page.evaluate(() => window.timelineCollapsedHistoryHarness!.metrics().scrollTop)) <
-        100
-      ) {
-        break;
-      }
-    }
+    await Promise.all([
+      scroller.evaluate(
+        (node) =>
+          new Promise<void>((resolve) =>
+            node.addEventListener("scrollend", () => resolve(), { once: true }),
+          ),
+      ),
+      page.mouse.wheel(0, -8_000),
+    ]);
     await page.waitForFunction(
       () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop < 100,
       undefined,
@@ -590,8 +594,10 @@ describe("timeline scroll ownership browser regression", () => {
     // remove surrounding chat rows nor destroy the usable scroll range.
     const step = page.getByRole("button", { name: /steps/ }).nth(4);
     const anchor = page.locator('[data-conversation-message="user-201"]');
-    await anchor.evaluate((node) => node.scrollIntoView({ block: "center" }));
-    const anchorTop = await anchor.evaluate((node) => node.getBoundingClientRect().top);
+    // The clicked disclosure owns position; another row can move as it folds.
+    await step.evaluate((node) => node.scrollIntoView({ block: "center" }));
+    await page.waitForTimeout(100);
+    const anchorTop = await step.evaluate((node) => node.getBoundingClientRect().top);
     await step.click();
     await page.waitForTimeout(180);
     await step.click();
@@ -602,7 +608,7 @@ describe("timeline scroll ownership browser regression", () => {
     expect(
       (await page.evaluate(() => window.timelineCollapsedHistoryHarness!.metrics())).maxScroll,
     ).toBeGreaterThan(0);
-    expect(await anchor.evaluate((node) => node.getBoundingClientRect().top)).toBeCloseTo(
+    expect(await step.evaluate((node) => node.getBoundingClientRect().top)).toBeCloseTo(
       anchorTop,
       0,
     );
@@ -984,11 +990,14 @@ describe("timeline scroll ownership browser regression", () => {
     // the reader leaves the seam and approaches the top again, exactly one new
     // sentinel request owns the replacement window.
     await page.evaluate(() => window.timelineCollapsedHistoryHarness!.settleLoad(1, "success"));
+    await scroller.hover();
     await page.mouse.wheel(0, 8_000);
     await page.waitForFunction(() => {
       const metrics = window.timelineCollapsedHistoryHarness!.metrics();
       return metrics.maxScroll - metrics.scrollTop < 2;
     });
+    await scroller.hover();
+    await page.waitForTimeout(100);
     await page.mouse.wheel(0, -8_000);
     await page.waitForFunction(
       () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop < 100,

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -636,7 +636,7 @@ describe("timeline scroll ownership browser regression", () => {
       node.dispatchEvent(new Event("scroll"));
     });
     await page.waitForFunction(
-      () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop > 400,
+      () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop > 500,
     );
     await scroller.hover();
     await page.mouse.wheel(0, -8_000);
@@ -1351,6 +1351,15 @@ describe("timeline scroll ownership browser regression", () => {
       { timeout: 5_000 },
     );
 
+    // Expansion now preserves the reader near the top. Move outside prefetch
+    // range so this test isolates collapse-triggered underfill navigation.
+    await page.evaluate(() => {
+      const node = window.timelineCollapsedHistoryHarness!.scroller();
+      node.scrollTop = node.scrollHeight;
+    });
+    await page.waitForFunction(
+      () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop > 500,
+    );
     await page.evaluate(() => window.timelineCollapsedHistoryHarness!.armOlder());
     await page.waitForTimeout(100);
     expect(await page.evaluate(() => window.timelineCollapsedHistoryHarness!.loadCalls())).toBe(0);
@@ -1358,7 +1367,7 @@ describe("timeline scroll ownership browser regression", () => {
 
     // Collapsing the window makes it underfilled while newer pagination owns
     // the first-party navigation lock. loadOlder declines with exact `false`.
-    await step.click();
+    await step.evaluate((node: HTMLButtonElement) => node.click());
     await page.waitForFunction(() => window.timelineCollapsedHistoryHarness!.loadCalls() === 1);
     const retry = page.getByRole("button", { name: "Retry earlier activity" });
     await retry.waitFor({ timeout: 5_000 });
@@ -1402,11 +1411,20 @@ describe("timeline scroll ownership browser regression", () => {
       { timeout: 5_000 },
     );
 
+    // Expansion now preserves the reader near the top. Move outside prefetch
+    // range so this test isolates collapse-triggered underfill navigation.
+    await page.evaluate(() => {
+      const node = window.timelineCollapsedHistoryHarness!.scroller();
+      node.scrollTop = node.scrollHeight;
+    });
+    await page.waitForFunction(
+      () => window.timelineCollapsedHistoryHarness!.metrics().scrollTop > 500,
+    );
     await page.evaluate(() => window.timelineCollapsedHistoryHarness!.armOlder());
     await page.waitForTimeout(100);
     expect(await page.evaluate(() => window.timelineCollapsedHistoryHarness!.loadCalls())).toBe(0);
 
-    await step.click();
+    await step.evaluate((node: HTMLButtonElement) => node.click());
     await page.locator('[data-conversation-message="user-1"]').waitFor({ timeout: 5_000 });
     expect(await page.evaluate(() => window.timelineCollapsedHistoryHarness!.loadCalls())).toBe(1);
     expect(await page.locator('[data-conversation-message^="user-"]').count()).toBe(9);

--- a/test/e2e/user-message-disclosure.browser.e2e.ts
+++ b/test/e2e/user-message-disclosure.browser.e2e.ts
@@ -392,7 +392,7 @@ describe("long sent user-message browser acceptance", () => {
     }
   }, 30_000);
 
-  test("keeps bottom-follow pinned when a near-tip message expands", async () => {
+  test("releases bottom-follow and preserves the reader anchor when a near-tip message expands", async () => {
     const page = await openHarness(browser, baseUrl, { width: 1280, height: 900 });
     try {
       const scroller = page.locator("[data-og-timeline-scroller]");
@@ -401,20 +401,32 @@ describe("long sent user-message browser acceptance", () => {
       });
       await page.waitForTimeout(100);
       expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("true");
-      const disclosure = page
-        .locator('[data-og-message-id="long-user-message"]')
-        .getByRole("button", { name: "Show more" });
+      const body = page.locator('[data-og-message-id="long-user-message"]');
+      const disclosure = body.locator("[data-og-user-message-disclosure]");
+      const group = page.locator("[data-og-timeline-group-anchor]").filter({ has: body });
+      const groupTop = await relativeTop(group, scroller);
+      const scrollerHeight = await scroller.evaluate((node) => node.clientHeight);
+      const anchor = groupTop >= -1 && groupTop < scrollerHeight ? group : disclosure;
+      const before = await relativeTop(anchor, scroller);
       await disclosure.evaluate((node: HTMLButtonElement) => node.click());
-      await page.waitForFunction(() => {
-        const node = document.querySelector<HTMLElement>("[data-og-timeline-scroller]");
-        return Boolean(node && node.scrollHeight - node.scrollTop - node.clientHeight < 2);
-      });
-      const result = await scroller.evaluate((node) => ({
-        gap: node.scrollHeight - node.scrollTop - node.clientHeight,
-        bottomFollow: node.getAttribute("data-og-bottom-follow"),
-      }));
-      expect(result.gap).toBeLessThan(2);
-      expect(result.bottomFollow).toBe("true");
+      await page.waitForFunction(
+        () =>
+          document
+            .querySelector("[data-og-timeline-scroller]")
+            ?.getAttribute("data-og-bottom-follow") === "false",
+      );
+      await page.waitForTimeout(100);
+      expect(await relativeTop(anchor, scroller)).toBeCloseTo(before, 0);
+      expect(
+        await page
+          .locator('[data-og-message-id="long-user-message"]')
+          .getByRole("button", { name: "Show less" })
+          .getAttribute("aria-expanded"),
+      ).toBe("true");
+      await page.evaluate(() => window.userMessageHarness!.stream());
+      await page.waitForTimeout(100);
+      expect(await relativeTop(anchor, scroller)).toBeCloseTo(before, 0);
+      expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("false");
     } finally {
       await page.context().close();
     }

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -984,7 +984,8 @@ describe("Temporal workflow integration", () => {
       const runs: WorkflowTestTurn[] = [];
       const controls: unknown[] = [];
       let cancellationWaitAttemptId: string | null = null;
-      let cancellationWaitPeeks = 0;
+      let reconciliationStarted = false;
+      let receiptWakeSent = false;
       let allowFirstRunToFinish = false;
       let wakeWorkflow: (() => Promise<void>) | null = null;
       const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
@@ -999,6 +1000,7 @@ describe("Temporal workflow integration", () => {
           // the same transaction's outbox now wakes this workflow.
           cancellationWaitAttemptId = null;
           await wakeWorkflow?.();
+          receiptWakeSent = true;
         }
         return { status: "idle" };
       });
@@ -1007,7 +1009,6 @@ describe("Temporal workflow integration", () => {
         ...admission.activities,
         peekSessionWork: async () => {
           if (cancellationWaitAttemptId) {
-            cancellationWaitPeeks += 1;
             return {
               kind: "cancellation-wait" as const,
               attemptId: cancellationWaitAttemptId,
@@ -1022,10 +1023,14 @@ describe("Temporal workflow integration", () => {
           cancellationWaitAttemptId = input.attemptId;
           return { action: "continue" as const };
         },
-        reconcileSessionAttemptQuiescence: async () =>
-          cancellationWaitAttemptId
-            ? { action: "pending" as const }
-            : { action: "quiesced" as const },
+        reconcileSessionAttemptQuiescence: async () => {
+          if (!cancellationWaitAttemptId) return { action: "quiesced" as const };
+          reconciliationStarted = true;
+          // Hold an old pending result until the receipt wake has already been
+          // accepted. The workflow must not swallow that wake on activity return.
+          await waitFor(() => receiptWakeSent, { timeoutMs: temporalWorkflowTestTimeoutMs });
+          return { action: "pending" as const };
+        },
       });
       const run = worker.run();
       try {
@@ -1043,7 +1048,7 @@ describe("Temporal workflow integration", () => {
         queuedTurns.push(second);
         await handle.signal("userMessage", second.triggerEventId);
         await handle.signal("sessionControl", "control-event");
-        await waitFor(() => cancellationWaitPeeks > 0, {
+        await waitFor(() => reconciliationStarted, {
           timeoutMs: temporalWorkflowTestTimeoutMs,
           describe: () => "workflow did not observe the durable cancellation-wait boundary",
         });


### PR DESCRIPTION
Scrolling upward through partial messages could reset the reader to the bottom: prepending earlier deltas changes projected message IDs, which the timeline mistook for a completely replaced history window. Classify overlap using source events and capture retained content immediately before DOM mutation, applying only the displacement left after browser anchoring.

Keep programmatic corrections from resuming follow, continue bounded pagination through collapsed pages, and separate history-request lifetime from SSE reconnects so successful pages do not cause spurious “Retry earlier activity.” Disclosure interaction releases follow; earlier-history controls occupy reserved space above the rows.

Validation: full-app local replay of 29,962 original events, including the exact previously failing message boundary, at 1280×720 and 390×844. Upward-only recordings showed no reset to bottom, re-pin, or retry failure. Added regression tests for retained event overlap, pre-mutation anchors, disclosure priority, and consecutive history requests across stream reconnects. Current-main validation: 1,621 React tests pass; the final pagination/anchor/event-hook suites pass 104 tests, including keyboard and touch continuation. Lint, React/web typechecks, generated CSS, and changeset validation pass. Independent review cleared the foreground replacement race and input handling.

The bounded budget intentionally permits up to eight follow-on pages per upward gesture while still near the top; requiring a new gesture for each folded page would restore the reported stall. Multi-touch gestures are excluded. Includes a correction to an inherited changeset using the nonexistent package name `@opengeni/api` (actual name: `@opengeni/api-router`), which blocked CI before typechecking.


Latest-main compatibility: 307 timeline/event/session-chrome tests pass on the combined tree. Regenerated CSS for the session-activity controls merged on main. Production build measurements: untouched main 2,309,542 raw / 643,869 gzip / 33,660 CSS gzip bytes; candidate 2,312,535 / 644,833 / 33,674. Updated only those three already-failing budgets using established measured envelopes (2,314,240 / 647,168 / 34,816); other gates remain fixed.

CI also exposed an existing interruption race: a quiescence receipt wake could arrive while reconciliation returned an older `pending` result, then be swallowed by a later signal snapshot. Capture the snapshot before the activity await under a Temporal patch marker, with a held-result regression that forces that ordering. The targeted real Temporal test passes. Session navigation now remounts timeline state explicitly.

Updated browser expectations for compact activity controls and intentional disclosure anchoring. Fixed the activity button's mobile touch width and text-action contrast; accessibility scans wait for revealed controls to settle. Corrected a concurrent admission test to accept either idempotent creation winner and excluded transient native-build fixtures from the production writer inventory. Targeted validation: disclosure browser 4/4, full session-controls browser scenario 42 assertions, SessionChrome 32/32, writer audit 8/8, real database admission race 1/1; lint and typecheck pass. CI and independent review run against the final commit before merge.

Final browser verification: all 34 timeline regressions pass locally in Chrome (151 assertions). Aligned the prefetch sentinel with scroll origin so the reserved gutter cannot cause duplicate declined requests; stationary scroll echoes cannot resume bottom-follow. Browser tests distinguish completed scrolling from ongoing native wheel momentum before asserting fixed positions. Pagination/anchor unit suites pass 73 tests (433 assertions), including duplicate scroll echoes followed by a real reader return to the tip.
