### PR TITLE
fix(runtime): enforce turn yield after accepted input wait

### DIFF
--- a/.changeset/runtime-input-wait-yield.md
+++ b/.changeset/runtime-input-wait-yield.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/runtime": patch
+---
+
+End model execution after a successful trusted `wait_for_input` call, including
+calls routed through native shell and Codemode. Preserve settled tool receipts
+and normal worker completion without requiring a final assistant message.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,11 @@ turn. A resumed attempt can attach a new batch after its resolved open suffix;
 preserve earlier receipts and canonical history order instead of requiring one
 history-item id for every update delivered to that turn.
 
+Successful first-party `wait_for_input` is an enforced runtime turn boundary,
+not model-visible advice to keep calling tools until a final answer appears.
+Preserve trusted acceptance state, the settled tool batch and canonical history,
+ordinary worker settlement, and the first same-turn deadline across retries.
+
 ## Pull-request delivery across moving `main`
 
 Treat a candidate as an immutable semantic source revision, not as a snapshot of

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -2765,7 +2765,7 @@ function registerGoalTools(
     "wait_for_input",
     {
       description:
-        "End the current turn and wait out of turn for relevant session input. This is self-only and does not require a goal. Use it for long or uncertain waits instead of sleeping or repeatedly calling session_wait/command_wait. timeoutSeconds is a relative safety-wake duration; OpenGeni persists its absolute deadline, and timeout never cancels a background command. A human/API prompt, agent message or Steer, child terminal result, scheduled input, terminal background-command result, or the deadline wakes the session. Always end your turn immediately after the tool succeeds. Use goal_pause instead when the active goal itself should stop pending a human decision.",
+        "End the current turn and wait out of turn for relevant session input. This is self-only and does not require a goal. After success, the production runtime ends the turn at the tool-batch boundary without another model step or final message. Use it for long or uncertain waits instead of sleeping or repeatedly calling session_wait/command_wait. timeoutSeconds is a relative safety-wake duration; OpenGeni persists the first absolute deadline for the turn, and repeated calls do not extend it. Timeout never cancels a background command. A human/API prompt, agent message or Steer, child terminal result, scheduled input, terminal background-command result, or the deadline wakes the session. Use goal_pause instead when the active goal itself should stop pending a human decision.",
       inputSchema: {
         reason: inputWaitReasonSchema,
         timeoutSeconds: z4
@@ -2812,7 +2812,7 @@ function registerGoalTools(
         operationId,
         replay,
         nextAction:
-          "End your turn now. Relevant input or the timeout deadline will start a new turn; the timeout does not cancel commands.",
+          "The runtime yields this turn after the tool batch settles. Relevant input or the timeout deadline will start a new turn; the timeout does not cancel commands.",
       });
     },
   );

--- a/apps/worker/src/activities/agent-turn/agent-build.ts
+++ b/apps/worker/src/activities/agent-turn/agent-build.ts
@@ -599,6 +599,7 @@ export async function buildTurnAgent(deps: BuildTurnAgentDeps) {
     let agentConstructionOutcome: "completed" | "failed" = "completed";
     try {
       return runtime.buildAgent(eventing.modelRunSettings, runtimeResources, {
+        ...(preparedTools.inputWaitYield ? { inputWaitYield: preparedTools.inputWaitYield } : {}),
         reasoningEffort: turn.reasoningEffort,
         latencyMode: turnExecutionPolicy.latencyMode,
         ...(serviceTier ? { serviceTier } : {}),

--- a/apps/worker/src/activities/agent-turn/quiescence.ts
+++ b/apps/worker/src/activities/agent-turn/quiescence.ts
@@ -346,8 +346,14 @@ export function assertAgentStreamNotCancelled(cancelled: boolean): void {
 }
 
 /** Interruption streams do not produce a normal final output. Call this only
- * after the interruption branch has settled any required action. */
-export function requireAgentStreamFinalOutput(finalOutput: unknown | undefined): unknown {
+ * after the interruption branch has settled any required action. A successful
+ * runtime-owned input wait is a normal terminal result without assistant text;
+ * its authority comes from prepared tools, never the provider's output. */
+export function requireAgentStreamFinalOutput(
+  finalOutput: unknown | undefined,
+  inputWaitYielded = false,
+): unknown {
+  if (inputWaitYielded) return "";
   if (finalOutput === undefined) {
     throw new IncompleteAgentStreamError();
   }

--- a/apps/worker/src/activities/agent-turn/run.ts
+++ b/apps/worker/src/activities/agent-turn/run.ts
@@ -1571,6 +1571,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         videoGenerationAcceptancesByCallId,
       });
     } catch (error) {
+      // Stop new external wait mutations before asynchronous failure
+      // persistence. Do not drain here: the original failure/cancellation and
+      // durable attempt fence retain authority over already-running calls.
+      eventing.preparedTools?.inputWaitYield?.closeAdmission();
       return await settleTurnFailure({
         error,
         input,

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -1652,7 +1652,10 @@ export async function runTurnStreamAttempt(
       return claimedResult({ status: "requires_action" });
     }
 
-    const finalOutput = String(requireAgentStreamFinalOutput(eventing.stream.finalOutput));
+    const inputWaitYielded = eventing.preparedTools?.inputWaitYield?.requested === true;
+    const finalOutput = String(
+      requireAgentStreamFinalOutput(eventing.stream.finalOutput, inputWaitYielded),
+    );
     await historySink.reconcileConversationTruth({ requireDurable: true });
     // Op-stream durability fence: the tool outputs are now durably in the
     // history store (a redispatch would NOT re-execute them), so this
@@ -1665,10 +1668,9 @@ export async function runTurnStreamAttempt(
     if (
       !(await eventing.settle!({
         events: [
-          {
-            type: "agent.message.completed",
-            payload: { text: finalOutput },
-          },
+          ...(inputWaitYielded
+            ? []
+            : [{ type: "agent.message.completed" as const, payload: { text: finalOutput } }]),
           { type: "turn.completed", payload: { output: finalOutput } },
           { type: "session.status.changed", payload: { status: "idle" } },
         ],

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -961,6 +961,7 @@ export async function runTurnStreamAttempt(
       ]);
     };
     const iterator = eventing.stream.toStream()[Symbol.asyncIterator]();
+    const closeStreamWaitAdmission = eventing.preparedTools?.inputWaitYield?.captureStreamClose();
     let streamDone = false;
     try {
       while (true) {
@@ -1330,6 +1331,10 @@ export async function runTurnStreamAttempt(
         }
       }
     } catch (error) {
+      // Event processing can fail while SDK completion is still pending.
+      // Close this stream before any failure publication; a legitimate
+      // compaction retry may start a new, independently fenced generation.
+      closeStreamWaitAdmission?.();
       if (fallbackProviderRequestLifecycleStartedAt !== null) {
         const durationMs = Math.max(
           0,
@@ -1399,8 +1404,13 @@ export async function runTurnStreamAttempt(
       temporalCancellationSignal: cancellationSignal,
       runtimeCancellationSignal,
     });
+    // External Codemode stays reachable until finalization. Close wait
+    // admission before any terminal output/history decision, and drain an
+    // already-admitted wait before consulting the actual runner-yield latch.
+    await eventing.preparedTools?.inputWaitYield?.sealForSettlement(runtimeCancellationSignal);
     if (
       options.requireTerminalModelResponse &&
+      !eventing.preparedTools?.inputWaitYield?.yielded &&
       eventing.stream.interruptions.length === 0 &&
       modelResponseState.responseCount === responseCountBeforeStream
     ) {
@@ -1409,7 +1419,8 @@ export async function runTurnStreamAttempt(
       // is not a completed logical turn: accepting finalOutput's undefined ->
       // empty-string fallback would release the queue and start newer user
       // work. Cancellation retains priority; otherwise checkpoint and recover
-      // this exact turn from the durable compacted history.
+      // this exact turn from the durable compacted history. An actual runtime
+      // wait yield deliberately needs no subsequent provider response.
       throwIfWorkerShuttingDown();
       throwIfTurnCancelled();
       throw new PostCompactionContinuationEmptyError();
@@ -1652,7 +1663,7 @@ export async function runTurnStreamAttempt(
       return claimedResult({ status: "requires_action" });
     }
 
-    const inputWaitYielded = eventing.preparedTools?.inputWaitYield?.requested === true;
+    const inputWaitYielded = eventing.preparedTools?.inputWaitYield?.yielded === true;
     const finalOutput = String(
       requireAgentStreamFinalOutput(eventing.stream.finalOutput, inputWaitYielded),
     );

--- a/apps/worker/test/agent-stream-terminal.test.ts
+++ b/apps/worker/test/agent-stream-terminal.test.ts
@@ -101,4 +101,14 @@ describe("agent stream terminal authority", () => {
       IncompleteAgentStreamError,
     );
   });
+
+  test("accepted wait without an actual runner yield preserves the completed answer", () => {
+    const acceptedOnly = { requested: true, yielded: false };
+    expect(requireAgentStreamFinalOutput("Completed answer", acceptedOnly.yielded)).toBe(
+      "Completed answer",
+    );
+    expect(() => requireAgentStreamFinalOutput(undefined, acceptedOnly.yielded)).toThrow(
+      IncompleteAgentStreamError,
+    );
+  });
 });

--- a/apps/worker/test/agent-stream-terminal.test.ts
+++ b/apps/worker/test/agent-stream-terminal.test.ts
@@ -88,4 +88,17 @@ describe("agent stream terminal authority", () => {
   test("an explicit empty final output remains a valid completed result", () => {
     expect(requireAgentStreamFinalOutput("")).toBe("");
   });
+
+  test("a trusted input wait settles without provider final output", () => {
+    expect(requireAgentStreamFinalOutput(undefined, true)).toBe("");
+    expect(requireAgentStreamFinalOutput("not a wait receipt", true)).toBe("");
+  });
+
+  test("a wait-shaped provider result does not confer runtime yield authority", () => {
+    const spoof = { status: "waiting_for_input" };
+    expect(requireAgentStreamFinalOutput(spoof)).toBe(spoof);
+    expect(() => requireAgentStreamFinalOutput(undefined, false)).toThrow(
+      IncompleteAgentStreamError,
+    );
+  });
 });

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -799,6 +799,24 @@ describe("turn exact-content boundaries", () => {
     const streamCompletionAuthority = source.indexOf(
       "await assertSuccessfulAgentStreamCompletion({",
     );
+    expect(source).toContain(
+      "const closeStreamWaitAdmission = eventing.preparedTools?.inputWaitYield?.captureStreamClose();",
+    );
+    const closedStreamAdmission = source.indexOf("closeStreamWaitAdmission?.();");
+    const streamFailureCatch = source.lastIndexOf("} catch (error) {", closedStreamAdmission);
+    expect(streamFailureCatch).toBeGreaterThan(-1);
+    expect(source.slice(streamFailureCatch, closedStreamAdmission)).not.toContain("await ");
+    const streamFailurePublication = source.indexOf(
+      "await eventing.publish!([",
+      closedStreamAdmission,
+    );
+    expect(closedStreamAdmission).toBeGreaterThan(-1);
+    expect(streamFailurePublication).toBeGreaterThan(closedStreamAdmission);
+    expect(streamCompletionAuthority).toBeGreaterThan(streamFailurePublication);
+    const sealedWaitAdmission = source.indexOf(
+      "await eventing.preparedTools?.inputWaitYield?.sealForSettlement(runtimeCancellationSignal);",
+      streamCompletionAuthority,
+    );
     const postCompactionRecovery = source.indexOf(
       "throw new PostCompactionContinuationEmptyError();",
       streamCompletionAuthority,
@@ -821,12 +839,29 @@ describe("turn exact-content boundaries", () => {
     );
     const successCompletion = source.indexOf('type: "turn.completed"', mandatoryBarrier);
     expect(streamCompletionAuthority).toBeGreaterThan(-1);
-    expect(postCompactionRecovery).toBeGreaterThan(streamCompletionAuthority);
+    expect(sealedWaitAdmission).toBeGreaterThan(streamCompletionAuthority);
+    expect(postCompactionRecovery).toBeGreaterThan(sealedWaitAdmission);
+    expect(source).toContain("eventing.preparedTools?.inputWaitYield?.yielded === true");
+    expect(source).toContain(
+      "options.requireTerminalModelResponse &&\n      !eventing.preparedTools?.inputWaitYield?.yielded &&",
+    );
+    expect(source).not.toContain("eventing.preparedTools?.inputWaitYield?.requested === true");
     expect(cancelledStreamGuard).toBeGreaterThan(postCompactionRecovery);
     expect(interruptionPath).toBeGreaterThan(cancelledStreamGuard);
     expect(completionPath).toBeGreaterThan(interruptionPath);
     expect(mandatoryBarrier).toBeGreaterThan(completionPath);
     expect(successCompletion).toBeGreaterThan(mandatoryBarrier);
+
+    const runSource = await Bun.file(
+      new URL("../src/activities/agent-turn/run.ts", import.meta.url),
+    ).text();
+    const closedFailureAdmission = runSource.indexOf(
+      "eventing.preparedTools?.inputWaitYield?.closeAdmission();",
+    );
+    expect(closedFailureAdmission).toBeGreaterThan(-1);
+    expect(runSource.indexOf("return await settleTurnFailure({")).toBeGreaterThan(
+      closedFailureAdmission,
+    );
 
     const failureSource = await Bun.file(
       new URL("../src/activities/agent-turn/failure-settlement.ts", import.meta.url),

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -812,7 +812,7 @@ describe("turn exact-content boundaries", () => {
       cancelledStreamGuard,
     );
     const completionPath = source.indexOf(
-      "String(requireAgentStreamFinalOutput(eventing.stream.finalOutput))",
+      "requireAgentStreamFinalOutput(eventing.stream.finalOutput, inputWaitYielded)",
       interruptionPath,
     );
     const mandatoryBarrier = source.indexOf(

--- a/apps/worker/test/connected-command-cleanup-integration.test.ts
+++ b/apps/worker/test/connected-command-cleanup-integration.test.ts
@@ -46,8 +46,11 @@ async function seed() {
     pubkey: `ed25519:${id}`,
   });
   await shared.admin`update enrollments set connection_instance_id='launch',connection_lease_expires_at=now()+interval '1 hour' where id=${enrollment.id}`;
-  await shared.admin`insert into session_background_commands(account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id)
- select ${accountId},${workspaceId!},${session.id},'connected_machine','running',${workspaceId!},${enrollment.id},'launch',gen_random_uuid()::text from generate_series(1,25)`;
+  // The sweep freezes a JavaScript millisecond due frontier. The database's
+  // clock_timestamp() default is evaluated per row at finer precision, so a
+  // fresh batch can straddle that frontier. Seed every fixture row as due.
+  await shared.admin`insert into session_background_commands(account_id,workspace_id,session_id,provider,state,control_workspace_id,enrollment_id,connection_instance_id,op_id,reconcile_after)
+ select ${accountId},${workspaceId!},${session.id},'connected_machine','running',${workspaceId!},${enrollment.id},'launch',gen_random_uuid()::text,'2000-01-01T00:00:00Z'::timestamptz from generate_series(1,25)`;
   return session.id;
 }
 const settings = {
@@ -128,7 +131,8 @@ test("offline commands remain tracked while one sweep shares failed connection o
   expect(queries).toBeGreaterThan(0);
   expect(queries).toBe(1);
   const [row] =
-    await shared.admin`select count(*)::int n,min(reconcile_attempts)::int attempts from session_background_commands where session_id=${sessionId} and state='running'`;
+    await shared.admin`select count(*)::int n,min(reconcile_attempts)::int attempts,max(reconcile_attempts)::int max_attempts from session_background_commands where session_id=${sessionId} and state='running'`;
   expect(row!.n).toBe(25);
   expect(row!.attempts).toBe(1);
+  expect(row!.max_attempts).toBe(1);
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,9 @@ Internal-update delivery is atomic per batch, not unique per logical turn:
 resumed attempts may append a new batch while retaining earlier receipts.
 Canonical model history owns their ordered, exactly-once inclusion.
 
+Successful `wait_for_input` ends model execution after tool-batch settlement;
+trusted runtime state and immutable same-turn deadlines preserve wait/wake authority.
+
 The full `runAgentTurn` activity is non-retryable by default because model,
 tool, sandbox, Git, connector, and cloud operations can have external effects.
 Recovery is explicit and attempt-fenced. Provider work occurs outside database

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1418,8 +1418,16 @@ uses ordinary turn settlement. Codemode shares the same trusted acceptance
 state; stdout and third-party lookalike tools cannot request a yield. Failed
 wait calls do not yield. Repeated accepted waits in the same logical turn keep
 the first deadline and reason rather than renewing the wait, including across
-attempt recovery. Durable input/deadline arbitration remains in the existing
-session wait transaction and workflow; this does not resume a paused session.
+attempt recovery. Acceptance is coordinated with provider dispatch and sealed
+before terminal settlement. Calls racing an already-sealed dispatch are rejected
+before the remote wait mutation. Only an actual runner yield suppresses a final
+assistant message, never late acceptance alone. Failure settlement closes new
+wait admission without waiting for stalled calls; already-running mutations
+remain subject to durable attempt fencing. Compaction recovery may start a new
+stream generation, but old callbacks cannot control its admission and pending
+or accepted waits are retained across the retry. Durable input/deadline
+arbitration remains in the existing session wait transaction and workflow;
+this does not resume a paused session.
 
 Teardown preserves that authority. Session-tree deletion locks and refuses any
 `running` or `stopping` command before cascading session-owned rows. Workspace

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1409,6 +1409,18 @@ never repeats provider execution.
 the durable command row. A longer wait uses session-level `wait_for_input`,
 whose timeout never cancels the command.
 
+A successful first-party `wait_for_input` is an enforced production-runtime
+boundary, not a request for the model to volunteer a final answer. The trusted
+tool transport records acceptance in attempt-local control state; after the
+tool batch settles, the runner returns without another model step. Canonical
+tool receipts and parallel sibling results remain in history and the worker
+uses ordinary turn settlement. Codemode shares the same trusted acceptance
+state; stdout and third-party lookalike tools cannot request a yield. Failed
+wait calls do not yield. Repeated accepted waits in the same logical turn keep
+the first deadline and reason rather than renewing the wait, including across
+attempt recovery. Durable input/deadline arbitration remains in the existing
+session wait transaction and workflow; this does not resume a paused session.
+
 Teardown preserves that authority. Session-tree deletion locks and refuses any
 `running` or `stopping` command before cascading session-owned rows. Workspace
 deletion takes a separate transaction-scoped background-command advisory prefix

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -58756,6 +58756,26 @@ export async function waitForSessionInputWithEvent(
           `Session ${sessionId} has no Temporal workflow identity`,
         );
       }
+      // The first wait owns the logical turn's deadline, not a renewable lease.
+      // Fresh operation keys and recovered attempts retain its receipt facts.
+      if (session.inputWaitTurnId === input.command.actor.turnId && session.inputWaitUntil) {
+        const deadlineAt = session.inputWaitUntil.toISOString();
+        await updateSessionCommandReceiptResult(tx, reserved.receipt.id, {
+          result: {
+            waitTurnId: session.inputWaitTurnId,
+            deadlineAt,
+            reason: session.inputWaitReason,
+          },
+        });
+        return {
+          events: [],
+          operationId: reserved.receipt.id,
+          replay: false,
+          waitTurnId: session.inputWaitTurnId,
+          deadlineAt,
+        };
+      }
+
       const now = await transactionNow(tx);
       const deadline = new Date(now.getTime() + input.timeoutSeconds * 1000);
       const deadlineAt = deadline.toISOString();

--- a/packages/db/test/durable-goal-wake.test.ts
+++ b/packages/db/test/durable-goal-wake.test.ts
@@ -2542,6 +2542,33 @@ describe("session-level wait_for_input", () => {
     expect(refreshedWake!.next_attempt_at.toISOString()).toBe(waiting.deadlineAt);
   });
 
+  test("fresh same-turn wait operations retain the original deadline and start receipt", async () => {
+    const ctx = await runningGoalFixture();
+    await clearSessionGoal(client.db, ctx.grant.workspaceId!, ctx.session.id);
+    const first = await wait(ctx, { timeoutSeconds: 600, reason: "Original wait" });
+    const originalColumns = await waitColumns(ctx);
+    const originalWake = await outboxRow(ctx);
+    const operationKey = crypto.randomUUID();
+    const duplicates = await Promise.all([
+      wait(ctx, { timeoutSeconds: 1800, reason: "Changed reason", operationKey }),
+      wait(ctx, { timeoutSeconds: 3600, reason: "Concurrent wait" }),
+    ]);
+    for (const duplicate of duplicates) {
+      expect(duplicate.deadlineAt).toBe(first.deadlineAt);
+      expect(duplicate.events).toEqual([]);
+    }
+    expect(await waitColumns(ctx)).toEqual(originalColumns);
+    expect(await outboxRow(ctx)).toEqual(originalWake);
+    const replay = await wait(ctx, {
+      timeoutSeconds: 1800,
+      reason: "Changed reason",
+      operationKey,
+    });
+    expect(replay.replay).toBe(true);
+    expect(replay.deadlineAt).toBe(first.deadlineAt);
+    expect(replay.events).toEqual([]);
+  });
+
   test("a replacement attempt replays the original wait instead of moving its deadline", async () => {
     const ctx = await runningGoalFixture();
     await clearSessionGoal(client.db, ctx.grant.workspaceId!, ctx.session.id);
@@ -2593,6 +2620,30 @@ describe("session-level wait_for_input", () => {
       deadlineAt: first.deadlineAt,
     });
     expect((await waitColumns(ctx)).input_wait_until?.toISOString()).toBe(first.deadlineAt);
+    const fresh = await waitForSessionInputWithEvent(
+      client.db,
+      ctx.grant.workspaceId!,
+      ctx.session.id,
+      {
+        reason: "Recovered attempt still waiting",
+        timeoutSeconds: 3600,
+        command: {
+          accountId: ctx.grant.accountId,
+          actor: {
+            type: "agent_attempt",
+            sessionId: ctx.session.id,
+            turnId: replacement.turn.id,
+            attemptId: replacementAttemptId,
+            executionGeneration: replacement.turn.executionGeneration,
+          },
+          operationKey: crypto.randomUUID(),
+        },
+      },
+    );
+    expect(fresh.deadlineAt).toBe(first.deadlineAt);
+    expect(fresh.events).toEqual([]);
+    await expect(wait(ctx, { timeoutSeconds: 3600 })).rejects.toThrow();
+    expect((await waitColumns(ctx)).input_wait_until?.toISOString()).toBe(first.deadlineAt);
   });
 
   test("human and API prompts wake the session before the safety deadline", async () => {
@@ -2637,63 +2688,67 @@ describe("session-level wait_for_input", () => {
     });
   });
 
-  test("immediate machine input wins and the later finished turn supersedes the wait", async () => {
-    const ctx = await runningGoalFixture();
-    await clearSessionGoal(client.db, ctx.grant.workspaceId!, ctx.session.id);
-    const waiting = await wait(ctx, { timeoutSeconds: 3600 });
-    await settleIdle(ctx);
+  test.each(["before", "after"] as const)(
+    "machine input arriving %s turn settlement supersedes the wait",
+    async (timing) => {
+      const ctx = await runningGoalFixture();
+      await clearSessionGoal(client.db, ctx.grant.workspaceId!, ctx.session.id);
+      const waiting = await wait(ctx, { timeoutSeconds: 3600 });
+      if (timing === "after") await settleIdle(ctx);
 
-    const input = await addSessionSystemUpdate(client.db, {
-      accountId: ctx.grant.accountId,
-      workspaceId: ctx.grant.workspaceId!,
-      sessionId: ctx.session.id,
-      kind: "agent_message",
-      classification: "info",
-      sourceId: crypto.randomUUID(),
-      dedupeKey: `agent-message-${crypto.randomUUID()}`,
-      summary: "Peer session finished",
-      payload: {
-        type: "agent_message",
-        text: "Peer session finished: PR opened",
-        operationId: crypto.randomUUID(),
-      },
-    });
-    if (!input.added) throw new Error("agent message was not inserted");
-    expect(await peekSessionWork(client.db, ctx.grant.workspaceId!, ctx.session.id)).toEqual({
-      kind: "runnable",
-    });
+      const input = await addSessionSystemUpdate(client.db, {
+        accountId: ctx.grant.accountId,
+        workspaceId: ctx.grant.workspaceId!,
+        sessionId: ctx.session.id,
+        kind: "agent_message",
+        classification: "info",
+        sourceId: crypto.randomUUID(),
+        dedupeKey: `agent-message-${crypto.randomUUID()}`,
+        summary: "Peer session finished",
+        payload: {
+          type: "agent_message",
+          text: "Peer session finished: PR opened",
+          operationId: crypto.randomUUID(),
+        },
+      });
+      if (!input.added) throw new Error("agent message was not inserted");
+      if (timing === "before") await settleIdle(ctx);
+      expect(await peekSessionWork(client.db, ctx.grant.workspaceId!, ctx.session.id)).toEqual({
+        kind: "runnable",
+      });
 
-    const attemptId = crypto.randomUUID();
-    const claimed = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
-      sessionId: ctx.session.id,
-      workflowId: `session-${ctx.session.id}`,
-      workflowRunId: crypto.randomUUID(),
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-      trigger: { kind: "next" },
-    });
-    expect(claimed.action).toBe("claimed");
-    if (claimed.action !== "claimed") return;
-    await settleClaimedIdle(ctx, claimed, attemptId);
+      const attemptId = crypto.randomUUID();
+      const claimed = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
+        sessionId: ctx.session.id,
+        workflowId: `session-${ctx.session.id}`,
+        workflowRunId: crypto.randomUUID(),
+        attemptId,
+        dispatchId: `dispatch-${crypto.randomUUID()}`,
+        trigger: { kind: "next" },
+      });
+      expect(claimed.action).toBe("claimed");
+      if (claimed.action !== "claimed") return;
+      await settleClaimedIdle(ctx, claimed, attemptId);
 
-    expect(await peekSessionWork(client.db, ctx.grant.workspaceId!, ctx.session.id)).toEqual({
-      kind: "input-wait",
-      disposition: "superseded",
-      waitTurnId: ctx.turn.id,
-      deadlineAt: waiting.deadlineAt,
-    });
-    const superseded = await settleSessionInputWait(client.db, {
-      accountId: ctx.grant.accountId,
-      workspaceId: ctx.grant.workspaceId!,
-      sessionId: ctx.session.id,
-      waitTurnId: ctx.turn.id,
-      disposition: "superseded",
-    });
-    expect(superseded.action).toBe("superseded");
-    expect(superseded.events.map((event) => event.type)).toEqual(["session.wait.finished"]);
-    expect(superseded.events[0]!.payload).toMatchObject({ outcome: "input" });
-    expect((await waitColumns(ctx)).input_wait_turn_id).toBeNull();
-  });
+      expect(await peekSessionWork(client.db, ctx.grant.workspaceId!, ctx.session.id)).toEqual({
+        kind: "input-wait",
+        disposition: "superseded",
+        waitTurnId: ctx.turn.id,
+        deadlineAt: waiting.deadlineAt,
+      });
+      const superseded = await settleSessionInputWait(client.db, {
+        accountId: ctx.grant.accountId,
+        workspaceId: ctx.grant.workspaceId!,
+        sessionId: ctx.session.id,
+        waitTurnId: ctx.turn.id,
+        disposition: "superseded",
+      });
+      expect(superseded.action).toBe("superseded");
+      expect(superseded.events.map((event) => event.type)).toEqual(["session.wait.finished"]);
+      expect(superseded.events[0]!.payload).toMatchObject({ outcome: "input" });
+      expect((await waitColumns(ctx)).input_wait_turn_id).toBeNull();
+    },
+  );
 
   test("deadline settlement queues one typed timeout input in the same transaction", async () => {
     const ctx = await runningGoalFixture();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -245,6 +245,8 @@ import {
   sandboxCommandStdout,
 } from "./sandbox/command-result";
 import { shellCodemodePath } from "./sandbox/codemode-token";
+import { InputWaitYield } from "./input-wait-yield";
+export { InputWaitYield } from "./input-wait-yield";
 import {
   createTurnToolCancellationController,
   TurnSandboxCommandCancelledError,
@@ -1636,8 +1638,11 @@ type ModelToolInvocation = {
 };
 
 const modelToolInvocation = new AsyncLocalStorage<ModelToolInvocation>();
+const agentInputWaitYields = new WeakMap<object, InputWaitYield>();
 
 export type BuildAgentOptions = {
+  /** Trusted attempt-local wait receipt shared with prepared tools. */
+  inputWaitYield?: InputWaitYield;
   model?: Model;
   /** Attach the built-in structured human-input tool. Default: enabled. */
   humanInputEnabled?: boolean;
@@ -2472,6 +2477,7 @@ export function buildOpenGeniAgent(
     // `new SandboxAgent({ ...baseConfig, ... })` path via the shared baseConfig
     // spread; the SDK concatenates these with MCP and sandbox capability tools.
     tools: agentTools,
+    ...(options.inputWaitYield ? { toolUseBehavior: options.inputWaitYield.toolUseBehavior } : {}),
     ...(options.mcpServers?.length ? { mcpServers: options.mcpServers } : {}),
     // Surface FAILED MCP tool calls as `{ isError: true }` tool output (see
     // mcpToolErrorFunction / mcpToolErrorOutput) instead of the SDK's default
@@ -2484,6 +2490,7 @@ export function buildOpenGeniAgent(
 
   if (settings.sandboxBackend === "none") {
     const agent = new Agent(baseConfig);
+    if (options.inputWaitYield) agentInputWaitYields.set(agent, options.inputWaitYield);
     agentInstructionInspection.set(agent, instructionInspection);
     if (options.missingSessionTitleHint ?? options.genesisTitleHint) {
       agentsNeedingGenesisTitleDirective.add(agent);
@@ -2569,6 +2576,7 @@ export function buildOpenGeniAgent(
     }),
   });
   agentSkillSelections.set(agent, skillComposition.selections);
+  if (options.inputWaitYield) agentInputWaitYields.set(agent, options.inputWaitYield);
   agentInstructionInspection.set(agent, instructionInspection);
   if (options.missingSessionTitleHint ?? options.genesisTitleHint) {
     agentsNeedingGenesisTitleDirective.add(agent);
@@ -3392,6 +3400,8 @@ export function sandboxRunAs(_settings: Settings): string | undefined {
 }
 
 export type PreparedAgentTools = {
+  /** Shared by eager/deferred MCP, Codemode, and this attempt's Agent. */
+  inputWaitYield?: InputWaitYield;
   mcpServers: MCPServer[];
   /** Protocol-neutral catalog for current-human HTTP, MCP, and browser adapters. */
   toolGatewayCatalog: ToolGatewayCatalog | null;
@@ -3777,6 +3787,7 @@ export async function prepareAgentTools(
   tools: ToolRef[],
   options: PrepareToolsOptions = {},
 ): Promise<PreparedAgentTools> {
+  const inputWaitYield = new InputWaitYield();
   // One live Set per prepared tool environment, shared with the codex_apps
   // sanitizing fetch and the current turn's tool_search description.
   const codexConnectorNamespaces = options.deferredCodexConnectorNamespaces ?? new Set<string>();
@@ -3971,6 +3982,11 @@ export async function prepareAgentTools(
           firstParty && !bestEffort,
           buildConnectorAttachmentAuthority(config, options, resolvedMcpToolConnectionIds, url),
           tool.eager !== true,
+          undefined,
+          undefined,
+          firstParty && config.id === "opengeni" && !config.connectionRef && !bridge
+            ? inputWaitYield
+            : undefined,
         );
         return {
           server,
@@ -4145,6 +4161,7 @@ export async function prepareAgentTools(
         toolGateway,
         attemptToolCatalog: attemptToolEnvironment?.catalog ?? null,
         attemptToolEnvironment,
+        inputWaitYield,
         // Keep this by-reference so connector approval can observe an identity
         // resolved while best-effort preparation was running in parallel.
         resolvedMcpConnectionIds,
@@ -4256,6 +4273,7 @@ export async function prepareAgentTools(
     toolGateway: null,
     attemptToolCatalog: null,
     attemptToolEnvironment: null,
+    inputWaitYield,
     resolvedMcpConnectionIds,
     close: async () => {
       let prepared: PreparedAgentTools;
@@ -6256,6 +6274,7 @@ export class PrefixedMcpServer implements MCPServer {
       LocalMcpServerRegistration["preflightCall"]
     >,
     private readonly approvalAuthority?: unknown,
+    private readonly inputWaitYield?: InputWaitYield,
   ) {
     this.registryId = registryId;
     // The SDK uses `name` for cache keys, traces, and lifecycle diagnostics.
@@ -6587,6 +6606,9 @@ export class PrefixedMcpServer implements MCPServer {
       const result = AttemptToolResult.parse(output);
       boundedMcpToolResult(result);
       recordOutcome(result.isError === true ? "provider_declared_error" : "success");
+      if (unprefixed === "wait_for_input" && result.isError !== true) {
+        this.inputWaitYield?.recordSuccess();
+      }
       return result;
     } catch (error) {
       // A brokered tools/call that receives 401 may already have changed provider
@@ -7058,6 +7080,7 @@ export async function runAgentStream(
   settings: Settings,
   overrides: RunAgentStreamOptions = {},
 ) {
+  const inputWaitYield = agentInputWaitYields.get(agent);
   const prepared: PreparedAgentInput =
     typeof input === "string"
       ? { input, persistedHistoryCount: 0 }
@@ -7201,6 +7224,7 @@ export async function runAgentStream(
     );
     const ownedFilter = composeCallModelInputFilters(
       [
+        inputWaitYield?.modelInputFilter,
         measuredModelInputFilter("input_filter_base", baseModelInputFilterForSettings(settings)),
         measuredModelInputFilter("input_filter_genesis", genesisTitleInputFilter),
         measuredModelInputFilter("input_filter_host", overrides.callModelInputFilter),
@@ -7234,6 +7258,8 @@ export async function runAgentStream(
               : {}),
           }),
         ),
+        // A Codemode wait can settle while an asynchronous host filter runs.
+        inputWaitYield?.modelInputFilter,
       ].filter((f): f is CallModelInputFilter => Boolean(f)),
     );
     const ownedRunOptions: Parameters<typeof run>[2] = {
@@ -7244,6 +7270,9 @@ export async function runAgentStream(
       toolExecution: { preApprovalInputGuardrails: true },
       ...lazyToolRunBindings(agent),
       callModelInputFilter: ownedFilter,
+      ...(inputWaitYield
+        ? { errorHandlers: inputWaitYield.runErrorHandlers(overrides.signal) }
+        : {}),
       ...(overrides.signal ? { signal: overrides.signal } : {}),
     };
     ownedRunOptions.sandbox = {
@@ -7350,6 +7379,7 @@ export async function runAgentStream(
   // pass an SDK session and reconciles durable truth from the untouched input.
   const callModelInputFilter = composeCallModelInputFilters(
     [
+      inputWaitYield?.modelInputFilter,
       measuredModelInputFilter("input_filter_base", baseModelInputFilterForSettings(settings)),
       measuredModelInputFilter("input_filter_genesis", genesisTitleInputFilter),
       measuredModelInputFilter("input_filter_host", overrides.callModelInputFilter),
@@ -7377,6 +7407,7 @@ export async function runAgentStream(
             : {}),
         }),
       ),
+      inputWaitYield?.modelInputFilter,
     ].filter((f): f is CallModelInputFilter => Boolean(f)),
   );
   const runOptions: Parameters<typeof run>[2] = {
@@ -7391,6 +7422,7 @@ export async function runAgentStream(
     // raise the proactive compaction signal. This runs for turn-start replay AND
     // every mid-turn follow-up.
     callModelInputFilter,
+    ...(inputWaitYield ? { errorHandlers: inputWaitYield.runErrorHandlers(overrides.signal) } : {}),
     ...(overrides.signal ? { signal: overrides.signal } : {}),
   };
   if (client) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -245,7 +245,7 @@ import {
   sandboxCommandStdout,
 } from "./sandbox/command-result";
 import { shellCodemodePath } from "./sandbox/codemode-token";
-import { InputWaitYield } from "./input-wait-yield";
+import { InputWaitYield, type InputWaitYieldStream } from "./input-wait-yield";
 export { InputWaitYield } from "./input-wait-yield";
 import {
   createTurnToolCancellationController,
@@ -6572,6 +6572,10 @@ export class PrefixedMcpServer implements MCPServer {
     };
     const operationId =
       meta && typeof meta.opengeniOperationId === "string" ? meta.opengeniOperationId : undefined;
+    // Admission must precede the physical remote call, not merely observe its
+    // result: model dispatch and terminal settlement drain this reservation.
+    const completeWait =
+      unprefixed === "wait_for_input" ? this.inputWaitYield?.beginWait() : undefined;
     try {
       const projectedOutput = this.inner.callToolResult
         ? await this.inner.callToolResult(unprefixed, args, meta, options)
@@ -6607,7 +6611,7 @@ export class PrefixedMcpServer implements MCPServer {
       boundedMcpToolResult(result);
       recordOutcome(result.isError === true ? "provider_declared_error" : "success");
       if (unprefixed === "wait_for_input" && result.isError !== true) {
-        this.inputWaitYield?.recordSuccess();
+        completeWait?.(true);
       }
       return result;
     } catch (error) {
@@ -6684,6 +6688,7 @@ export class PrefixedMcpServer implements MCPServer {
       }
       throw error;
     } finally {
+      completeWait?.(false);
       if (operationId) {
         this.connectorAttachmentAuthority?.releaseOperation(operationId);
       }
@@ -7080,7 +7085,33 @@ export async function runAgentStream(
   settings: Settings,
   overrides: RunAgentStreamOptions = {},
 ) {
-  const inputWaitYield = agentInputWaitYields.get(agent);
+  const gate = agentInputWaitYields.get(agent);
+  const scope = gate?.beginStream(overrides.signal);
+  try {
+    if (scope) agent.toolUseBehavior = scope.toolUseBehavior;
+    const stream = await runAgentStreamInternal(agent, input, settings, overrides, scope);
+    // Observe the SDK's own settlement promise before exposing the stream. Do
+    // not wrap/replace SDK history, errors, cancellation, or stream iteration.
+    // In particular a fatal sibling tool error must not leave admission open
+    // throughout the worker's asynchronous failure-persistence path.
+    if (scope) {
+      const finish = () => scope.endStream(stream.cancelled);
+      void stream.completed.then(finish, finish);
+    }
+    return stream;
+  } catch (error) {
+    scope?.endStream();
+    throw error;
+  }
+}
+
+async function runAgentStreamInternal(
+  agent: Agent<any, any>,
+  input: PreparedAgentInput | string | RunState<any, any>,
+  settings: Settings,
+  overrides: RunAgentStreamOptions = {},
+  inputWaitYield?: InputWaitYieldStream,
+) {
   const prepared: PreparedAgentInput =
     typeof input === "string"
       ? { input, persistedHistoryCount: 0 }
@@ -7258,8 +7289,8 @@ export async function runAgentStream(
               : {}),
           }),
         ),
-        // A Codemode wait can settle while an asynchronous host filter runs.
-        inputWaitYield?.modelInputFilter,
+        // Seal admission before any provider preparation/transport awaits.
+        inputWaitYield?.modelDispatchFilter,
       ].filter((f): f is CallModelInputFilter => Boolean(f)),
     );
     const ownedRunOptions: Parameters<typeof run>[2] = {
@@ -7270,9 +7301,7 @@ export async function runAgentStream(
       toolExecution: { preApprovalInputGuardrails: true },
       ...lazyToolRunBindings(agent),
       callModelInputFilter: ownedFilter,
-      ...(inputWaitYield
-        ? { errorHandlers: inputWaitYield.runErrorHandlers(overrides.signal) }
-        : {}),
+      ...(inputWaitYield ? { errorHandlers: inputWaitYield.errorHandlers } : {}),
       ...(overrides.signal ? { signal: overrides.signal } : {}),
     };
     ownedRunOptions.sandbox = {
@@ -7291,7 +7320,11 @@ export async function runAgentStream(
             "sandbox_session_manifest_inventory",
             (agentSession as { state?: { manifest?: Manifest } }).state?.manifest,
           );
-          return runScopedRunner(settings, agent).run(agent, prepared.input, ownedRunOptions);
+          return runScopedRunner(settings, agent, inputWaitYield).run(
+            agent,
+            prepared.input,
+            ownedRunOptions,
+          );
         }),
       ),
     );
@@ -7407,7 +7440,7 @@ export async function runAgentStream(
             : {}),
         }),
       ),
-      inputWaitYield?.modelInputFilter,
+      inputWaitYield?.modelDispatchFilter,
     ].filter((f): f is CallModelInputFilter => Boolean(f)),
   );
   const runOptions: Parameters<typeof run>[2] = {
@@ -7422,7 +7455,7 @@ export async function runAgentStream(
     // raise the proactive compaction signal. This runs for turn-start replay AND
     // every mid-turn follow-up.
     callModelInputFilter,
-    ...(inputWaitYield ? { errorHandlers: inputWaitYield.runErrorHandlers(overrides.signal) } : {}),
+    ...(inputWaitYield ? { errorHandlers: inputWaitYield.errorHandlers } : {}),
     ...(overrides.signal ? { signal: overrides.signal } : {}),
   };
   if (client) {
@@ -7438,7 +7471,11 @@ export async function runAgentStream(
           "sandbox_agent_manifest_inventory",
           (agent as { defaultManifest?: Manifest }).defaultManifest,
         );
-        return runScopedRunner(settings, agent).run(agent, prepared.input, runOptions);
+        return runScopedRunner(settings, agent, inputWaitYield).run(
+          agent,
+          prepared.input,
+          runOptions,
+        );
       }),
     ),
   );
@@ -7494,16 +7531,25 @@ function lazyToolRunBindings(agent: Agent<any, any>): {
   };
 }
 
-function runScopedRunner(settings: Settings, agent: Agent<any, any>): Runner {
+function runScopedRunner(
+  settings: Settings,
+  agent: Agent<any, any>,
+  inputWaitYield?: InputWaitYieldStream,
+): Runner {
   const baseProvider = new MultiProviderModelProvider(settings);
   const lazyRuntime = lazyToolRuntimeForAgent(agent);
   // LazyToolModel already captures the post-hide request. Non-lazy string models
   // resolve through this provider, which is the actual getResponse seam.
-  return new Runner({
+  const runner = new Runner({
     modelProvider: lazyRuntime
       ? new LazyToolModelProvider(baseProvider, lazyRuntime)
       : new ModelRequestCaptureProvider(baseProvider),
   });
+  if (inputWaitYield) {
+    runner.on("agent_tool_start", inputWaitYield.beginToolExecution);
+    runner.on("agent_end", inputWaitYield.closeStream);
+  }
+  return runner;
 }
 
 export { restoreGenericDispatchHistoryItems } from "./lazy-tool-transport";

--- a/packages/runtime/src/input-wait-yield.ts
+++ b/packages/runtime/src/input-wait-yield.ts
@@ -1,0 +1,64 @@
+import {
+  MaxTurnsExceededError,
+  type Agent,
+  type CallModelInputFilter,
+  type RunErrorHandlers,
+} from "@openai/agents";
+
+/** Attempt-local control state, never reconstructed from model/tool output text.
+ * The trusted transport records success; Runner observes it only after settling
+ * the tool batch, preserving receipts and parallel siblings in normal history.
+ */
+export class InputWaitYield {
+  private accepted = false;
+  // Identity, not name/message/shape, authorizes the SDK boundary exit. Never
+  // swallow a provider/tool failure just because a wait also succeeded.
+  // The SDK's supported max-turn handler is its pre-inference graceful-stop
+  // seam. Treat a committed wait as exhausting this attempt's inference budget,
+  // but recognize this request by identity, never by its error name or text.
+  private readonly boundaryExit = new MaxTurnsExceededError("Runtime input wait yield");
+
+  get requested(): boolean {
+    return this.accepted;
+  }
+
+  recordSuccess(): void {
+    this.accepted = true;
+  }
+
+  readonly toolUseBehavior: Agent["toolUseBehavior"] = () =>
+    this.accepted
+      ? { isFinalOutput: true, isInterrupted: undefined, finalOutput: "" }
+      : { isFinalOutput: false, isInterrupted: undefined };
+
+  /** Agents SDK 0.14.3 skips toolUseBehavior for native shell-only batches.
+   * Stop those at the existing input-filter seam, before another inference or
+   * host filter. The completed shell receipts already belong to SDK history.
+   */
+  readonly modelInputFilter: CallModelInputFilter = ({ modelData }) => {
+    if (this.accepted) throw this.boundaryExit;
+    return modelData;
+  };
+
+  /** Use SDK normal finalization, not abort EOF or a replacement stream/state.
+   * Native shell receipts remain in history; the empty terminal output does not.
+   * A genuine SDK turn cap can precede the input filter after the last allowed
+   * shell batch, so a successful wait also takes precedence at that boundary.
+   */
+  runErrorHandlers(signal?: AbortSignal): RunErrorHandlers<any, any> {
+    return {
+      maxTurns: ({ error, runData }) => {
+        if (!this.accepted || signal?.aborted) return;
+        if (
+          error !== this.boundaryExit &&
+          (!runData.state ||
+            error.state !== runData.state ||
+            runData.state._maxTurns === null ||
+            runData.state._currentTurn <= runData.state._maxTurns)
+        )
+          return;
+        return { finalOutput: "", includeInHistory: false };
+      },
+    };
+  }
+}

--- a/packages/runtime/src/input-wait-yield.ts
+++ b/packages/runtime/src/input-wait-yield.ts
@@ -169,18 +169,48 @@ export class InputWaitYield {
   }
 
   private filterInput(scope: StreamScope, { modelData }: Parameters<CallModelInputFilter>[0]) {
+    if (scope.signal?.aborted) {
+      this.closeCancelledDispatch(scope);
+      return modelData;
+    }
     this.assertCurrent(scope);
     if (this.accepted) throw this.boundaryExit;
     return modelData;
   }
 
   private async dispatch(scope: StreamScope, { modelData }: Parameters<CallModelInputFilter>[0]) {
+    if (scope.signal?.aborted) {
+      this.closeCancelledDispatch(scope);
+      return modelData;
+    }
     this.assertCurrent(scope);
     scope.phase = "dispatch";
-    await this.drain(scope);
+    try {
+      await this.drain(scope);
+    } catch (error) {
+      // Filter exceptions become SDK stream failures, not cancelled EOF. Keep
+      // admission sealed. Native initial-adapter cancellation is safe only if
+      // no wait has committed and no reserved mutation can still commit.
+      if (!scope.signal?.aborted) throw error;
+      this.closeCancelledDispatch(scope);
+      return modelData;
+    }
     this.assertCurrent(scope);
     if (this.accepted) throw this.boundaryExit;
     return modelData;
+  }
+
+  private closeCancelledDispatch(scope: StreamScope): void {
+    this.endStream(scope);
+    if (this.accepted || this.pending.size > 0) {
+      // Never permit even an aborted adapter dispatch after wait acceptance,
+      // or race a pending mutation that may accept before the adapter starts.
+      // Preserve cancellation authority without claiming a successful yield.
+      throw scope.signal?.reason ?? new DOMException("The operation was aborted", "AbortError");
+    }
+    // SDK 0.14.3 deliberately enters its initial adapter with an aborted signal.
+    // With no accepted/pending wait, preserve that native cancelled-EOF path;
+    // physical cancellation remains the transport's responsibility.
   }
 
   private async finishTools(scope: StreamScope) {

--- a/packages/runtime/src/input-wait-yield.ts
+++ b/packages/runtime/src/input-wait-yield.ts
@@ -5,50 +5,208 @@ import {
   type RunErrorHandlers,
 } from "@openai/agents";
 
-/** Attempt-local control state, never reconstructed from model/tool output text.
- * The trusted transport records success; Runner observes it only after settling
- * the tool batch, preserving receipts and parallel siblings in normal history.
+type StreamScope = {
+  generation: number;
+  phase: "open" | "dispatch" | "settled";
+  ended: boolean;
+  finished: boolean;
+  signal: AbortSignal | undefined;
+};
+
+/** Attempt-wide trusted receipts, with separately fenced SDK stream generations.
+ * Recovery may start a new stream, never erase an accepted/pending wait. Only
+ * SDK yield selection sets yielded; receipt acceptance alone cannot hide output.
  */
 export class InputWaitYield {
   private accepted = false;
-  // Identity, not name/message/shape, authorizes the SDK boundary exit. Never
-  // swallow a provider/tool failure just because a wait also succeeded.
-  // The SDK's supported max-turn handler is its pre-inference graceful-stop
-  // seam. Treat a committed wait as exhausting this attempt's inference budget,
-  // but recognize this request by identity, never by its error name or text.
+  private didYield = false;
+  private terminal = false;
+  private readonly pending = new Set<Promise<void>>();
+  private scope: StreamScope = {
+    generation: 0,
+    phase: "open",
+    ended: false,
+    finished: false,
+    signal: undefined,
+  };
+  // Recognize our SDK boundary exit by identity, not a provider/tool error's text.
   private readonly boundaryExit = new MaxTurnsExceededError("Runtime input wait yield");
 
   get requested(): boolean {
     return this.accepted;
   }
-
-  recordSuccess(): void {
-    this.accepted = true;
+  get yielded(): boolean {
+    return this.didYield;
   }
 
-  readonly toolUseBehavior: Agent["toolUseBehavior"] = () =>
-    this.accepted
-      ? { isFinalOutput: true, isInterrupted: undefined, finalOutput: "" }
-      : { isFinalOutput: false, isInterrupted: undefined };
-
-  /** Agents SDK 0.14.3 skips toolUseBehavior for native shell-only batches.
-   * Stop those at the existing input-filter seam, before another inference or
-   * host filter. The completed shell receipts already belong to SDK history.
+  /** Explicit SDK invocation boundary. A prior stream must have settled first.
+   * Returned callbacks capture this generation, including across async drains.
+   * Parent terminal closure and an actual yield can never be reopened by retry.
    */
-  readonly modelInputFilter: CallModelInputFilter = ({ modelData }) => {
-    if (this.accepted) throw this.boundaryExit;
-    return modelData;
+  beginStream(signal?: AbortSignal) {
+    if (this.terminal || this.didYield) throw new Error("Input wait attempt is terminal");
+    if (this.scope.signal?.aborted) {
+      this.closeAdmission();
+      throw this.scope.signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+    }
+    if (this.scope.generation > 0 && !this.scope.finished) {
+      throw new Error("Input wait stream is still active");
+    }
+    const scope: StreamScope = {
+      generation: this.scope.generation + 1,
+      phase: "open",
+      ended: false,
+      finished: false,
+      signal,
+    };
+    this.scope = scope;
+    return {
+      modelInputFilter: ((args) => this.filterInput(scope, args)) as CallModelInputFilter,
+      modelDispatchFilter: ((args) => this.dispatch(scope, args)) as CallModelInputFilter,
+      toolUseBehavior: (() => this.finishTools(scope)) as Agent["toolUseBehavior"],
+      errorHandlers: this.errorHandlers(scope),
+      beginToolExecution: () => this.openTools(scope),
+      closeStream: () => this.endStream(scope),
+      endStream: (cancelled = false) => {
+        // SDK iterator cancellation can be independent of the host signal.
+        // A late completion from an older scope cannot cancel its successor.
+        if (cancelled && scope === this.scope) this.closeAdmission();
+        this.endStream(scope);
+        scope.finished = true;
+      },
+    };
+  }
+
+  /** Acquire synchronously BEFORE invoking the trusted remote mutation. Failed
+   * acquisition must not execute it. Completion only changes receipt truth; it
+   * cannot reopen a stream or retrospectively select successful finalization.
+   */
+  beginWait(): (success: boolean) => void {
+    if (this.scope.signal?.aborted) this.endStream(this.scope);
+    if (this.terminal || this.scope.ended || this.scope.phase !== "open") {
+      throw new Error("Input wait was not executed: model dispatch or settlement is sealed");
+    }
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.pending.add(pending);
+    let completed = false;
+    return (success) => {
+      if (completed) return;
+      completed = true;
+      if (success) this.accepted = true;
+      this.pending.delete(pending);
+      release();
+    };
+  }
+
+  /** Irreversible, synchronous attempt-terminal fence. Failure paths call this
+   * before asynchronous persistence without joining remote work or replacing
+   * the original failure. Runtime stream closure uses its narrower scope instead.
+   */
+  readonly closeAdmission = (): void => {
+    this.terminal = true;
+    this.endStream(this.scope);
   };
 
-  /** Use SDK normal finalization, not abort EOF or a replacement stream/state.
-   * Native shell receipts remain in history; the empty terminal output does not.
-   * A genuine SDK turn cap can precede the input filter after the last allowed
-   * shell batch, so a successful wait also takes precedence at that boundary.
+  /** Worker event-processing errors may precede SDK settlement. Capture once
+   * for that stream; invoking this later cannot close a recovery successor.
    */
-  runErrorHandlers(signal?: AbortSignal): RunErrorHandlers<any, any> {
+  captureStreamClose(): () => void {
+    const scope = this.scope;
+    return () => this.endStream(scope);
+  }
+
+  /** Close the attempt and drain receipts before parent terminal persistence.
+   * Cancellation rejects promptly with the existing abort reason; it neither
+   * rolls back the remote mutation nor replaces its durable attempt authority.
+   */
+  async sealForSettlement(signal = this.scope.signal): Promise<void> {
+    this.closeAdmission();
+    await this.drain(this.scope, signal);
+  }
+
+  private endStream(scope: StreamScope): void {
+    scope.phase = "settled";
+    scope.ended = true;
+  }
+
+  private assertCurrent(scope: StreamScope): void {
+    if (this.terminal || scope !== this.scope || scope.ended) {
+      throw new Error("Model dispatch was not executed: input wait gate is settled or superseded");
+    }
+  }
+
+  private openTools(scope: StreamScope): void {
+    if (scope.signal?.aborted) this.endStream(scope);
+    if (!this.terminal && scope === this.scope && !scope.ended && scope.phase === "dispatch") {
+      scope.phase = "open";
+    }
+  }
+
+  private async drain(scope: StreamScope, signal = scope.signal): Promise<void> {
+    if (!signal) {
+      await Promise.all(this.pending);
+      return;
+    }
+    const onAborted = () => {
+      this.endStream(scope);
+      return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+    };
+    if (signal.aborted) throw onAborted();
+    let abort!: () => void;
+    const cancelled = new Promise<never>((_resolve, reject) => {
+      abort = () => reject(onAborted());
+      signal.addEventListener("abort", abort, { once: true });
+    });
+    try {
+      await Promise.race([Promise.all(this.pending), cancelled]);
+      if (signal.aborted) throw onAborted();
+    } finally {
+      signal.removeEventListener("abort", abort);
+    }
+  }
+
+  private filterInput(scope: StreamScope, { modelData }: Parameters<CallModelInputFilter>[0]) {
+    this.assertCurrent(scope);
+    if (this.accepted) throw this.boundaryExit;
+    return modelData;
+  }
+
+  private async dispatch(scope: StreamScope, { modelData }: Parameters<CallModelInputFilter>[0]) {
+    this.assertCurrent(scope);
+    scope.phase = "dispatch";
+    await this.drain(scope);
+    this.assertCurrent(scope);
+    if (this.accepted) throw this.boundaryExit;
+    return modelData;
+  }
+
+  private async finishTools(scope: StreamScope) {
+    this.assertCurrent(scope);
+    scope.phase = "dispatch";
+    try {
+      await this.drain(scope);
+    } catch (error) {
+      // Let the SDK retain its cancelled-stream path, not a new tool failure.
+      if (!scope.signal?.aborted) throw error;
+      return { isFinalOutput: false as const, isInterrupted: undefined };
+    }
+    this.assertCurrent(scope);
+    if (!this.accepted) {
+      this.openTools(scope);
+      return { isFinalOutput: false as const, isInterrupted: undefined };
+    }
+    scope.phase = "settled";
+    this.didYield = true;
+    return { isFinalOutput: true as const, isInterrupted: undefined, finalOutput: "" };
+  }
+
+  private errorHandlers(scope: StreamScope): RunErrorHandlers<any, any> {
     return {
-      maxTurns: ({ error, runData }) => {
-        if (!this.accepted || signal?.aborted) return;
+      maxTurns: async ({ error, runData }) => {
+        if (scope.signal?.aborted || scope !== this.scope || scope.ended || this.terminal) return;
         if (
           error !== this.boundaryExit &&
           (!runData.state ||
@@ -57,8 +215,51 @@ export class InputWaitYield {
             runData.state._currentTurn <= runData.state._maxTurns)
         )
           return;
+        // Native-shell caps precede the input filter. Seal this stream, not the
+        // attempt: a real cap/failure may lead to an explicitly invoked retry.
+        scope.phase = "settled";
+        try {
+          await this.drain(scope);
+        } catch (drainError) {
+          if (!scope.signal?.aborted) throw drainError;
+          return;
+        }
+        if (
+          scope !== this.scope ||
+          scope.ended ||
+          this.terminal ||
+          !this.accepted ||
+          scope.signal?.aborted
+        )
+          return;
+        this.didYield = true;
         return { finalOutput: "", includeInHistory: false };
       },
     };
   }
+
+  // Pre-run/embedding seams also capture the scope when the callback is read.
+  // Keeping one of these callbacks never grants authority over a successor.
+  get beginToolExecution(): () => void {
+    const scope = this.scope;
+    return () => this.openTools(scope);
+  }
+  get modelInputFilter(): CallModelInputFilter {
+    const scope = this.scope;
+    return (args) => this.filterInput(scope, args);
+  }
+  get modelDispatchFilter(): CallModelInputFilter {
+    const scope = this.scope;
+    return (args) => this.dispatch(scope, args);
+  }
+  get toolUseBehavior(): Agent["toolUseBehavior"] {
+    const scope = this.scope;
+    return () => this.finishTools(scope);
+  }
+  runErrorHandlers(signal?: AbortSignal): RunErrorHandlers<any, any> {
+    this.scope.signal = signal;
+    return this.errorHandlers(this.scope);
+  }
 }
+
+export type InputWaitYieldStream = ReturnType<InputWaitYield["beginStream"]>;

--- a/packages/runtime/test/input-wait-yield-races.test.ts
+++ b/packages/runtime/test/input-wait-yield-races.test.ts
@@ -7,6 +7,76 @@ const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false 
 const emptyParameters = { type: "object" as const, properties: {}, additionalProperties: false };
 
 describe("accepted input wait terminal authority", () => {
+  test("stale stream callbacks cannot close or reopen a recovery successor", async () => {
+    const gate = new InputWaitYield();
+    const first = gate.beginStream();
+    const staleClose = gate.captureStreamClose();
+    const staleToolStart = gate.beginToolExecution;
+    await first.modelDispatchFilter({ modelData: {} } as never);
+    staleClose();
+    expect(() => gate.beginStream()).toThrow("still active");
+    first.endStream();
+    const second = gate.beginStream();
+    first.endStream();
+    first.endStream(true);
+    staleClose();
+    const receipt = gate.beginWait();
+    receipt(false); // stale end callbacks did not close the successor
+    await second.modelDispatchFilter({ modelData: {} } as never);
+    first.beginToolExecution();
+    staleToolStart();
+    expect(() => gate.beginWait()).toThrow("sealed");
+    expect(() => first.modelInputFilter({ modelData: {} } as never)).toThrow("superseded");
+    await expect(
+      Promise.resolve(first.modelDispatchFilter({ modelData: {} } as never)),
+    ).rejects.toThrow("superseded");
+    await expect((first.toolUseBehavior as () => Promise<unknown>)()).rejects.toThrow("superseded");
+    second.beginToolExecution();
+    gate.beginWait()(false);
+    expect(gate.yielded).toBe(false);
+    gate.closeAdmission();
+    second.beginToolExecution();
+    expect(() => gate.beginWait()).toThrow("sealed");
+    expect(() => gate.beginStream()).toThrow("terminal");
+  });
+
+  test("an obsolete asynchronous tool drain cannot latch a successor yield", async () => {
+    const gate = new InputWaitYield();
+    const first = gate.beginStream();
+    const complete = gate.beginWait();
+    const oldDrain = (first.toolUseBehavior as () => Promise<unknown>)();
+    first.endStream();
+    const second = gate.beginStream();
+    complete(true);
+    await expect(oldDrain).rejects.toThrow("superseded");
+    expect(gate.requested).toBe(true);
+    expect(gate.yielded).toBe(false);
+    await expect(
+      Promise.resolve(second.modelDispatchFilter({ modelData: {} } as never)),
+    ).rejects.toBeInstanceOf(MaxTurnsExceededError);
+    expect(gate.yielded).toBe(false);
+  });
+
+  test("overlapping SDK streams cannot obtain a new generation", () => {
+    const gate = new InputWaitYield();
+    const first = gate.beginStream();
+    expect(() => gate.beginStream()).toThrow("still active");
+    first.endStream();
+    gate.beginStream();
+    gate.closeAdmission();
+    expect(() => gate.beginStream()).toThrow("terminal");
+  });
+
+  test("a cancelled stream never grants same-attempt retry authority", () => {
+    const gate = new InputWaitYield();
+    const cancellation = new AbortController();
+    const first = gate.beginStream(cancellation.signal);
+    cancellation.abort(new Error("attempt cancelled"));
+    first.endStream();
+    expect(() => gate.beginStream()).toThrow("attempt cancelled");
+    expect(() => gate.beginWait()).toThrow("sealed");
+  });
+
   test("a sibling execution failure remains a failure after wait acceptance", async () => {
     const yieldState = new InputWaitYield();
     const failure = new Error("sibling execution failed");
@@ -21,7 +91,7 @@ describe("accepted input wait terminal authority", () => {
         parameters: emptyParameters,
         strict: false,
         execute: () => {
-          yieldState.recordSuccess();
+          yieldState.beginWait()(true);
           return "wait accepted";
         },
       }),
@@ -45,6 +115,7 @@ describe("accepted input wait terminal authority", () => {
       })(),
     ).rejects.toThrow("sibling execution failed");
     expect(yieldState.requested).toBe(true);
+    expect(yieldState.yielded).toBe(false);
     expect(model.calls).toBe(1);
     expect(stream.error).not.toBeNull();
   });
@@ -63,7 +134,7 @@ describe("accepted input wait terminal authority", () => {
         parameters: emptyParameters,
         strict: false,
         execute: () => {
-          yieldState.recordSuccess();
+          yieldState.beginWait()(true);
           return "wait accepted";
         },
       }),
@@ -84,6 +155,7 @@ describe("accepted input wait terminal authority", () => {
     }
     await stream.completed;
     expect(yieldState.requested).toBe(true);
+    expect(yieldState.yielded).toBe(false);
     expect(model.calls).toBe(1);
     expect(executed).toBe(false);
     expect(stream.interruptions).toHaveLength(1);
@@ -91,15 +163,96 @@ describe("accepted input wait terminal authority", () => {
     expect(JSON.stringify(stream.history)).toContain("wait accepted");
   });
 
-  test("an aborted attempt cannot normalize its accepted wait into successful completion", () => {
+  test("an aborted attempt cannot normalize its accepted wait into successful completion", async () => {
     const yieldState = new InputWaitYield();
-    yieldState.recordSuccess();
+    yieldState.beginWait()(true);
     const controller = new AbortController();
     controller.abort();
     const state = { _maxTurns: 1, _currentTurn: 2 };
     const error = new MaxTurnsExceededError("turn limit");
     Object.assign(error, { state });
     const handler = yieldState.runErrorHandlers(controller.signal).maxTurns!;
-    expect(handler({ error, runData: { state } } as never)).toBeUndefined();
+    expect(await handler({ error, runData: { state } } as never)).toBeUndefined();
+    expect(yieldState.yielded).toBe(false);
   });
+
+  test("settlement drains reservations without claiming yield and cannot reopen", async () => {
+    const gate = new InputWaitYield();
+    const complete = gate.beginWait();
+    let settled = false;
+    const settlement = gate.sealForSettlement().then(() => {
+      settled = true;
+    });
+    expect(() => gate.beginWait()).toThrow("sealed");
+    gate.beginToolExecution();
+    expect(() => gate.beginWait()).toThrow("sealed");
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    complete(true);
+    await settlement;
+    expect(gate.requested).toBe(true);
+    expect(gate.yielded).toBe(false);
+    expect(() => gate.beginWait()).toThrow("sealed");
+  });
+
+  test("a real SDK cap joins pending wait success before selecting yield", async () => {
+    const gate = new InputWaitYield();
+    const complete = gate.beginWait();
+    const state = { _maxTurns: 1, _currentTurn: 2 };
+    const error = new MaxTurnsExceededError("turn limit");
+    Object.assign(error, { state });
+    const handled = gate.runErrorHandlers().maxTurns!({ error, runData: { state } } as never);
+    expect(gate.yielded).toBe(false);
+    expect(() => gate.beginWait()).toThrow("sealed");
+    complete(true);
+    expect(await handled).toEqual({ finalOutput: "", includeInHistory: false });
+    expect(gate.yielded).toBe(true);
+  });
+
+  test("settlement racing the pending dispatch drain cannot permit dispatch", async () => {
+    const gate = new InputWaitYield();
+    const complete = gate.beginWait();
+    const dispatch = gate.modelDispatchFilter({ modelData: {} } as never);
+    const settled = gate.sealForSettlement();
+    complete(false);
+    await expect(Promise.resolve(dispatch)).rejects.toThrow("gate is settled");
+    await settled;
+    expect(gate.yielded).toBe(false);
+  });
+
+  for (const boundary of ["settlement", "dispatch", "tools", "cap"] as const) {
+    test(`cancellation releases a hanging ${boundary} drain without reopening admission`, async () => {
+      const gate = new InputWaitYield();
+      const cancellation = new AbortController();
+      const handlers = gate.runErrorHandlers(cancellation.signal);
+      const complete = gate.beginWait();
+      const state = { _maxTurns: 1, _currentTurn: 2 };
+      const error = new MaxTurnsExceededError("turn limit");
+      Object.assign(error, { state });
+      const pending =
+        boundary === "settlement"
+          ? gate.sealForSettlement(cancellation.signal)
+          : boundary === "dispatch"
+            ? gate.modelDispatchFilter({ modelData: {} } as never)
+            : boundary === "tools"
+              ? (gate.toolUseBehavior as () => unknown)()
+              : handlers.maxTurns!({ error, runData: { state } } as never);
+      cancellation.abort(new Error("attempt cancelled"));
+      if (boundary === "tools") {
+        expect(await pending).toEqual({ isFinalOutput: false, isInterrupted: undefined });
+      } else if (boundary === "cap") {
+        expect(await pending).toBeUndefined();
+      } else {
+        await expect(Promise.resolve(pending)).rejects.toThrow("attempt cancelled");
+      }
+      expect(gate.yielded).toBe(false);
+      // Remote completion is allowed to report truth, never to reopen admission
+      // or retroactively select a successful terminal result after cancellation.
+      complete(true);
+      gate.beginToolExecution();
+      expect(gate.requested).toBe(true);
+      expect(gate.yielded).toBe(false);
+      expect(() => gate.beginWait()).toThrow("sealed");
+    });
+  }
 });

--- a/packages/runtime/test/input-wait-yield-races.test.ts
+++ b/packages/runtime/test/input-wait-yield-races.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { MaxTurnsExceededError, tool } from "@openai/agents";
+import { functionCall, ScriptedModel, testSettings } from "@opengeni/testing";
+import { buildOpenGeniAgent, InputWaitYield, runAgentStream } from "../src/index";
+
+const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+const emptyParameters = { type: "object" as const, properties: {}, additionalProperties: false };
+
+describe("accepted input wait terminal authority", () => {
+  test("a sibling execution failure remains a failure after wait acceptance", async () => {
+    const yieldState = new InputWaitYield();
+    const failure = new Error("sibling execution failed");
+    const model = new ScriptedModel([
+      { output: [functionCall("wait", {}, "wait"), functionCall("sibling", {}, "sibling")] },
+      { error: new Error("must not reach another inference") },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], { model, inputWaitYield: yieldState });
+    agent.tools.push(
+      tool({
+        name: "wait",
+        parameters: emptyParameters,
+        strict: false,
+        execute: () => {
+          yieldState.recordSuccess();
+          return "wait accepted";
+        },
+      }),
+      tool({
+        name: "sibling",
+        parameters: emptyParameters,
+        strict: false,
+        errorFunction: null,
+        execute: () => {
+          throw failure;
+        },
+      }),
+    );
+    const stream = await runAgentStream(agent, "wait", settings);
+    await expect(
+      (async () => {
+        for await (const _event of stream) {
+          /* consume the real SDK stream */
+        }
+        await stream.completed;
+      })(),
+    ).rejects.toThrow("sibling execution failed");
+    expect(yieldState.requested).toBe(true);
+    expect(model.calls).toBe(1);
+    expect(stream.error).not.toBeNull();
+  });
+
+  test("parallel approval remains an interruption rather than normal wait completion", async () => {
+    const yieldState = new InputWaitYield();
+    const model = new ScriptedModel([
+      { output: [functionCall("wait", {}, "wait"), functionCall("approval", {}, "approval")] },
+      { error: new Error("must not reach another inference") },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], { model, inputWaitYield: yieldState });
+    let executed = false;
+    agent.tools.push(
+      tool({
+        name: "wait",
+        parameters: emptyParameters,
+        strict: false,
+        execute: () => {
+          yieldState.recordSuccess();
+          return "wait accepted";
+        },
+      }),
+      tool({
+        name: "approval",
+        parameters: emptyParameters,
+        strict: false,
+        needsApproval: true,
+        execute: () => {
+          executed = true;
+          return "approved";
+        },
+      }),
+    );
+    const stream = await runAgentStream(agent, "wait", settings);
+    for await (const _event of stream) {
+      /* consume the real SDK stream */
+    }
+    await stream.completed;
+    expect(yieldState.requested).toBe(true);
+    expect(model.calls).toBe(1);
+    expect(executed).toBe(false);
+    expect(stream.interruptions).toHaveLength(1);
+    expect(stream.finalOutput).toBeUndefined();
+    expect(JSON.stringify(stream.history)).toContain("wait accepted");
+  });
+
+  test("an aborted attempt cannot normalize its accepted wait into successful completion", () => {
+    const yieldState = new InputWaitYield();
+    yieldState.recordSuccess();
+    const controller = new AbortController();
+    controller.abort();
+    const state = { _maxTurns: 1, _currentTurn: 2 };
+    const error = new MaxTurnsExceededError("turn limit");
+    Object.assign(error, { state });
+    const handler = yieldState.runErrorHandlers(controller.signal).maxTurns!;
+    expect(handler({ error, runData: { state } } as never)).toBeUndefined();
+  });
+});

--- a/packages/runtime/test/input-wait-yield-races.test.ts
+++ b/packages/runtime/test/input-wait-yield-races.test.ts
@@ -7,6 +7,23 @@ const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false 
 const emptyParameters = { type: "object" as const, properties: {}, additionalProperties: false };
 
 describe("accepted input wait terminal authority", () => {
+  for (const acceptFirst of [false, true]) {
+    test(`wait success concurrent with dispatch-drain abort retains cancellation barrier (acceptFirst=${acceptFirst})`, async () => {
+      const gate = new InputWaitYield();
+      const cancellation = new AbortController();
+      const binding = gate.beginStream(cancellation.signal);
+      const complete = gate.beginWait();
+      const dispatch = binding.modelDispatchFilter({ modelData: {} } as never);
+      if (acceptFirst) complete(true);
+      cancellation.abort(new Error("attempt cancelled"));
+      if (!acceptFirst) complete(true);
+      await expect(Promise.resolve(dispatch)).rejects.toBe(cancellation.signal.reason);
+      expect(gate.requested).toBe(true);
+      expect(gate.yielded).toBe(false);
+      expect(() => gate.beginWait()).toThrow("sealed");
+    });
+  }
+
   test("stale stream callbacks cannot close or reopen a recovery successor", async () => {
     const gate = new InputWaitYield();
     const first = gate.beginStream();

--- a/packages/runtime/test/input-wait-yield.test.ts
+++ b/packages/runtime/test/input-wait-yield.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { MaxTurnsExceededError, Runner, shellTool, tool } from "@openai/agents";
+import { SandboxAgent } from "@openai/agents/sandbox";
 import { functionCall, shellCall, ScriptedModel, testSettings } from "@opengeni/testing";
-import { buildOpenGeniAgent, prepareAgentTools, runAgentStream } from "../src/index";
+import {
+  buildOpenGeniAgent,
+  CompactionNeededError,
+  prepareAgentTools,
+  runAgentStream,
+} from "../src/index";
 import { normalizeSdkEvent } from "../src/run-events";
+import { instrumentedModelFetch } from "../src/model-provider-client";
 
-const scope = {
+const attemptScope = {
   accountId: "11111111-1111-4111-8111-111111111111",
   workspaceId: "22222222-2222-4222-8222-222222222222",
   sessionId: "33333333-3333-4333-8333-333333333333",
@@ -24,6 +31,7 @@ async function fixture(
     outcome?: "success" | "error" | "throw";
     deferred?: boolean;
     siblingIsError?: boolean;
+    beforeWaitResult?: () => Promise<void>;
   } = {},
 ) {
   const calls: string[] = [];
@@ -45,7 +53,7 @@ async function fixture(
     ],
   });
   const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: serverId }], {
-    ...scope,
+    ...attemptScope,
     deferNonEagerUntilToolDemand: options.deferred,
     mcpFetchImpl: async (_url, init) => {
       if (init?.method !== "POST") return new Response(null, { status: 405 });
@@ -70,6 +78,7 @@ async function fixture(
           break;
         case "tools/call":
           calls.push(request.params.name);
+          if (request.params.name === "wait_for_input") await options.beforeWaitResult?.();
           if (options.outcome === "throw") {
             return Response.json({
               jsonrpc: "2.0",
@@ -92,84 +101,713 @@ async function fixture(
   return { settings, prepared, calls, serverId };
 }
 
+function gatewayWait(f: Awaited<ReturnType<typeof fixture>>) {
+  return f.prepared.attemptToolEnvironment!.call({
+    operationId: crypto.randomUUID(),
+    catalogDigest: f.prepared.attemptToolCatalog!.digest,
+    identity: { serverId: "opengeni", toolName: "wait_for_input" },
+    arguments: {},
+    caller: { kind: "codemode", subjectId: "agent:test" },
+  });
+}
+
+function ownedSandboxFor(agent: ReturnType<typeof buildOpenGeniAgent>) {
+  expect(agent).toBeInstanceOf(SandboxAgent);
+  // Real SDK provided-session preparation; in-memory physical session, no I/O.
+  return {
+    client: { backendId: "unix_local", serializeSessionState: async () => ({}) },
+    session: {
+      state: { manifest: (agent as unknown as { defaultManifest: unknown }).defaultManifest },
+      exec: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      execCommand: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      createEditor: () => ({}),
+      listDir: async () => [],
+      readFile: async () => "",
+      pathExists: async () => false,
+      materializeEntry: async () => undefined,
+    },
+  };
+}
+
+async function consumeStream(stream: Awaited<ReturnType<typeof runAgentStream>>) {
+  for await (const _event of stream) {
+    /* drain real SDK stream */
+  }
+  await stream.completed;
+}
+
 describe("trusted input wait runtime yield", () => {
-  for (const { maxCalls, outcome, trusted } of [
-    { maxCalls: 1, outcome: "success", trusted: true },
-    { maxCalls: 10, outcome: "success", trusted: true },
-    { maxCalls: 10, outcome: "error", trusted: true },
-    { maxCalls: 10, outcome: "throw", trusted: true },
-    { maxCalls: 10, outcome: "success", trusted: false },
-  ] as const) {
-    test(`native shell Codemode termination (cap=${maxCalls}, outcome=${outcome}, trusted=${trusted})`, async () => {
-      const f = await fixture({ outcome, trusted });
-      f.settings.agentMaxModelCallsPerTurn = maxCalls;
-      const shouldYield = outcome === "success" && trusted;
+  for (const owned of [false, true]) {
+    test(`consumer failure closes admission while real SDK tool execution is stalled (owned=${owned})`, async () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const f = await fixture();
+      if (owned) f.settings.sandboxBackend = "local";
       try {
         const model = new ScriptedModel([
-          { output: [shellCall(["invoke program"], "native-shell-call")] },
-          shouldYield
-            ? { error: new Error("native shell wait must not reach inference again") }
-            : { outputText: "recover" },
+          { output: [functionCall("stall", {})] },
+          { outputText: "recovered answer" },
         ]);
+        const gate = f.prepared.inputWaitYield!;
+        const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+        agent.tools.push(
+          tool({
+            name: "stall",
+            strict: false,
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+            execute: async () => {
+              entered.resolve();
+              await release.promise;
+              return "finished";
+            },
+          }),
+        );
+        const options = owned ? { ownedSandbox: ownedSandboxFor(agent) } : {};
+        const stream = await runAgentStream(agent, "work", f.settings, options);
+        const closeStream = gate.captureStreamClose();
+        const iterator = stream.toStream()[Symbol.asyncIterator]();
+        await entered.promise;
+        let sdkFinished = false;
+        void stream.completed.then(
+          () => {
+            sdkFinished = true;
+          },
+          () => {
+            sdkFinished = true;
+          },
+        );
+        const failure = new Error("consumer event validation failed");
+        let caught: unknown;
+        try {
+          expect((await iterator.next()).done).toBe(false);
+          throw failure;
+        } catch (error) {
+          // This is the worker's first catch action, before asynchronous failure
+          // publication. It must not wait for the still-running tool to finish.
+          closeStream();
+          caught = error;
+        }
+        expect(caught).toBe(failure);
+        expect(sdkFinished).toBe(false);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        expect(f.calls).toEqual([]);
+        await expect(runAgentStream(agent, "overlap", f.settings, options)).rejects.toThrow(
+          "still active",
+        );
+        expect(model.calls).toBe(1);
+        release.resolve();
+        const drain = (async () => {
+          while (!(await iterator.next()).done) {
+            /* drain remainder */
+          }
+          await stream.completed;
+        })();
+        await expect(drain).rejects.toThrow("settled");
+        await expect(stream.completed).rejects.toThrow("settled");
+        expect(sdkFinished).toBe(true);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        expect(f.calls).toEqual([]);
+        expect(gate.yielded).toBe(false);
+        const successor = await runAgentStream(agent, "recover", f.settings, {
+          ...options,
+          callModelInputFilter: ({ modelData }) => {
+            closeStream();
+            return modelData;
+          },
+        });
+        await consumeStream(successor);
+        expect(successor.finalOutput).toBe("recovered answer");
+        expect(model.calls).toBe(2);
+      } finally {
+        release.resolve();
+        await f.prepared.close();
+      }
+    });
+  }
+
+  test("SDK iterator cancellation prevents reuse even when the host signal is not aborted", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const host = new AbortController();
+    const f = await fixture();
+    try {
+      const model = new ScriptedModel([
+        { output: [functionCall("stall", {})] },
+        { error: new Error("cancelled SDK must not dispatch again") },
+      ]);
+      const gate = f.prepared.inputWaitYield!;
+      const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+      agent.tools.push(
+        tool({
+          name: "stall",
+          strict: false,
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          execute: async () => {
+            entered.resolve();
+            await release.promise;
+            return "finished";
+          },
+        }),
+      );
+      const stream = await runAgentStream(agent, "work", f.settings, { signal: host.signal });
+      const iterator = stream.toStream()[Symbol.asyncIterator]();
+      await iterator.next();
+      await entered.promise;
+      await iterator.return!();
+      expect(stream.cancelled).toBe(true);
+      expect(host.signal.aborted).toBe(false);
+      await expect(runAgentStream(agent, "overlap", f.settings)).rejects.toThrow("still active");
+      release.resolve();
+      await stream.completed;
+      await expect(runAgentStream(agent, "retry", f.settings)).rejects.toThrow("terminal");
+      await expect(gatewayWait(f)).rejects.toThrow("sealed");
+      expect(f.calls).toEqual([]);
+      expect(gate.yielded).toBe(false);
+      expect(model.calls).toBe(1);
+    } finally {
+      release.resolve();
+      await f.prepared.close();
+    }
+  });
+
+  for (const owned of [false, true]) {
+    test(`same-agent retry after compaction-needed can dispatch and execute tools (owned=${owned})`, async () => {
+      const f = await fixture();
+      if (owned) f.settings.sandboxBackend = "local";
+      try {
+        const model = new ScriptedModel([
+          { output: [functionCall("opengeni__sibling", {})] },
+          { outputText: "recovered answer" },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          inputWaitYield: f.prepared.inputWaitYield,
+          mcpServers: f.prepared.mcpServers,
+        });
+        const options = owned ? { ownedSandbox: ownedSandboxFor(agent) } : {};
+        const first = await runAgentStream(agent, "answer", f.settings, {
+          ...options,
+          callModelInputFilter: () => {
+            throw new CompactionNeededError({
+              signalTokens: 10,
+              thresholdTokens: 5,
+              signalSource: "provider",
+            });
+          },
+        });
+        await expect(consumeStream(first)).rejects.toBeInstanceOf(CompactionNeededError);
+        expect(model.calls).toBe(0);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        const staleClose = f.prepared.inputWaitYield!.captureStreamClose();
+        const second = await runAgentStream(agent, "compacted input", f.settings, {
+          ...options,
+          callModelInputFilter: ({ modelData }) => {
+            staleClose();
+            return modelData;
+          },
+        });
+        await consumeStream(second);
+        expect(second.finalOutput).toBe("recovered answer");
+        expect(model.calls).toBe(2);
+        expect(f.calls).toEqual(["sibling"]);
+        expect(f.prepared.inputWaitYield!.yielded).toBe(false);
+        await f.prepared.inputWaitYield!.sealForSettlement();
+        await expect(runAgentStream(agent, "too late", f.settings, options)).rejects.toThrow(
+          "terminal",
+        );
+        expect(model.calls).toBe(2);
+      } finally {
+        await f.prepared.close();
+      }
+    });
+
+    for (const outcome of ["success", "error"] as const) {
+      test(`pending external wait survives same-agent recovery: ${outcome} (owned=${owned})`, async () => {
+        const entered = Promise.withResolvers<void>();
+        const release = Promise.withResolvers<void>();
+        const atRetryGate = Promise.withResolvers<void>();
+        const f = await fixture({
+          outcome,
+          beforeWaitResult: async () => {
+            entered.resolve();
+            await release.promise;
+          },
+        });
+        if (owned) f.settings.sandboxBackend = "local";
+        const gate = f.prepared.inputWaitYield!;
+        const begin = gate.beginStream.bind(gate);
+        let streams = 0;
+        const observed = spyOn(gate, "beginStream").mockImplementation((signal) => {
+          const scope = begin(signal);
+          if (++streams === 2) {
+            const dispatch = scope.modelDispatchFilter;
+            scope.modelDispatchFilter = (args) => {
+              const result = dispatch(args);
+              atRetryGate.resolve();
+              return result;
+            };
+          }
+          return scope;
+        });
+        let pending: Promise<unknown> | undefined;
+        try {
+          const model = new ScriptedModel([
+            { output: [functionCall("need_compaction", {})] },
+            { outputText: "recovered answer" },
+          ]);
+          const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+          agent.tools.push(
+            tool({
+              name: "need_compaction",
+              strict: false,
+              errorFunction: null,
+              parameters: { type: "object", properties: {}, additionalProperties: false },
+              execute: async () => {
+                pending = gatewayWait(f).catch(() => undefined);
+                await entered.promise;
+                throw new CompactionNeededError({
+                  signalTokens: 10,
+                  thresholdTokens: 5,
+                  signalSource: "provider",
+                });
+              },
+            }),
+          );
+          const options = owned ? { ownedSandbox: ownedSandboxFor(agent) } : {};
+          const first = await runAgentStream(agent, "wait", f.settings, options);
+          await expect(consumeStream(first)).rejects.toThrow("Context compaction needed");
+          await expect(gatewayWait(f)).rejects.toThrow("sealed");
+          const second = await runAgentStream(agent, "compacted input", f.settings, options);
+          const consumed = consumeStream(second);
+          await atRetryGate.promise;
+          expect(model.calls).toBe(1);
+          expect(gate.requested).toBe(false);
+          await expect(gatewayWait(f)).rejects.toThrow("sealed");
+          release.resolve();
+          await pending;
+          await consumed;
+          expect(second.finalOutput).toBe(outcome === "success" ? "" : "recovered answer");
+          expect(model.calls).toBe(outcome === "success" ? 1 : 2);
+          expect(gate.yielded).toBe(outcome === "success");
+          expect(f.calls).toEqual(["wait_for_input"]);
+        } finally {
+          observed.mockRestore();
+          release.resolve();
+          await pending;
+          await f.prepared.close();
+        }
+      });
+    }
+  }
+
+  for (const owned of [false, true]) {
+    test(`external gateway wait is rejected inside literal transport-start gap (owned=${owned})`, async () => {
+      const f = await fixture();
+      if (owned) f.settings.sandboxBackend = "local";
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      let providerRequests = 0;
+      try {
+        const fetchModel = instrumentedModelFetch("fixture", (async () => {
+          providerRequests++;
+          return Response.json({});
+        }) as typeof fetch);
+        const scripted = new ScriptedModel([{ outputText: "completed answer" }]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          inputWaitYield: f.prepared.inputWaitYield,
+          model: {
+            getResponse: (request) => scripted.getResponse(request),
+            async *getStreamedResponse(request) {
+              await fetchModel("https://provider.example/v1/responses", { method: "POST" });
+              yield* scripted.getStreamedResponse(request);
+            },
+          },
+        });
+        const stream = await runAgentStream(agent, "answer", f.settings, {
+          ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+          onModelTransportStarted: async () => {
+            entered.resolve();
+            await release.promise;
+          },
+        });
+        const consume = (async () => {
+          for await (const _event of stream) {
+            /* drain */
+          }
+          await stream.completed;
+        })();
+        await entered.promise;
+        const wait = () =>
+          f.prepared.attemptToolEnvironment!.call({
+            operationId: crypto.randomUUID(),
+            catalogDigest: f.prepared.attemptToolCatalog!.digest,
+            identity: { serverId: "opengeni", toolName: "wait_for_input" },
+            arguments: {},
+            caller: { kind: "codemode", subjectId: "agent:test" },
+          });
+        await expect(wait()).rejects.toThrow("sealed");
+        expect(f.calls).toEqual([]);
+        expect(providerRequests).toBe(0);
+        release.resolve();
+        await consume;
+        expect(providerRequests).toBe(1);
+        expect(stream.finalOutput).toBe("completed answer");
+        await expect(wait()).rejects.toThrow("sealed");
+        await f.prepared.inputWaitYield!.sealForSettlement();
+        await expect(wait()).rejects.toThrow("sealed");
+        expect(f.calls).toEqual([]);
+        expect(f.prepared.inputWaitYield!.yielded).toBe(false);
+      } finally {
+        release.resolve();
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const owned of [false, true]) {
+    for (const outcome of ["success", "error", "throw"] as const) {
+      test(`model gate joins pending external wait: ${outcome} (owned=${owned})`, async () => {
+        const entered = Promise.withResolvers<void>();
+        const release = Promise.withResolvers<void>();
+        const f = await fixture({
+          outcome,
+          beforeWaitResult: async () => {
+            entered.resolve();
+            await release.promise;
+          },
+        });
+        if (owned) f.settings.sandboxBackend = "local";
+        const atGate = Promise.withResolvers<void>();
+        const gate = f.prepared.inputWaitYield!;
+        const begin = gate.beginStream.bind(gate);
+        const observed = spyOn(gate, "beginStream").mockImplementation((signal) => {
+          const scope = begin(signal);
+          const dispatch = scope.modelDispatchFilter;
+          scope.modelDispatchFilter = (args) => {
+            const pending = dispatch(args);
+            atGate.resolve();
+            return pending;
+          };
+          return scope;
+        });
+        try {
+          const wait = f.prepared
+            .attemptToolEnvironment!.call({
+              operationId: crypto.randomUUID(),
+              catalogDigest: f.prepared.attemptToolCatalog!.digest,
+              identity: { serverId: "opengeni", toolName: "wait_for_input" },
+              arguments: {},
+              caller: { kind: "codemode", subjectId: "agent:test" },
+            })
+            .catch(() => undefined);
+          await entered.promise;
+          const model = new ScriptedModel([{ outputText: "normal answer" }]);
+          const agent = buildOpenGeniAgent(f.settings, [], {
+            model,
+            inputWaitYield: f.prepared.inputWaitYield,
+          });
+          const stream = await runAgentStream(agent, "answer", f.settings, {
+            ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+          });
+          const consume = (async () => {
+            for await (const _event of stream) {
+              /* drain */
+            }
+            await stream.completed;
+          })();
+          await atGate.promise;
+          expect(model.calls).toBe(0);
+          expect(gate.requested).toBe(false);
+          await expect(gatewayWait(f)).rejects.toThrow("sealed");
+          expect(f.calls).toEqual(["wait_for_input"]);
+          release.resolve();
+          await wait;
+          await consume;
+          expect(model.calls).toBe(outcome === "success" ? 0 : 1);
+          expect(f.prepared.inputWaitYield!.yielded).toBe(outcome === "success");
+          expect(stream.finalOutput).toBe(outcome === "success" ? "" : "normal answer");
+        } finally {
+          observed.mockRestore();
+          release.resolve();
+          await f.prepared.close();
+        }
+      });
+    }
+  }
+
+  for (const pendingOutcome of [undefined, "success", "error"] as const) {
+    test(`fatal runner tool error closes external wait admission (pending=${pendingOutcome})`, async () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const f = await fixture({
+        ...(pendingOutcome ? { outcome: pendingOutcome } : {}),
+        beforeWaitResult: async () => {
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      let pending: Promise<unknown> | undefined;
+      try {
+        const model = new ScriptedModel([{ output: [functionCall("fatal", {})] }]);
         const agent = buildOpenGeniAgent(f.settings, [], {
           model,
           inputWaitYield: f.prepared.inputWaitYield,
         });
         agent.tools.push(
+          tool({
+            name: "fatal",
+            strict: false,
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+            errorFunction: null,
+            execute: async () => {
+              if (pendingOutcome) {
+                pending = gatewayWait(f).catch(() => undefined);
+                await entered.promise;
+              }
+              throw new Error("original fatal tool failure");
+            },
+          }),
+        );
+        const stream = await runAgentStream(agent, "fail", f.settings);
+        await expect(consumeStream(stream)).rejects.toThrow("original fatal tool failure");
+        // Attempt immediately on reader failure, before a worker completion
+        // check or any explicit closeAdmission/sealForSettlement call.
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        await expect(stream.completed).rejects.toThrow("original fatal tool failure");
+        expect(f.calls).toEqual(pendingOutcome ? ["wait_for_input"] : []);
+        expect(f.prepared.inputWaitYield!.yielded).toBe(false);
+        release.resolve();
+        await pending;
+        expect(f.prepared.inputWaitYield!.requested).toBe(pendingOutcome === "success");
+        expect(f.prepared.inputWaitYield!.yielded).toBe(false);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        expect(model.calls).toBe(1);
+      } finally {
+        release.resolve();
+        await pending;
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const outcome of ["success", "error"] as const) {
+    test(`real native-shell SDK cap joins unresolved external wait: ${outcome}`, async () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const atCap = Promise.withResolvers<void>();
+      const f = await fixture({
+        outcome,
+        beforeWaitResult: async () => {
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      f.settings.agentMaxModelCallsPerTurn = 1;
+      const gate = f.prepared.inputWaitYield!;
+      const begin = gate.beginStream.bind(gate);
+      const observed = spyOn(gate, "beginStream").mockImplementation((signal) => {
+        const scope = begin(signal);
+        const maxTurns = scope.errorHandlers.maxTurns!;
+        scope.errorHandlers.maxTurns = (args) => {
+          const pending = maxTurns(args);
+          atCap.resolve();
+          return pending;
+        };
+        return scope;
+      });
+      let pending: Promise<unknown> | undefined;
+      try {
+        const model = new ScriptedModel([{ output: [shellCall(["external wait"], "shell")] }]);
+        const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+        agent.tools.push(
           shellTool({
             shell: {
               run: async () => {
-                await f.prepared.attemptToolEnvironment!.call({
-                  operationId: "66666666-6666-4666-8666-666666666666",
-                  catalogDigest: f.prepared.attemptToolCatalog!.digest,
-                  identity: { serverId: "opengeni", toolName: "wait_for_input" },
-                  arguments: {},
-                  caller: { kind: "codemode", subjectId: "agent:test" },
-                });
+                pending = gatewayWait(f).catch(() => undefined);
+                await entered.promise;
                 return {
                   output: [
-                    {
-                      stdout: "program receipt",
-                      stderr: "",
-                      outcome: { type: "exit", exitCode: 0 },
-                    },
+                    { stdout: "submitted", stderr: "", outcome: { type: "exit", exitCode: 0 } },
                   ],
                 };
               },
             },
           }),
         );
-        let hostFilterCalls = 0;
-        const stream = await runAgentStream(agent, "wait", f.settings, {
-          callModelInputFilter: ({ modelData }) => {
-            hostFilterCalls += 1;
-            return modelData;
-          },
-        });
-        const normalized = [];
-        for await (const event of stream.toStream()) normalized.push(...normalizeSdkEvent(event));
-        await stream.completed;
-        expect(model.calls).toBe(shouldYield ? 1 : 2);
-        expect(hostFilterCalls).toBe(shouldYield ? 1 : 2);
-        expect(stream.finalOutput).toBe(shouldYield ? "" : "recover");
-        expect(stream.error).toBeNull();
-        expect(stream.cancelled).toBe(false);
-        const outputs = stream.history.filter((item) => item.type === "shell_call_output");
-        expect(outputs).toHaveLength(1);
-        if (outcome !== "throw") expect(JSON.stringify(outputs)).toContain("program receipt");
-        expect(JSON.stringify(outputs)).toContain("native-shell-call");
-        expect(
-          stream.history.filter((item) => item.type === "message" && item.role === "assistant"),
-        ).toHaveLength(shouldYield ? 0 : 1);
-        if (shouldYield) {
-          expect(
-            normalized.filter((event) => event.type === "agent.message.completed"),
-          ).toHaveLength(0);
+        const stream = await runAgentStream(agent, "wait", f.settings);
+        const finished = consumeStream(stream).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        await atCap.promise;
+        expect(gate.requested).toBe(false);
+        expect(gate.yielded).toBe(false);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        release.resolve();
+        await pending;
+        const error = await finished;
+        if (outcome === "success") {
+          expect(error).toBeNull();
+          expect(stream.finalOutput).toBe("");
+        } else {
+          expect(error).toBeInstanceOf(MaxTurnsExceededError);
+          await expect(stream.completed).rejects.toBeInstanceOf(MaxTurnsExceededError);
         }
+        expect(gate.yielded).toBe(outcome === "success");
+        expect(model.calls).toBe(1);
       } finally {
+        observed.mockRestore();
+        release.resolve();
+        await pending;
         await f.prepared.close();
       }
     });
+  }
+
+  test("real runner cancellation releases an unresolved external gateway wait drain", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const atDrain = Promise.withResolvers<void>();
+    const cancellation = new AbortController();
+    const f = await fixture({
+      beforeWaitResult: async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    });
+    const gate = f.prepared.inputWaitYield!;
+    const begin = gate.beginStream.bind(gate);
+    const observed = spyOn(gate, "beginStream").mockImplementation((signal) => {
+      const scope = begin(signal);
+      const behavior = scope.toolUseBehavior as (...args: any[]) => Promise<any>;
+      scope.toolUseBehavior = (...args: any[]) => {
+        const result = behavior(...args);
+        atDrain.resolve();
+        return result;
+      };
+      return scope;
+    });
+    let pending: Promise<unknown> | undefined;
+    try {
+      const model = new ScriptedModel([{ output: [functionCall("start_wait", {})] }]);
+      const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+      agent.tools.push(
+        tool({
+          name: "start_wait",
+          strict: false,
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          execute: async () => {
+            pending = gatewayWait(f).catch(() => undefined);
+            await entered.promise;
+            return "submitted";
+          },
+        }),
+      );
+      const stream = await runAgentStream(agent, "wait", f.settings, {
+        signal: cancellation.signal,
+      });
+      const consumed = consumeStream(stream);
+      await atDrain.promise;
+      cancellation.abort(new Error("turn cancelled"));
+      await consumed;
+      expect(stream.cancelled).toBe(true);
+      expect(gate.yielded).toBe(false);
+      expect(gate.requested).toBe(false);
+      await expect(gatewayWait(f)).rejects.toThrow("sealed");
+      release.resolve();
+      await pending;
+      expect(gate.requested).toBe(true);
+      expect(gate.yielded).toBe(false);
+      expect(model.calls).toBe(1);
+    } finally {
+      observed.mockRestore();
+      release.resolve();
+      await pending;
+      await f.prepared.close();
+    }
+  });
+
+  for (const owned of [false, true]) {
+    for (const { maxCalls, outcome, trusted } of [
+      { maxCalls: 1, outcome: "success", trusted: true },
+      { maxCalls: 10, outcome: "success", trusted: true },
+      { maxCalls: 10, outcome: "error", trusted: true },
+      { maxCalls: 10, outcome: "throw", trusted: true },
+      { maxCalls: 10, outcome: "success", trusted: false },
+    ] as const) {
+      test(`native shell Codemode termination (cap=${maxCalls}, outcome=${outcome}, trusted=${trusted}, owned=${owned})`, async () => {
+        const f = await fixture({ outcome, trusted });
+        if (owned) f.settings.sandboxBackend = "local";
+        f.settings.agentMaxModelCallsPerTurn = maxCalls;
+        const shouldYield = outcome === "success" && trusted;
+        try {
+          const model = new ScriptedModel([
+            { output: [shellCall(["invoke program"], "native-shell-call")] },
+            shouldYield
+              ? { error: new Error("native shell wait must not reach inference again") }
+              : { outputText: "recover" },
+          ]);
+          const agent = buildOpenGeniAgent(f.settings, [], {
+            model,
+            inputWaitYield: f.prepared.inputWaitYield,
+          });
+          agent.tools.push(
+            shellTool({
+              shell: {
+                run: async () => {
+                  await f.prepared.attemptToolEnvironment!.call({
+                    operationId: "66666666-6666-4666-8666-666666666666",
+                    catalogDigest: f.prepared.attemptToolCatalog!.digest,
+                    identity: { serverId: "opengeni", toolName: "wait_for_input" },
+                    arguments: {},
+                    caller: { kind: "codemode", subjectId: "agent:test" },
+                  });
+                  return {
+                    output: [
+                      {
+                        stdout: "program receipt",
+                        stderr: "",
+                        outcome: { type: "exit", exitCode: 0 },
+                      },
+                    ],
+                  };
+                },
+              },
+            }),
+          );
+          let hostFilterCalls = 0;
+          const stream = await runAgentStream(agent, "wait", f.settings, {
+            ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+            callModelInputFilter: ({ modelData }) => {
+              hostFilterCalls += 1;
+              return modelData;
+            },
+          });
+          const normalized = [];
+          for await (const event of stream.toStream()) normalized.push(...normalizeSdkEvent(event));
+          await stream.completed;
+          expect(model.calls).toBe(shouldYield ? 1 : 2);
+          expect(hostFilterCalls).toBe(shouldYield ? 1 : 2);
+          expect(stream.finalOutput).toBe(shouldYield ? "" : "recover");
+          expect(stream.error).toBeNull();
+          expect(stream.cancelled).toBe(false);
+          const outputs = stream.history.filter((item) => item.type === "shell_call_output");
+          expect(outputs).toHaveLength(1);
+          if (outcome !== "throw") expect(JSON.stringify(outputs)).toContain("program receipt");
+          expect(JSON.stringify(outputs)).toContain("native-shell-call");
+          expect(
+            stream.history.filter((item) => item.type === "message" && item.role === "assistant"),
+          ).toHaveLength(shouldYield ? 0 : 1);
+          if (shouldYield) {
+            expect(
+              normalized.filter((event) => event.type === "agent.message.completed"),
+            ).toHaveLength(0);
+          }
+        } finally {
+          await f.prepared.close();
+        }
+      });
+    }
   }
 
   for (const { deferred, siblingIsError } of [
@@ -481,7 +1119,7 @@ describe("trusted input wait runtime yield", () => {
       ],
     });
     const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "opengeni" }], {
-      ...scope,
+      ...attemptScope,
       localMcpServers: [
         {
           id: "opengeni",

--- a/packages/runtime/test/input-wait-yield.test.ts
+++ b/packages/runtime/test/input-wait-yield.test.ts
@@ -138,6 +138,155 @@ async function consumeStream(stream: Awaited<ReturnType<typeof runAgentStream>>)
 
 describe("trusted input wait runtime yield", () => {
   for (const owned of [false, true]) {
+    test(`repeated same-agent recovery keeps one capture per model call and stable wrapper (owned=${owned})`, async () => {
+      const f = await fixture();
+      f.settings.lazyToolSearchEnabled = false;
+      if (owned) f.settings.sandboxBackend = "local";
+      try {
+        const compaction = new CompactionNeededError({
+          signalTokens: 10,
+          thresholdTokens: 5,
+          signalSource: "provider",
+        });
+        const model = new ScriptedModel([
+          { error: compaction },
+          { error: compaction },
+          { outputText: "recovered answer" },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          inputWaitYield: f.prepared.inputWaitYield,
+        });
+        let captures = 0;
+        let wrappedModel: typeof agent.model | undefined;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const stream = await runAgentStream(agent, "recover", f.settings, {
+            onModelVisibleContext: () => {
+              captures++;
+            },
+            ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+          });
+          if (attempt < 2) {
+            await expect(consumeStream(stream)).rejects.toBeInstanceOf(CompactionNeededError);
+          } else {
+            await consumeStream(stream);
+            expect(stream.finalOutput).toBe("recovered answer");
+          }
+          if (attempt === 0) wrappedModel = agent.model;
+          expect(agent.model).toBe(wrappedModel);
+          expect(captures).toBe(attempt + 1);
+          expect(model.calls).toBe(attempt + 1);
+          expect(f.prepared.inputWaitYield!.yielded).toBe(false);
+        }
+      } finally {
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const owned of [false, true]) {
+    for (const accepted of [false, true]) {
+      test(`pre-aborted runner preserves cancellation and accepted-wait barrier (owned=${owned}, accepted=${accepted})`, async () => {
+        const f = await fixture();
+        if (owned) f.settings.sandboxBackend = "local";
+        try {
+          if (accepted) await gatewayWait(f);
+          const cancellation = new AbortController();
+          cancellation.abort(new Error("synthetic cancelled continuation"));
+          const model = new ScriptedModel([
+            { outputText: "cancelled response must not become a final answer" },
+            { error: new Error("cancelled SDK must not request another response") },
+          ]);
+          const gate = f.prepared.inputWaitYield!;
+          const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+          const stream = await runAgentStream(agent, "continue", f.settings, {
+            signal: cancellation.signal,
+            ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+          });
+          if (accepted) {
+            await expect(consumeStream(stream)).rejects.toBe(cancellation.signal.reason);
+            expect(stream.error).toBe(cancellation.signal.reason);
+            expect(model.calls).toBe(0);
+          } else {
+            await consumeStream(stream);
+            expect(stream.error).toBeNull();
+            // Only the no-wait path retains the SDK's native aborted adapter.
+            expect(model.calls).toBe(1);
+            expect(model.requests[0]?.signal?.aborted).toBe(true);
+          }
+          expect(stream.cancelled).toBe(true);
+          expect(stream.finalOutput).toBeUndefined();
+          expect(gate.requested).toBe(accepted);
+          expect(gate.yielded).toBe(false);
+          await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        } finally {
+          await f.prepared.close();
+        }
+      });
+    }
+
+    test(`abort during pending dispatch drain cannot dispatch before late wait success (owned=${owned})`, async () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const atGate = Promise.withResolvers<void>();
+      const cancellation = new AbortController();
+      const f = await fixture({
+        beforeWaitResult: async () => {
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      if (owned) f.settings.sandboxBackend = "local";
+      const gate = f.prepared.inputWaitYield!;
+      const begin = gate.beginStream.bind(gate);
+      const observed = spyOn(gate, "beginStream").mockImplementation((signal) => {
+        const binding = begin(signal);
+        const dispatch = binding.modelDispatchFilter;
+        binding.modelDispatchFilter = (args) => {
+          const result = dispatch(args);
+          atGate.resolve();
+          return result;
+        };
+        return binding;
+      });
+      const pending = gatewayWait(f);
+      try {
+        await entered.promise;
+        const model = new ScriptedModel([
+          { outputText: "cancelled response must not become a final answer" },
+          { error: new Error("cancelled SDK must not request another response") },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], { model, inputWaitYield: gate });
+        const stream = await runAgentStream(agent, "continue", f.settings, {
+          signal: cancellation.signal,
+          ...(owned ? { ownedSandbox: ownedSandboxFor(agent) } : {}),
+        });
+        const consumed = consumeStream(stream);
+        await atGate.promise;
+        cancellation.abort(new Error("cancelled while draining wait"));
+        await expect(consumed).rejects.toBe(cancellation.signal.reason);
+        expect(stream.cancelled).toBe(true);
+        expect(stream.error).toBe(cancellation.signal.reason);
+        expect(stream.finalOutput).toBeUndefined();
+        expect(model.calls).toBe(0);
+        expect(gate.requested).toBe(false);
+        expect(gate.yielded).toBe(false);
+        await expect(gatewayWait(f)).rejects.toThrow("sealed");
+        release.resolve();
+        await pending;
+        expect(gate.requested).toBe(true);
+        expect(gate.yielded).toBe(false);
+        expect(model.calls).toBe(0);
+      } finally {
+        observed.mockRestore();
+        release.resolve();
+        await pending;
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const owned of [false, true]) {
     test(`consumer failure closes admission while real SDK tool execution is stalled (owned=${owned})`, async () => {
       const entered = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();

--- a/packages/runtime/test/input-wait-yield.test.ts
+++ b/packages/runtime/test/input-wait-yield.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, test } from "bun:test";
+import { MaxTurnsExceededError, Runner, shellTool, tool } from "@openai/agents";
+import { functionCall, shellCall, ScriptedModel, testSettings } from "@opengeni/testing";
+import { buildOpenGeniAgent, prepareAgentTools, runAgentStream } from "../src/index";
+import { normalizeSdkEvent } from "../src/run-events";
+
+const scope = {
+  accountId: "11111111-1111-4111-8111-111111111111",
+  workspaceId: "22222222-2222-4222-8222-222222222222",
+  sessionId: "33333333-3333-4333-8333-333333333333",
+  turnId: "44444444-4444-4444-8444-444444444444",
+  attemptId: "55555555-5555-4555-8555-555555555555",
+  executionGeneration: 1,
+};
+const receipt = {
+  content: [{ type: "text", text: "canonical wait receipt" }],
+  structuredContent: { status: "waiting_for_input", operationId: "wait-operation" },
+};
+
+async function fixture(
+  options: {
+    trusted?: boolean;
+    serverId?: string;
+    outcome?: "success" | "error" | "throw";
+    deferred?: boolean;
+    siblingIsError?: boolean;
+  } = {},
+) {
+  const calls: string[] = [];
+  const serverId = options.serverId ?? "opengeni";
+  const settings = testSettings({
+    sandboxBackend: "none",
+    webSearchEnabled: false,
+    lazyToolSearchEnabled: true,
+    integrationsAllowPrivateNetworkTargets: true,
+    mcpServers: [
+      {
+        id: serverId,
+        url:
+          options.trusted === false
+            ? "http://127.0.0.1:9876/third-party"
+            : "http://127.0.0.1:8000/v1/workspaces/{workspaceId}/mcp",
+        cacheToolsList: false,
+      },
+    ],
+  });
+  const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: serverId }], {
+    ...scope,
+    deferNonEagerUntilToolDemand: options.deferred,
+    mcpFetchImpl: async (_url, init) => {
+      if (init?.method !== "POST") return new Response(null, { status: 405 });
+      const request = JSON.parse(String(init.body));
+      if (request.id === undefined) return new Response(null, { status: 202 });
+      let result: unknown;
+      switch (request.method) {
+        case "initialize":
+          result = {
+            protocolVersion: "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: { name: "fixture", version: "1" },
+          };
+          break;
+        case "tools/list":
+          result = {
+            tools: ["wait_for_input", "sibling"].map((name) => ({
+              name,
+              inputSchema: { type: "object", properties: {}, additionalProperties: false },
+            })),
+          };
+          break;
+        case "tools/call":
+          calls.push(request.params.name);
+          if (options.outcome === "throw") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: request.id,
+              error: { code: -32603, message: "fixture execution failed" },
+            });
+          }
+          result =
+            options.outcome === "error" ||
+            (options.siblingIsError && request.params.name === "sibling")
+              ? { ...receipt, isError: true }
+              : receipt;
+          break;
+        default:
+          throw new Error(`Unexpected MCP method: ${request.method}`);
+      }
+      return Response.json({ jsonrpc: "2.0", id: request.id, result });
+    },
+  });
+  return { settings, prepared, calls, serverId };
+}
+
+describe("trusted input wait runtime yield", () => {
+  for (const { maxCalls, outcome, trusted } of [
+    { maxCalls: 1, outcome: "success", trusted: true },
+    { maxCalls: 10, outcome: "success", trusted: true },
+    { maxCalls: 10, outcome: "error", trusted: true },
+    { maxCalls: 10, outcome: "throw", trusted: true },
+    { maxCalls: 10, outcome: "success", trusted: false },
+  ] as const) {
+    test(`native shell Codemode termination (cap=${maxCalls}, outcome=${outcome}, trusted=${trusted})`, async () => {
+      const f = await fixture({ outcome, trusted });
+      f.settings.agentMaxModelCallsPerTurn = maxCalls;
+      const shouldYield = outcome === "success" && trusted;
+      try {
+        const model = new ScriptedModel([
+          { output: [shellCall(["invoke program"], "native-shell-call")] },
+          shouldYield
+            ? { error: new Error("native shell wait must not reach inference again") }
+            : { outputText: "recover" },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          inputWaitYield: f.prepared.inputWaitYield,
+        });
+        agent.tools.push(
+          shellTool({
+            shell: {
+              run: async () => {
+                await f.prepared.attemptToolEnvironment!.call({
+                  operationId: "66666666-6666-4666-8666-666666666666",
+                  catalogDigest: f.prepared.attemptToolCatalog!.digest,
+                  identity: { serverId: "opengeni", toolName: "wait_for_input" },
+                  arguments: {},
+                  caller: { kind: "codemode", subjectId: "agent:test" },
+                });
+                return {
+                  output: [
+                    {
+                      stdout: "program receipt",
+                      stderr: "",
+                      outcome: { type: "exit", exitCode: 0 },
+                    },
+                  ],
+                };
+              },
+            },
+          }),
+        );
+        let hostFilterCalls = 0;
+        const stream = await runAgentStream(agent, "wait", f.settings, {
+          callModelInputFilter: ({ modelData }) => {
+            hostFilterCalls += 1;
+            return modelData;
+          },
+        });
+        const normalized = [];
+        for await (const event of stream.toStream()) normalized.push(...normalizeSdkEvent(event));
+        await stream.completed;
+        expect(model.calls).toBe(shouldYield ? 1 : 2);
+        expect(hostFilterCalls).toBe(shouldYield ? 1 : 2);
+        expect(stream.finalOutput).toBe(shouldYield ? "" : "recover");
+        expect(stream.error).toBeNull();
+        expect(stream.cancelled).toBe(false);
+        const outputs = stream.history.filter((item) => item.type === "shell_call_output");
+        expect(outputs).toHaveLength(1);
+        if (outcome !== "throw") expect(JSON.stringify(outputs)).toContain("program receipt");
+        expect(JSON.stringify(outputs)).toContain("native-shell-call");
+        expect(
+          stream.history.filter((item) => item.type === "message" && item.role === "assistant"),
+        ).toHaveLength(shouldYield ? 0 : 1);
+        if (shouldYield) {
+          expect(
+            normalized.filter((event) => event.type === "agent.message.completed"),
+          ).toHaveLength(0);
+        }
+      } finally {
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const { deferred, siblingIsError } of [
+    { deferred: false, siblingIsError: false },
+    { deferred: true, siblingIsError: false },
+    { deferred: false, siblingIsError: true },
+  ]) {
+    test(`direct MCP terminates after one model step and retains parallel receipts (deferred=${deferred}, sibling error=${siblingIsError})`, async () => {
+      const f = await fixture({ deferred, siblingIsError });
+      try {
+        const model = new ScriptedModel([
+          {
+            output: [
+              deferred
+                ? functionCall(
+                    "tool_invoke",
+                    { name: "opengeni__wait_for_input", arguments: {} },
+                    "wait-call",
+                  )
+                : functionCall("opengeni__wait_for_input", {}, "wait-call"),
+              functionCall("opengeni__sibling", {}, "sibling-call"),
+            ],
+          },
+          { error: new Error("a successful wait must never request another model step") },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          mcpServers: f.prepared.mcpServers,
+          inputWaitYield: f.prepared.inputWaitYield,
+          ...(deferred
+            ? {
+                lazyToolTransport: "generic_dispatch",
+                toolPreparationReady: f.prepared.ready!.then(() => undefined),
+              }
+            : {}),
+        });
+        const stream = await runAgentStream(agent, "wait", f.settings);
+        const events = [];
+        for await (const event of stream) events.push(event);
+        await stream.completed;
+        expect(model.calls).toBe(1);
+        expect(stream.finalOutput).toBe("");
+        expect(stream.cancelled).toBe(false);
+        expect(stream.error).toBeNull();
+        expect(f.prepared.inputWaitYield?.requested).toBe(true);
+        expect(f.calls.sort()).toEqual(["sibling", "wait_for_input"]);
+        const outputs = stream.history.filter((item) => item.type === "function_call_result");
+        expect(outputs).toHaveLength(2);
+        expect(JSON.stringify(outputs)).toContain("canonical wait receipt");
+        expect(JSON.stringify(outputs)).toContain("wait-call");
+        expect(JSON.stringify(outputs)).toContain("sibling-call");
+        if (siblingIsError) {
+          const sibling = outputs.find((item) => item.callId === "sibling-call");
+          const output = sibling?.output as { type: "text"; text: string };
+          expect(JSON.parse(output.text).isError).toBe(true);
+        }
+        expect(
+          stream.history.filter((item) => item.type === "message" && item.role === "assistant"),
+        ).toHaveLength(0);
+        expect(events.length).toBeGreaterThan(0);
+        if (f.prepared.ready) {
+          expect((await f.prepared.ready).inputWaitYield).toBe(f.prepared.inputWaitYield);
+        }
+      } finally {
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const outcome of ["success", "error", "throw"] as const) {
+    test(`Codemode gateway ${outcome} uses the same receipt and runner termination boundary`, async () => {
+      const f = await fixture({ outcome });
+      try {
+        const model = new ScriptedModel([
+          { output: [functionCall("execute_program", {}, "program-call")] },
+          { outputText: "recover" },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          inputWaitYield: f.prepared.inputWaitYield,
+        });
+        let result: unknown;
+        agent.tools.push(
+          tool({
+            name: "execute_program",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+            strict: false,
+            execute: async () => {
+              [result] = await Promise.all([
+                f.prepared.attemptToolEnvironment!.call({
+                  operationId: "66666666-6666-4666-8666-666666666666",
+                  catalogDigest: f.prepared.attemptToolCatalog!.digest,
+                  identity: { serverId: "opengeni", toolName: "wait_for_input" },
+                  arguments: {},
+                  caller: { kind: "codemode", subjectId: "agent:test" },
+                }),
+                f.prepared.attemptToolEnvironment!.call({
+                  operationId: "77777777-7777-4777-8777-777777777777",
+                  catalogDigest: f.prepared.attemptToolCatalog!.digest,
+                  identity: { serverId: "opengeni", toolName: "sibling" },
+                  arguments: {},
+                  caller: { kind: "codemode", subjectId: "agent:test" },
+                }),
+              ]);
+              // Program stdout is unrelated to (and need not contain) the wait receipt.
+              return "program finished";
+            },
+          }),
+        );
+        const stream = await new Runner({ tracingDisabled: true }).run(agent, "wait", {
+          stream: true,
+        });
+        for await (const _event of stream) {
+          /* drain normal SDK history */
+        }
+        await stream.completed;
+        expect(model.calls).toBe(outcome === "success" ? 1 : 2);
+        expect(f.prepared.inputWaitYield?.requested).toBe(outcome === "success");
+        if (outcome === "success") expect(result).toEqual(receipt);
+        expect(JSON.stringify(stream.history)).toContain("program-call");
+      } finally {
+        await f.prepared.close();
+      }
+    });
+  }
+
+  for (const options of [
+    { outcome: "error" as const },
+    { outcome: "throw" as const },
+    { trusted: false },
+    { trusted: false, serverId: "third_party" },
+  ]) {
+    test(`failed or spoofed direct MCP does not yield: ${JSON.stringify(options)}`, async () => {
+      const f = await fixture(options);
+      try {
+        const model = new ScriptedModel([
+          { output: [functionCall(`${f.serverId}__wait_for_input`, {})] },
+          { outputText: "recover" },
+        ]);
+        const agent = buildOpenGeniAgent(f.settings, [], {
+          model,
+          mcpServers: f.prepared.mcpServers,
+          inputWaitYield: f.prepared.inputWaitYield,
+        });
+        const result = await new Runner({ tracingDisabled: true }).run(agent, "wait");
+        expect(result.finalOutput).toBe("recover");
+        expect(model.calls).toBe(2);
+        expect(f.prepared.inputWaitYield?.requested).toBe(false);
+      } finally {
+        await f.prepared.close();
+      }
+    });
+  }
+
+  test("unrelated trusted tool cannot yield by returning a wait-shaped result", async () => {
+    const f = await fixture();
+    try {
+      const model = new ScriptedModel([
+        { output: [functionCall("opengeni__sibling", {})] },
+        { outputText: "continue" },
+      ]);
+      const agent = buildOpenGeniAgent(f.settings, [], {
+        model,
+        mcpServers: f.prepared.mcpServers,
+        inputWaitYield: f.prepared.inputWaitYield,
+      });
+      await new Runner({ tracingDisabled: true }).run(agent, "continue");
+      expect(model.calls).toBe(2);
+      expect(f.prepared.inputWaitYield?.requested).toBe(false);
+    } finally {
+      await f.prepared.close();
+    }
+  });
+
+  test("a tool throwing an SDK-shaped yield error remains failed even after a successful wait", async () => {
+    const f = await fixture();
+    try {
+      const model = new ScriptedModel([{ output: [functionCall("program", {})] }]);
+      const agent = buildOpenGeniAgent(f.settings, [], {
+        model,
+        inputWaitYield: f.prepared.inputWaitYield,
+      });
+      const failure = new MaxTurnsExceededError("Runtime input wait yield");
+      agent.tools.push(
+        tool({
+          name: "program",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          strict: false,
+          errorFunction: null,
+          execute: async () => {
+            await f.prepared.attemptToolEnvironment!.callModel({
+              modelName: "opengeni__wait_for_input",
+              arguments: {},
+              subjectId: "agent:test",
+            });
+            throw failure;
+          },
+        }),
+      );
+      const stream = await runAgentStream(agent, "wait", f.settings);
+      await expect(
+        (async () => {
+          for await (const _event of stream) {
+            /* drain */
+          }
+        })(),
+      ).rejects.toThrow();
+      await expect(stream.completed).rejects.toThrow();
+      expect(f.prepared.inputWaitYield?.requested).toBe(true);
+      expect(stream.error).not.toBeNull();
+      expect(stream.finalOutput).toBeUndefined();
+      expect(model.calls).toBe(1);
+    } finally {
+      await f.prepared.close();
+    }
+  });
+
+  test("a Codemode wait arriving during a host filter still prevents the next inference", async () => {
+    const f = await fixture();
+    try {
+      const model = new ScriptedModel([
+        { output: [functionCall("opengeni__sibling", {}, "completed-before-wait")] },
+        { error: new Error("a wait accepted during preparation must prevent inference") },
+      ]);
+      const agent = buildOpenGeniAgent(f.settings, [], {
+        model,
+        mcpServers: f.prepared.mcpServers,
+        inputWaitYield: f.prepared.inputWaitYield,
+      });
+      let filters = 0;
+      const stream = await runAgentStream(agent, "wait", f.settings, {
+        callModelInputFilter: async ({ modelData }) => {
+          if (++filters === 2) {
+            await f.prepared.attemptToolEnvironment!.call({
+              operationId: "66666666-6666-4666-8666-666666666666",
+              catalogDigest: f.prepared.attemptToolCatalog!.digest,
+              identity: { serverId: "opengeni", toolName: "wait_for_input" },
+              arguments: {},
+              caller: { kind: "codemode", subjectId: "agent:test" },
+            });
+          }
+          return modelData;
+        },
+      });
+      for await (const _event of stream) {
+        /* drain */
+      }
+      await stream.completed;
+      expect(model.calls).toBe(1);
+      expect(filters).toBe(2);
+      expect(stream.error).toBeNull();
+      expect(stream.finalOutput).toBe("");
+      expect(JSON.stringify(stream.history)).toContain("completed-before-wait");
+    } finally {
+      await f.prepared.close();
+    }
+  });
+
+  test("cancellation after accepted wait retains cancellation authority", async () => {
+    const f = await fixture();
+    try {
+      const cancellation = new AbortController();
+      const model = new ScriptedModel([{ output: [functionCall("program", {})] }]);
+      const agent = buildOpenGeniAgent(f.settings, [], {
+        model,
+        inputWaitYield: f.prepared.inputWaitYield,
+      });
+      agent.tools.push(
+        tool({
+          name: "program",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          strict: false,
+          execute: async () => {
+            await f.prepared.attemptToolEnvironment!.callModel({
+              modelName: "opengeni__wait_for_input",
+              arguments: {},
+              subjectId: "agent:test",
+            });
+            cancellation.abort(new Error("turn cancelled"));
+            return "program complete";
+          },
+        }),
+      );
+      const stream = await runAgentStream(agent, "wait", f.settings, {
+        signal: cancellation.signal,
+      });
+      for await (const _event of stream) {
+        /* drain */
+      }
+      await stream.completed;
+      expect(f.prepared.inputWaitYield?.requested).toBe(true);
+      expect(stream.cancelled).toBe(true);
+      expect(model.calls).toBe(1);
+    } finally {
+      await f.prepared.close();
+    }
+  });
+
+  test("a local server impersonating the first-party registry receives no yield authority", async () => {
+    const settings = testSettings({
+      sandboxBackend: "none",
+      webSearchEnabled: false,
+      mcpServers: [
+        {
+          id: "opengeni",
+          url: "http://127.0.0.1:8000/v1/workspaces/{workspaceId}/mcp",
+          cacheToolsList: false,
+        },
+      ],
+    });
+    const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "opengeni" }], {
+      ...scope,
+      localMcpServers: [
+        {
+          id: "opengeni",
+          server: {
+            name: "opengeni",
+            cacheToolsList: false,
+            async connect() {},
+            async close() {},
+            async invalidateToolsCache() {},
+            async listTools() {
+              return [{ name: "wait_for_input", inputSchema: { type: "object", properties: {} } }];
+            },
+            async callTool() {
+              return receipt;
+            },
+          },
+        },
+      ],
+    });
+    try {
+      const model = new ScriptedModel([
+        { output: [functionCall("opengeni__wait_for_input", {})] },
+        { outputText: "continue" },
+      ]);
+      const agent = buildOpenGeniAgent(settings, [], {
+        model,
+        mcpServers: prepared.mcpServers,
+        inputWaitYield: prepared.inputWaitYield,
+      });
+      const stream = await runAgentStream(agent, "wait", settings);
+      for await (const _event of stream) {
+        /* drain */
+      }
+      await stream.completed;
+      expect(model.calls).toBe(2);
+      expect(prepared.inputWaitYield?.requested).toBe(false);
+    } finally {
+      await prepared.close();
+    }
+  });
+});

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1012,7 +1012,7 @@ describe("API component integration", () => {
     }>(mcp, "wait_for_input", waitArgs);
     expect(held).toMatchObject({ status: "waiting_for_input", replay: false });
     expect(new Date(held.deadlineAt).getTime()).toBeGreaterThan(Date.now() + 800_000);
-    expect(held.nextAction).toContain("End your turn now");
+    expect(held.nextAction).toContain("runtime yields this turn");
     const heldReplay = await callMcpTool<{ replay: boolean; deadlineAt: string }>(
       mcp,
       "wait_for_input",


### PR DESCRIPTION
## Summary

Make successful first-party `wait_for_input` a runtime-enforced turn boundary,
instead of depending on the model to obey an instruction to stop.

- Trusted direct MCP, deferred dispatch, and Codemode share attempt-local wait
  acceptance. The runner stops after the settled tool batch without another
  model request. Native-shell-only batches use the supported SDK input-filter
  and finalization hooks, including the model-call-cap boundary.
- Preserve canonical tool receipts and parallel results. Normal worker
  settlement does not require or emit a fabricated assistant final message.
  Cancellation, fatal sibling failures, and approvals retain their authority.
- Keep the first same-turn deadline and reason across fresh operation keys,
  concurrent calls, and recovery. Do not emit a second wait-start event or
  advance the workflow wake for a duplicate wait.
- Update API guidance, lifecycle documentation, and the runtime changeset.

## Validation

- 294 tests passed across runtime wait/yield, authority races, worker turn and
  terminal handling, and durable goal/wait lifecycle suites.
- 11 command/control algebra tests passed, including background result delivery
  and pause fencing.
- API session-lifecycle MCP integration passed.
- Runtime, worker, API, and database type checks passed. Targeted lint,
  documentation references, and public repository hygiene checks passed.
- Duplicate-deadline regression reproduced the original defect before the
  source fix; both input-before-settlement and input-after-settlement pass.
- Independent source review traced external Codemode through the actual
  attempt dispatcher and verified the shared acceptance state.

Already-running tools drain normally. This change does not cancel background
commands, resume paused sessions, or promise deployment simply from merging.
Native-shell behavior is covered against the pinned Agents SDK 0.14.3.

Responsible agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/1c7d1a07-58e9-4d94-b8ac-eecf09a1d133

## Summary by Sourcery

Enforce trusted `wait_for_input` as a runtime-controlled turn boundary while preserving tool settlement, lifecycle authority, and durable wait semantics.

Bug Fixes:
- Enforce a runtime turn boundary after successful trusted `wait_for_input` calls so execution stops without another model request.
- Preserve first-turn wait deadlines and reasons across duplicate calls, concurrent operations, and recovery attempts.
- Maintain cancellation, approval, fatal-error, and tool-settlement authority while preventing stale or untrusted callbacks from triggering a yield.

Enhancements:
- Share trusted wait acceptance across direct MCP, deferred dispatch, Codemode, and native-shell execution paths.
- Preserve canonical tool receipts and parallel results while allowing normal worker completion without a fabricated assistant message.
- Add runtime lifecycle guidance describing enforced wait boundaries, recovery behavior, and deadline semantics.

Documentation:
- Document the runtime-enforced `wait_for_input` boundary in architecture, lifecycle, API guidance, and agent instructions.

Tests:
- Add comprehensive runtime, worker, database, and integration coverage for wait-yield behavior, authority races, recovery, cancellation, terminal handling, duplicate deadlines, and native-shell model-call caps.

Chores:
- Add a runtime patch changeset for the enforced input-wait yield behavior.