### PR TITLE
fix(web): keep healthy Variable Set notes inside the picker

### DIFF
--- a/apps/web/src/components/personal-resource-attachment-control.test.tsx
+++ b/apps/web/src/components/personal-resource-attachment-control.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { PersonalResourceAttachmentController } from "@/lib/use-personal-resource-attachment";
+import { PersonalResourceAttachmentControl } from "./personal-resource-attachment-control";
+
+function controller(
+  overrides: Partial<PersonalResourceAttachmentController> = {},
+): PersonalResourceAttachmentController {
+  return {
+    eligible: true,
+    loading: false,
+    refreshing: false,
+    error: null,
+    notice: null,
+    sourceLost: false,
+    truncated: false,
+    catalog: null,
+    selected: {
+      variableSets: [],
+      rigs: [],
+      connectedMachines: [{ enrollmentId: "machine-1", name: "My machine" }],
+      resourceCount: 1,
+      personalResourceCount: 1,
+      closureUnverified: false,
+    },
+    mode: "once",
+    visibility: "workspace",
+    requiresDecision: false,
+    intent: undefined,
+    refresh: async () => undefined,
+    onAccepted: () => undefined,
+    onDeliveryError: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("PersonalResourceAttachmentControl", () => {
+  test("does not add passive personal-resource copy above the composer", () => {
+    expect(
+      renderToStaticMarkup(<PersonalResourceAttachmentControl controller={controller()} compact />),
+    ).toBe("");
+  });
+
+  test("keeps actionable recovery states visible", () => {
+    const markup = renderToStaticMarkup(
+      <PersonalResourceAttachmentControl
+        controller={controller({ error: new Error("catalog unavailable") })}
+        compact
+      />,
+    );
+
+    expect(markup).toContain("The selected personal resource is unavailable");
+    expect(markup).toContain("Retry");
+  });
+});

--- a/apps/web/src/components/personal-resource-attachment-control.tsx
+++ b/apps/web/src/components/personal-resource-attachment-control.tsx
@@ -10,49 +10,35 @@ export function PersonalResourceAttachmentControl(props: {
   compact?: boolean;
 }) {
   const { controller } = props;
-  if (
-    !controller.eligible ||
-    (!controller.loading &&
-      controller.selected.resourceCount === 0 &&
-      !controller.sourceLost &&
-      !controller.error &&
-      !controller.truncated)
-  ) {
+  // Healthy selections are already described inside their pickers. Keep the
+  // composer-top surface for transient or actionable status only.
+  const hasVisibleStatus =
+    controller.loading ||
+    controller.notice !== null ||
+    controller.error !== null ||
+    controller.truncated;
+  if (!controller.eligible || !hasVisibleStatus) {
     return null;
   }
   const disabled = props.disabled || controller.loading || controller.refreshing;
-  const names = [
-    ...controller.selected.variableSets.map((resource) => `Variable set: ${resource.name}`),
-    ...controller.selected.rigs.map((resource) => `Rig: ${resource.name}`),
-    ...controller.selected.connectedMachines.map(
-      (resource) => `Connected machine: ${resource.name}`,
-    ),
-  ];
   return (
     <div
       data-personal-resource-attachment
-      className={cn("min-w-0", props.compact ? "mt-2" : "mt-4")}
+      className={cn("min-w-0 space-y-2", props.compact ? "mt-2" : "mt-4")}
       aria-busy={controller.loading || controller.refreshing}
     >
       {controller.loading ? (
         <p role="status" className="text-xs text-fg-subtle">
           Loading selected personal resources…
         </p>
-      ) : controller.selected.resourceCount > 0 ? (
-        <p className="text-xs text-fg-muted">
-          {names.join(" · ")}{" "}
-          {controller.visibility === "private"
-            ? "is available in this private session."
-            : "will be used only for messages you send. Other members may see the result, but cannot use your credential."}
-        </p>
       ) : null}
       {controller.notice ? (
-        <p className="mt-2 text-xs text-fg-muted" role="status" aria-live="polite">
+        <p className="text-xs text-fg-muted" role="status" aria-live="polite">
           {controller.notice}
         </p>
       ) : null}
       {controller.error ? (
-        <div className="mt-2 flex items-center justify-between gap-3" role="alert">
+        <div className="flex items-center justify-between gap-3" role="alert">
           <span className="text-xs text-danger">
             The selected personal resource is unavailable. Retry, or open Variable Sets to replace
             or remove it.
@@ -70,7 +56,7 @@ export function PersonalResourceAttachmentControl(props: {
         </div>
       ) : null}
       {controller.truncated ? (
-        <p className="mt-2 text-2xs text-fg-subtle" role="status">
+        <p className="text-2xs text-fg-subtle" role="status">
           Showing the first 400 personal resources of each supported type.
         </p>
       ) : null}

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -182,11 +182,15 @@ describe("session control surface architecture", () => {
       "const busy = props.busy || props.goalActive || props.voiceActive",
     );
     expect(establishedPicker).toContain("End voice mode before changing Variable Sets.");
+    expect(establishedPicker).toContain(
+      "Only-me Variable Sets are used only for messages you send.",
+    );
     expect(establishedControl).not.toContain('value: "once"');
     expect(establishedControl).not.toContain('value: "session"');
     expect(establishedControl).not.toContain('value: "always"');
     expect(establishedControl).not.toContain('type="checkbox"');
-    expect(establishedControl).toContain("is available in this private session");
+    expect(establishedControl).not.toContain("is available in this private session");
+    expect(establishedControl).not.toContain("will be used only for messages you send");
   });
 
   test("announces pin results through an independent live region", async () => {

--- a/test/e2e/personal-resource-attachments.browser.e2e.ts
+++ b/test/e2e/personal-resource-attachments.browser.e2e.ts
@@ -51,17 +51,10 @@ describe("personal resource attachments in Chromium", () => {
     await Promise.allSettled([browserContext?.close(), browser?.close(), web?.stop()]);
   }, 30_000);
 
-  test("create and Send/Steer use automatic message-only authority plus exact shared warning", async () => {
+  test("create and Send/Steer retain message-only authority without passive composer copy", async () => {
     const control = page.locator("[data-personal-resource-attachment]");
-    expect(await control.first().ariaSnapshot()).toContain("Private deploy keys");
-    expect(await control.first().locator("fieldset").count()).toBe(0);
-    expect(await control.first().getByText("Your resource access").count()).toBe(0);
-    expect(await control.first().getByRole("radiogroup").count()).toBe(0);
-    expect(await control.first().getByRole("radio").count()).toBe(0);
-    expect(await control.first().getByRole("checkbox").count()).toBe(0);
+    expect(await control.count()).toBe(0);
     expect(await page.getByRole("button", { name: "Create session" }).isDisabled()).toBe(false);
-    expect(await control.first().textContent()).toContain("used only for messages you send");
-    expect(await control.first().textContent()).toContain("cannot use your credential");
     await page.getByRole("button", { name: "Create session" }).click();
     expect(JSON.parse((await page.getByTestId("create-receipt").textContent()) ?? "{}")).toEqual({
       mode: "once",


### PR DESCRIPTION
Healthy personal Variable Set selections currently add a persistent note above the composer even though the picker already explains who can use the credentials. Keep that explanation inside the picker and reserve the composer status area for loading, access changes, errors, and retry actions.

This recovers the existing preserved implementation branch. Personal-resource authority, Send/Steer receipts, and recovery fencing remain unchanged.

Validation: 44 component/hook/surface tests pass. Chromium acceptance passes both tests, including unchanged message-only authority receipts, source-loss and principal-transition fencing, and accessibility checks.

Tracked in OPE-435. Independent review and CI remain required before merge.

## Summary by Sourcery

Keep healthy personal-resource explanations inside the picker and reserve the composer status area for actionable attachment states.

Bug Fixes:
- Remove passive personal-resource status text from above the composer while preserving actionable loading, notice, error, and truncation states.

Enhancements:
- Keep healthy Variable Set access explanations within the picker and retain existing personal-resource authority behavior.

Tests:
- Add component coverage for suppressing healthy composer copy and preserving retry states.
- Update surface and Chromium acceptance tests to verify picker-local explanations and the absence of passive composer status.