### PR TITLE
fix(runtime): recover safe MCP setup socket loss

### DIFF
--- a/.changeset/mcp-setup-socket-recovery.md
+++ b/.changeset/mcp-setup-socket-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Recover typed Undici socket disconnections during safe first-party MCP initialization and tool discovery, while preserving terminal authentication failures and avoiding retries of tool invocations.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5524,6 +5524,7 @@ function inspectMcpTransportError(
   complete: boolean;
   hasConnectionClosed: boolean;
   hasConnectivityCode: boolean;
+  hasSetupSocketCode: boolean;
   hasConnectivityMarker: boolean;
   hasTypedError: boolean;
   hasRequestTimeout: boolean;
@@ -5535,6 +5536,7 @@ function inspectMcpTransportError(
   const statuses: number[] = [];
   let hasConnectionClosed = false;
   let hasConnectivityCode = false;
+  let hasSetupSocketCode = false;
   let hasConnectivityMarker = false;
   let hasTypedError = false;
   let hasRequestTimeout = false;
@@ -5582,6 +5584,7 @@ function inspectMcpTransportError(
         statuses.push(value);
       }
     }
+    if (code === "UND_ERR_SOCKET") hasSetupSocketCode = true;
     if (typeof code === "string" && MCP_CONNECTIVITY_ERROR_CODES.has(code.toUpperCase())) {
       hasConnectivityCode = true;
     }
@@ -5631,6 +5634,7 @@ function inspectMcpTransportError(
     complete,
     hasConnectionClosed,
     hasConnectivityCode,
+    hasSetupSocketCode,
     hasConnectivityMarker,
     hasTypedError,
     hasRequestTimeout,
@@ -5673,7 +5677,12 @@ function isRawMcpTransportConnectivityError(
   if (options.recoverySafeSetup === true && inspection.statuses.includes(404)) {
     return true;
   }
-  if (inspection.hasConnectivityCode) {
+  // Undici's typed socket loss is safe to recover only during the explicit
+  // first-party initialize/tools-list boundary, never after a tool invocation.
+  if (
+    inspection.hasConnectivityCode ||
+    (options.recoverySafeSetup === true && inspection.hasSetupSocketCode)
+  ) {
     return true;
   }
   // The MCP SDK can erase the transport's socket code while wrapping a failed

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3952,13 +3952,9 @@ export async function prepareAgentTools(
             // The upstream transport logger receives raw thrown errors, whose
             // messages may contain response bodies, URLs, headers, or echoed
             // credentials. Keep its diagnostic surface structural only.
-            logger: mcpTransportLogger(config.id, {
-              // Codex Apps setup is a read-only initialize/tools-list handshake.
-              // A statusless transport failure is safe to retry, while auth
-              // responses remain non-retryable and publish their specific
-              // reconnect reason through codexAppsAuthFetch.
-              recoverySafeSetup: isCodexAppsMcpServer(config),
-            }),
+            // This logger spans tool invocation as well as setup. Only the
+            // connect/list lifecycle wrappers may add setup-safe recovery facts.
+            logger: mcpTransportLogger(config.id),
             // codex_apps returns connector tools with empty `outputSchema: {}` that the
             // MCP SDK's strict Tool schema rejects (fails the turn during tools/list);
             // sanitize the response on the wire before validation. The namespace Set
@@ -5766,7 +5762,7 @@ function exactMcpLifecycleError(error: unknown, options: McpTransportErrorOption
   return exactError;
 }
 
-function mcpTransportLogger(serverId: string, options: McpTransportErrorOptions = {}) {
+function mcpTransportLogger(serverId: string) {
   const logFailure = (_message: string, ...args: unknown[]) => {
     let error: unknown;
     for (let index = args.length - 1; index >= 0; index -= 1) {
@@ -5777,7 +5773,7 @@ function mcpTransportLogger(serverId: string, options: McpTransportErrorOptions 
     }
     console.warn(
       "[mcp] transport operation failed",
-      mcpErrorFields(error, "mcp_transport_failed", serverId, options),
+      mcpErrorFields(error, "mcp_transport_failed", serverId),
     );
   };
   return {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -354,6 +354,75 @@ test("recovers only rollout-safe first-party MCP setup 404 and statusless Error 
   expect(routeNotReady.message).toContain("secret detail");
 });
 
+test("recovers typed Undici socket loss only at the safe MCP setup boundary", () => {
+  class SocketError extends Error {
+    readonly code = "UND_ERR_SOCKET";
+  }
+  const socketFailure = () =>
+    new TypeError("fetch failed", { cause: new SocketError("other side closed") });
+  const setupError = socketFailure();
+  expect(mcpTransportErrorWithRetryMetadata(setupError, { recoverySafeSetup: true })).toBe(
+    setupError,
+  );
+  expect(isMcpTransportConnectivityError(setupError)).toBe(true);
+  expect(isMcpTransportConnectivityError(mcpTransportErrorWithRetryMetadata(socketFailure()))).toBe(
+    false,
+  );
+  const rejected = Object.assign(socketFailure(), { status: 401 });
+  expect(
+    isMcpTransportConnectivityError(
+      mcpTransportErrorWithRetryMetadata(rejected, { recoverySafeSetup: true }),
+    ),
+  ).toBe(false);
+  expect(
+    isMcpTransportConnectivityError(
+      mcpTransportErrorWithRetryMetadata(new TypeError("invalid protocol"), {
+        recoverySafeSetup: true,
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("preserves socket setup recovery through the MCP lifecycle wrapper", async () => {
+  class SocketError extends Error {
+    readonly code = "UND_ERR_SOCKET";
+  }
+  const exact = new TypeError("fetch failed", { cause: new SocketError("other side closed") });
+  let connects = 0;
+  const inner: MCPServer = {
+    name: "setup-socket",
+    cacheToolsList: false,
+    async connect() {
+      connects += 1;
+      throw exact;
+    },
+    async close() {},
+    async listTools() {
+      return [];
+    },
+    async callTool() {
+      return [];
+    },
+  };
+  const server = new PrefixedMcpServer(
+    inner,
+    "opengeni",
+    undefined,
+    false,
+    undefined,
+    "opengeni",
+    true,
+  );
+  const failure = await server.connect().then(
+    () => undefined,
+    (error: Error) => error,
+  );
+  expect(failure).toBeDefined();
+  expect(server.unwrapLifecycleError(failure!, "connect")).toBe(exact);
+  expect(isMcpTransportConnectivityError(exact)).toBe(true);
+  expect(connects).toBe(1);
+});
+
 describe("structured human-input runtime boundary", () => {
   const interruption = {
     name: HUMAN_INPUT_TOOL_NAME,


### PR DESCRIPTION
A socket disconnect during first-party MCP initialization or tool discovery produced a typed Undici error that escaped the setup recovery classifier, terminalizing a durable turn. Recognize `UND_ERR_SOCKET` only at the existing recovery-safe setup boundary. Authentication failures, typed protocol errors, and tool invocation failures keep their existing behavior; the wrapper performs no retry itself.

Reproduced using an HTTP endpoint that closes its socket during MCP initialization, Node's actual fetch transport, and the production MCP lifecycle wrapper. Before the change the setup error had no recovery marker; afterward both public diagnostics and the unwrapped original error retain retryable setup classification.

Validation: runtime suite 310 passed (1,213 assertions); worker MCP tests 12 passed (42 assertions); runtime typecheck, focused lint and diff checks passed. Clean current-main merge-tree verified without changing the candidate.

Focused recovery follow-up under [OPE-18](https://linear.app/cloudgeni/issue/OPE-18/clean-session-control-plane-prompt-queue-steer-pause-updates-and). This does not close the broader control-plane issue or claim repair of already-stalled live attempts.

## Summary by Sourcery

Recover safe first-party MCP setup from typed socket disconnects while preserving existing handling for authentication, protocol, and tool invocation failures.

Bug Fixes:
- Recover typed Undici socket disconnections during first-party MCP initialization and tool discovery without retrying tool invocations.
- Preserve retryable setup classification through MCP lifecycle error wrapping while keeping authentication and protocol failures non-retryable.

Tests:
- Add coverage for setup-boundary socket recovery, lifecycle error unwrapping, and preservation of existing failure behavior.