### PR TITLE
fix(react): restore goal timeline landmarks in production bundles

### DIFF
--- a/.changeset/quiet-goal-landmarks.md
+++ b/.changeset/quiet-goal-landmarks.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Resolve goal landmark icons when rendered so circular production chunks cannot leave continuation rows permanently unavailable.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -3400,41 +3400,46 @@ type GoalMeta = { label: string; pill: string; icon: ComponentType<{ className?:
 
 const NEUTRAL_PILL = "border-og-border bg-og-surface-1 text-og-fg-muted";
 
-const GOAL_META: Record<GoalItem["action"], GoalMeta> = {
-  set: {
-    label: "Goal set",
-    pill: "border-og-accent/30 bg-og-accent/10 text-og-accent",
-    icon: TargetIcon,
-  },
-  updated: { label: "Goal updated", pill: NEUTRAL_PILL, icon: PencilLineIcon },
-  completed: {
-    label: "Goal completed",
-    pill: "border-og-status-idle/30 bg-og-status-idle/10 text-og-status-idle",
-    icon: CheckIcon,
-  },
-  paused: {
-    label: "Goal paused",
-    pill: WAITING_PILL_CLASS,
-    icon: PauseIcon,
-  },
-  resumed: { label: "Goal resumed", pill: NEUTRAL_PILL, icon: PlayIcon },
-  cleared: { label: "Goal cleared", pill: NEUTRAL_PILL, icon: Trash2Icon },
-  held: {
-    label: "Goal held",
-    pill: WAITING_PILL_CLASS,
-    icon: PauseCircleIcon,
-  },
-  continuation: { label: "Continuing toward the goal", pill: NEUTRAL_PILL, icon: ArrowRightIcon },
-};
+// Shared production chunks can be cyclic. Resolve icon bindings during render,
+// after their modules initialize, rather than permanently capturing undefined.
+function goalMeta(action: GoalItem["action"]): GoalMeta {
+  const metadata: Record<GoalItem["action"], GoalMeta> = {
+    set: {
+      label: "Goal set",
+      pill: "border-og-accent/30 bg-og-accent/10 text-og-accent",
+      icon: TargetIcon,
+    },
+    updated: { label: "Goal updated", pill: NEUTRAL_PILL, icon: PencilLineIcon },
+    completed: {
+      label: "Goal completed",
+      pill: "border-og-status-idle/30 bg-og-status-idle/10 text-og-status-idle",
+      icon: CheckIcon,
+    },
+    paused: {
+      label: "Goal paused",
+      pill: WAITING_PILL_CLASS,
+      icon: PauseIcon,
+    },
+    resumed: { label: "Goal resumed", pill: NEUTRAL_PILL, icon: PlayIcon },
+    cleared: { label: "Goal cleared", pill: NEUTRAL_PILL, icon: Trash2Icon },
+    held: {
+      label: "Goal held",
+      pill: WAITING_PILL_CLASS,
+      icon: PauseCircleIcon,
+    },
+    continuation: { label: "Continuing toward the goal", pill: NEUTRAL_PILL, icon: ArrowRightIcon },
+  };
+  return metadata[action];
+}
 
 /**
  * A goal landmark pill. Resolves its label, accent/tone, and glyph from
- * {@link GOAL_META} so all six actions are visually distinguishable while the
+ * {@link goalMeta} so all six actions are visually distinguishable while the
  * palette stays restrained — see that table for the per-action rationale.
  */
 function GoalRow({ item }: { item: GoalItem }) {
   const enter = useEntranceAnimation();
-  const { label, pill, icon: Icon } = GOAL_META[item.action];
+  const { label, pill, icon: Icon } = goalMeta(item.action);
   return (
     <div className={cn(enter && "animate-og-enter", "flex justify-center")}>
       <span

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import AxeBuilder from "@axe-core/playwright";
 import {
   createDb,
+  appendSessionEvents,
   createSession,
   grantWorkspaceAccess,
   removeWorkspaceMember,
@@ -143,6 +144,53 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await api?.stop(false);
     await dbClient?.close().catch(() => undefined);
     await shared?.release();
+  }, 60_000);
+
+  test("renders goal landmarks through the production session chunk graph", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (
+        message.type() === "error" &&
+        /React error|Element type is invalid/.test(message.text())
+      ) {
+        errors.push(message.text());
+      }
+    });
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const session = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Goal landmark production proof",
+      );
+      await appendSessionEvents(dbClient.db, workspaceId, session.id, [
+        { type: "goal.set", payload: { text: "Review the candidate" } },
+        { type: "goal.held", payload: { reason: "Waiting for review" } },
+        { type: "goal.continuation", payload: { text: "Review the candidate" } },
+      ]);
+      // A fresh page follows the same lazy route import order as the stock app.
+      // Isolated MessageTimeline builds do not reproduce this chunk cycle.
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${session.id}`);
+      await page
+        .getByText("Continuing toward the goal: Review the candidate", { exact: true })
+        .waitFor();
+      expect(await page.getByText("Timeline item unavailable", { exact: true }).count()).toBe(0);
+      expect(errors).toEqual([]);
+      const landmark = page.getByText("Continuing toward the goal: Review the candidate", {
+        exact: true,
+      });
+      expect(await landmark.locator("..").locator("svg").count()).toBe(1);
+    } finally {
+      await context.close();
+    }
   }, 60_000);
 
   test("keeps the selected session grouping after a page refresh", async () => {


### PR DESCRIPTION
Goal continuation landmarks can render as “Timeline item unavailable” in the production web app. A cycle among shared chunks initializes the timeline's module-level metadata before its imported icon component, permanently capturing `undefined` and causing React error 130.

Resolve the icon binding when the goal row renders, after module initialization. Event payloads and history remain unchanged. This restores the existing goal landmarks without hiding rendering failures.

Validation: the added browser test uses the full production app, real API, and non-superuser PostgreSQL. It fails on current main because the continuation never appears, then passes with this fix, verifying visible text and glyph, no unavailable cards, and no React errors. The original staging orchestrator independently reproduces the error; an isolated component build does not exercise the shared chunk cycle.

Tracks [OPE-437](https://linear.app/cloudgeni/issue/OPE-437/fix-unavailable-goal-timeline-rows-in-the-production-bundle).

## Summary by Sourcery

Restore reliable rendering of goal timeline landmarks in production bundles.

Bug Fixes:
- Restore goal timeline landmarks in production bundles by resolving their icons after module initialization, preventing unavailable continuation rows and React rendering errors.

Tests:
- Add a production-app browser test covering goal landmark text, icon rendering, unavailable-card absence, and React error reporting.