### PR TITLE
fix(web): explain pre-claim failures without reusing old provider errors

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1582,6 +1582,55 @@ describe("summarizeSessionFailure", () => {
     );
   });
 
+  test("reports an unclaimed failure instead of reusing a previous provider rejection", () => {
+    const failure = {
+      ...event(3, "session.status.changed", {
+        status: "failed",
+        code: "pre_claim_failure",
+        failedSystemUpdateIds: ["update-1"],
+      }),
+      turnId: null,
+    };
+    const summary = summarizeSessionFailure(
+      [
+        {
+          ...event(1, "turn.failed", { code: "provider_safety_refusal", error: "Old rejection" }),
+          turnId: "previous-turn",
+        },
+        event(2, "session.status.changed", { status: "queued" }),
+        failure,
+      ],
+      "failed",
+    );
+    expect(summary.reason).toBe(
+      "The session failed before a turn could start. No error details were recorded.",
+    );
+    expect(summary.safetyRefusal).toBe(false);
+    expect(summary.failedAt).toBe(failure.occurredAt);
+    expect(summary.failedTurnCount).toBe(1);
+  });
+
+  test("keeps the detailed same-turn failure paired with its pre-claim status", () => {
+    const summary = summarizeSessionFailure(
+      [
+        {
+          ...event(1, "turn.failed", {
+            code: "pre_claim_failure",
+            error: "Database connection lost",
+          }),
+          turnId: "failed-turn",
+        },
+        {
+          ...event(2, "session.status.changed", { status: "failed", code: "pre_claim_failure" }),
+          turnId: "failed-turn",
+        },
+      ],
+      "failed",
+    );
+    expect(summary.reason).toBe("Database connection lost");
+    expect(summary.failedTurnCount).toBe(1);
+  });
+
   test("reports nothing for a clean session", () => {
     expect(summarizeSessionFailure([event(1, "user.message", { text: "hi" })], "failed")).toEqual({
       reason: null,

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -60,7 +60,7 @@ export function projectSessionTimeline(
 }
 
 export type SessionFailureSummary = {
-  /** Human-readable reason from the most recent turn.failed event, if any. */
+  /** Human-readable reason from the latest recorded failure boundary, if any. */
   reason: string | null;
   safetyRefusal?: boolean;
   /** When the most recent failure happened. */
@@ -84,12 +84,14 @@ export function summarizeSessionFailure(
   let failedAt: string | null = null;
   let recoveryCount = 0;
   let failedTurnCount = 0;
+  let latestFailedTurnId: string | null = null;
   for (const event of events) {
     if (event.type === "turn.recovery.requested") {
       recoveryCount += 1;
     }
     if (event.type === "turn.failed") {
       failedTurnCount += 1;
+      latestFailedTurnId = event.turnId ?? null;
       const payload =
         event.payload && typeof event.payload === "object" && !Array.isArray(event.payload)
           ? (event.payload as Record<string, unknown>)
@@ -98,6 +100,24 @@ export function summarizeSessionFailure(
       reason = presentation.reason;
       safetyRefusal = presentation.safetyRefusal;
       failedAt = event.occurredAt;
+    }
+    if (event.type === "session.status.changed") {
+      const payload = event.payload as Record<string, unknown>;
+      if (
+        payload?.status === "failed" &&
+        payload.code === "pre_claim_failure" &&
+        (!event.turnId || event.turnId !== latestFailedTurnId)
+      ) {
+        // An unclaimed machine update has no turn.failed event. Its status is a
+        // new failure boundary, never evidence that an older provider error
+        // happened again. Preserve a paired same-turn diagnostic when present.
+        const presentation = presentFailure(payload);
+        reason =
+          presentation.reason ??
+          "The session failed before a turn could start. No error details were recorded.";
+        safetyRefusal = presentation.safetyRefusal;
+        failedAt = event.occurredAt;
+      }
     }
   }
   return { reason, safetyRefusal, failedAt, recoveryCount, failedTurnCount };


### PR DESCRIPTION
A session can fail before a turn is claimed and record only a `session.status.changed` failure. The web banner previously ignored that boundary, so it showed no reason or reused an older provider rejection as if it had happened again.

Recognize the pre-claim failure as the current failure. When no detail was recorded, explain that the session failed before a turn could start. Preserve an exact same-turn paired diagnostic when available; do not invent a provider cause or count a non-turn failure as another failed turn. Stored events remain unchanged.

Validation: a regression reproduces the old provider/safety rejection leaking into the new failure; all six failure-summary tests pass after the correction. Full repository typecheck passes.

Tracks [OPE-439](https://linear.app/cloudgeni/issue/OPE-439/show-the-current-pre-claim-failure-instead-of-an-older-provider).

## Summary by Sourcery

Show the current pre-claim failure accurately without attributing stale provider errors or inflating failed-turn counts.

Bug Fixes:
- Ensure pre-claim session failures are shown as the current failure instead of reusing an older provider rejection.
- Provide a clear fallback explanation when a pre-claim failure has no recorded details.
- Preserve detailed diagnostics only when they are paired with the same failed turn.

Enhancements:
- Update failure summaries to treat the latest recorded failure boundary as authoritative without counting pre-claim failures as additional failed turns.

Tests:
- Add regression coverage for stale provider-error reuse and same-turn pre-claim diagnostics.