### PR TITLE
fix(react): distinguish historical wait outcomes from current activity

### DIFF
--- a/.changeset/tidy-recorded-waits.md
+++ b/.changeset/tidy-recorded-waits.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Label preserved wait outcomes with their recorded date and time and expose them as static notes, keeping historical agent text distinct from current session state.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -3635,12 +3635,24 @@ function NoticeRow({ item }: { item: NoticeItem }) {
         "flex items-start gap-2.5 rounded-og-md border px-3.5 py-2.5 text-og-menu",
         tone,
       )}
-      role="status"
+      role={item.recordedOutcome ? "note" : "status"}
+      data-og-recorded-outcome={item.recordedOutcome ? "wait" : undefined}
     >
       <TriangleAlertIcon
         className={cn("mt-0.5 size-4 shrink-0", item.tone === "cancelled" && "opacity-60")}
       />
       <div className="min-w-0 flex-1">
+        {item.recordedOutcome ? (
+          <p className="mb-1 text-og-control font-medium">
+            Wait recorded{" "}
+            <time dateTime={item.occurredAt}>
+              {new Date(item.occurredAt).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </time>
+          </p>
+        ) : null}
         <span className="whitespace-pre-wrap break-words">{item.text}</span>
         {item.details ? (
           <details className="mt-2 text-og-control">

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1050,6 +1050,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
             id: `${pendingWaitOutcome.id}-visible-outcome`,
             tone: "waiting",
             text: waitingOutcomeText(pendingWaitOutcome.reason),
+            recordedOutcome: true,
             occurredAt: pendingWaitOutcome.occurredAt,
           });
         }

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -349,6 +349,8 @@ export type NoticeItem = {
   id: string;
   tone: "waiting" | "cancelled" | "failed" | "input";
   text: string;
+  /** A preserved turn-end outcome, not a claim about current session state. */
+  recordedOutcome?: true;
   /** Optional evidence kept inspectable without overwhelming the main rail. */
   details?: { label: string; value: unknown };
   action?: { label: string; url: string };

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1184,10 +1184,18 @@ describe("MessageTimeline — settled turn folding", () => {
     expect(trigger?.getAttribute("aria-expanded")).toBe("false");
     expect(r.container.textContent).toContain(`Waiting: ${reason}`);
     expect(r.container.textContent?.split(reason)).toHaveLength(2);
-    const visibleOutcome = Array.from(r.container.querySelectorAll('[role="status"]')).find(
-      (element) => element.textContent?.includes(`Waiting: ${reason}`),
-    );
+    const visibleOutcome = Array.from(
+      r.container.querySelectorAll('[data-og-recorded-outcome="wait"]'),
+    ).find((element) => element.textContent?.includes(`Waiting: ${reason}`));
     expect(visibleOutcome).not.toBeUndefined();
+    expect(visibleOutcome?.getAttribute("role")).toBe("note");
+    expect(visibleOutcome?.textContent).toContain("Wait recorded");
+    expect(visibleOutcome?.querySelector("time")?.getAttribute("datetime")).toBe(
+      events[2]!.occurredAt,
+    );
+    expect(visibleOutcome?.querySelector("time")?.textContent).toContain(
+      String(new Date(events[2]!.occurredAt).getFullYear()),
+    );
 
     await act(async () => {
       trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
Preserved wait outcomes now say “Wait recorded” with the event's date and time. This distinguishes an agent's historical statement about running children from current session activity, while retaining the exact reason text.

These specific turn-end outcomes use the static note role and semantic time values, rather than a live status announcement. Other notices retain their existing behavior; stored events remain unchanged.

Validation: 252 timeline projection/renderer tests pass and full repository typecheck passes. Browser checks of the retained original orchestrator timeline verify all four historical labels and timestamps, static note roles, and no horizontal overflow at desktop and 375px mobile widths. The styled mobile rendering was inspected.

Tracks [OPE-440](https://linear.app/cloudgeni/issue/OPE-440/label-preserved-wait-outcomes-as-historical-with-their-event-time).

## Summary by Sourcery

Present preserved wait outcomes as timestamped historical notes instead of current activity status messages.

New Features:
- Display preserved wait outcomes with a recorded date and time while retaining the original reason text.

Bug Fixes:
- Distinguish historical wait outcomes from live session status announcements.

Enhancements:
- Expose preserved wait outcomes as static notes with semantic time information while leaving other notices unchanged.

Tests:
- Update timeline renderer coverage for historical labels, timestamps, and note roles.