### PR TITLE
fix(db): re-arm paused attempt quiescence reconciliation

### DIFF
--- a/.changeset/paused-quiescence-nudge.md
+++ b/.changeset/paused-quiescence-nudge.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Repeat Pause on an already-paused session to re-arm its missing exact-attempt quiescence reconciliation without resuming work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,8 +175,8 @@ A recoverable activity shutdown creates a transactional workflow-wake
 obligation in Postgres. Delivery remains unacknowledged until the exact closed
 attempt has durable quiescence, and every attempt-owned retained-process
 settlement advances that same outbox row in its settlement transaction. A
-workflow close or a writer exit racing the final reconciliation check therefore
-cannot orphan a session in recovery.
+workflow close or writer exit racing reconciliation cannot orphan recovery;
+repeated Pause re-arms a missing quiescence wake.
 
 A background command becomes session-owned only after its exact provider
 identity is durably adopted. Before adoption it remains attempt-owned. After

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -2038,3 +2038,8 @@ transport throws the bounded exact provider message. Rate-limit/capacity
 refusals are marked 429 and enter the durable same-turn waiter; other
 terminals persist that diagnostic on `turn.failed`. Lifecycle audit stays
 metadata-only; worker stdout stays sanitized.
+
+An already-paused session can receive Pause with a new idempotency key to re-arm
+its own settled interruption's missing quiescence wake. This preserves control
+revision and paused admission; the existing worker still proves exact activity
+settlement and writer quiescence. Replaying the same key adds no wake revision.

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -3501,12 +3501,44 @@ export async function mutateSessionControlInTransaction(
             rootSessionId: input.sessionId,
           }));
     if (!changed) {
+      // Repeating Pause may repair a lost reconciliation wake without changing
+      // control authority. The exact closed attempt still needs the existing
+      // worker's Temporal and writer-set proof; this is never new turn work.
+      const [quiescence] =
+        input.action === "pause"
+          ? await db.execute<{ needed: boolean }>(sql`
+            select exists (
+              select 1 from ${schema.sessionTurnAttempts} attempt
+              where attempt.workspace_id = ${input.workspaceId}
+                and attempt.session_id = ${input.sessionId}
+                and attempt.state = 'closed'
+                and attempt.quiesced_at is null
+                and exists (
+                  select 1 from ${schema.sessionAttemptInterruptions} interruption
+                  where interruption.workspace_id = attempt.workspace_id
+                    and interruption.session_id = attempt.session_id
+                    and interruption.attempt_id = attempt.id
+                    and interruption.state in ('settled', 'rejected_stale')
+                )
+            ) as needed
+          `)
+          : [];
+      const wakeCount = quiescence?.needed ? 1 : 0;
+      if (wakeCount > 0) {
+        await registerSessionWorkflowWakeInTransaction(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          temporalWorkflowId: targetSession.temporalWorkflowId ?? `session-${input.sessionId}`,
+          reason: "session_pause_quiescence_reconciliation",
+        });
+      }
       const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
         result: {
           outcome: "unchanged",
           interruptionCount: 0,
           backgroundCommandCount: 0,
-          wakeCount: 0,
+          wakeCount,
           cancelledSessionCount: 0,
           cancelledTurnCount: 0,
           affectedSessionEvents: [],
@@ -3519,11 +3551,16 @@ export async function mutateSessionControlInTransaction(
         workspaceControlEventId: null,
         interruptionCount: 0,
         backgroundCommandCount: 0,
-        wakeCount: 0,
+        wakeCount,
         cancelledSessionCount: 0,
         cancelledTurnCount: 0,
         affectedSessionEvents: [],
-        workflowWake: null,
+        workflowWake: await pendingSessionControlWorkflowWake(
+          db,
+          input.workspaceId,
+          input.sessionId,
+          wakeCount,
+        ),
         outcome: "unchanged",
         replay: false,
       };

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -184,6 +184,7 @@ async function controlSession(
   grant: { accountId: string; workspaceId: string; subjectId: string },
   sessionId: string,
   action: "pause" | "resume" | "cancel",
+  operationKey = crypto.randomUUID(),
 ) {
   return await withWorkspaceSessionActivityRls(client.db, grant.workspaceId, (db) =>
     db.transaction((tx) =>
@@ -192,7 +193,7 @@ async function controlSession(
         workspaceId: grant.workspaceId,
         sessionId,
         actor: { type: "human", subjectId: grant.subjectId },
-        operationKey: crypto.randomUUID(),
+        operationKey,
         action,
       }),
     ),
@@ -4803,6 +4804,45 @@ describe("clean session control plane", () => {
       kind: "cancellation-wait",
       attemptId,
     });
+    const beforeNudge = await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      const [wake] = await db
+        .select()
+        .from(schema.sessionWorkflowWakeOutbox)
+        .where(eq(schema.sessionWorkflowWakeOutbox.sessionId, session.id));
+      return {
+        wake: wake!,
+        control: await evaluateSessionControl(db, grant.workspaceId!, session.id),
+      };
+    });
+    const nudgeKey = crypto.randomUUID();
+    const nudge = await controlSession(grant, session.id, "pause", nudgeKey);
+    expect(nudge.outcome).toBe("unchanged");
+    expect(nudge.interruptionCount).toBe(0);
+    expect(nudge.wakeCount).toBe(1);
+    expect(nudge.control.controlVersion).toBe(beforeNudge.control.controlVersion);
+    expect(nudge.control.state).toBe("paused");
+    const afterNudge = await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      const [wake] = await db
+        .select()
+        .from(schema.sessionWorkflowWakeOutbox)
+        .where(eq(schema.sessionWorkflowWakeOutbox.sessionId, session.id));
+      return wake!;
+    });
+    expect(afterNudge.wakeRevision).toBeGreaterThan(beforeNudge.wake.wakeRevision);
+    const replay = await controlSession(grant, session.id, "pause", nudgeKey);
+    expect(replay.outcome).toBe("replayed");
+    const replayWake = await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      const [wake] = await db
+        .select()
+        .from(schema.sessionWorkflowWakeOutbox)
+        .where(eq(schema.sessionWorkflowWakeOutbox.sessionId, session.id));
+      return wake!;
+    });
+    expect(replayWake.wakeRevision).toBe(afterNudge.wakeRevision);
+
+    expect(
+      await claimTestSessionWork(client.db, grant.workspaceId!, session.id, workflowId),
+    ).toBeNull();
     expect(
       await reconcileSessionAttemptQuiescence(client.db, {
         accountId: grant.accountId,

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -1074,6 +1074,54 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
+    "a paused reconciliation wake settles the exact old attempt without running a turn",
+    async () => {
+      const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+      const scope = workflowScope();
+      const sessionId = crypto.randomUUID();
+      const workflowId = `wf-${crypto.randomUUID()}`;
+      const attemptId = crypto.randomUUID();
+      const reconciled: unknown[] = [];
+      let quiesced = false;
+      let runs = 0;
+      const admission = createTurnAdmission([], async () => {
+        runs += 1;
+        return { status: "idle" };
+      });
+      const worker = await testWorker(nativeConnection, taskQueue, {
+        ...admission.activities,
+        peekSessionWork: async () =>
+          quiesced ? { kind: "idle" as const } : { kind: "cancellation-wait" as const, attemptId },
+        reconcileSessionAttemptQuiescence: async (input) => {
+          reconciled.push(input);
+          quiesced = true;
+          return { action: "quiesced" as const };
+        },
+        markSessionIdle: async () => undefined,
+      });
+      const run = worker.run();
+      try {
+        const client = new Client({ connection });
+        const handle = await client.workflow.signalWithStart("sessionWorkflow", {
+          taskQueue,
+          workflowId,
+          workflowIdReusePolicy: "ALLOW_DUPLICATE",
+          args: [{ ...scope, sessionId }],
+          signal: "queueChanged",
+          signalArgs: [],
+        });
+        await handle.result();
+        expect(reconciled).toEqual([{ ...scope, sessionId, attemptId, workflowId }]);
+        expect(runs).toBe(0);
+      } finally {
+        worker.shutdown();
+        await run;
+      }
+    },
+    temporalWorkflowTestTimeoutMs,
+  );
+
+  test(
     "Temporal activity failure closes boundedly and a later wake retries exact quiescence",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;


### PR DESCRIPTION
Repeating Pause on an already-paused session previously returned no wake even when its logically settled interruption still lacked a physical-quiescence receipt. Three preserved review sessions remained stuck in the stopping state after their provider had gone away.

A fresh Pause operation now re-arms the existing durable workflow wake for that selected session’s closed, interrupted attempt. Control remains paused at the same revision. The worker still proves exact Temporal activity settlement and writer quiescence; this creates no new turn or model/tool work. Replaying the same operation key adds no wake revision.

Validation: desired-success regression fails before the change (wakeCount 0), full PostgreSQL control-plane suite passes 88 tests / 669 assertions, and real Temporal signalWithStart integration proves exact-attempt reconciliation with zero turn executions. Database typecheck, focused lint, docs references, and diff checks pass. Clean integration against main e9d092a30 produced tree d63f6a0b31b4c8e35db455f6d3f0f630ceebf508.

[OPE-441](https://linear.app/cloudgeni/issue/OPE-441/re-arm-reconciliation-when-pause-is-repeated-on-an-already-paused) is a focused follow-up to OPE-169 and OPE-18. Historical ownership remains unchanged. Existing live sessions remain paused; production recovery requires deployment before using this behavior.

## Summary by Sourcery

Restore reconciliation progress for paused sessions with unsettled physical quiescence while preserving control state and avoiding new work.

Bug Fixes:
- Re-arm the missing exact-attempt quiescence reconciliation wake when Pause is repeated on an already-paused session.

Enhancements:
- Preserve paused control state and revision while allowing the existing worker to reconcile settled interruptions without starting new turn work.

Documentation:
- Document repeated Pause as a recovery mechanism for missing quiescence wakes and clarify that it preserves paused admission and idempotent replay behavior.

Tests:
- Add control-plane coverage for wake re-arming, unchanged control state, idempotent replay, and prevention of new session work.
- Add Temporal integration coverage proving the exact interrupted attempt is reconciled without executing a turn.