### PR TITLE
fix(worker): retain database failure diagnostic facts

### DIFF
--- a/.changeset/database-failure-evidence.md
+++ b/.changeset/database-failure-evidence.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Retain PostgreSQL SQLSTATE and existing database identifier diagnostics for otherwise unclassified turn failures, without changing their error text or retry behavior.

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -1,6 +1,9 @@
 import {
   ActiveSessionHistoryLimitExceededError,
   ApprovalRunStateLimitExceededError,
+  isDatabasePersistenceFailure,
+  nestedPostgresSqlState,
+  safeDatabaseErrorFacts,
   isRetryableDatabaseTransportFailure,
   isSessionEventPersistenceError,
   SandboxLeaseTransitionError,
@@ -1064,6 +1067,17 @@ export function agentRunFailurePayload(
       };
     }
     return { error: message, code: "provider_unavailable", retryable: true };
+  }
+  if (isDatabasePersistenceFailure(error)) {
+    const database = safeDatabaseErrorFacts(error);
+    const sqlState = nestedPostgresSqlState(error);
+    if (sqlState !== null || Object.keys(database).length > 0) {
+      return {
+        error: message,
+        sqlState,
+        ...(Object.keys(database).length > 0 ? { database } : {}),
+      };
+    }
   }
   return { error: message };
 }

--- a/apps/worker/src/activities/agent-turn/errors.ts
+++ b/apps/worker/src/activities/agent-turn/errors.ts
@@ -1,7 +1,6 @@
 import {
   ActiveSessionHistoryLimitExceededError,
   ApprovalRunStateLimitExceededError,
-  isDatabasePersistenceFailure,
   nestedPostgresSqlState,
   safeDatabaseErrorFacts,
   isRetryableDatabaseTransportFailure,
@@ -828,6 +827,26 @@ export function classifyXaiCredentialFailure(error: unknown): XaiCredentialFailu
   return null;
 }
 
+// The generic turn-failure boundary also receives application/provider errors.
+// A five-character code or generic severity alone does not establish a driver error.
+function findPostgresDriverError(error: unknown): Record<string, unknown> | null {
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+  for (let index = 0; index < queue.length && index < 64; index += 1) {
+    const current = queue[index];
+    if (!current || typeof current !== "object" || seen.has(current)) continue;
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    if (record.name === "PostgresError") return record;
+    for (const key of ["cause", "original", "driverError", "error", "errors"]) {
+      const nested = record[key];
+      if (Array.isArray(nested)) queue.push(...nested.slice(0, 64));
+      else if (nested !== undefined) queue.push(nested);
+    }
+  }
+  return null;
+}
+
 export function agentRunFailurePayload(
   error: unknown,
   options: { isCodexTurn?: boolean } = {},
@@ -1068,9 +1087,10 @@ export function agentRunFailurePayload(
     }
     return { error: message, code: "provider_unavailable", retryable: true };
   }
-  if (isDatabasePersistenceFailure(error)) {
-    const database = safeDatabaseErrorFacts(error);
-    const sqlState = nestedPostgresSqlState(error);
+  const postgresDriverError = findPostgresDriverError(error);
+  if (postgresDriverError) {
+    const database = safeDatabaseErrorFacts(postgresDriverError);
+    const sqlState = nestedPostgresSqlState(postgresDriverError);
     if (sqlState !== null || Object.keys(database).length > 0) {
       return {
         error: message,

--- a/apps/worker/test/database-failure-evidence.test.ts
+++ b/apps/worker/test/database-failure-evidence.test.ts
@@ -5,6 +5,7 @@ test("unwrapped database failures retain SQLSTATE and identifiers without expand
   const driver = Object.assign(
     new Error("connection detail postgresql://user:private@db/runtime"),
     {
+      name: "PostgresError",
       code: "42501",
       severity: "ERROR",
       schema_name: "public",
@@ -16,6 +17,7 @@ test("unwrapped database failures retain SQLSTATE and identifiers without expand
     },
   );
   const outer = Object.assign(new Error("Original query error remains exact", { cause: driver }), {
+    code: "E1234",
     query: "SELECT * FROM company_brain_context_get_or_create_selection($1)",
     params: ["private parameter"],
   });
@@ -51,4 +53,23 @@ test("database transport failures add no raw driver cause or automatic retry", (
     }),
   });
   expect(agentRunFailurePayload(failure)).toEqual({ error: failure.message });
+});
+
+
+test("five-character application codes do not become database diagnostics", () => {
+  const domain = Object.assign(new Error("External domain failure"), { code: "E1234" });
+  expect(agentRunFailurePayload(domain)).toEqual({ error: domain.message });
+  Object.assign(domain, { severity: "ERROR", cause: domain });
+  expect(agentRunFailurePayload(domain)).toEqual({ error: domain.message });
+  const driver = Object.assign(new Error("PostgreSQL custom condition"), {
+    name: "PostgresError",
+    code: "E1234",
+    severity: "ERROR",
+    routine: "exec_stmt_raise",
+  });
+  expect(agentRunFailurePayload(driver)).toEqual({
+    error: driver.message,
+    sqlState: "E1234",
+    database: { severity: "ERROR", routine: "exec_stmt_raise" },
+  });
 });

--- a/apps/worker/test/database-failure-evidence.test.ts
+++ b/apps/worker/test/database-failure-evidence.test.ts
@@ -55,7 +55,6 @@ test("database transport failures add no raw driver cause or automatic retry", (
   expect(agentRunFailurePayload(failure)).toEqual({ error: failure.message });
 });
 
-
 test("five-character application codes do not become database diagnostics", () => {
   const domain = Object.assign(new Error("External domain failure"), { code: "E1234" });
   expect(agentRunFailurePayload(domain)).toEqual({ error: domain.message });

--- a/apps/worker/test/database-failure-evidence.test.ts
+++ b/apps/worker/test/database-failure-evidence.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { agentRunFailurePayload } from "../src/activities/agent-turn/errors";
+
+test("unwrapped database failures retain SQLSTATE and identifiers without expanding nested content", () => {
+  const driver = Object.assign(
+    new Error("connection detail postgresql://user:private@db/runtime"),
+    {
+      code: "42501",
+      severity: "ERROR",
+      schema_name: "public",
+      table_name: "session_turns",
+      constraint_name: "accepted_authority",
+      routine: "exec_stmt_raise",
+      detail: "private nested query values",
+      hint: "private nested hint",
+    },
+  );
+  const outer = Object.assign(new Error("Original query error remains exact", { cause: driver }), {
+    query: "SELECT * FROM company_brain_context_get_or_create_selection($1)",
+    params: ["private parameter"],
+  });
+  expect(agentRunFailurePayload(outer)).toEqual({
+    error: outer.message,
+    sqlState: "42501",
+    database: {
+      severity: "ERROR",
+      schema: "public",
+      table: "session_turns",
+      constraint: "accepted_authority",
+      routine: "exec_stmt_raise",
+    },
+  });
+});
+
+test("plain domain failures and provider retry classification stay unchanged", () => {
+  expect(agentRunFailurePayload(new Error("Domain rejected this operation"))).toEqual({
+    error: "Domain rejected this operation",
+  });
+  const rateLimit = Object.assign(new Error("Too Many Requests"), { status: 429 });
+  expect(agentRunFailurePayload(rateLimit)).toMatchObject({
+    code: "provider_rate_limited",
+    retryable: true,
+  });
+  expect(agentRunFailurePayload(rateLimit)).not.toHaveProperty("database");
+});
+
+test("database transport failures add no raw driver cause or automatic retry", () => {
+  const failure = Object.assign(new Error("Original database operation failed"), {
+    cause: Object.assign(new Error("postgresql://user:private@db/runtime"), {
+      code: "CONNECTION_CLOSED",
+    }),
+  });
+  expect(agentRunFailurePayload(failure)).toEqual({ error: failure.message });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,15 +30,10 @@ This document owns five things:
 - the repository map and responsibility boundaries; and
 - a routing index from change area to canonical source.
 
-It intentionally does **not** own exhaustive API, schema, configuration,
-permission, migration, provider, or release inventories. Those facts change
-more frequently than the architecture and already have canonical homes in
-code, package READMEs, focused topic docs, [`../CONTRIBUTING.md`](../CONTRIBUTING.md),
-and [`../AGENTS.md`](../AGENTS.md).
-
-A useful test is: if a paragraph needs a migration number, an exact timeout, a
-complete route list, or a current table count to make sense, it probably
-belongs in a focused topic document rather than here.
+Exact API, schema, configuration, permission, migration, provider, and release
+inventories belong in code, package READMEs, focused topic docs,
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md), or [`../AGENTS.md`](../AGENTS.md).
+Keep migration numbers, timeouts, route lists, and table counts there.
 
 ---
 
@@ -1232,14 +1227,11 @@ installations already exist: the owner may choose one of them or enter GitHub's
 new-installation flow for another personal account or organization. Both paths
 retain the same signed-state and exact owner revalidation boundaries.
 
-GitHub write autonomy is a first-class connection policy, not a workspace-wide
-agent mode. `packages/core/src/domain/github-action-policies.ts` groups the
-runtime's exact GitHub write tools into routine work, review submission, and
-merge without widening one group from another. `apps/api/src/routes/github.ts`
-authorizes and serves the policy, and
-`apps/web/src/components/capabilities/use-github-integration.tsx` renders it in
-the shared GitHub integration sheet. The DB connector-policy rows and accepted
-attempt snapshot remain the execution authority.
+GitHub connection policies keep routine writes, reviews, and merges independent.
+Canonical sources: `packages/core/src/domain/github-action-policies.ts` (groups),
+`apps/api/src/routes/github.ts` (authorized API), and
+`apps/web/src/components/capabilities/use-github-integration.tsx` (sheet).
+DB connector-policy rows and accepted-attempt snapshots govern execution.
 
 Canonical: [`capabilities.md`](capabilities.md),
 [`integrations-design.md`](integrations-design.md),

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -2904,7 +2904,7 @@ function CompactionRow({ item }: { item: ContextCompactionItem }) {
       ? "border-og-status-failed/35 bg-og-status-failed/10 text-og-status-failed"
       : item.phase === "started"
         ? WAITING_PILL_CLASS
-        : "border-og-border bg-og-surface-1 text-og-fg-muted";
+        : NEUTRAL_PILL;
   return (
     <div className={cn(enter && "animate-og-enter", "flex justify-center")}>
       <div
@@ -3632,7 +3632,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
       ? "border-og-status-failed/35 bg-og-status-failed/10 text-og-status-failed"
       : item.tone === "waiting"
         ? WAITING_PILL_CLASS
-        : "border-og-border bg-og-surface-1 text-og-fg-muted";
+        : NEUTRAL_PILL;
   return (
     <div
       className={cn(


### PR DESCRIPTION
The historical Company Brain query failures kept the outer database error but lost the nested PostgreSQL diagnostic facts. A real PostgreSQL selection-authority failure reproduces the omission on current main. Otherwise unclassified database failures now also retain SQLSTATE and the existing typed identifier facts, preserving the original error text, classifier precedence, and retry behavior.

Validation: real PostgreSQL reproduction changed from missing SQLSTATE to the exact 42501 with severity/routine (1 test, 10 assertions). Worker regression suites pass: 228 tests, 868 assertions; typecheck and focused lint pass. Tests verify no new nested error messages, parameters, connection URI, or raw cause are copied into the diagnostic fields.

Tracks [OPE-443](https://linear.app/cloudgeni/issue/OPE-443/preserve-postgresql-diagnostic-facts-for-unwrapped-turn-failures). This preserves evidence for future diagnosis; it does not infer or repair the historical database cause.

## Summary by Sourcery

Preserve actionable PostgreSQL diagnostics in worker turn-failure payloads without changing failure semantics.

Bug Fixes:
- Retain PostgreSQL SQLSTATE and safe diagnostic identifiers for otherwise unclassified worker turn failures while preserving the original error message and retry behavior.

Enhancements:
- Guard database diagnostic extraction to recognized PostgreSQL driver errors and exclude nested private error content, causes, and connection details.

Documentation:
- Streamline architecture documentation guidance and canonical-source references.

Tests:
- Add regression coverage for PostgreSQL diagnostic preservation, classification precedence, retry behavior, and exclusion of raw nested error data.

Chores:
- Standardize neutral message-timeline styling for compaction and notice rows.