### PR TITLE
Offer safe Continue and model selection after session failure

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1636,6 +1636,7 @@ describe("summarizeSessionFailure", () => {
       reason: null,
       safetyRefusal: false,
       failedAt: null,
+      failureEventId: null,
       recoveryCount: 0,
       failedTurnCount: 0,
     });
@@ -1647,6 +1648,7 @@ describe("summarizeSessionFailure", () => {
         "This request was blocked by our safety systems. Reason: Potentially unintended activity.",
     });
     expect(summarizeSessionFailure([refusal], "failed")).toMatchObject({
+      failureEventId: refusal.id,
       safetyRefusal: true,
       reason:
         "The model provider blocked this request. This request was blocked by our safety systems. Reason: Potentially unintended activity.",

--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -1,7 +1,6 @@
 import {
   AlertTriangleIcon,
   ArrowLeftIcon,
-  CreditCardIcon,
   DownloadIcon,
   FileJsonIcon,
   GitBranchIcon,
@@ -14,14 +13,12 @@ import {
   useLightboxOptional,
   type UserMessageItem,
 } from "@opengeni/react";
-import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { MarkdownText } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/context";
-import type { SessionFailureSummary } from "@/lib/events";
 import { formatTimestamp } from "@/lib/format";
 import { repositoryDisplayName } from "@/lib/session-tools";
 import { cn } from "@/lib/utils";
@@ -51,92 +48,6 @@ export function TerminalSessionBanner(props: { session: Session; onNewSession: (
         <ArrowLeftIcon className="size-3.5" />
         Back to sessions
       </Button>
-    </div>
-  );
-}
-
-/**
- * Failure honesty: the reason the session failed, how many turns timed out and
- * were retried automatically before it, and the fact that the composer stays
- * usable — sending a message revives the session.
- *
- * Credit exhaustion gets its own copy: "send a message to revive" is a lie
- * when the workspace has no credits (the revive turn dies the same death), so
- * the banner points at the actual fix — the organization's Credits section.
- */
-export function FailedSessionBanner({
-  failure,
-  creditExhausted,
-  workspaceId,
-}: {
-  failure: SessionFailureSummary;
-  creditExhausted?: boolean;
-  workspaceId?: string;
-}) {
-  if (creditExhausted) {
-    return (
-      <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
-        <div
-          data-testid="failed-session-banner"
-          className="flex flex-col gap-3 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed sm:flex-row sm:items-center sm:justify-between"
-        >
-          <div className="flex min-w-0 gap-2.5">
-            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
-            <div className="min-w-0 text-sm">
-              <span className="font-medium">
-                This workspace is out of OpenGeni credits
-                {failure.failedAt ? ` (since ${formatTimestamp(failure.failedAt)})` : ""}.
-              </span>
-              <div className="mt-1 text-xs text-fg-muted">
-                The conversation history is preserved. Add credits to the organization, then keep
-                working from right here.
-              </div>
-            </div>
-          </div>
-          {workspaceId ? (
-            <Button asChild type="button" size="sm" variant="secondary" className="shrink-0">
-              <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId }}>
-                <CreditCardIcon className="size-3.5" />
-                Add credits
-              </Link>
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
-      <div
-        data-testid="failed-session-banner"
-        className="flex gap-2.5 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed"
-      >
-        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
-        <div className="min-w-0 text-sm">
-          <span className="font-medium">
-            This session failed{failure.failedAt ? ` ${formatTimestamp(failure.failedAt)}` : ""}.
-          </span>{" "}
-          {failure.reason ? (
-            <span className="text-status-failed/90">{failure.reason}</span>
-          ) : (
-            <span className="text-fg-muted">No failure detail was recorded.</span>
-          )}
-          <div className="mt-1 text-xs text-fg-muted">
-            {failure.recoveryCount > 0 ? (
-              <>
-                {failure.recoveryCount} same-turn recovery attempt
-                {failure.recoveryCount === 1 ? "" : "s"} occurred before this failure.{" "}
-              </>
-            ) : null}
-            {failure.failedTurnCount > 1 ? (
-              <>{failure.failedTurnCount} turns have failed in this session. </>
-            ) : null}
-            {failure.safetyRefusal
-              ? "The conversation history is preserved. Automatic retries are stopped."
-              : "The conversation history is preserved — send a message to revive the session and keep working."}
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/session/failed-session-actions.test.tsx
+++ b/apps/web/src/components/session/failed-session-actions.test.tsx
@@ -1,0 +1,137 @@
+import { FailureRecoveryBoundary } from "./failure-recovery-boundary";
+import { afterEach, beforeAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { FailedSessionActions } from "./failed-session-actions";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+});
+let root: Root | undefined;
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  document.body.replaceChildren();
+});
+async function render(props: Parameters<typeof FailedSessionActions>[0]) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root!.render(<FailedSessionActions {...props} />));
+  return container;
+}
+test("one Continue click sequence submits one visible follow-up and leaves delivery to its message", async () => {
+  let settle!: (accepted: boolean) => void;
+  const receipt = new Promise<boolean>((resolve) => {
+    settle = resolve;
+  });
+  let sends = 0;
+  let modelOpens = 0;
+  const container = await render({
+    onContinue: async () => {
+      sends++;
+      return receipt;
+    },
+    continueBlockedReason: null,
+    onChooseModel: () => {
+      modelOpens++;
+    },
+    modelDisabled: false,
+  });
+  const [continueButton, modelButton] = [...container.querySelectorAll("button")];
+  await act(async () => {
+    continueButton!.click();
+    continueButton!.click();
+  });
+  expect(sends).toBe(1);
+  expect(continueButton!.textContent).toBe("Adding follow-up…");
+  await act(async () => settle(true));
+  await act(async () => continueButton!.click());
+  expect(sends).toBe(1);
+  expect(continueButton!.textContent).toBe("Continue requested");
+  expect(container.querySelector('[role="status"]')?.textContent).toContain("delivery status");
+  await act(async () => modelButton!.click());
+  expect(modelOpens).toBe(1);
+});
+test("failed local submission remains retryable and blocked drafts explain the reason", async () => {
+  let sends = 0;
+  const props = {
+    onContinue: async () => {
+      sends++;
+      return false;
+    },
+    continueBlockedReason: null as string | null,
+    onChooseModel: () => {},
+    modelDisabled: false,
+  };
+  const container = await render(props);
+  await act(async () => container.querySelector("button")!.click());
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain("could not be added");
+  expect(container.querySelector("button")!.disabled).toBe(false);
+  await act(async () =>
+    root!.render(
+      <FailedSessionActions
+        {...props}
+        continueBlockedReason="Send your draft below to continue."
+      />,
+    ),
+  );
+  expect(container.textContent).toContain("Send your draft below to continue.");
+  await act(async () => container.querySelector("button")!.click());
+  expect(sends).toBe(1);
+});
+
+test("unavailable recovery options preserve the reason and usable composer", async () => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  function UnavailableOptions(): never {
+    throw new Error("fixture recovery chunk unavailable");
+  }
+  await act(async () =>
+    root!.render(
+      <>
+        <FailureRecoveryBoundary fallback={<p role="alert">Provider connection failed.</p>}>
+          <UnavailableOptions />
+        </FailureRecoveryBoundary>
+        <textarea aria-label="Message" defaultValue="My preserved draft" />
+      </>,
+    ),
+  );
+  expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+    "Provider connection failed.",
+  );
+  expect(container.querySelector("textarea")?.value).toBe("My preserved draft");
+});
+
+test("history hydration preserves a request while a distinct failure gets a fresh guard", async () => {
+  let settleFirst!: (accepted: boolean) => void;
+  let sends = 0;
+  const props = {
+    onContinue: () => {
+      sends++;
+      return sends === 1
+        ? new Promise<boolean>((resolve) => {
+            settleFirst = resolve;
+          })
+        : Promise.resolve(true);
+    },
+    continueBlockedReason: null,
+    onChooseModel: () => {},
+    modelDisabled: false,
+  };
+  const container = await render({ ...props, failureId: null });
+  await act(async () => container.querySelector("button")!.click());
+  await act(async () =>
+    root!.render(<FailedSessionActions {...props} failureId="original-event" />),
+  );
+  expect(container.querySelector("button")!.textContent).toBe("Adding follow-up…");
+  await act(async () => root!.render(<FailedSessionActions {...props} failureId="next-event" />));
+  expect(container.querySelector("button")!.disabled).toBe(false);
+  await act(async () => settleFirst(true));
+  expect(container.querySelector("button")!.textContent).toBe("Continue");
+  await act(async () => container.querySelector("button")!.click());
+  expect(sends).toBe(2);
+  expect(container.querySelector("button")!.textContent).toBe("Continue requested");
+});

--- a/apps/web/src/components/session/failed-session-actions.test.tsx
+++ b/apps/web/src/components/session/failed-session-actions.test.tsx
@@ -1,3 +1,5 @@
+import { getComposerSendBlocker } from "@/lib/composer-send-blocking";
+import { FailedSessionBanner } from "./failed-session-banner";
 import { FailureRecoveryBoundary } from "./failure-recovery-boundary";
 import { afterEach, beforeAll, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
@@ -33,7 +35,7 @@ test("one Continue click sequence submits one visible follow-up and leaves deliv
       sends++;
       return receipt;
     },
-    continueBlockedReason: null,
+    continuationBlocker: null,
     onChooseModel: () => {
       modelOpens++;
     },
@@ -61,7 +63,7 @@ test("failed local submission remains retryable and blocked drafts explain the r
       sends++;
       return false;
     },
-    continueBlockedReason: null as string | null,
+    continuationBlocker: null as "draft" | null,
     onChooseModel: () => {},
     modelDisabled: false,
   };
@@ -70,12 +72,7 @@ test("failed local submission remains retryable and blocked drafts explain the r
   expect(container.querySelector('[role="alert"]')?.textContent).toContain("could not be added");
   expect(container.querySelector("button")!.disabled).toBe(false);
   await act(async () =>
-    root!.render(
-      <FailedSessionActions
-        {...props}
-        continueBlockedReason="Send your draft below to continue."
-      />,
-    ),
+    root!.render(<FailedSessionActions {...props} continuationBlocker="draft" />),
   );
   expect(container.textContent).toContain("Send your draft below to continue.");
   await act(async () => container.querySelector("button")!.click());
@@ -117,7 +114,7 @@ test("history hydration preserves a request while a distinct failure gets a fres
           })
         : Promise.resolve(true);
     },
-    continueBlockedReason: null,
+    continuationBlocker: null,
     onChooseModel: () => {},
     modelDisabled: false,
   };
@@ -134,4 +131,84 @@ test("history hydration preserves a request while a distinct failure gets a fres
   await act(async () => container.querySelector("button")!.click());
   expect(sends).toBe(2);
   expect(container.querySelector("button")!.textContent).toBe("Continue requested");
+});
+
+test("credit exhaustion retains model selection without offering automatic Continue", async () => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  let opened = 0;
+  await act(async () =>
+    root!.render(
+      <FailedSessionBanner
+        creditExhausted
+        failure={{
+          reason: "No credits available",
+          failedAt: null,
+          recoveryCount: 0,
+          failedTurnCount: 1,
+        }}
+        actions={{
+          onContinue: async () => true,
+          continuationBlocker: null,
+          modelDisabled: false,
+          onChooseModel: () => {
+            opened++;
+          },
+        }}
+      />,
+    ),
+  );
+  expect(container.textContent).toContain("choose another");
+  expect([...container.querySelectorAll("button")].map((button) => button.textContent)).toEqual([
+    "Choose another model",
+  ]);
+  await act(async () => container.querySelector("button")!.click());
+  expect(opened).toBe(1);
+});
+
+test("shared composer blockers disable Continue and explain the actual unresolved choice", async () => {
+  const ready = {
+    uploadPending: false,
+    repositoryError: null,
+    policyValid: true,
+    variableSetBlocked: false,
+    personalDecision: false,
+    personalLoading: false,
+  };
+  let sends = 0;
+  const props = {
+    onContinue: async () => {
+      sends++;
+      return true;
+    },
+    continuationBlocker: "draft" as const,
+    onChooseModel: () => {},
+    modelDisabled: false,
+  };
+  const container = await render(props);
+  for (const [change, expected] of [
+    [{ uploadPending: true }, "upload"],
+    [{ repositoryError: "Repository access expired" }, "Repository access expired"],
+    [{ repositoryError: "" }, "repository access"],
+    [{ policyValid: false }, "supported model"],
+    [{ variableSetBlocked: true }, "Variable Sets"],
+    [{ personalDecision: true }, "personal resource attachment"],
+    [{ personalLoading: true }, "personal resource access"],
+  ] as const) {
+    const input = { ...ready, ...change };
+    await act(async () =>
+      root!.render(
+        <FailedSessionActions
+          {...props}
+          composerBlocker={getComposerSendBlocker(input)}
+          repositoryError={input.repositoryError}
+        />,
+      ),
+    );
+    expect(container.querySelector("button")!.disabled).toBe(true);
+    expect(container.textContent).toContain(expected);
+    await act(async () => container.querySelector("button")!.click());
+  }
+  expect(sends).toBe(0);
 });

--- a/apps/web/src/components/session/failed-session-actions.tsx
+++ b/apps/web/src/components/session/failed-session-actions.tsx
@@ -1,0 +1,92 @@
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+/** Normal Send owns delivery and retry; this shortcut never replays a tool. */
+export function FailedSessionActions(props: {
+  failureId?: string | null;
+  onContinue: () => Promise<boolean>;
+  continueBlockedReason: string | null;
+  onChooseModel: () => void;
+  modelDisabled: boolean;
+}) {
+  const [identity, setIdentity] = useState(props.failureId ?? null);
+  const [generation, setGeneration] = useState(0);
+  if (props.failureId && props.failureId !== identity) {
+    setIdentity(props.failureId);
+    // Initial history hydration identifies the same failure. A later distinct
+    // boundary permits a new continuation even if React skipped the running state.
+    if (identity) setGeneration(generation + 1);
+  }
+  return <FailureActionsAttempt key={generation} {...props} />;
+}
+
+function FailureActionsAttempt({
+  onContinue,
+  continueBlockedReason,
+  onChooseModel,
+  modelDisabled,
+}: {
+  onContinue: () => Promise<boolean>;
+  continueBlockedReason: string | null;
+  onChooseModel: () => void;
+  modelDisabled: boolean;
+}) {
+  const pending = useRef(false);
+  const accepted = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function submit() {
+    if (pending.current || accepted.current || continueBlockedReason) return;
+    pending.current = true;
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (await onContinue()) {
+        accepted.current = true;
+        setSubmitted(true);
+      } else setError("The follow-up could not be added. Check the composer below and try again.");
+    } catch {
+      setError("The follow-up could not be added. Check the composer below and try again.");
+    } finally {
+      pending.current = false;
+      setSubmitting(false);
+    }
+  }
+  return (
+    <div className="mt-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={submitting || submitted || Boolean(continueBlockedReason)}
+          onClick={() => void submit()}
+        >
+          {submitting ? "Adding follow-up…" : submitted ? "Continue requested" : "Continue"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={modelDisabled}
+          onClick={onChooseModel}
+        >
+          Choose another model
+        </Button>
+      </div>
+      {submitted ? (
+        <p className="mt-2 text-xs text-fg-muted" role="status">
+          Follow-up added below. Its delivery status and retry controls appear with the message.
+        </p>
+      ) : continueBlockedReason ? (
+        <p className="mt-2 text-xs text-fg-muted">{continueBlockedReason}</p>
+      ) : null}
+      {error ? (
+        <p className="mt-2 text-xs" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/session/failed-session-actions.tsx
+++ b/apps/web/src/components/session/failed-session-actions.tsx
@@ -1,11 +1,23 @@
+import type { ComposerSendBlocker } from "@/lib/composer-send-blocking";
 import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+
+type ContinuationBlocker = "draft" | "unsent" | "delivery" | "queued" | "loading";
+const CONTINUATION_REASONS: Record<ContinuationBlocker, string> = {
+  draft: "Send your draft below to continue.",
+  unsent: "Retry or remove the unsent message below before continuing.",
+  delivery: "A message is being delivered below. Check its delivery status.",
+  queued: "Work is already queued or running. Check the activity controls below.",
+  loading: "Wait for the composer to finish loading or sending.",
+};
 
 /** Normal Send owns delivery and retry; this shortcut never replays a tool. */
 export function FailedSessionActions(props: {
   failureId?: string | null;
+  composerBlocker?: ComposerSendBlocker | null;
+  repositoryError?: string | null;
   onContinue: () => Promise<boolean>;
-  continueBlockedReason: string | null;
+  continuationBlocker: ContinuationBlocker | null;
   onChooseModel: () => void;
   modelDisabled: boolean;
 }) {
@@ -22,15 +34,31 @@ export function FailedSessionActions(props: {
 
 function FailureActionsAttempt({
   onContinue,
-  continueBlockedReason,
+  composerBlocker,
+  repositoryError,
+  continuationBlocker,
   onChooseModel,
   modelDisabled,
 }: {
   onContinue: () => Promise<boolean>;
-  continueBlockedReason: string | null;
+  composerBlocker?: ComposerSendBlocker | null;
+  repositoryError?: string | null;
+  continuationBlocker: ContinuationBlocker | null;
   onChooseModel: () => void;
   modelDisabled: boolean;
 }) {
+  const continueBlockedReason = composerBlocker
+    ? {
+        upload: "Wait for the upload below to finish, or remove it.",
+        repository: repositoryError || "Resolve repository access below.",
+        policy: "Choose a supported model, reasoning level and speed below.",
+        variable_sets: "Review the Variable Sets selection below.",
+        personal_decision: "Review the personal resource attachment below.",
+        personal_loading: "Wait for personal resource access to finish loading.",
+      }[composerBlocker]
+    : continuationBlocker
+      ? CONTINUATION_REASONS[continuationBlocker]
+      : null;
   const pending = useRef(false);
   const accepted = useRef(false);
   const [submitting, setSubmitting] = useState(false);

--- a/apps/web/src/components/session/failed-session-banner.tsx
+++ b/apps/web/src/components/session/failed-session-banner.tsx
@@ -11,9 +11,9 @@ import { FailedSessionActions } from "./failed-session-actions";
  * were retried automatically before it, and the fact that the composer stays
  * usable — sending a message revives the session.
  *
- * Credit exhaustion gets its own copy: "send a message to revive" is a lie
- * when the workspace has no credits (the revive turn dies the same death), so
- * the banner points at the actual fix — the organization's Credits section.
+ * Credit exhaustion keeps Add credits and the policy-constrained model picker
+ * available. The automatic continuation shortcut stays hidden until the user
+ * resolves that billing choice through the existing composer flow.
  */
 export function FailedSessionBanner({
   failure,
@@ -41,19 +41,32 @@ export function FailedSessionBanner({
                 {failure.failedAt ? ` (since ${formatTimestamp(failure.failedAt)})` : ""}.
               </span>
               <div className="mt-1 text-xs text-fg-muted">
-                The conversation history is preserved. Add credits to the organization, then keep
-                working from right here.
+                The conversation history is preserved. Add organization credits or choose another
+                available model, then keep working here.
               </div>
             </div>
           </div>
-          {workspaceId ? (
-            <Button asChild type="button" size="sm" variant="secondary" className="shrink-0">
-              <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId }}>
-                <CreditCardIcon className="size-3.5" />
-                Add credits
-              </Link>
-            </Button>
-          ) : null}
+          <div className="flex flex-wrap gap-2">
+            {actions ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={actions.modelDisabled}
+                onClick={actions.onChooseModel}
+              >
+                Choose another model
+              </Button>
+            ) : null}
+            {workspaceId ? (
+              <Button asChild type="button" size="sm" variant="secondary" className="shrink-0">
+                <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId }}>
+                  <CreditCardIcon className="size-3.5" />
+                  Add credits
+                </Link>
+              </Button>
+            ) : null}
+          </div>
         </div>
       </div>
     );

--- a/apps/web/src/components/session/failed-session-banner.tsx
+++ b/apps/web/src/components/session/failed-session-banner.tsx
@@ -1,0 +1,96 @@
+import { AlertTriangleIcon, CreditCardIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import type { ComponentProps } from "react";
+import { Button } from "@/components/ui/button";
+import type { SessionFailureSummary } from "@/lib/events";
+import { formatTimestamp } from "@/lib/format";
+import { FailedSessionActions } from "./failed-session-actions";
+
+/**
+ * Failure honesty: the reason the session failed, how many turns timed out and
+ * were retried automatically before it, and the fact that the composer stays
+ * usable — sending a message revives the session.
+ *
+ * Credit exhaustion gets its own copy: "send a message to revive" is a lie
+ * when the workspace has no credits (the revive turn dies the same death), so
+ * the banner points at the actual fix — the organization's Credits section.
+ */
+export function FailedSessionBanner({
+  failure,
+  creditExhausted,
+  workspaceId,
+  actions,
+}: {
+  failure: SessionFailureSummary;
+  creditExhausted?: boolean;
+  workspaceId?: string;
+  actions?: ComponentProps<typeof FailedSessionActions>;
+}) {
+  if (creditExhausted) {
+    return (
+      <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
+        <div
+          data-testid="failed-session-banner"
+          className="flex flex-col gap-3 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex min-w-0 gap-2.5">
+            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
+            <div className="min-w-0 text-sm">
+              <span className="font-medium">
+                This workspace is out of OpenGeni credits
+                {failure.failedAt ? ` (since ${formatTimestamp(failure.failedAt)})` : ""}.
+              </span>
+              <div className="mt-1 text-xs text-fg-muted">
+                The conversation history is preserved. Add credits to the organization, then keep
+                working from right here.
+              </div>
+            </div>
+          </div>
+          {workspaceId ? (
+            <Button asChild type="button" size="sm" variant="secondary" className="shrink-0">
+              <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId }}>
+                <CreditCardIcon className="size-3.5" />
+                Add credits
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
+      <div
+        data-testid="failed-session-banner"
+        className="flex gap-2.5 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed"
+      >
+        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
+        <div className="min-w-0 text-sm">
+          <span className="font-medium">
+            This session failed{failure.failedAt ? ` ${formatTimestamp(failure.failedAt)}` : ""}.
+          </span>{" "}
+          {failure.reason ? (
+            <span className="text-status-failed/90">{failure.reason}</span>
+          ) : (
+            <span className="text-fg-muted">No failure detail was recorded.</span>
+          )}
+          <div className="mt-1 text-xs text-fg-muted">
+            {failure.recoveryCount > 0 ? (
+              <>
+                {failure.recoveryCount} same-turn recovery attempt
+                {failure.recoveryCount === 1 ? "" : "s"} occurred before this failure.{" "}
+              </>
+            ) : null}
+            {failure.failedTurnCount > 1 ? (
+              <>{failure.failedTurnCount} turns have failed in this session. </>
+            ) : null}
+            {failure.safetyRefusal
+              ? "The conversation history is preserved. Automatic retries are stopped."
+              : "The conversation history is preserved — send a message to revive the session and keep working."}
+          </div>
+          {actions ? <FailedSessionActions {...actions} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/failure-recovery-boundary.tsx
+++ b/apps/web/src/components/session/failure-recovery-boundary.tsx
@@ -1,0 +1,15 @@
+import { Component, type ReactNode } from "react";
+
+/** A failed recovery-options chunk must never take the conversation down. */
+export class FailureRecoveryBoundary extends Component<
+  { children: ReactNode; fallback: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}

--- a/apps/web/src/lib/composer-send-blocking.test.ts
+++ b/apps/web/src/lib/composer-send-blocking.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { getComposerSendBlocker } from "./composer-send-blocking";
+
+test("each synchronous composer blocker identifies its recovery reason", () => {
+  const ready = {
+    uploadPending: false,
+    repositoryError: null,
+    policyValid: true,
+    variableSetBlocked: false,
+    personalDecision: false,
+    personalLoading: false,
+  };
+  expect(getComposerSendBlocker(ready)).toBeNull();
+  for (const [change, expected] of [
+    [{ uploadPending: true }, "upload"],
+    [{ repositoryError: "Repository access expired" }, "repository"],
+    [{ repositoryError: "" }, "repository"],
+    [{ policyValid: false }, "policy"],
+    [{ variableSetBlocked: true }, "variable_sets"],
+    [{ personalDecision: true }, "personal_decision"],
+    [{ personalLoading: true }, "personal_loading"],
+  ] as const) {
+    expect(getComposerSendBlocker({ ...ready, ...change })).toBe(expected);
+  }
+});

--- a/apps/web/src/lib/composer-send-blocking.ts
+++ b/apps/web/src/lib/composer-send-blocking.ts
@@ -1,0 +1,23 @@
+export type ComposerSendBlocker =
+  | "upload"
+  | "repository"
+  | "policy"
+  | "variable_sets"
+  | "personal_decision"
+  | "personal_loading";
+export function getComposerSendBlocker(input: {
+  uploadPending: boolean;
+  repositoryError: string | null;
+  policyValid: boolean;
+  variableSetBlocked: boolean;
+  personalDecision: boolean;
+  personalLoading: boolean;
+}): ComposerSendBlocker | null {
+  if (input.uploadPending) return "upload";
+  if (input.repositoryError !== null) return "repository";
+  if (!input.policyValid) return "policy";
+  if (input.variableSetBlocked) return "variable_sets";
+  if (input.personalDecision) return "personal_decision";
+  if (input.personalLoading) return "personal_loading";
+  return null;
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -65,6 +65,8 @@ export type SessionFailureSummary = {
   safetyRefusal?: boolean;
   /** When the most recent failure happened. */
   failedAt: string | null;
+  /** Exact durable event identity; independent of history hydration or clock precision. */
+  failureEventId?: string | null;
   /** Same-turn recovery attempts recorded by the control plane. */
   recoveryCount: number;
   /** Total failed turns in the log — > 1 means the session failed before and was revived. */
@@ -82,6 +84,7 @@ export function summarizeSessionFailure(
   let reason: string | null = null;
   let safetyRefusal = false;
   let failedAt: string | null = null;
+  let failureEventId: string | null = null;
   let recoveryCount = 0;
   let failedTurnCount = 0;
   let latestFailedTurnId: string | null = null;
@@ -100,6 +103,7 @@ export function summarizeSessionFailure(
       reason = presentation.reason;
       safetyRefusal = presentation.safetyRefusal;
       failedAt = event.occurredAt;
+      failureEventId = event.id;
     }
     if (event.type === "session.status.changed") {
       const payload = event.payload as Record<string, unknown>;
@@ -117,10 +121,11 @@ export function summarizeSessionFailure(
           "The session failed before a turn could start. No error details were recorded.";
         safetyRefusal = presentation.safetyRefusal;
         failedAt = event.occurredAt;
+        failureEventId = event.id;
       }
     }
   }
-  return { reason, safetyRefusal, failedAt, recoveryCount, failedTurnCount };
+  return { reason, safetyRefusal, failedAt, failureEventId, recoveryCount, failedTurnCount };
 }
 
 export function reasoningSummaryText(payload: unknown): string {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -467,18 +467,21 @@ export function SessionRoute({
     sessionId,
     workspaceId,
   ]);
+  const acknowledgementSessionId = session?.id ?? null;
+  const acknowledgementEligible = shouldAcknowledgeActiveSession({
+    activeSessionId: sessionId,
+    workspaceId,
+    session: routeUnreadProjection,
+    ...foreground,
+  });
+  // Same-value list/focus projections must not invalidate an in-flight retry.
   useEffect(() => {
     const projectionKey = activeReadProjectionKey;
     if (
-      !session ||
+      !acknowledgementSessionId ||
       !projectionKey ||
       acknowledgedProjectionRef.current === projectionKey ||
-      !shouldAcknowledgeActiveSession({
-        activeSessionId: sessionId,
-        workspaceId,
-        session: routeUnreadProjection,
-        ...foreground,
-      })
+      !acknowledgementEligible
     ) {
       return;
     }
@@ -487,7 +490,7 @@ export function SessionRoute({
     if (!acceptedTransition) return;
     acknowledgedProjectionRef.current = projectionKey;
     void client
-      .updateSessionAttention(workspaceId, session.id, {
+      .updateSessionAttention(workspaceId, acknowledgementSessionId, {
         unread: false,
         acknowledgedThroughSequence: readThroughSequence,
       })
@@ -526,17 +529,15 @@ export function SessionRoute({
       active = false;
     };
   }, [
+    acknowledgementEligible,
+    acknowledgementSessionId,
     attentionRetryRevision,
     activeReadProjectionKey,
     captureWorkspaceInvocation,
     client,
-    foreground,
     ownsWorkspaceInvocation,
     projectSessionAttention,
     readThroughSequence,
-    routeUnreadProjection,
-    session,
-    sessionId,
     workspaceId,
   ]);
   useEffect(() => {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,3 +1,4 @@
+import { FailureRecoveryBoundary } from "@/components/session/failure-recovery-boundary";
 // The session view — live timeline plus one compact prompt queue above the
 // composer. Enter queues and Cmd/Ctrl+Enter steers; failed sessions stay
 // honest (reason + retry history) and revivable from the same composer.
@@ -57,7 +58,6 @@ import {
 import { MarkdownText } from "@/components/markdown";
 import { ModelPicker, SessionToolPicker, type SessionToolSelection } from "@/components/pickers";
 import {
-  FailedSessionBanner,
   TerminalSessionArchive,
   TerminalSessionBanner,
   UserMessageBody,
@@ -148,6 +148,14 @@ import {
 import { useWorkspaceModelCatalog } from "@/lib/use-workspace-model-catalog";
 import type { LineageNode, SessionRealtimeModel } from "@opengeni/sdk";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
+
+const FAILURE_CONTINUATION_MESSAGE =
+  "Continue from the last failure. Check current progress before repeating work.";
+const LazyFailedSessionBanner = lazy(() =>
+  import("@/components/session/failed-session-banner").then((module) => ({
+    default: module.FailedSessionBanner,
+  })),
+);
 
 const LazySessionInspector = lazy(() =>
   import("@/components/session/inspector").then(({ SessionInspector }) => ({
@@ -1181,9 +1189,28 @@ function SessionChatPane(props: {
     () => createWorkspaceRetainedVideoLoader(context.client, props.session.workspaceId),
     [context.client, props.session.workspaceId],
   );
+  const failureFallback = props.failure ? (
+    <div
+      role="alert"
+      className="mx-auto my-2 w-full max-w-3xl rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-sm text-status-failed"
+    >
+      <p>
+        {props.creditExhausted
+          ? "This workspace is out of OpenGeni credits."
+          : "This session failed."}{" "}
+        {props.failure.reason ?? "No failure detail was recorded."}
+      </p>
+      <p className="mt-1 text-xs text-fg-muted">
+        {props.creditExhausted
+          ? "The conversation is preserved. Add credits in organization settings before continuing."
+          : "The conversation is preserved. You can keep working in the composer below."}
+      </p>
+    </div>
+  ) : null;
   const terminal = isTerminalSessionStatus(props.session.status);
   const composerRegionRef = useRef<HTMLDivElement | null>(null);
   const [composerFocusSignal, setComposerFocusSignal] = useState(0);
+  const [modelPickerSession, setModelPickerSession] = useState<string | null>(null);
   useEffect(() => {
     const onFocusRequest = (event: Event) => {
       const detail = (event as CustomEvent<SessionComposerFocusIntent>).detail;
@@ -1816,11 +1843,43 @@ function SessionChatPane(props: {
           {props.failure &&
           (props.session.status === "failed" ||
             (props.creditExhausted && props.session.status === "idle")) ? (
-            <FailedSessionBanner
-              failure={props.failure}
-              creditExhausted={props.creditExhausted}
-              workspaceId={props.session.workspaceId}
-            />
+            <FailureRecoveryBoundary key={props.session.id} fallback={failureFallback}>
+              <Suspense fallback={failureFallback}>
+                <LazyFailedSessionBanner
+                  key={props.session.id}
+                  failure={props.failure}
+                  creditExhausted={props.creditExhausted}
+                  workspaceId={props.session.workspaceId}
+                  actions={{
+                    failureId: props.failure.failureEventId,
+                    onContinue: () =>
+                      composer.hasDraftContent()
+                        ? Promise.resolve(false)
+                        : composer.send(FAILURE_CONTINUATION_MESSAGE),
+                    continueBlockedReason:
+                      composer.hasDraftContent() ||
+                      attachments.readyResources.length > 0 ||
+                      repositories.pendingResources.length > 0
+                        ? "Send your draft below to continue."
+                        : failedOptimisticMessageCount > 0
+                          ? "Retry or remove the unsent message below before continuing."
+                          : (optimisticMessages ?? []).some(
+                                (message) => !acceptedClientEventIds.has(message.clientEventId),
+                              )
+                            ? "A message is being delivered below. Check its delivery status."
+                            : props.session.activeTurnId !== null || props.queue.queue.length > 0
+                              ? "Work is already queued or running. Check the activity controls below."
+                              : composer.sending || composer.draftLoading || !hasComposerPolicy
+                                ? "Wait for the composer to finish loading or sending."
+                                : attachments.hasUnresolved
+                                  ? "Wait for the upload below to finish, or remove it."
+                                  : null,
+                    onChooseModel: () => setModelPickerSession(props.session.id),
+                    modelDisabled: composer.sending || composer.draftLoading || !hasComposerPolicy,
+                  }}
+                />
+              </Suspense>
+            </FailureRecoveryBoundary>
           ) : null}
           <div data-testid="session-timeline" className="min-h-0 min-w-0 flex-1">
             <MessageTimeline
@@ -2094,6 +2153,8 @@ function SessionChatPane(props: {
             controls={
               <div className="flex min-w-0 items-center gap-1.5 max-sm:min-w-0 max-sm:flex-nowrap">
                 <ModelPicker
+                  open={modelPickerSession === props.session.id}
+                  onOpenChange={(open) => setModelPickerSession(open ? props.session.id : null)}
                   rows={modelCatalog.rows}
                   model={model}
                   effort={reasoningEffort}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,3 +1,4 @@
+import { getComposerSendBlocker } from "@/lib/composer-send-blocking";
 import { FailureRecoveryBoundary } from "@/components/session/failure-recovery-boundary";
 // The session view — live timeline plus one compact prompt queue above the
 // composer. Enter queues and Cmd/Ctrl+Enter steers; failed sessions stay
@@ -1203,7 +1204,7 @@ function SessionChatPane(props: {
       </p>
       <p className="mt-1 text-xs text-fg-muted">
         {props.creditExhausted
-          ? "The conversation is preserved. Add credits in organization settings before continuing."
+          ? "The conversation is preserved. Add organization credits or choose another available model below."
           : "The conversation is preserved. You can keep working in the composer below."}
       </p>
     </div>
@@ -1519,6 +1520,15 @@ function SessionChatPane(props: {
     personalWorkspaceTarget: isPersonalWorkspace(workspace, context.managedSelfContext),
     onReloadSession: props.onReloadSession,
   });
+  const composerSendBlocker = () =>
+    getComposerSendBlocker({
+      uploadPending: attachments.hasUnresolved,
+      repositoryError: repositories.error,
+      policyValid: composerPolicyValidRef.current,
+      variableSetBlocked: variableSetComposerBlocked,
+      personalDecision: personalAttachment.requiresDecision,
+      personalLoading: personalAttachment.loading || personalAttachment.refreshing,
+    });
   const composer = useComposer(props.session.id, {
     events: props.events,
     sendExtras: () => ({
@@ -1533,14 +1543,7 @@ function SessionChatPane(props: {
         ? { personalResourceAttachment: personalAttachment.intent }
         : {}),
     }),
-    sendBlocked: () =>
-      attachments.hasUnresolved ||
-      repositories.error !== null ||
-      !composerPolicyValidRef.current ||
-      variableSetComposerBlocked ||
-      personalAttachment.requiresDecision ||
-      personalAttachment.loading ||
-      personalAttachment.refreshing,
+    sendBlocked: () => composerSendBlocker() !== null,
     effectiveControl: props.queue.effectiveControl ?? props.session.effectiveControl,
     sendDestination: () =>
       props.session.activeTurnId !== null || props.queue.queue.length > 0 ? "queue" : "chat",
@@ -1853,28 +1856,25 @@ function SessionChatPane(props: {
                   workspaceId={props.session.workspaceId}
                   actions={{
                     failureId: props.failure.failureEventId,
+                    composerBlocker: composerSendBlocker(),
+                    repositoryError: repositories.error,
                     onContinue: () =>
                       composer.hasDraftContent()
                         ? Promise.resolve(false)
                         : composer.send(FAILURE_CONTINUATION_MESSAGE),
-                    continueBlockedReason:
-                      composer.hasDraftContent() ||
-                      attachments.readyResources.length > 0 ||
-                      repositories.pendingResources.length > 0
-                        ? "Send your draft below to continue."
-                        : failedOptimisticMessageCount > 0
-                          ? "Retry or remove the unsent message below before continuing."
-                          : (optimisticMessages ?? []).some(
-                                (message) => !acceptedClientEventIds.has(message.clientEventId),
-                              )
-                            ? "A message is being delivered below. Check its delivery status."
-                            : props.session.activeTurnId !== null || props.queue.queue.length > 0
-                              ? "Work is already queued or running. Check the activity controls below."
-                              : composer.sending || composer.draftLoading || !hasComposerPolicy
-                                ? "Wait for the composer to finish loading or sending."
-                                : attachments.hasUnresolved
-                                  ? "Wait for the upload below to finish, or remove it."
-                                  : null,
+                    continuationBlocker: composer.hasDraftContent()
+                      ? "draft"
+                      : failedOptimisticMessageCount > 0
+                        ? "unsent"
+                        : (optimisticMessages ?? []).some(
+                              (message) => !acceptedClientEventIds.has(message.clientEventId),
+                            )
+                          ? "delivery"
+                          : props.session.activeTurnId !== null || props.queue.queue.length > 0
+                            ? "queued"
+                            : composer.sending || composer.draftLoading || !hasComposerPolicy
+                              ? "loading"
+                              : null,
                     onChooseModel: () => setModelPickerSession(props.session.id),
                     modelDisabled: composer.sending || composer.draftLoading || !hasComposerPolicy,
                   }}

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -235,7 +235,9 @@ describe("session control surface architecture", () => {
     expect(establishedPicker).toContain("committedSelection?.sessionId === props.session.id &&");
     expect(establishedRoute).toContain("const variableSetComposerBlocked =");
     expect(establishedRoute).toContain("variableSetPickerState.saving ||");
-    expect(establishedRoute).toContain("variableSetComposerBlocked ||");
+    expect(establishedRoute).toContain("getComposerSendBlocker({");
+    expect(establishedRoute).toContain("variableSetBlocked: variableSetComposerBlocked,");
+    expect(establishedRoute).toContain("sendBlocked: () => composerSendBlocker() !== null,");
     expect(establishedPicker).toContain("props.canControl && props.canAttach");
     expect(
       establishedRoute.match(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,15 +30,10 @@ This document owns five things:
 - the repository map and responsibility boundaries; and
 - a routing index from change area to canonical source.
 
-It intentionally does **not** own exhaustive API, schema, configuration,
-permission, migration, provider, or release inventories. Those facts change
-more frequently than the architecture and already have canonical homes in
-code, package READMEs, focused topic docs, [`../CONTRIBUTING.md`](../CONTRIBUTING.md),
-and [`../AGENTS.md`](../AGENTS.md).
-
-A useful test is: if a paragraph needs a migration number, an exact timeout, a
-complete route list, or a current table count to make sense, it probably
-belongs in a focused topic document rather than here.
+Exact API, schema, configuration, permission, migration, provider, and release
+inventories belong in code, package READMEs, focused topic docs,
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md), or [`../AGENTS.md`](../AGENTS.md).
+Keep migration numbers, timeouts, route lists, and table counts there.
 
 ---
 
@@ -1232,14 +1227,11 @@ installations already exist: the owner may choose one of them or enter GitHub's
 new-installation flow for another personal account or organization. Both paths
 retain the same signed-state and exact owner revalidation boundaries.
 
-GitHub write autonomy is a first-class connection policy, not a workspace-wide
-agent mode. `packages/core/src/domain/github-action-policies.ts` groups the
-runtime's exact GitHub write tools into routine work, review submission, and
-merge without widening one group from another. `apps/api/src/routes/github.ts`
-authorizes and serves the policy, and
-`apps/web/src/components/capabilities/use-github-integration.tsx` renders it in
-the shared GitHub integration sheet. The DB connector-policy rows and accepted
-attempt snapshot remain the execution authority.
+GitHub connection policies keep routine writes, reviews, and merges independent.
+Canonical sources: `packages/core/src/domain/github-action-policies.ts` (groups),
+`apps/api/src/routes/github.ts` (authorized API), and
+`apps/web/src/components/capabilities/use-github-integration.tsx` (sheet).
+DB connector-policy rows and accepted-attempt snapshots govern execution.
 
 Canonical: [`capabilities.md`](capabilities.md),
 [`integrations-design.md`](integrations-design.md),

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -368,6 +368,8 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       const targetRow = page.locator(`a[data-session-row="${target.id}"]`);
       await targetRow.waitFor({ state: "visible", timeout: 10_000 });
       expect(await targetRow.getAttribute("aria-label")).not.toContain("unread");
+      await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+      await page.waitForTimeout(100);
       releaseFirstAcknowledgement();
       const firstAcknowledgementResponse = await firstAcknowledgement;
       const firstReadThrough = Number(
@@ -446,6 +448,115 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await context.close();
     }
   }, 60_000);
+
+  for (const transition of ["frontier", "workspace"] as const) {
+    test(`does not retry an obsolete attention frontier after a ${transition} change`, async () => {
+      const context = await configuredContext(browser, {
+        viewport: { width: 1280, height: 800 },
+        extraHTTPHeaders: ownerHeaders,
+      });
+      const page = await context.newPage();
+      let release = () => {};
+      try {
+        await page.goto(webBaseUrl);
+        const workspaceId = await workspaceFromPage(page);
+        const target = await createSessionThroughApi(
+          page,
+          apiBaseUrl,
+          workspaceId,
+          `Attention ${transition} fence`,
+        );
+        let nextWorkspaceId = workspaceId;
+        if (transition === "workspace") {
+          const response = await fetch(`${apiBaseUrl}/v1/workspaces`, {
+            method: "POST",
+            headers: { ...ownerHeaders, "content-type": "application/json" },
+            body: JSON.stringify({ name: "Attention alternate workspace" }),
+          });
+          expect(response.status).toBe(201);
+          nextWorkspaceId = (await response.json()).id;
+        }
+        const attentionPath = `/v1/workspaces/${workspaceId}/sessions/${target.id}/attention`;
+        let markStarted = () => {};
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        const released = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const attempts: number[] = [];
+        await page.route(`**${attentionPath}`, async (route) => {
+          attempts.push(Number(route.request().postDataJSON().acknowledgedThroughSequence));
+          if (attempts.length === 1) {
+            markStarted();
+            await released;
+            await route.fulfill({
+              status: 503,
+              contentType: "application/json",
+              body: JSON.stringify({ message: "held acknowledgement failure" }),
+            });
+          } else await route.continue();
+        });
+        await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
+        await started;
+        const firstSequence = attempts[0]!;
+        const firstFailure = page.waitForResponse(
+          (response) =>
+            response.request().method() === "PUT" &&
+            new URL(response.url()).pathname === attentionPath &&
+            response.status() === 503,
+        );
+        if (transition === "frontier") {
+          const newer = page.waitForResponse(
+            (response) =>
+              response.request().method() === "PUT" &&
+              new URL(response.url()).pathname === attentionPath &&
+              response.ok() &&
+              Number(response.request().postDataJSON().acknowledgedThroughSequence) > firstSequence,
+          );
+          const message = await fetch(
+            `${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions/${target.id}/events`,
+            {
+              method: "POST",
+              headers: { ...ownerHeaders, "content-type": "application/json" },
+              body: JSON.stringify({
+                type: "user.message",
+                clientEventId: crypto.randomUUID(),
+                payload: { text: "A newer visible frontier" },
+              }),
+            },
+          );
+          expect(message.status).toBe(202);
+          await newer;
+        } else {
+          const documentMarker = await page.evaluate(() => {
+            const marker = crypto.randomUUID();
+            (window as Window & { __attentionFenceDocument?: string }).__attentionFenceDocument =
+              marker;
+            return marker;
+          });
+          await page.getByRole("button", { name: /Switch workspace/ }).click();
+          await page
+            .getByRole("menuitem", { name: "Attention alternate workspace", exact: true })
+            .click();
+          await page.waitForURL(`**/workspaces/${nextWorkspaceId}/sessions`);
+          expect(
+            await page.evaluate(
+              () =>
+                (window as Window & { __attentionFenceDocument?: string }).__attentionFenceDocument,
+            ),
+          ).toBe(documentMarker);
+        }
+        release();
+        expect((await firstFailure).status()).toBe(503);
+        await page.waitForTimeout(300);
+        expect(attempts.filter((sequence) => sequence === firstSequence)).toHaveLength(1);
+      } finally {
+        release();
+        await context.close();
+      }
+    }, 60_000);
+  }
 
   test("keeps a rapidly viewed chat read after switching to another chat", async () => {
     const context = await configuredContext(browser, {

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -3,6 +3,7 @@ import AxeBuilder from "@axe-core/playwright";
 import {
   createDb,
   appendSessionEvents,
+  appendSessionEventsAndUpdateSession,
   createSession,
   grantWorkspaceAccess,
   removeWorkspaceMember,
@@ -1246,6 +1247,120 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await context.close();
     }
   }, 120_000);
+
+  test("continues a failed session through normal Send and opens the constrained model picker", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const owner = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Failure fixture owner",
+      );
+      const failed = await createTitledSession(dbClient.db, {
+        accountId: owner.accountId,
+        workspaceId,
+        initialMessage: "Failed session actions",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sandboxBackend: "none",
+        createdBy: { kind: "subject", subjectId: "sessionpin-owner" },
+      });
+      await appendSessionEventsAndUpdateSession(
+        dbClient.db,
+        workspaceId,
+        failed.id,
+        [
+          {
+            type: "session.status.changed",
+            payload: { status: "failed", code: "pre_claim_failure" },
+          },
+        ],
+        { status: "failed" },
+      );
+      await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${failed.id}`);
+      const banner = page.getByTestId("failed-session-banner");
+      const chooseModel = banner.getByRole("button", { name: "Choose another model", exact: true });
+      await chooseModel.waitFor();
+      await waitFor(async () => !(await chooseModel.isDisabled()));
+      await chooseModel.click();
+      await page.getByRole("menu").waitFor();
+      await page.keyboard.press("Escape");
+      const continueButton = banner.getByRole("button", { name: "Continue", exact: true });
+      await waitFor(async () => !(await continueButton.isDisabled()));
+      let submissions = 0;
+      await page.route(
+        `${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions/${failed.id}/composer-draft/submit`,
+        async (route) => {
+          submissions++;
+          if (submissions === 1)
+            await route.fulfill({
+              status: 503,
+              contentType: "application/json",
+              body: JSON.stringify({ error: "Fixture temporarily unavailable" }),
+            });
+          else await route.continue();
+        },
+      );
+      const submission = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          response.url().includes("/composer-draft/submit"),
+      );
+      await continueButton.click();
+      const receipt = await submission;
+      expect(receipt.status()).toBe(503);
+      const retry = page.getByRole("button", { name: "Retry", exact: true });
+      await retry.waitFor();
+      expect(
+        await banner.getByRole("button", { name: "Continue requested", exact: true }).isDisabled(),
+      ).toBe(true);
+      await page.setViewportSize({ width: 375, height: 812 });
+      await banner
+        .getByText("Retry or remove the unsent message below before continuing.")
+        .waitFor();
+      expect(await banner.getByRole("button", { name: "Continue", exact: true }).isDisabled()).toBe(
+        true,
+      );
+      const retryReceipt = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          response.url().includes("/composer-draft/submit"),
+      );
+      await retry.click();
+      expect((await retryReceipt).ok()).toBe(true);
+      expect(submissions).toBe(2);
+      const text = "Continue from the last failure. Check current progress before repeating work.";
+      await page.getByText(text, { exact: true }).waitFor();
+      const evidence = await page.evaluate(
+        async ({ apiBaseUrl: fixtureApiUrl, workspaceId: fixtureWorkspaceId, id }) => {
+          const response = await fetch(
+            `${fixtureApiUrl}/v1/workspaces/${fixtureWorkspaceId}/sessions/${id}/events`,
+          );
+          if (!response.ok) throw new Error(`events failed: ${response.status}`);
+          return await response.json();
+        },
+        { apiBaseUrl, workspaceId, id: failed.id },
+      );
+      expect(
+        evidence.filter(
+          (event: { type: string; payload: { text?: string } }) =>
+            event.type === "user.message" && event.payload.text === text,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
 
   test("renders one truthful queue, goal, and agents stack above the composer", async () => {
     const desktop = await configuredContext(browser, {


### PR DESCRIPTION
Failed sessions explain the error but leave users to discover how to continue or change models. The failure card now offers Continue through the existing composer Send flow, adding a visible follow-up, and Choose another model opens the existing policy-constrained picker.

Continue preserves drafts, attachments and queued work, guards duplicate clicks, and directs unsent-message retries through the existing delivery controls. Its guard follows the exact durable failure event, preserving history hydration while permitting a later failure; late completion from an older request cannot relock the new one. A failure-only lazy chunk keeps normal session bundle budgets intact, with the exact reason and composer preserved during loading or chunk failure.

Validation: 131 App/component tests (343 assertions), full repository typecheck, lint and formatting; production Chromium with actual authenticated API and non-superuser PostgreSQL verifies model picker, a simulated failed delivery, responsive remount, existing Retry, and exactly one durable continuation (1 test, 6 assertions). Mobile 375px screenshot inspected. Production browser build passes existing bundle budgets. No full-turn or tool replay was added.

Tracks [OPE-445](https://linear.app/cloudgeni/issue/OPE-445/expose-safe-continue-and-model-selection-actions-after-session-failure).

The failure-only loading change exposed an existing attention acknowledgement race: same-value session/focus objects cleaned up a held request before its503 retry, even while the same frontier remained current. The effect now uses scalar session ID and eligibility dependencies, retaining real frontier/workspace/foreground cancellation and the existing single retry. The regression is red on the original effect and green on the correction. Four production browser cases (21 assertions) verify positive retry, newer-frontier cancellation, actual SPA workspace switching with a same-document marker, and the failure actions. Full repository typecheck, lint and formatting pass after this correction. Tracked additionally by OPE-447.


Final review corrections preserve model selection alongside Add credits when OpenGeni credits are exhausted, without offering automatic Continue in that branch. One synchronous typed composer-blocker projection now drives both Send rejection and recovery disabled-state explanations, including repository/policy/Variable Set/personal-resource blockers and empty repository errors. All user-facing explanations stay in the failure-only chunk. Final validation: 134 App/component/helper tests (369 assertions), four configured production browser/API/PG cases (21 assertions), full repository types/lint/format, plus read-only combination with frozen2202: default graph 2,313,993 and configured API graph 2,314,011 against unchanged2,314,240 cap.

## Summary by Sourcery

Provide safe recovery actions for failed sessions while preserving composer delivery semantics and preventing stale session state from interfering with retries.

New Features:
- Add Continue and Choose another model actions to failed-session banners, with model selection remaining available when credits are exhausted.
- Preserve normal composer delivery, retry, drafts, and queued work when continuing from a failed session.

Bug Fixes:
- Prevent stale attention acknowledgement retries from cancelling or relocking newer session frontiers.
- Ensure late completion from an earlier continuation cannot affect a later failure recovery attempt.
- Preserve failure details and the usable composer when the lazy recovery UI fails to load.

Enhancements:
- Centralize composer send-blocking decisions so recovery actions share accurate explanations for uploads, repository access, model policy, Variable Sets, and personal-resource states.
- Track the exact durable failure event to distinguish hydrated history from subsequent failures.

Build:
- Load failure recovery UI lazily to preserve normal session bundle budgets.

Tests:
- Add component and helper coverage for continuation guards, blocked recovery states, failure-chunk fallback, model selection, and credit exhaustion.
- Add production browser/API/PostgreSQL coverage for failure recovery, model picker behavior, responsive remounts, and stale attention cancellation.