### PR TITLE
Offer idle session-chrome queue with sticky dismiss

### DIFF
--- a/.changeset/session-chrome-queue-offer.md
+++ b/.changeset/session-chrome-queue-offer.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Offer the session-chrome queue when chrome is idle and at least one authoritative prompt is waiting. Closing it dismisses that session until occupancy drains; a different session on the same chrome instance may still offer. A live Send stays a paint-only chip receipt.

--- a/apps/web/src/dev/composer-chrome-fixtures.ts
+++ b/apps/web/src/dev/composer-chrome-fixtures.ts
@@ -724,7 +724,8 @@ export function chromeScenarios(): ChromeScenario[] {
     {
       id: "queued-only",
       title: "Queued messages only",
-      description: "Human prompts waiting ahead of send; no machine inputs or goal.",
+      description:
+        "Human prompts waiting ahead of send; no machine inputs or goal. Idle chrome opens the queue itself.",
       session,
       queue: galleryQueue({
         queue: [
@@ -738,12 +739,13 @@ export function chromeScenarios(): ChromeScenario[] {
       }),
       goal: galleryGoal(null),
       agentNodes: [],
-      defaultActive: "queue",
+      defaultActive: null,
     },
     {
       id: "incoming-and-queued",
       title: "Incoming + queued",
-      description: "Collapsed chips show both counts; open either segment.",
+      description:
+        "Idle chrome opens the queue. Closing it leaves both chips collapsed until you open one.",
       session,
       queue: galleryQueue({
         queue: [galleryTurn(0, "Follow up once the child session is inspected.")],

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -482,11 +482,8 @@ export function SessionChrome({
   const queueOfferAdmissionSuppressedRef = useRef(
     defaultActive == null &&
       initialAuthoritativeQueuedCount === 0 &&
-      countOptimisticQueuedMessages(
-        composer?.optimisticMessages,
-        queuedTurnIds,
-        queue.snapshot,
-      ) > 0,
+      countOptimisticQueuedMessages(composer?.optimisticMessages, queuedTurnIds, queue.snapshot) >
+        0,
   );
   const queueOfferDismissedSessionIdsRef = useRef<Set<string>>(new Set());
   const occupancySessionId = queuedTurns[0]?.sessionId ?? null;

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -28,6 +28,13 @@
  * Inbox has no product dismiss API; pass `onDismissIncoming` when the host
  * wants a visible action (dev harness may use a local dummy).
  *
+ * Queue opens by default when chrome is idle and at least one authoritative
+ * prompt is queued. Closing the queue dismisses that session's offer until
+ * occupancy drains; a different session on the same chrome instance may
+ * offer again. An in-flight optimistic Send never opens the drawer —
+ * admission stays a paint-only receipt on the chip so layout does not jump
+ * under the pointer.
+ *
  * Segment switches keep the panel shell mounted and crossfade content. The
  * shell uses one CSS grid-track transition for deliberate open/close actions;
  * live queue reconciliation never feeds measurements back into layout.
@@ -216,6 +223,82 @@ function isSteeringTurn(turn: SessionTurn): boolean {
   return turn.metadata.delivery === "steer";
 }
 
+function isAuthoritativeQueuedTurn(
+  turn: SessionTurn,
+  mutationFor: UseTurnQueueResult["mutationFor"],
+): boolean {
+  return !isSteeringTurn(turn) && mutationFor(turn.id) !== "steer";
+}
+
+export function countAuthoritativeQueuedTurns(
+  turns: readonly SessionTurn[],
+  mutationFor: UseTurnQueueResult["mutationFor"],
+): number {
+  return turns.filter((turn) => isAuthoritativeQueuedTurn(turn, mutationFor)).length;
+}
+
+function isOptimisticQueuedMessage(
+  message: ComposerOptimisticMessage,
+  queuedTurnIds: ReadonlySet<string>,
+  snapshot: UseTurnQueueResult["snapshot"],
+): boolean {
+  return (
+    message.delivery === "send" &&
+    message.destination === "queue" &&
+    (!message.turnId || !queuedTurnIds.has(message.turnId)) &&
+    !(
+      message.turnId &&
+      message.appliedQueueVersion !== null &&
+      message.appliedQueueVersion !== undefined &&
+      snapshot &&
+      snapshot.version >= message.appliedQueueVersion
+    )
+  );
+}
+
+export function countOptimisticQueuedMessages(
+  messages: readonly ComposerOptimisticMessage[] | undefined,
+  queuedTurnIds: ReadonlySet<string>,
+  snapshot: UseTurnQueueResult["snapshot"],
+): number {
+  return (messages ?? []).filter((message) =>
+    isOptimisticQueuedMessage(message, queuedTurnIds, snapshot),
+  ).length;
+}
+
+/**
+ * First uncontrolled segment. An existing authoritative queue opens itself
+ * when the host did not pick another default; optimistic-only occupancy
+ * stays collapsed so a live Send does not shove a drawer under the pointer.
+ */
+export function sessionChromeInitialActive(input: {
+  defaultActive: SessionChromeSignalId | null;
+  authoritativeQueuedCount: number;
+}): SessionChromeSignalId | null {
+  if (input.defaultActive != null) return input.defaultActive;
+  return input.authoritativeQueuedCount >= 1 ? "queue" : null;
+}
+
+/**
+ * Whether idle chrome should offer the queue panel. A dismissed session
+ * stays collapsed until occupancy drains. Controlled hosts own this.
+ */
+export function sessionChromeShouldOfferQueue(input: {
+  controlled: boolean;
+  active: SessionChromeSignalId | null;
+  activityOpen: boolean;
+  authoritativeQueuedCount: number;
+  suppressed: boolean;
+}): boolean {
+  return (
+    !input.controlled &&
+    input.active === null &&
+    !input.activityOpen &&
+    input.authoritativeQueuedCount >= 1 &&
+    !input.suppressed
+  );
+}
+
 function objectValue(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -353,24 +436,14 @@ export function SessionChrome({
   const turns = queue.queue;
   const queueMutationFor = queue.mutationFor;
   const queuedTurns = useMemo(
-    () => turns.filter((turn) => !isSteeringTurn(turn) && queueMutationFor(turn.id) !== "steer"),
+    () => turns.filter((turn) => isAuthoritativeQueuedTurn(turn, queueMutationFor)),
     [queueMutationFor, turns],
   );
   const queuedTurnIds = useMemo(() => new Set(queuedTurns.map((turn) => turn.id)), [queuedTurns]);
   const optimisticQueued = useMemo(
     () =>
-      (composer?.optimisticMessages ?? []).filter(
-        (message) =>
-          message.delivery === "send" &&
-          message.destination === "queue" &&
-          (!message.turnId || !queuedTurnIds.has(message.turnId)) &&
-          !(
-            message.turnId &&
-            message.appliedQueueVersion !== null &&
-            message.appliedQueueVersion !== undefined &&
-            queue.snapshot &&
-            queue.snapshot.version >= message.appliedQueueVersion
-          ),
+      (composer?.optimisticMessages ?? []).filter((message) =>
+        isOptimisticQueuedMessage(message, queuedTurnIds, queue.snapshot),
       ),
     [composer?.optimisticMessages, queue.snapshot, queuedTurnIds],
   );
@@ -387,8 +460,15 @@ export function SessionChrome({
   const elapsed = useLiveElapsed(record?.createdAt, Boolean(record));
   const goalState = record ? sessionChromeGoalPillState(record.status, record.continuation) : null;
 
-  const [activeUncontrolled, setActiveUncontrolled] = useState<SessionChromeSignalId | null>(
-    defaultActive,
+  const initialAuthoritativeQueuedCount = countAuthoritativeQueuedTurns(
+    queue.queue,
+    queue.mutationFor,
+  );
+  const [activeUncontrolled, setActiveUncontrolled] = useState<SessionChromeSignalId | null>(() =>
+    sessionChromeInitialActive({
+      defaultActive,
+      authoritativeQueuedCount: initialAuthoritativeQueuedCount,
+    }),
   );
   const active = activeControlled !== undefined ? activeControlled : activeUncontrolled;
   const activityOpen =
@@ -396,7 +476,28 @@ export function SessionChrome({
     Boolean(compact && active && ["incoming", "agents", "commands"].includes(active));
   const activityVisibleRef = useRef(activityOpen);
   activityVisibleRef.current = activityOpen;
+  // Two independent suppressions, both occupancy-scoped:
+  // - admission: a live Send while idle must not open a drawer under the pointer
+  // - dismiss: closing the queue remembers that session until occupancy drains
+  const queueOfferAdmissionSuppressedRef = useRef(
+    defaultActive == null &&
+      initialAuthoritativeQueuedCount === 0 &&
+      countOptimisticQueuedMessages(
+        composer?.optimisticMessages,
+        queuedTurnIds,
+        queue.snapshot,
+      ) > 0,
+  );
+  const queueOfferDismissedSessionIdsRef = useRef<Set<string>>(new Set());
+  const occupancySessionId = queuedTurns[0]?.sessionId ?? null;
   const setActive = (next: SessionChromeSignalId | null) => {
+    if (active === "queue" && next === null) {
+      if (occupancySessionId) {
+        queueOfferDismissedSessionIdsRef.current.add(occupancySessionId);
+      } else {
+        queueOfferAdmissionSuppressedRef.current = true;
+      }
+    }
     if (activeControlled === undefined) setActiveUncontrolled(next);
     onActiveChange?.(next);
   };
@@ -538,7 +639,45 @@ export function SessionChrome({
     // the pointer. A stable, paint-only receipt on the queue chip communicates
     // destination without participating in layout.
     setQueueArrivalNonce((current) => current + 1);
-  }, [optimisticQueueKeys, optimisticQueued]);
+    if (activeControlled === undefined && active === null) {
+      queueOfferAdmissionSuppressedRef.current = true;
+    }
+  }, [active, activeControlled, optimisticQueueKeys, optimisticQueued]);
+  const queueOccupied = queuedTurns.length > 0 || optimisticQueued.length > 0;
+  useEffect(() => {
+    if (queueOccupied) return;
+    // A later wave may offer again. A prior session's dismiss must not stick
+    // after this instance has actually gone empty.
+    queueOfferAdmissionSuppressedRef.current = false;
+    queueOfferDismissedSessionIdsRef.current.clear();
+  }, [queueOccupied]);
+  const queueOfferSuppressed =
+    queueOfferAdmissionSuppressedRef.current ||
+    (occupancySessionId != null &&
+      queueOfferDismissedSessionIdsRef.current.has(occupancySessionId));
+  useEffect(() => {
+    if (
+      !sessionChromeShouldOfferQueue({
+        controlled: activeControlled !== undefined,
+        active,
+        activityOpen,
+        authoritativeQueuedCount: queuedTurns.length,
+        suppressed: queueOfferSuppressed,
+      })
+    ) {
+      return;
+    }
+    if (activeControlled === undefined) setActiveUncontrolled("queue");
+    onActiveChange?.("queue");
+  }, [
+    active,
+    activeControlled,
+    activityOpen,
+    occupancySessionId,
+    onActiveChange,
+    queueOfferSuppressed,
+    queuedTurns.length,
+  ]);
   const [replaceDraftFor, setReplaceDraftFor] = useState<string | null>(null);
 
   const chipRefs = useRef<Partial<Record<SessionChromeSignalId, HTMLButtonElement | null>>>({});

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -24,7 +24,7 @@ let mounted: RenderedComponent | null = null;
 function expectChromeCollapsed(container: HTMLElement) {
   expect(container.querySelector('[data-og-session-chrome-open="true"]')).toBeNull();
   expect(container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
-  const queueChip = container.querySelector("[data-og-session-chrome-signal=\"queue\"]");
+  const queueChip = container.querySelector('[data-og-session-chrome-signal="queue"]');
   if (queueChip) expect(queueChip.getAttribute("aria-expanded")).toBe("false");
 }
 
@@ -1099,7 +1099,9 @@ describe("SessionChrome compact actions", () => {
       <SessionChrome compact queue={queue()} composer={composer()} />,
     );
     expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
-    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).not.toBeNull();
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]'),
+    ).not.toBeNull();
     expect(
       mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')?.textContent,
     ).toContain("first queued prompt");
@@ -1137,7 +1139,9 @@ describe("SessionChrome compact actions", () => {
         .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="goal"]')
         ?.click();
     });
-    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).not.toBeNull();
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]'),
+    ).not.toBeNull();
     expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
   });
 

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -6,6 +6,8 @@ import {
   sessionChromeGoalPillExplanation,
   sessionChromeGoalPillLabel,
   sessionChromeGoalPillState,
+  sessionChromeInitialActive,
+  sessionChromeShouldOfferQueue,
 } from "../src/components/session-chrome";
 import { formatClockTime } from "../src/lib/format";
 import type { ComposerState } from "../src/hooks/use-composer";
@@ -17,6 +19,14 @@ import { registerDom, renderComponent, type RenderedComponent } from "./render-h
 registerDom();
 
 let mounted: RenderedComponent | null = null;
+
+/** Collapsed chrome. Do not require the queue panel node to unmount — AnimatePresence may keep an exiting frame. */
+function expectChromeCollapsed(container: HTMLElement) {
+  expect(container.querySelector('[data-og-session-chrome-open="true"]')).toBeNull();
+  expect(container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+  const queueChip = container.querySelector("[data-og-session-chrome-signal=\"queue\"]");
+  if (queueChip) expect(queueChip.getAttribute("aria-expanded")).toBe("false");
+}
 
 afterEach(async () => {
   if (mounted) {
@@ -246,6 +256,83 @@ describe("sessionChromeGoalPillState", () => {
   });
 });
 
+describe("session chrome idle queue offer", () => {
+  test("opens an authoritative idle queue on first paint", () => {
+    expect(
+      sessionChromeInitialActive({
+        defaultActive: null,
+        authoritativeQueuedCount: 1,
+      }),
+    ).toBe("queue");
+  });
+
+  test("keeps first paint closed without an authoritative queue", () => {
+    expect(
+      sessionChromeInitialActive({
+        defaultActive: null,
+        authoritativeQueuedCount: 0,
+      }),
+    ).toBeNull();
+  });
+
+  test("does not steal a host-chosen default segment", () => {
+    expect(
+      sessionChromeInitialActive({
+        defaultActive: "goal",
+        authoritativeQueuedCount: 2,
+      }),
+    ).toBe("goal");
+  });
+
+  test("offers when idle, uncontrolled, and occupied", () => {
+    expect(
+      sessionChromeShouldOfferQueue({
+        controlled: false,
+        active: null,
+        activityOpen: false,
+        authoritativeQueuedCount: 1,
+        suppressed: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not steal an already-open segment", () => {
+    expect(
+      sessionChromeShouldOfferQueue({
+        controlled: false,
+        active: "goal",
+        activityOpen: false,
+        authoritativeQueuedCount: 1,
+        suppressed: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not re-offer after an explicit queue close", () => {
+    expect(
+      sessionChromeShouldOfferQueue({
+        controlled: false,
+        active: null,
+        activityOpen: false,
+        authoritativeQueuedCount: 1,
+        suppressed: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not offer when the host controls the segment", () => {
+    expect(
+      sessionChromeShouldOfferQueue({
+        controlled: true,
+        active: null,
+        activityOpen: false,
+        authoritativeQueuedCount: 1,
+        suppressed: false,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("SessionChrome", () => {
   test("hides when there are no signals", async () => {
     mounted = await renderComponent(<SessionChrome queue={queue({ queue: [] })} />);
@@ -310,9 +397,6 @@ describe("SessionChrome", () => {
     expect(queueChip?.textContent).not.toContain("realtime_delegation");
     expect(queueChip?.querySelector(".lucide-audio-lines")).not.toBeNull();
 
-    await act(async () => {
-      queueChip?.click();
-    });
     const panel = mounted.container.querySelector('[data-og-session-chrome-panel="queue"]');
     expect(panel?.textContent).toContain(transcript);
     expect(panel?.textContent).not.toContain("realtime_delegation");
@@ -341,8 +425,6 @@ describe("SessionChrome", () => {
       mounted.container.querySelector('[data-og-session-chrome-signal="steering"]'),
     ).toBeNull();
     expect(queueChip?.textContent).toContain("1 queued prompt");
-
-    await act(async () => queueChip?.click());
     const queuePanel = mounted.container.querySelector('[data-og-session-chrome-panel="queue"]');
     expect(queuePanel?.textContent).toContain("Then update the documentation");
     expect(queuePanel?.textContent).not.toContain("Focus on the authentication failure first");
@@ -709,9 +791,6 @@ describe("SessionChrome", () => {
       '[data-og-session-chrome-signal="queue"]',
     );
     expect(queueChip).not.toBeNull();
-    await act(async () => {
-      queueChip?.click();
-    });
     expect(
       mounted.container.querySelector('[data-og-session-chrome-panel="queue"]'),
     ).not.toBeNull();
@@ -1015,6 +1094,222 @@ describe("SessionChrome compact actions", () => {
     expect(chip?.getAttribute("aria-label")).toBe("Goal · Needs attention");
   });
 
+  test("opens an idle authoritative queue without a click", async () => {
+    mounted = await renderComponent(
+      <SessionChrome compact queue={queue()} composer={composer()} />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).not.toBeNull();
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')?.textContent,
+    ).toContain("first queued prompt");
+  });
+
+  test("keeps the compact queue closed after the operator dismisses it", async () => {
+    mounted = await renderComponent(
+      <SessionChrome compact queue={queue()} composer={composer()} />,
+    );
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="queue"]')
+        ?.click();
+    });
+    expectChromeCollapsed(mounted.container);
+    await mounted.rerender(<SessionChrome compact queue={queue()} composer={composer()} />);
+    expectChromeCollapsed(mounted.container);
+  });
+
+  test("opens the compact queue after a default-open goal is closed", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        compact
+        defaultActive="goal"
+        queue={queue()}
+        composer={composer()}
+        goal={goal()}
+      />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="goal"]')).not.toBeNull();
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).toBeNull();
+
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="goal"]')
+        ?.click();
+    });
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).not.toBeNull();
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+  });
+
+  test("does not re-offer the queue after a dismiss and a later goal close", async () => {
+    mounted = await renderComponent(
+      <SessionChrome compact queue={queue()} composer={composer()} goal={goal()} />,
+    );
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="queue"]')
+        ?.click();
+    });
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="goal"]')
+        ?.click();
+    });
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="goal"]')).not.toBeNull();
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="goal"]')
+        ?.click();
+    });
+    expectChromeCollapsed(mounted.container);
+  });
+
+  test("keeps a live Send collapsed after the optimistic row becomes authoritative", async () => {
+    mounted = await renderComponent(
+      <SessionChrome compact queue={queue({ queue: [] })} composer={composer()} />,
+    );
+    await mounted.rerender(
+      <SessionChrome
+        compact
+        queue={queue({ queue: [] })}
+        composer={composer({
+          optimisticMessages: [
+            {
+              clientEventId: "client-send-live-1",
+              delivery: "send",
+              destination: "queue",
+              text: "live send",
+              annotations: [],
+              resources: [],
+              occurredAt: new Date().toISOString(),
+              state: "sending",
+            },
+          ],
+        })}
+      />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+
+    await mounted.rerender(
+      <SessionChrome
+        compact
+        queue={queue({
+          queue: [fakeTurn({ id: "turn-live-1", prompt: "live send" })],
+        })}
+        composer={composer()}
+      />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).toBeNull();
+  });
+
+  test("leaves a controlled collapsed queue closed even when occupancy exists", async () => {
+    mounted = await renderComponent(
+      <SessionChrome compact active={null} queue={queue()} composer={composer()} />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+    expect(mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')).toBeNull();
+  });
+
+  test("offers the next authoritative wave after the previous occupancy drains", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        compact
+        queue={queue({ queue: [fakeTurn({ id: "wave-1", prompt: "first wave" })] })}
+        composer={composer()}
+      />,
+    );
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="queue"]')
+        ?.click();
+    });
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+
+    await mounted.rerender(
+      <SessionChrome compact queue={queue({ queue: [] })} composer={composer()} />,
+    );
+    await mounted.rerender(
+      <SessionChrome
+        compact
+        queue={queue({
+          queue: [fakeTurn({ id: "wave-2", prompt: "later wave" })],
+        })}
+        composer={composer()}
+      />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')?.textContent,
+    ).toContain("later wave");
+  });
+
+  test("re-offers after a dismiss when a different session occupies the same chrome", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        compact
+        queue={queue({
+          queue: [
+            fakeTurn({
+              id: "session-a-turn",
+              sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              prompt: "session a",
+            }),
+          ],
+        })}
+        composer={composer()}
+      />,
+    );
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="queue"]')
+        ?.click();
+    });
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
+
+    await mounted.rerender(
+      <SessionChrome
+        compact
+        queue={queue({
+          queue: [
+            fakeTurn({
+              id: "session-b-turn",
+              sessionId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+              prompt: "session b",
+            }),
+          ],
+        })}
+        composer={composer()}
+      />,
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]')?.textContent,
+    ).toContain("session b");
+
+    await act(async () => {
+      mounted!.container
+        .querySelector<HTMLButtonElement>('[data-og-session-chrome-signal="queue"]')
+        ?.click();
+    });
+    await mounted.rerender(
+      <SessionChrome
+        compact
+        queue={queue({
+          queue: [
+            fakeTurn({
+              id: "session-a-turn",
+              sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              prompt: "session a",
+            }),
+          ],
+        })}
+        composer={composer()}
+      />,
+    );
+    expectChromeCollapsed(mounted.container);
+  });
+
   test("steers the first queued message without opening the panel", async () => {
     const ids: string[] = [];
     mounted = await renderComponent(
@@ -1028,6 +1323,12 @@ describe("SessionChrome compact actions", () => {
         })}
       />,
     );
+    const queueChip = mounted.container.querySelector<HTMLButtonElement>(
+      '[data-og-session-chrome-signal="queue"]',
+    );
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+    await act(async () => queueChip?.click());
+    expect(mounted.container.querySelector('[data-og-session-chrome-open="false"]')).not.toBeNull();
     const action = mounted.container.querySelector<HTMLButtonElement>(
       '[aria-label="Steer first queued message"]',
     )!;

--- a/scripts/web-bundle-budget-unified-tool-gateway.test.ts
+++ b/scripts/web-bundle-budget-unified-tool-gateway.test.ts
@@ -19,7 +19,7 @@ describe("unified tool gateway web bundle budget", () => {
     );
   });
   test("fits the measured session-history graph with bounded headroom", () => {
-    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBe(2260 * KIB);
-    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET - 2_312_535).toBe(1_705);
+    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET).toBe(2263 * KIB);
+    expect(EFFECTIVE_DIRECT_SESSION_RAW_BUDGET - 2_315_348).toBe(1_964);
   });
 });

--- a/scripts/web-bundle-budget-unified-tool-gateway.ts
+++ b/scripts/web-bundle-budget-unified-tool-gateway.ts
@@ -25,5 +25,6 @@ export const EFFECTIVE_DIRECT_SESSION_RAW_BUDGET = Math.max(
   UNIFIED_TOOL_GATEWAY_BROWSER_RAW_BUDGET,
   // September 6, Bun 1.4 macOS/arm64: main 52ff56a94 measures 2,309,542
   // raw bytes; history anchoring and input handling measure 2,312,535.
-  wholeKibEnvelope(2_312_535),
+  // September 7: idle queue-offer chrome lifts the graph to 2,315,348.
+  wholeKibEnvelope(2_315_348),
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Session chrome now opens the queue when nothing else is expanded and at least one **authoritative** prompt is waiting. Closing the queue dismisses that session until occupancy drains, so it does not auto-expand again. A different session on the same chrome instance may still offer. A live Send stays a paint-only chip receipt so the drawer does not jump under the pointer.

The UX rule:

- Idle + authoritative queued count ≥ 1 → offer queue
- Operator closes queue → sticky dismiss for that session
- Switching to goal/incoming/etc. is not a dismiss; closing that other segment can re-offer
- Occupancy drain resets dismiss so a later wave can offer again
- Optimistic-only occupancy (live Send) never opens the drawer

## Testing

- [x] `bun test packages/react/test/session-chrome.test.tsx` (48 pass)
- [x] `bun run typecheck` (all 32 projects clean)
- [x] Browser: `/dev/composer-chrome` queued-only auto-open + dismiss; incoming-and-queued re-offer after incoming close; sticky dismiss after explicit queue close

[session_chrome_queue_auto_expand-2.mp4](https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_chrome_queue_auto_expand-2.mp4)

[Idle queue auto-open](https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_idle_auto_open.webp)
[Queue stays closed after dismiss](https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_dismissed_collapsed.webp)
[Incoming+queued auto-open](https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincoming_queued_auto_open.webp)
[Queue re-offered after incoming close](https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_reoffer_after_incoming_close.webp)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advanced, I kept the candidate head frozen and verified mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change. Freeze-head source admission is required only for `hotfix/*` into `production`.

## Notes

- Production session route remounts the same chrome instance across sessions, so dismiss is keyed by `queuedTurns[0].sessionId`.
- Controlled `active` is left alone.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f7176bb-f840-40af-a418-3c33b8948628?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f7176bb-f840-40af-a418-3c33b8948628&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Make the session chrome proactively offer authoritative queued prompts while keeping dismissals sticky per session and live sends visually non-disruptive.

New Features:
- Automatically offer the session queue when idle authoritative prompts are waiting, while preserving explicit host-selected segments.
- Support session-scoped sticky queue dismissal, re-offering for different sessions, and resetting the dismissal after occupancy drains.

Bug Fixes:
- Prevent optimistic live Send messages from opening the queue drawer or causing layout shifts before authoritative occupancy arrives.

Enhancements:
- Refine queue occupancy and offer eligibility to distinguish authoritative prompts from steering and optimistic messages.

Build:
- Update the web bundle budget for the session chrome size increase.

Tests:
- Add coverage for idle queue offers, dismissal behavior, session changes, occupancy waves, optimistic sends, and controlled chrome.