### PR TITLE
Roll up only running sub-agents in the sidebar

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -163,7 +163,6 @@ import {
   writeSessionBrowseGroupBy,
 } from "@/lib/session-browse-preferences";
 import { railRowCreator } from "@/lib/creator-initials";
-import { formatWaitingSince } from "@/lib/format";
 import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
 import { requestCreateComposerFocus } from "@/lib/create-composer-focus";
 import {
@@ -2952,7 +2951,7 @@ function SessionRow(props: {
   childCountTruncated: boolean;
   hasChildren: boolean;
   expanded: boolean;
-  /** One status for this session and every hidden descendant. */
+  /** Own waiting/failed/unread, plus live work rolled up from descendants. */
   aggregateStatus: RailAggregateStatus;
   onToggleExpand: () => void;
   active: boolean;
@@ -3266,10 +3265,6 @@ function sessionDescendantLabel(session: Session): string | null {
   if (!stats || stats.totalDescendants === 0) return null;
   const live = stats.runningDescendants + stats.queuedDescendants;
   const total = sessionDescendantCountText(stats.totalDescendants, stats.truncated);
-  if (stats.attentionDescendants > 0) {
-    const waiting = stats.attentionSince ? formatWaitingSince(stats.attentionSince) : "";
-    return `${stats.attentionDescendants} need you${waiting ? ` for ${waiting}` : ""} · ${total} total`;
-  }
   if (live > 0) return `${live} active · ${total} total`;
   return `${total} session${stats.totalDescendants === 1 && !stats.truncated ? "" : "s"}`;
 }

--- a/apps/web/src/components/rail/session-row-content.tsx
+++ b/apps/web/src/components/rail/session-row-content.tsx
@@ -125,9 +125,8 @@ export function RailTrailingMetadata({
   const hasStatusMarker = summary.kind !== "neutral";
   const hasRelativeTime = Boolean(relativeTime);
   const hasMonogram = creator ? creatorInitials(creator) !== null : false;
-  // How long the longest-waiting session behind a "needs you" marker has been
-  // blocked on a human. A collapsed parent with a child parked for ten hours
-  // must say so, not hide it behind a dot.
+  // How long this row itself has been blocked on a human. Parked children
+  // keep their own wait on the child row, not on the parent.
   const waitingFor =
     summary.kind === "needs_attention" && summary.attentionSince
       ? formatWaitingSince(summary.attentionSince)

--- a/apps/web/src/lib/sessions-group-channels.test.ts
+++ b/apps/web/src/lib/sessions-group-channels.test.ts
@@ -154,7 +154,7 @@ describe("summarizeRailNodes", () => {
     expect(nodes[0]?.session.status).toBe("idle");
   });
 
-  test("keeps a loaded child's local failure visible through server tree stats", () => {
+  test("does not paint a parent with a child's local send failure", () => {
     const forest = buildRailForest([
       session({
         id: "root",
@@ -172,16 +172,23 @@ describe("summarizeRailNodes", () => {
       session({ id: "child", parentSessionId: "root" }),
     ]);
     const nodes = forest.grouped.flatMap((bucket) => bucket.sessions);
+    const child = nodes[0]!.children[0]!;
 
     expect(summarizeRailNodes(nodes, new Map([["child", 1]]))).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 2,
+      label: "Read",
+    });
+    expect(summarizeRailNodes([child], new Map([["child", 1]]))).toEqual({
       kind: "send_failed",
       count: 1,
-      total: 2,
+      total: 1,
       label: "1 message not sent",
     });
   });
 
-  test("uses the highest-priority hidden descendant state", () => {
+  test("rolls up only live descendant work, not waiting or failed children", () => {
     const forest = buildRailForest([
       session({
         id: "root",
@@ -200,10 +207,116 @@ describe("summarizeRailNodes", () => {
     ]);
     const summary = summarizeRailNodes(forest.running);
     expect(summary).toEqual({
+      kind: "active",
+      count: 2,
+      total: 5,
+      label: "2 working",
+    });
+  });
+
+  test("keeps a parent's own wait ahead of descendant live work", () => {
+    const forest = buildRailForest([
+      session({
+        id: "root",
+        status: "requires_action",
+        treeStats: {
+          directChildren: 1,
+          totalDescendants: 1,
+          runningDescendants: 1,
+          queuedDescendants: 0,
+          attentionDescendants: 0,
+          pausedDescendants: 0,
+          failedDescendants: 0,
+          truncated: false,
+        },
+      }),
+    ]);
+    expect(summarizeRailNodes(forest.running)).toEqual({
       kind: "needs_attention",
       count: 1,
-      total: 5,
+      total: 2,
       label: "1 needs you",
+    });
+  });
+
+  test("does not promote an idle parent for parked or failed children", () => {
+    const waitingOnly = buildRailForest([
+      session({
+        id: "waiting-parent",
+        status: "idle",
+        treeStats: {
+          directChildren: 2,
+          totalDescendants: 2,
+          runningDescendants: 0,
+          queuedDescendants: 0,
+          attentionDescendants: 2,
+          pausedDescendants: 0,
+          failedDescendants: 0,
+          unreadFailedDescendants: 0,
+          truncated: false,
+        },
+      }),
+    ]);
+    expect(waitingOnly.running).toEqual([]);
+    expect(summarizeRailNodes(waitingOnly.grouped[0]!.sessions)).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 3,
+      label: "Read",
+    });
+
+    const failedChild = buildRailForest([
+      session({ id: "root" }),
+      session({
+        id: "failed-child",
+        parentSessionId: "root",
+        status: "failed",
+        unread: true,
+      }),
+    ]);
+    expect(failedChild.running).toEqual([]);
+    expect(summarizeRailNodes(failedChild.grouped[0]!.sessions)).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 2,
+      label: "Read",
+    });
+    expect(summarizeRailNodes(failedChild.grouped[0]!.sessions[0]!.children)).toEqual({
+      kind: "failed",
+      count: 1,
+      total: 1,
+      label: "1 failed",
+    });
+  });
+
+  test("a loaded waiting child stays on the child row and does not pin the parent", () => {
+    const forest = buildRailForest([
+      session({ id: "root", status: "idle", updatedAt: "2026-08-01T00:00:00.000Z" }),
+      session({
+        id: "child",
+        parentSessionId: "root",
+        status: "requires_action",
+        requiresActionSince: "2026-08-01T01:00:00.000Z",
+        updatedAt: "2026-08-01T02:00:00.000Z",
+      }),
+    ]);
+    expect(forest.running).toEqual([]);
+    const parent = forest.grouped[0]!.sessions[0]!;
+    expect(parent.hasActiveDescendant).toBe(false);
+    expect(summarizeRailNodes([parent])).toEqual({
+      kind: "neutral",
+      count: 0,
+      total: 2,
+      label: "Read",
+    });
+    expect(
+      summarizeRailNodes(parent.children, new Map(), new Date("2026-08-01T02:00:00.000Z")),
+    ).toEqual({
+      kind: "needs_attention",
+      count: 1,
+      total: 1,
+      label: "1 needs you · 1h",
+      attentionSince: "2026-08-01T01:00:00.000Z",
     });
   });
 
@@ -368,7 +481,7 @@ describe("summarizeRailNodes waiting duration", () => {
   const NOW = new Date("2026-08-22T12:00:00.000Z");
   const hoursAgo = (hours: number) => new Date(NOW.getTime() - hours * 3_600_000).toISOString();
 
-  test("says how long the longest-waiting hidden descendant has needed input", () => {
+  test("does not advertise a parked child's wait on the idle parent", () => {
     const forest = buildRailForest([
       session({
         id: "root",
@@ -386,16 +499,16 @@ describe("summarizeRailNodes waiting duration", () => {
         },
       }),
     ]);
-    expect(summarizeRailNodes(forest.running, new Map(), NOW)).toEqual({
-      kind: "needs_attention",
-      count: 2,
+    expect(forest.running).toEqual([]);
+    expect(summarizeRailNodes(forest.grouped[0]!.sessions, new Map(), NOW)).toEqual({
+      kind: "neutral",
+      count: 0,
       total: 4,
-      label: "2 need you · 10h",
-      attentionSince: hoursAgo(10),
+      label: "Read",
     });
   });
 
-  test("takes the earliest wait across the node's own turn and its descendants", () => {
+  test("takes the earliest wait across represented roots, not their children", () => {
     const forest = buildRailForest([
       session({
         id: "root",
@@ -422,9 +535,9 @@ describe("summarizeRailNodes waiting duration", () => {
     const nodes = [...forest.running, ...forest.grouped.flatMap((bucket) => bucket.sessions)];
     expect(summarizeRailNodes(nodes, new Map(), NOW)).toMatchObject({
       kind: "needs_attention",
-      count: 3,
-      label: "3 need you · 26h",
-      attentionSince: hoursAgo(26),
+      count: 2,
+      label: "2 need you · 5h",
+      attentionSince: hoursAgo(5),
     });
   });
 

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -31,6 +31,15 @@ const RUNNING_STATUSES = new Set<SessionStatus>([
   "requires_action",
 ]);
 
+/** In-flight work that a parent may roll up from sub-agents. Waiting and
+ *  failed stay on the child (and For You); they do not paint the parent. */
+const LIVE_WORK_STATUSES = new Set<SessionStatus>([
+  "running",
+  "queued",
+  "waiting_capacity",
+  "recovering",
+]);
+
 export function isRunningStatus(status: SessionStatus): boolean {
   return RUNNING_STATUSES.has(status);
 }
@@ -39,9 +48,19 @@ function hasActiveEffectiveControl(session: Session): boolean {
   return (session.effectiveControl?.state ?? "active") === "active";
 }
 
+function isLiveWork(session: Session): boolean {
+  if (session.backgroundCommandActivity) return true;
+  return hasActiveEffectiveControl(session) && LIVE_WORK_STATUSES.has(session.status);
+}
+
 function isEffectivelyRunning(session: Session): boolean {
   if (session.backgroundCommandActivity) return true;
   return hasActiveEffectiveControl(session) && isRunningStatus(session.status);
+}
+
+function hasSummarizedLiveWork(session: Session): boolean {
+  const stats = session.treeStats;
+  return Boolean(stats && stats.runningDescendants + stats.queuedDescendants > 0);
 }
 
 /** Most-recent activity timestamp for a session (updatedAt, then createdAt). */
@@ -155,17 +174,24 @@ export function groupSessionsForRail(sessions: Session[], now: Date = new Date()
    The rail nests spawned worker sessions under the manager that spawned them
    (parentSessionId). A session is a ROOT in the rail when it has no parent OR
    its parent isn't in the loaded page (an orphan child renders at the root, as
-   before). Roots are pinned/bucketed exactly like the flat list — but a root
-   counts as "running" when it OR any descendant is active, so a manager whose
-   only activity is a live child still floats to the top.
+   before).    Roots are pinned/bucketed exactly like the flat list — but a root
+   counts as "running" when it OR any descendant is in live work, so a manager
+   whose only activity is a running child still floats to the top. A parked or
+   failed child does not promote the parent: those states stay on the child row
+   and the For You surface.
    -------------------------------------------------------------------------- */
 
 export type SessionTreeNode = {
   session: Session;
   children: SessionTreeNode[];
-  /** A descendant (any depth, not the node itself) is running/queued/awaiting action. */
+  /** A descendant (any depth, not the node itself) is running or queued. */
   hasActiveDescendant: boolean;
 };
+
+/** True when this node, or any descendant, is actually running/queued. */
+export function nodeHasLiveWork(node: SessionTreeNode): boolean {
+  return isLiveWork(node.session) || node.hasActiveDescendant || hasSummarizedLiveWork(node.session);
+}
 
 export type RailAggregateStatusKind =
   | "send_failed"
@@ -184,9 +210,9 @@ export type RailAggregateStatus = {
   total: number;
   label: string;
   /**
-   * `needs_attention` only: when the longest-waiting represented session
-   * entered `requires_action` (the earliest known `requiresActionSince` /
-   * `treeStats.attentionSince`). Absent when no server reported it.
+   * `needs_attention` only: when the longest-waiting represented *root*
+   * entered `requires_action` (`requiresActionSince`). Spawned descendants
+   * are not included. Absent when no represented session reported it.
    */
   attentionSince?: string;
 };
@@ -248,6 +274,13 @@ function addRailStatusCounts(target: RailStatusCounts, source: RailStatusCounts)
   target.activeWork += source.activeWork;
 }
 
+/** Descendants contribute in-flight work only. Waiting, failed, unread, and
+ *  local send failures stay on the child row (and For You). */
+function addDescendantWorkCounts(target: RailStatusCounts, source: RailStatusCounts): void {
+  target.total += source.total;
+  target.active += source.active;
+}
+
 function railStatusCounts(
   node: SessionTreeNode,
   localDeliveryAttention: ReadonlyMap<string, number>,
@@ -256,50 +289,26 @@ function railStatusCounts(
   const stats = node.session.treeStats;
   if (stats) {
     counts.total += stats.totalDescendants;
-    counts.attention += stats.attentionDescendants;
-    counts.attentionSince = earliestIso(counts.attentionSince, stats.attentionSince);
-    counts.failed += stats.unreadFailedDescendants ?? stats.failedDescendants;
     counts.active += stats.runningDescendants + stats.queuedDescendants;
-    counts.unread += stats.unreadDescendants ?? 0;
-    counts.activeWork += stats.activelyWorkingDescendants ?? 0;
 
     // Scheduled-task grouping appends older root runs as synthetic children of
     // the newest run. They are not part of that run's server treeStats, unlike
     // ordinary spawned children, so include only those extra roots here.
     for (const child of node.children) {
       if (child.session.parentSessionId !== node.session.id) {
-        addRailStatusCounts(counts, railStatusCounts(child, localDeliveryAttention));
-      } else {
-        counts.sendFailed += loadedLocalDeliveryFailureCount(child, localDeliveryAttention);
+        addDescendantWorkCounts(counts, railStatusCounts(child, localDeliveryAttention));
       }
     }
   } else {
     for (const child of node.children) {
-      addRailStatusCounts(counts, railStatusCounts(child, localDeliveryAttention));
+      addDescendantWorkCounts(counts, railStatusCounts(child, localDeliveryAttention));
     }
   }
   return counts;
 }
 
-/**
- * Durable treeStats already account for ordinary descendants' lifecycle state,
- * but browser-local delivery failures have no server aggregate. Fold only that
- * local fact through the loaded child tree so collapsed parents stay truthful.
- */
-function loadedLocalDeliveryFailureCount(
-  node: SessionTreeNode,
-  localDeliveryAttention: ReadonlyMap<string, number>,
-): number {
-  return (
-    (localDeliveryAttention.get(node.session.id) ?? 0) +
-    node.children.reduce(
-      (total, child) => total + loadedLocalDeliveryFailureCount(child, localDeliveryAttention),
-      0,
-    )
-  );
-}
-
-/** One status for a collapsed parent or workstream, including all descendants. */
+/** One status for a row or workstream. The row's own waiting/failed/unread
+ *  still win; spawned descendants only add live work to "N working". */
 export function summarizeRailNodes(
   nodes: readonly SessionTreeNode[],
   localDeliveryAttention: ReadonlyMap<string, number> = new Map(),
@@ -329,8 +338,8 @@ export function summarizeRailNodes(
   }
 
   if (counts.attention > 0) {
-    // "2 need you · 10h": how long the longest-waiting one has been blocked on
-    // a human, so a parked child is never silent in a collapsed parent row.
+    // "2 need you · 10h" is this row's own wait (or a workstream of roots).
+    // Parked children are not rolled up here.
     const waiting = counts.attentionSince ? formatWaitingSince(counts.attentionSince, now) : "";
     return {
       kind: "needs_attention",
@@ -652,16 +661,15 @@ export type PinnedRailSections = {
   ordinary: SessionForest;
 };
 
-/** Whether the node's own status, or any descendant, is in a live state. */
+/** Pin this root when it itself is live, or a descendant is actually working. */
 export function nodeIsActive(node: SessionTreeNode): boolean {
-  const stats = node.session.treeStats;
-  const summarizedActive = Boolean(
-    stats && stats.runningDescendants + stats.queuedDescendants + stats.attentionDescendants > 0,
+  return (
+    isEffectivelyRunning(node.session) ||
+    node.hasActiveDescendant ||
+    hasSummarizedLiveWork(node.session)
   );
-  return isEffectivelyRunning(node.session) || node.hasActiveDescendant || summarizedActive;
 }
 
-/** Bucket already-built roots using the rail's activity and recency rules. */
 /**
  * The scheduled task a session was created for, or null. The worker stamps this
  * onto every session it generates for a run; it is deliberately read from
@@ -722,8 +730,7 @@ export function groupScheduledRuns(roots: SessionTreeNode[]): SessionTreeNode[] 
       // so a subagent of the latest run never sorts below an older run.
       children: [...latestRun.children, ...olderRuns],
       hasActiveDescendant:
-        latestRun.hasActiveDescendant ||
-        olderRuns.some((run) => nodeIsActive(run) || run.hasActiveDescendant),
+        latestRun.hasActiveDescendant || olderRuns.some((run) => nodeHasLiveWork(run)),
     });
   }
   return grouped;
@@ -790,7 +797,7 @@ export function buildRailForest(sessions: Session[], now: Date = new Date()): Se
       : (childrenOf.get(session.id) ?? [])
           .sort(compareSessionActivity)
           .map((child) => build(child, new Set(seen).add(session.id)));
-    const hasActiveDescendant = children.some((child) => nodeIsActive(child));
+    const hasActiveDescendant = children.some((child) => nodeHasLiveWork(child));
     return { session, children, hasActiveDescendant };
   };
 
@@ -951,7 +958,7 @@ function prunePinnedSubtreesWithCounts(
     node: {
       session,
       children,
-      hasActiveDescendant: children.some((child) => nodeIsActive(child)),
+      hasActiveDescendant: children.some((child) => nodeHasLiveWork(child)),
     },
     removed,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parent sidebar rows now roll up **only live work** from sub-agents (`running`, `queued`, `waiting_capacity`, `recovering`). Waiting, failed, unread, and local send-failures stay on the child row (and For You / priority feed). The parent’s own wait, fail, or unread still wins on that row.

Idle parents with parked or failed children stay unpinned and visually neutral. The descendant label is “N active · total” rather than “N need you”.

## Why

The old aggregation painted parent rows with every child attention state. A tree with one waiting or failed sub-agent looked like the parent itself needed you, which hid the actual child and made the rail noisy.

## Test plan

- [x] Unit tests in `sessions-group-channels.test.ts` cover: no child send-fail on parent; only live work rolls up; parent’s own wait still wins; idle parent + parked/failed children stay unpinned and neutral; loaded waiting child stays on the child row.
- [x] `bun run --cwd apps/web typecheck`
- [x] Browser check of the idle sidebar (no children, so rollup is not visually demonstrated on the smoke session).

[Sidebar after status change](https://cursor.com/agents/bc-ef162323-d367-4d83-aa0c-b2be831e9471/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopengeni_sidebar_after_status_change.webp)
[sidebar-subagent-status-walkthrough.mp4](https://cursor.com/agents/bc-ef162323-d367-4d83-aa0c-b2be831e9471/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar-subagent-status-walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef162323-d367-4d83-aa0c-b2be831e9471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef162323-d367-4d83-aa0c-b2be831e9471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Limit sidebar aggregation to live sub-agent work while keeping child-specific attention states visible on their respective rows.

New Features:
- Roll up only live descendant work into parent sidebar rows and active/pinned grouping.

Bug Fixes:
- Keep waiting, failed, unread, and local send-failure states on their child rows instead of incorrectly promoting them to parents.
- Preserve parent-owned attention states as the highest-priority status on the parent row.

Enhancements:
- Update descendant labels to report active work and total descendants without implying that parked children need user attention.
- Keep idle parents with only parked or failed children visually neutral and unpinned.

Tests:
- Expand rail status coverage for live-work rollups, parent-owned attention, child-local failures, and neutral idle parents.