### PR TITLE
fix(api): honor workspace API keys on MCP OAuth callback

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -15,6 +15,7 @@ import {
   createConnection,
   decryptEnvironmentValue,
   encryptEnvironmentValue,
+  findActiveWorkspaceApiKeyById,
   getConnectionMetadata,
   getGlobalCatalogOAuthProfile,
   getWorkspaceGrant,
@@ -818,7 +819,7 @@ async function requireOAuthCallbackGrant(db: Database, state: OAuthStatePayload)
       ? membershipGrant
       : state.personalOwnerVerified
         ? await resolveNamedManagedPersonalWorkspaceGrant(db, state)
-        : null;
+        : await apiKeyCallbackGrant(db, state);
   if (
     !grant ||
     grant.accountId !== state.accountId ||
@@ -828,6 +829,25 @@ async function requireOAuthCallbackGrant(db: Database, state: OAuthStatePayload)
       message: "OAuth subject no longer has permission to write this workspace connection",
     });
   }
+}
+
+async function apiKeyCallbackGrant(
+  db: Database,
+  state: OAuthStatePayload,
+): Promise<{ accountId: string; permissions: Parameters<typeof hasPermission>[0] } | null> {
+  const prefix = "api_key:";
+  if (!state.subjectId.startsWith(prefix)) {
+    return null;
+  }
+  const apiKey = await findActiveWorkspaceApiKeyById(db, {
+    accountId: state.accountId,
+    workspaceId: state.workspaceId,
+    apiKeyId: state.subjectId.slice(prefix.length),
+  });
+  if (!apiKey) {
+    return null;
+  }
+  return { accountId: apiKey.accountId, permissions: apiKey.permissions };
 }
 
 /** The hosted-Slack profile's origin pins, kept exported for its tests. */

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   WORKSPACE_OPENROUTER_CONNECTION_DOMAIN,
   WORKSPACE_OPENROUTER_CONNECTION_ROLE,
@@ -18,6 +18,7 @@ import {
   type Permission,
 } from "@opengeni/contracts";
 import {
+  createApiKey,
   createConnection,
   createDb,
   decryptEnvironmentValue,
@@ -2204,6 +2205,73 @@ describe("connections routes", () => {
       });
       expect(loaded?.metadata.mcpToolsVerification).toMatchObject({
         status: "ok",
+      });
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth callback still writes a workspace connection for an API key that can start OAuth", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const token = `ogk_${randomUUID().replaceAll("-", "")}`;
+    const apiKey = await createApiKey(client.db, {
+      accountId: workspace.accountId,
+      workspaceId: workspace.workspaceId,
+      name: "runtime",
+      prefix: token.slice(0, 14),
+      keyHash: createHash("sha256").update(token).digest("hex"),
+      permissions: ["connections:read", "connections:write", "workspace:read"],
+    });
+    const as = startFakeAuthorizationServer({
+      clientIdMetadataDocumentSupported: true,
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource"`,
+    });
+    try {
+      const response = await app().request(
+        `/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            providerDomain: "linear.app",
+            mcpUrl: mcp.url,
+            ownership: "workspace",
+            returnPath: "/integrations?connect_item=linear",
+          }),
+        },
+      );
+      const responseText = await response.clone().text();
+      expect(response.status, responseText).toBe(200);
+      const body = (await response.json()) as { state: string };
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown>;
+      expect(state.subjectId).toBe(`api_key:${apiKey.id}`);
+      expect(state.ownership).toBe("workspace");
+
+      const callback = await publicApp(client.db).request(
+        `/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`,
+      );
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(callback.headers.get("location")).not.toContain("integration_oauth=error");
+
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "linear.app",
+        kind: "oauth2",
+        subjectId: `api_key:${apiKey.id}`,
+        allowSubjectOwned: false,
+      });
+      expect(loaded?.credential).toMatchObject({
+        access_token: "mcp-access-token",
+        mcp_url: mcp.url,
       });
     } finally {
       mcp.close();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4067,6 +4067,44 @@ export async function findActiveApiKeyByHash(
   });
 }
 
+export async function findActiveWorkspaceApiKeyById(
+  db: Database,
+  input: { accountId: string; workspaceId: string; apiKeyId: string },
+): Promise<(ApiKey & { credentialKind: schema.ApiKeyCredentialKind }) | null> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const [row] = await scopedDb
+        .select()
+        .from(schema.apiKeys)
+        .where(
+          and(
+            eq(schema.apiKeys.id, input.apiKeyId),
+            eq(schema.apiKeys.accountId, input.accountId),
+            sql`${schema.apiKeys.revokedAt} is null`,
+            sql`(${schema.apiKeys.expiresAt} is null or ${schema.apiKeys.expiresAt} > now())`,
+            or(
+              eq(schema.apiKeys.workspaceId, input.workspaceId),
+              isNull(schema.apiKeys.workspaceId),
+            ),
+          ),
+        )
+        .limit(1);
+      if (!row) {
+        return null;
+      }
+      if (row.workspaceId !== null && row.workspaceId !== input.workspaceId) {
+        return null;
+      }
+      return {
+        ...mapApiKey(row),
+        credentialKind: row.credentialKind,
+      };
+    },
+  );
+}
+
 export type GitHubInstallation = {
   id: string;
   accountId: string;


### PR DESCRIPTION
## Summary

Workspace API keys can start MCP OAuth, but the public callback only accepted a workspace membership or a managed personal grant. That returned 403 before token exchange, so the connection was never stored.

This looks up the still-active API key from the signed callback state and reuses its permissions for the grant check. Membership-backed and personal-owner callbacks are unchanged.

## Testing

- [x] `bun test apps/api/test/connections-routes.test.ts` (58 pass / 0 fail)
- [ ] `bun run typecheck`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Rebased onto current `main` before opening.

## Notes

New coverage: a workspace API key that can start OAuth can also complete the callback and persist a workspace connection.

## Summary by Sourcery

Honor active workspace API key permissions during MCP OAuth callbacks.

Bug Fixes:
- Allow workspace API keys that initiate MCP OAuth to complete the public callback and persist the resulting workspace connection.

Enhancements:
- Validate callback API keys against their workspace scope and active status before reusing their permissions for authorization.

Tests:
- Add end-to-end coverage for completing and storing an OAuth connection initiated with a workspace API key.