### PR TITLE
Fix member permission errors and add password recovery

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -986,6 +986,15 @@ async function managedBrowserMutation<T>(path: string, body: unknown): Promise<T
   return (await response.json()) as T;
 }
 
+// Request uses the same public auth boundary as sign-in and returns no account
+// existence information. Better Auth sends a link only for an eligible account.
+export async function requestPasswordReset(email: string): Promise<unknown> {
+  return await authRequest<unknown>("/request-password-reset", {
+    method: "POST",
+    body: JSON.stringify({ email, redirectTo: "/reset-password" }),
+  });
+}
+
 // Completes a password reset. `token` comes from the emailed link
 // (`<PUBLIC_BASE_URL>/reset-password?token=…`); Better Auth mounts this at
 // `/v1/auth/reset-password` and expects `{ newPassword, token }`.

--- a/apps/web/src/components/managed-auth-panel.test.tsx
+++ b/apps/web/src/components/managed-auth-panel.test.tsx
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { ManagedAuthPanel } from "./managed-auth-panel";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+test("password recovery validates email, posts no password, and keeps failures retryable", async () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; body: unknown }> = [];
+  let fail = true;
+  globalThis.fetch = (async (input, init) => {
+    requests.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+    return new Response(JSON.stringify(fail ? { message: "Unavailable" } : { status: true }), {
+      status: fail ? 503 : 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  const button = (name: string) =>
+    Array.from(host.querySelectorAll("button")).find((b) => b.textContent?.trim() === name)!;
+  try {
+    await act(async () =>
+      root.render(
+        <ManagedAuthPanel
+          onSubmit={async () => {
+            throw new Error("must not sign in");
+          }}
+        />,
+      ),
+    );
+    await act(async () => button("Forgot password?").click());
+    expect(host.querySelector('input[type="password"]')).toBeNull();
+    await act(async () =>
+      host
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    );
+    expect(requests).toHaveLength(0);
+    expect(host.textContent).toContain("Enter your email address.");
+    const input = host.querySelector<HTMLInputElement>("#managed-auth-email")!;
+    const propsKey = Object.keys(input).find((k) => k.startsWith("__reactProps$"))!;
+    await act(async () => {
+      (input as unknown as Record<string, { onChange: (e: unknown) => void }>)[propsKey]!.onChange({
+        target: { value: "member@example.test" },
+      });
+    });
+    await act(async () =>
+      host
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    );
+    expect(host.textContent).toContain("We couldn't request a password reset.");
+    fail = false;
+    await act(async () =>
+      host
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    );
+    expect(requests[1]).toEqual({
+      url: expect.stringContaining("/v1/auth/request-password-reset"),
+      body: { email: "member@example.test", redirectTo: "/reset-password" },
+    });
+    expect(host.textContent).toContain("If this email has an account");
+    await act(async () => button("Back to sign in").click());
+    expect(host.querySelector('input[type="password"]')).not.toBeNull();
+    expect(host.textContent).not.toContain("If this email has an account");
+  } finally {
+    globalThis.fetch = originalFetch;
+    await act(async () => root.unmount());
+    host.remove();
+  }
+});

--- a/apps/web/src/components/managed-auth-panel.tsx
+++ b/apps/web/src/components/managed-auth-panel.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, Loader2Icon, RefreshCwIcon, UserIcon } from "lucide-react";
 import { useState } from "react";
 
-import { sendVerificationEmail } from "@/api";
+import { requestPasswordReset, sendVerificationEmail } from "@/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -46,6 +46,7 @@ export function ManagedAuthPanel(props: {
   const [name, setName] = useState("");
   const [email, setEmail] = useState(props.invitation?.targetEmail ?? "");
   const [password, setPassword] = useState("");
+  const [resetMode, setResetMode] = useState(false);
   const [busy, setBusy] = useState(false);
   const [socialBusy, setSocialBusy] = useState<ManagedSocialProvider | null>(null);
   const [resendBusy, setResendBusy] = useState(false);
@@ -57,6 +58,7 @@ export function ManagedAuthPanel(props: {
 
   function selectMode(nextMode: ManagedAuthMode) {
     setMode(nextMode);
+    setResetMode(false);
     setFieldErrors({});
     setFormError(null);
     setFormActionMode(null);
@@ -88,7 +90,10 @@ export function ManagedAuthPanel(props: {
 
   async function submit() {
     const input = { name: name.trim(), email: email.trim(), password };
-    const validationErrors = validateManagedAuthInput(mode, input);
+    const validationErrors = validateManagedAuthInput(
+      resetMode ? "signin" : mode,
+      resetMode ? { ...input, password: "reset-request" } : input,
+    );
     setFieldErrors(validationErrors);
     setFormError(null);
     setFormActionMode(null);
@@ -97,6 +102,13 @@ export function ManagedAuthPanel(props: {
     if (Object.keys(validationErrors).length > 0) return;
     setBusy(true);
     try {
+      if (resetMode) {
+        await requestPasswordReset(input.email);
+        setSuccessMessage(
+          "If this email has an account, we sent a password-reset link. Check your inbox and spam folder.",
+        );
+        return;
+      }
       await props.onSubmit(mode, { ...input, name: input.name || input.email });
       if (mode === "signup") {
         if (emailVerificationRequired) setVerificationEmail(input.email);
@@ -107,6 +119,10 @@ export function ManagedAuthPanel(props: {
         );
       }
     } catch (error) {
+      if (resetMode) {
+        setFormError("We couldn't request a password reset. Please try again.");
+        return;
+      }
       const failure = managedAuthFailure(mode, error);
       setFieldErrors(failure.fields);
       setFormError(failure.message);
@@ -167,6 +183,10 @@ export function ManagedAuthPanel(props: {
   const formInteractionBusy = busy || resendBusy || socialBusy !== null;
   const resendVerificationControl = verificationEmail ? (
     <div className="mt-2">
+      <p className="text-xs text-fg-subtle">
+        Look for “Verify your OpenGeni email” in your inbox or spam folder. After verifying, return
+        here to sign in.
+      </p>
       <Button
         type="button"
         variant="ghost"
@@ -210,14 +230,16 @@ export function ManagedAuthPanel(props: {
           </span>
           <div>
             <h1 className="text-base font-semibold">
-              {mode === "signup" ? "Create account" : "Sign in"}
+              {resetMode ? "Reset password" : mode === "signup" ? "Create account" : "Sign in"}
             </h1>
             <p className="text-sm text-fg-subtle">
-              {invitation
-                ? mode === "signup"
-                  ? `Create an account for ${invitation.targetEmail} to continue joining ${invitation.organizationName}.`
-                  : `Sign in as ${invitation.targetEmail} to continue joining ${invitation.organizationName}.`
-                : "Use your preferred account to access the managed console."}
+              {resetMode
+                ? "Enter your email to receive a password-reset link."
+                : invitation
+                  ? mode === "signup"
+                    ? `Create an account for ${invitation.targetEmail} to continue joining ${invitation.organizationName}.`
+                    : `Sign in as ${invitation.targetEmail} to continue joining ${invitation.organizationName}.`
+                  : "Use your preferred account to access the managed console."}
             </p>
           </div>
         </div>
@@ -255,7 +277,7 @@ export function ManagedAuthPanel(props: {
             </Button>
           </div>
         ) : null}
-        {!invitation && props.socialProviders?.length && props.onSocialSubmit ? (
+        {!resetMode && !invitation && props.socialProviders?.length && props.onSocialSubmit ? (
           <>
             <ManagedSocialAuthButtons
               providers={props.socialProviders}
@@ -315,35 +337,59 @@ export function ManagedAuthPanel(props: {
             </p>
           ) : null}
         </div>
-        <div>
-          <Label htmlFor="managed-auth-password">Password</Label>
-          <Input
-            id="managed-auth-password"
-            type="password"
-            value={password}
+        {!resetMode ? (
+          <div>
+            <Label htmlFor="managed-auth-password">Password</Label>
+            <Input
+              id="managed-auth-password"
+              type="password"
+              value={password}
+              disabled={formInteractionBusy}
+              onChange={(event) => updateField("password", event.target.value)}
+              autoComplete={mode === "signin" ? "current-password" : "new-password"}
+              className="mt-2"
+              aria-invalid={Boolean(fieldErrors.password)}
+              aria-describedby={fieldErrors.password ? "managed-auth-password-error" : undefined}
+            />
+            {fieldErrors.password ? (
+              <p
+                id="managed-auth-password-error"
+                role="alert"
+                className="mt-1.5 text-xs text-status-failed"
+              >
+                {fieldErrors.password}
+              </p>
+            ) : mode === "signup" ? (
+              <p className="mt-1.5 text-xs text-fg-subtle">Use at least 8 characters.</p>
+            ) : null}
+          </div>
+        ) : null}
+        {mode === "signin" ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-2 px-0"
             disabled={formInteractionBusy}
-            onChange={(event) => updateField("password", event.target.value)}
-            autoComplete={mode === "signin" ? "current-password" : "new-password"}
-            className="mt-2"
-            aria-invalid={Boolean(fieldErrors.password)}
-            aria-describedby={fieldErrors.password ? "managed-auth-password-error" : undefined}
-          />
-          {fieldErrors.password ? (
-            <p
-              id="managed-auth-password-error"
-              role="alert"
-              className="mt-1.5 text-xs text-status-failed"
-            >
-              {fieldErrors.password}
-            </p>
-          ) : mode === "signup" ? (
-            <p className="mt-1.5 text-xs text-fg-subtle">Use at least 8 characters.</p>
-          ) : null}
-        </div>
+            onClick={() => {
+              selectMode("signin");
+              setResetMode(!resetMode);
+              setPassword("");
+            }}
+          >
+            {resetMode ? "Back to sign in" : "Forgot password?"}
+          </Button>
+        ) : null}
         {formError ? (
           <Notice
             tone="failed"
-            title={mode === "signup" ? "Couldn't create account" : "Couldn't sign in"}
+            title={
+              resetMode
+                ? "Couldn't request password reset"
+                : mode === "signup"
+                  ? "Couldn't create account"
+                  : "Couldn't sign in"
+            }
             className="mt-4"
             action={
               formActionMode && formActionMode !== mode && allowedModes.includes(formActionMode) ? (
@@ -366,7 +412,7 @@ export function ManagedAuthPanel(props: {
         {successMessage ? (
           <Notice
             tone="success"
-            title={emailVerificationRequired ? "Check your email" : "Account created"}
+            title={resetMode || emailVerificationRequired ? "Check your email" : "Account created"}
             className="mt-4"
           >
             {successMessage}
@@ -379,7 +425,7 @@ export function ManagedAuthPanel(props: {
           ) : (
             <CheckIcon className="size-4" />
           )}
-          {mode === "signup" ? "Create account" : "Sign in"}
+          {resetMode ? "Send reset link" : mode === "signup" ? "Create account" : "Sign in"}
         </Button>
         {mode === "signup" ? (
           <p className="mt-2 text-center text-xs text-fg-subtle">

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -1,8 +1,8 @@
+import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 import {
   SessionStatus as SessionStatusBadge,
   type SessionEventsConnectionState,
-  useRigs,
   useVariableSets,
 } from "@opengeni/react";
 import { MACHINES_SESSION_POLL_MS } from "@opengeni/react/machines";
@@ -48,7 +48,7 @@ export function SessionInspector(props: {
   const context = useAppContext();
   const navigate = useNavigate();
   const variableSets = useVariableSets({ workspaceId: props.session.workspaceId });
-  const rigs = useRigs({ workspaceId: props.session.workspaceId });
+  const rigs = useWorkspaceRigs({ workspaceId: props.session.workspaceId });
   const sessionVariableSetIds = useMemo(
     () =>
       props.session.variableSetIds ??

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -1,10 +1,11 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 import {
   SessionStatus as SessionStatusBadge,
   type SessionEventsConnectionState,
   useRigs,
   useVariableSets,
 } from "@opengeni/react";
-import { MACHINES_SESSION_POLL_MS, useMachines } from "@opengeni/react/machines";
+import { MACHINES_SESSION_POLL_MS } from "@opengeni/react/machines";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ChevronDownIcon,
@@ -156,7 +157,7 @@ export function SessionInspector(props: {
   // inspector agrees with the "Run on" header instead of reading "modal" while a
   // selfhosted box runs the turn. Degrades to the home backend when no machine is
   // active (or selfhosted is disabled → the fleet 404s to empty).
-  const fleet = useMachines({
+  const fleet = useWorkspaceMachines({
     sessionId: props.session.id,
     pollIntervalMs: MACHINES_SESSION_POLL_MS,
   });

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -1,12 +1,13 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 // The compact "Run on" control in the session header: shows the session's
 // currently-active machine and, on click, opens a dropdown to live-swap the
 // session's active sandbox to any online machine (the session's own box + the
-// enrolled selfhosted machines). Backed by `useMachines({ sessionId })`, whose
+// enrolled selfhosted machines). Backed by `useWorkspaceMachines({ sessionId })`, whose
 // `attach(sandboxId)` performs the swap and re-polls the pointer.
 //
 // Degrades gracefully: when selfhosted is disabled the machines API 404s and
 // `fleet.machines` is empty, so this falls back to a static compute label.
-import { MACHINES_SESSION_POLL_MS, useMachines, type MachineView } from "@opengeni/react/machines";
+import { MACHINES_SESSION_POLL_MS, type MachineView } from "@opengeni/react/machines";
 import type { SandboxBackend } from "@opengeni/sdk";
 import { CheckIcon, ChevronDownIcon, Loader2Icon, ServerIcon } from "lucide-react";
 
@@ -42,7 +43,7 @@ export function SessionSandboxSwitcher({
   sessionId: string;
   sandboxBackend: SandboxBackend;
 }) {
-  const fleet = useMachines({ sessionId, pollIntervalMs: MACHINES_SESSION_POLL_MS });
+  const fleet = useWorkspaceMachines({ sessionId, pollIntervalMs: MACHINES_SESSION_POLL_MS });
   const machines = fleet.machines;
   const activeMachine = machines.find((machine) => machine.active) ?? null;
   const activeName =

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -1,3 +1,4 @@
+import { hasWorkspacePermission } from "@/lib/permissions";
 // Root providers: client config bootstrap, auth (deployment key / configured
 // token / managed session), workspace access, and the cross-route console
 // state (model choice, repo selection, tool toggles). Everything below the
@@ -565,6 +566,10 @@ export function RootRouteComponent() {
   const [authSession, setAuthSession] = useState<AuthSession | null | undefined>(undefined);
   const [managedAuthBootstrapComplete, setManagedAuthBootstrapComplete] = useState(false);
   const [accessContext, setAccessContext] = useState<AccessContext | null>(null);
+  const accessContextRef = useRef(accessContext);
+  useInsertionEffect(() => {
+    accessContextRef.current = accessContext;
+  }, [accessContext]);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [managedSelfContext, setManagedSelfContext] = useState<ManagedSelfContext | null>(null);
   const [slackLinkContinuationWorkspaceId, setSlackLinkContinuationWorkspaceId] = useState<
@@ -1546,6 +1551,17 @@ export function RootRouteComponent() {
           acceptedTransition,
           workspaceId,
         ) && personalGitHubRefreshId.current === refreshId;
+      if (!hasWorkspacePermission(accessContextRef.current, workspaceId, "connections:read")) {
+        setPersonalGitHubStatus(null);
+        setPersonalGitHubRepositories([]);
+        setPersonalGitHubSelection(null);
+        setPersonalGitHubAuthorityCache(null);
+        setSelectedPersonalGitHubRepoIds(new Set());
+        setSelectedPersonalGitHubRepoRefs({});
+        setPersonalGitHubCatalogReady(true);
+        setPersonalGitHubBusy(false);
+        return;
+      }
       setPersonalGitHubBusy(true);
       try {
         const status = await client.personalGitHubStatus(workspaceId);

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -50,7 +50,6 @@ import {
   startManagedSocialSignIn,
 } from "@/api";
 import { LoadingPanel, ProblemPanel } from "@/components/common";
-import { OrganizationOnboardingPanel } from "@/components/organization-onboarding-panel";
 import { SecureContextWarning } from "@/components/secure-context-warning";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -155,6 +154,12 @@ import type {
 const AnalyticsManager = lazy(() =>
   import("@/components/analytics-consent").then((module) => ({
     default: module.AnalyticsManager,
+  })),
+);
+
+const OrganizationOnboardingPanel = lazy(() =>
+  import("@/components/organization-onboarding-panel").then((module) => ({
+    default: module.OrganizationOnboardingPanel,
   })),
 );
 
@@ -2776,17 +2781,19 @@ export function RootRouteComponent() {
         onComplete={revalidatePrincipalAccess}
       />
     ) : (
-      <OrganizationOnboardingPanel
-        client={client}
-        activeEmail={authSession?.user.email ?? null}
-        invitation={organizationInvitationContinuation}
-        onUseInvitedAccount={() => {
-          void handleManagedSignOut().catch((error) =>
-            toast.error("Sign out failed", { description: String(error) }),
-          );
-        }}
-        onComplete={revalidatePrincipalAccess}
-      />
+      <Suspense fallback={<LoadingPanel label="Loading organization setup" />}>
+        <OrganizationOnboardingPanel
+          client={client}
+          activeEmail={authSession?.user.email ?? null}
+          invitation={organizationInvitationContinuation}
+          onUseInvitedAccount={() => {
+            void handleManagedSignOut().catch((error) =>
+              toast.error("Sign out failed", { description: String(error) }),
+            );
+          }}
+          onComplete={revalidatePrincipalAccess}
+        />
+      </Suspense>
     )
   ) : accessLoading || !appContext ? (
     <LoadingPanel label="Loading workspace access" />

--- a/apps/web/src/lib/use-workspace-machines.ts
+++ b/apps/web/src/lib/use-workspace-machines.ts
@@ -13,15 +13,32 @@ export function useWorkspaceMachines(options: UseMachinesOptions = {}) {
     options.workspaceId ?? workspaceId,
     "enrollments:read",
   );
+  const canManage =
+    canRead &&
+    hasWorkspacePermission(accessContext, options.workspaceId ?? workspaceId, "enrollments:manage");
+  const canControl =
+    canRead &&
+    hasWorkspacePermission(accessContext, options.workspaceId ?? workspaceId, "sessions:control");
   const fleet = useMachines({ ...options, enabled: canRead && options.enabled !== false });
   return {
     ...fleet,
     canRead,
+    canManage,
+    canControl,
+    canRemove: canManage && fleet.canRemove,
+    canUpdateAgent: canManage && fleet.canUpdateAgent,
+    canUpdateOperationPolicy: canManage && fleet.canUpdateOperationPolicy,
+    remove: canManage ? fleet.remove : async () => null,
+    updateAgent: canManage ? fleet.updateAgent : async () => null,
+    updateOperationPolicy: canManage ? fleet.updateOperationPolicy : async () => null,
+    attach: canControl ? fleet.attach : async () => false,
+    fetchSeries: canRead ? fleet.fetchSeries : async () => [],
+    mutationError: canRead ? fleet.mutationError : null,
     machines: canRead ? fleet.machines : [],
     activeSandboxId: canRead ? fleet.activeSandboxId : null,
     loading: canRead && fleet.loading,
     error: canRead ? fleet.error : null,
     refresh: canRead ? fleet.refresh : async () => {},
-    canAttach: canRead && fleet.canAttach,
+    canAttach: canControl && fleet.canAttach,
   };
 }

--- a/apps/web/src/lib/use-workspace-machines.ts
+++ b/apps/web/src/lib/use-workspace-machines.ts
@@ -1,0 +1,27 @@
+import { useOpenGeni } from "@opengeni/react";
+import { useMachines, type UseMachinesOptions } from "@opengeni/react/machines";
+import { useAppContext } from "@/context";
+import { hasWorkspacePermission } from "@/lib/permissions";
+
+// Stock-console reads follow the current workspace grant. The public React
+// hook remains usable by embedding hosts with their own authorization model.
+export function useWorkspaceMachines(options: UseMachinesOptions = {}) {
+  const { workspaceId } = useOpenGeni();
+  const { accessContext } = useAppContext();
+  const canRead = hasWorkspacePermission(
+    accessContext,
+    options.workspaceId ?? workspaceId,
+    "enrollments:read",
+  );
+  const fleet = useMachines({ ...options, enabled: canRead && options.enabled !== false });
+  return {
+    ...fleet,
+    canRead,
+    machines: canRead ? fleet.machines : [],
+    activeSandboxId: canRead ? fleet.activeSandboxId : null,
+    loading: canRead && fleet.loading,
+    error: canRead ? fleet.error : null,
+    refresh: canRead ? fleet.refresh : async () => {},
+    canAttach: canRead && fleet.canAttach,
+  };
+}

--- a/apps/web/src/lib/use-workspace-machines.ts
+++ b/apps/web/src/lib/use-workspace-machines.ts
@@ -1,7 +1,18 @@
 import { useOpenGeni } from "@opengeni/react";
-import { useMachines, type UseMachinesOptions } from "@opengeni/react/machines";
+import {
+  useMachines,
+  type MachineView,
+  type MetricSample,
+  type UseMachinesOptions,
+} from "@opengeni/react/machines";
 import { useAppContext } from "@/context";
 import { hasWorkspacePermission } from "@/lib/permissions";
+
+const EMPTY_MACHINES: MachineView[] = [];
+const ignoreRefresh = async () => {};
+const denyMutation = async () => null;
+const denyAttach = async () => false;
+const emptySeries = async (): Promise<MetricSample[]> => [];
 
 // Stock-console reads follow the current workspace grant. The public React
 // hook remains usable by embedding hosts with their own authorization model.
@@ -28,17 +39,17 @@ export function useWorkspaceMachines(options: UseMachinesOptions = {}) {
     canRemove: canManage && fleet.canRemove,
     canUpdateAgent: canManage && fleet.canUpdateAgent,
     canUpdateOperationPolicy: canManage && fleet.canUpdateOperationPolicy,
-    remove: canManage ? fleet.remove : async () => null,
-    updateAgent: canManage ? fleet.updateAgent : async () => null,
-    updateOperationPolicy: canManage ? fleet.updateOperationPolicy : async () => null,
-    attach: canControl ? fleet.attach : async () => false,
-    fetchSeries: canRead ? fleet.fetchSeries : async () => [],
+    remove: canManage ? fleet.remove : denyMutation,
+    updateAgent: canManage ? fleet.updateAgent : denyMutation,
+    updateOperationPolicy: canManage ? fleet.updateOperationPolicy : denyMutation,
+    attach: canControl ? fleet.attach : denyAttach,
+    fetchSeries: canRead ? fleet.fetchSeries : emptySeries,
     mutationError: canRead ? fleet.mutationError : null,
-    machines: canRead ? fleet.machines : [],
+    machines: canRead ? fleet.machines : EMPTY_MACHINES,
     activeSandboxId: canRead ? fleet.activeSandboxId : null,
     loading: canRead && fleet.loading,
     error: canRead ? fleet.error : null,
-    refresh: canRead ? fleet.refresh : async () => {},
+    refresh: canRead ? fleet.refresh : ignoreRefresh,
     canAttach: canControl && fleet.canAttach,
   };
 }

--- a/apps/web/src/lib/use-workspace-rigs.ts
+++ b/apps/web/src/lib/use-workspace-rigs.ts
@@ -1,6 +1,10 @@
+import type { Rig } from "@opengeni/sdk";
 import { useOpenGeni, useRigs, type UseRigsOptions } from "@opengeni/react";
 import { useAppContext } from "@/context";
 import { hasWorkspacePermission } from "@/lib/permissions";
+
+const EMPTY_RIGS: Rig[] = [];
+const ignoreRefresh = async () => {};
 
 // Keep stock-console catalog reads and retries inside the workspace grant.
 export function useWorkspaceRigs(options: UseRigsOptions = {}) {
@@ -14,9 +18,9 @@ export function useWorkspaceRigs(options: UseRigsOptions = {}) {
   const rigs = useRigs({ ...options, enabled: canUse && options.enabled !== false });
   return {
     ...rigs,
-    rigs: canUse ? rigs.rigs : [],
+    rigs: canUse ? rigs.rigs : EMPTY_RIGS,
     loading: canUse && rigs.loading,
     error: canUse ? rigs.error : null,
-    refresh: canUse ? rigs.refresh : async () => {},
+    refresh: canUse ? rigs.refresh : ignoreRefresh,
   };
 }

--- a/apps/web/src/lib/use-workspace-rigs.ts
+++ b/apps/web/src/lib/use-workspace-rigs.ts
@@ -1,0 +1,22 @@
+import { useOpenGeni, useRigs, type UseRigsOptions } from "@opengeni/react";
+import { useAppContext } from "@/context";
+import { hasWorkspacePermission } from "@/lib/permissions";
+
+// Keep stock-console catalog reads and retries inside the workspace grant.
+export function useWorkspaceRigs(options: UseRigsOptions = {}) {
+  const { workspaceId } = useOpenGeni();
+  const { accessContext } = useAppContext();
+  const canUse = hasWorkspacePermission(
+    accessContext,
+    options.workspaceId ?? workspaceId,
+    "rigs:use",
+  );
+  const rigs = useRigs({ ...options, enabled: canUse && options.enabled !== false });
+  return {
+    ...rigs,
+    rigs: canUse ? rigs.rigs : [],
+    loading: canUse && rigs.loading,
+    error: canUse ? rigs.error : null,
+    refresh: canUse ? rigs.refresh : async () => {},
+  };
+}

--- a/apps/web/src/lib/workspace-resource-permissions.test.ts
+++ b/apps/web/src/lib/workspace-resource-permissions.test.ts
@@ -1,0 +1,93 @@
+import { expect, mock, test } from "bun:test";
+
+let permissions: string[] = [];
+let machineEnabled: boolean | undefined;
+let rigsEnabled: boolean | undefined;
+const action = mock(async () => null);
+const refresh = mock(async () => {});
+const attach = mock(async () => true);
+const machine = { sandboxId: "machine" };
+mock.module("@/context", () => ({
+  useAppContext: () => ({
+    accessContext: { workspaceGrants: [{ workspaceId: "workspace", permissions }] },
+  }),
+}));
+mock.module("@opengeni/react", () => ({
+  useOpenGeni: () => ({ workspaceId: "workspace" }),
+  useRigs: (options: { enabled?: boolean }) => {
+    rigsEnabled = options.enabled;
+    return { rigs: [{ id: "rig" }], loading: false, error: null, refresh };
+  },
+}));
+mock.module("@opengeni/react/machines", () => ({
+  useMachines: (options: { enabled?: boolean }) => {
+    machineEnabled = options.enabled;
+    return {
+      machines: [machine],
+      activeSandboxId: "machine",
+      loading: false,
+      error: null,
+      refresh,
+      canRemove: true,
+      canUpdateAgent: true,
+      canUpdateOperationPolicy: true,
+      canAttach: true,
+      remove: action,
+      updateAgent: action,
+      updateOperationPolicy: action,
+      attach,
+      fetchSeries: action,
+      mutationError: null,
+    };
+  },
+}));
+const { useWorkspaceMachines } = await import("./use-workspace-machines");
+const { useWorkspaceRigs } = await import("./use-workspace-rigs");
+
+test("denied resource reads and manual retries remain request-free, including after revocation", async () => {
+  permissions = ["workspace:admin"];
+  expect(useWorkspaceMachines().machines.map((item) => item.sandboxId)).toEqual([
+    machine.sandboxId,
+  ]);
+  expect(useWorkspaceRigs().rigs).toHaveLength(1);
+  permissions = [];
+  const machines = useWorkspaceMachines();
+  const rigs = useWorkspaceRigs();
+  expect(machineEnabled).toBe(false);
+  expect(rigsEnabled).toBe(false);
+  expect(machines.machines).toEqual([]);
+  expect(rigs.rigs).toEqual([]);
+  await machines.refresh();
+  await rigs.refresh();
+  expect(refresh).not.toHaveBeenCalled();
+  expect(await machines.attach("machine")).toBe(false);
+  expect(attach).not.toHaveBeenCalled();
+});
+
+test("machine readers cannot manage machines; controls recover with exact grants", async () => {
+  permissions = ["enrollments:read"];
+  let machines = useWorkspaceMachines();
+  expect(machineEnabled).toBe(true);
+  expect(machines.machines.map((item) => item.sandboxId)).toEqual([machine.sandboxId]);
+  expect(machines.canManage).toBe(false);
+  expect(machines.canRemove).toBe(false);
+  expect(machines.canUpdateAgent).toBe(false);
+  expect(machines.canUpdateOperationPolicy).toBe(false);
+  expect(machines.canAttach).toBe(false);
+  await machines.remove("machine");
+  await machines.updateAgent("machine");
+  await machines.updateOperationPolicy("machine", {} as never);
+  expect(action).not.toHaveBeenCalled();
+  permissions = ["enrollments:read", "enrollments:manage", "sessions:control", "rigs:use"];
+  machines = useWorkspaceMachines();
+  expect(machines.canManage).toBe(true);
+  expect(machines.canRemove).toBe(true);
+  expect(machines.canAttach).toBe(true);
+  await machines.remove("machine");
+  await useWorkspaceRigs().refresh();
+  expect(action).toHaveBeenCalledTimes(1);
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(rigsEnabled).toBe(true);
+  useWorkspaceRigs({ enabled: false });
+  expect(rigsEnabled).toBe(false);
+});

--- a/apps/web/src/lib/workspace-resource-permissions.test.ts
+++ b/apps/web/src/lib/workspace-resource-permissions.test.ts
@@ -53,6 +53,11 @@ test("denied resource reads and manual retries remain request-free, including af
   permissions = [];
   const machines = useWorkspaceMachines();
   const rigs = useWorkspaceRigs();
+  expect(useWorkspaceMachines().fetchSeries).toBe(machines.fetchSeries);
+  expect(useWorkspaceMachines().machines).toBe(machines.machines);
+  expect(useWorkspaceMachines().refresh).toBe(machines.refresh);
+  expect(useWorkspaceRigs().rigs).toBe(rigs.rigs);
+  expect(useWorkspaceRigs().refresh).toBe(rigs.refresh);
   expect(machineEnabled).toBe(false);
   expect(rigsEnabled).toBe(false);
   expect(machines.machines).toEqual([]);

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 // Plugins: the workspace integrations marketplace. A single scrollable
 // page with exactly three sections: Integrations, Connectors, and Bundles.
 // Integrations (Slack, GitHub, Google
@@ -17,7 +18,7 @@
 // row (see `bundles-section.tsx`) instead of three unheaded blocks. Nothing
 // with kind skill, plugin, or pack ever reaches the Connectors Enabled/Browse
 // projections.
-import { usePacks, useRigs, useVariableSets } from "@opengeni/react";
+import { usePacks, useVariableSets } from "@opengeni/react";
 import { PlugIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -272,7 +273,7 @@ export function CapabilitiesRoute({
   const [registrySearched, setRegistrySearched] = useState<string | null>(null);
 
   const packs = usePacks({ workspaceId });
-  const rigs = useRigs({ workspaceId });
+  const rigs = useWorkspaceRigs({ workspaceId });
   const variableSets = useVariableSets({ workspaceId });
 
   // The Connectors surface owns exactly MCP servers and API connectors. Skills,

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 // Machines: the workspace's bring-your-own-compute fleet — enrolled selfhosted
 // machines, each with its connection-status pill, state badges, latest metrics
 // (CPU/load/mem/disk/GPU), and an enroll affordance. The session-scoped attach/
@@ -10,7 +11,6 @@ import {
   MachineDetail,
   MachinesDashboard,
   connectionStatusForState,
-  useMachines,
   MACHINES_DASHBOARD_POLL_MS,
   type DeviceFlowPhase,
   type MetricSample,
@@ -66,7 +66,7 @@ export async function copyToClipboard(text: string, successMessage: string) {
 
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   const { client } = useAppContext();
-  const machines = useMachines({ pollIntervalMs: MACHINES_DASHBOARD_POLL_MS });
+  const machines = useWorkspaceMachines({ pollIntervalMs: MACHINES_DASHBOARD_POLL_MS });
   const pageLive = usePageLiveActivity();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<MachineView | null>(null);
@@ -213,7 +213,12 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       />
 
       <div className="mt-5">
-        {featureUnavailable ? (
+        {!machines.canRead ? (
+          <Notice tone="muted" title="Machines are managed by your workspace admin">
+            You do not have permission to view connected machines in this workspace. Ask a workspace
+            admin for access.
+          </Notice>
+        ) : featureUnavailable ? (
           <Notice tone="muted">
             Connected machines aren't enabled on this deployment. Sessions run on the managed
             sandbox.

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -269,7 +269,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
             onOpenDetail={(m) => setDetailId(m.sandboxId)}
             now={now}
             onRefresh={() => void machines.refresh()}
-            onEnroll={() => setEnrollOpen(true)}
+            onEnroll={machines.canManage ? () => setEnrollOpen(true) : undefined}
             {...(machines.canUpdateAgent
               ? {
                   onUpdateAgent: (machine: MachineView) => {
@@ -301,7 +301,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
         </Notice>
       ) : null}
 
-      <Dialog open={enrollOpen} onOpenChange={setEnrollOpen}>
+      <Dialog open={enrollOpen && machines.canManage} onOpenChange={setEnrollOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>Connect a machine</DialogTitle>
@@ -313,12 +313,14 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
           {/* Gated on `enrollOpen` so the body mounts (and mints a fresh token)
               each time the dialog is opened, and unmounts on close — Radix already
               unmounts closed content, this just makes the mint-on-open explicit. */}
-          {enrollOpen ? <EnrollDialogBody workspaceId={workspaceId} origin={origin} /> : null}
+          {enrollOpen && machines.canManage ? (
+            <EnrollDialogBody workspaceId={workspaceId} origin={origin} />
+          ) : null}
         </DialogContent>
       </Dialog>
 
       <ConfirmDialog
-        open={removeTarget !== null}
+        open={removeTarget !== null && machines.canManage}
         onOpenChange={(open) => {
           if (!open) {
             setRemoveTarget(null);
@@ -331,12 +333,15 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
         description="Access will be revoked immediately while the machine is offline. Its session, route, lease, archive, and audit history will be kept; reconnecting later requires a fresh human-approved enrollment."
         confirmLabel={
           removeBlocked?.code === "active_route"
-            ? "Move sessions and remove machine"
+            ? machines.canControl
+              ? "Move sessions and remove machine"
+              : "Close"
             : "Remove machine"
         }
         onConfirm={async () => {
           const target = removeTarget;
-          if (!target?.enrollmentId) return false;
+          if (!target?.enrollmentId || !machines.canManage) return false;
+          if (removeBlocked?.code === "active_route" && !machines.canControl) return true;
           const sessionsToMove =
             removeBlocked?.code === "active_route" ? removeBlocked.dependentSessions : [];
           if (sessionsToMove.length > 0) {
@@ -389,6 +394,11 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
                   : "Never connected"}
               </p>
             </div>
+            {removeBlocked?.code === "active_route" && !machines.canControl ? (
+              <Notice tone="muted">
+                Ask a workspace admin to move the active sessions before removing this machine.
+              </Notice>
+            ) : null}
             {removeMoveError ? (
               <Notice tone="failed" title="Couldn't move every session">
                 {removeMoveError.message}

--- a/apps/web/src/routes/onboarding.test.tsx
+++ b/apps/web/src/routes/onboarding.test.tsx
@@ -74,6 +74,7 @@ mock.module("@/api", () => ({
     state: "required" as const,
   })),
   sendVerificationEmail: resendVerification,
+  requestPasswordReset: mock(async () => ({ status: true })),
   subscribeManagedActorInvalidation: () => () => undefined,
   subscribeManagedActorMutationBusy: () => () => undefined,
 }));

--- a/apps/web/src/routes/rigs.tsx
+++ b/apps/web/src/routes/rigs.tsx
@@ -1,8 +1,9 @@
+import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 // Rigs: organization-, workspace-, or user-scoped sandbox machine definitions. A rig is the
 // team's machine — a setup/check layer over the platform sandbox image plus
 // default variable sets, versioned and self-healing. This page lists them and
 // creates new ones; the per-rig detail owns versions, changes, and promotion.
-import { useRigs, useVariableSets } from "@opengeni/react";
+import { useVariableSets } from "@opengeni/react";
 import { Link } from "@tanstack/react-router";
 import {
   CheckIcon,
@@ -62,7 +63,7 @@ export function RigsRoute({ workspaceId }: { workspaceId: string }) {
         membership.status === "active" && membership.organizationId === workspace.accountId,
     ),
   );
-  const rigs = useRigs({ enabled: canView });
+  const rigs = useWorkspaceRigs({ enabled: canView });
   const defaultRigId =
     context.workspaces.find((candidate) => candidate.id === workspaceId)?.defaultRigId ?? null;
   const [createOpen, setCreateOpen] = useState(false);

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -1,8 +1,9 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 import { loadSessionSchedules } from "@/lib/scheduled-tasks";
 // Shared schedules for agent turns and deterministic knowledge-source syncs,
 // with honest per-run outcomes and no implied agent session for connector work.
 import { useNavigate } from "@tanstack/react-router";
-import { MACHINES_COMPOSER_POLL_MS, useMachines, type MachineView } from "@opengeni/react/machines";
+import { MACHINES_COMPOSER_POLL_MS, type MachineView } from "@opengeni/react/machines";
 import {
   BotIcon,
   CalendarClockIcon,
@@ -160,7 +161,7 @@ export function SchedulesRoute({
   const navigate = useNavigate();
   const client = context.client;
   const modelCatalog = useWorkspaceModelCatalog(workspaceId);
-  const fleet = useMachines({ pollIntervalMs: MACHINES_COMPOSER_POLL_MS });
+  const fleet = useWorkspaceMachines({ pollIntervalMs: MACHINES_COMPOSER_POLL_MS });
   const [list, setList] = useState<ScheduleListSnapshot>(EMPTY_LIST);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,10 +1,11 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 import { getComposerSendBlocker } from "@/lib/composer-send-blocking";
 import { FailureRecoveryBoundary } from "@/components/session/failure-recovery-boundary";
 // The session view — live timeline plus one compact prompt queue above the
 // composer. Enter queues and Cmd/Ctrl+Enter steers; failed sessions stay
 // honest (reason + retry history) and revivable from the same composer.
 import { LightboxProvider, type WorkspaceTab } from "@opengeni/react";
-import { MACHINES_SESSION_POLL_MS, useMachines } from "@opengeni/react/machines";
+import { MACHINES_SESSION_POLL_MS } from "@opengeni/react/machines";
 import { HumanInputSurface, MessageTimeline, SessionChrome } from "@opengeni/react/session-ui";
 import {
   creditExhaustedFromEvents,
@@ -1168,7 +1169,7 @@ function SessionChatPane(props: {
 }) {
   const context = useAppContext();
   const modelCatalog = useWorkspaceModelCatalog(props.session.workspaceId);
-  const fleet = useMachines({
+  const fleet = useWorkspaceMachines({
     sessionId: props.session.id,
     pollIntervalMs: MACHINES_SESSION_POLL_MS,
   });

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 // The sessions index: the centered "Start a session" composer. The form is
 // organised top-down — (A) message + model/tools/repos pills → (B) WHERE SHOULD
 // THIS RUN? (when machines exist) → (C) rig/variable-set or machine fields.
@@ -23,7 +24,7 @@ import {
   type ComposerState,
 } from "@opengeni/react";
 import { resolveWorkspaceSessionToolDefaults } from "@opengeni/contracts";
-import { MACHINES_COMPOSER_POLL_MS, useMachines, type MachineView } from "@opengeni/react/machines";
+import { MACHINES_COMPOSER_POLL_MS, type MachineView } from "@opengeni/react/machines";
 import {
   NewSessionRealtimeControl,
   RealtimeVoiceModelPanel,
@@ -273,7 +274,8 @@ function SessionsIndexRouteContent({
   const variableSets = useVariableSets({
     enabled: fixedResourceCatalogEnabled && canLoadVariableSetCatalog,
   });
-  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled });
+  const canUseRigs = hasWorkspacePermission(context.accessContext, workspaceId, "rigs:use");
+  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled && canUseRigs });
   const [tenancyCapabilities, setTenancyCapabilities] = useState<{
     activated: boolean;
     canCreatePrivate: boolean;
@@ -500,7 +502,7 @@ function SessionsIndexRouteContent({
       : [];
   });
   const [fleetPollMs, setFleetPollMs] = useState<number | undefined>(undefined);
-  const fleet = useMachines({ pollIntervalMs: fleetPollMs });
+  const fleet = useWorkspaceMachines({ pollIntervalMs: fleetPollMs });
   const machines = fleet.machines.filter((machine) => machine.kind === "selfhosted");
   const fleetEmpty = machines.length === 0;
   const fleetLoadFailed =
@@ -550,7 +552,7 @@ function SessionsIndexRouteContent({
           : canResolveVariableSetAttachments
             ? resolveVariableSetAttachments()
             : Promise.resolve(),
-        rigs.refresh(),
+        canUseRigs ? rigs.refresh() : Promise.resolve(),
       ]);
     } finally {
       if (personalResourceCatalogRefreshGeneration.current === generation) {
@@ -1912,7 +1914,7 @@ function ComputeTargetControl(props: {
   onComputeChange: (draft: SessionDraft) => void;
   disabled: boolean;
   personalResourceAccess: NewSessionPersonalResourceAccess;
-  fleet: ReturnType<typeof useMachines>;
+  fleet: ReturnType<typeof useWorkspaceMachines>;
   machines: MachineView[];
   variableSets: VariableSet[];
   rigs: Rig[];

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 // The sessions index: the centered "Start a session" composer. The form is
 // organised top-down — (A) message + model/tools/repos pills → (B) WHERE SHOULD
@@ -18,7 +19,6 @@ import {
   FILE_ONLY_MESSAGE_TEXT,
   LightboxProvider,
   useChannels,
-  useRigs,
   useVariableSets,
   useWorkspaceSessions,
   type ComposerState,
@@ -275,7 +275,7 @@ function SessionsIndexRouteContent({
     enabled: fixedResourceCatalogEnabled && canLoadVariableSetCatalog,
   });
   const canUseRigs = hasWorkspacePermission(context.accessContext, workspaceId, "rigs:use");
-  const rigs = useRigs({ enabled: fixedResourceCatalogEnabled && canUseRigs });
+  const rigs = useWorkspaceRigs({ enabled: fixedResourceCatalogEnabled && canUseRigs });
   const [tenancyCapabilities, setTenancyCapabilities] = useState<{
     activated: boolean;
     canCreatePrivate: boolean;

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -798,6 +798,30 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     });
     expect(changedCompletionReplay.status).toBe(409);
 
+    // Real member journey must not make admin-only fleet/connection reads.
+    const deniedReads: string[] = [];
+    setupPage.on("response", (response) => {
+      if (response.status() === 403) deniedReads.push(new URL(response.url()).pathname);
+    });
+    await setupPage.goto(`${publicOrigin}/workspaces/${sharedWorkspaceId}/sessions`);
+    await setupPage.getByRole("heading", { name: "What should the agent do?" }).waitFor();
+
+    expect(await setupPage.locator("body").textContent()).not.toContain(
+      "GitHub account is unavailable",
+    );
+    expect(await setupPage.locator("body").textContent()).not.toContain(
+      "Couldn't load your connected machines",
+    );
+    await setupPage.goto(`${publicOrigin}/workspaces/${sharedWorkspaceId}/machines`);
+    await setupPage
+      .getByText("Machines are managed by your workspace admin", { exact: true })
+      .waitFor();
+    expect(await setupPage.getByRole("button", { name: /Connect a machine/ }).count()).toBe(0);
+    expect(deniedReads).toEqual([]);
+    await setupPage.screenshot({
+      path: `${EVIDENCE_DIR}/member-machines-restricted.png`,
+      fullPage: true,
+    });
     expectNoBrowserProblems(ownerProblems);
     expectNoBrowserProblems(setupProblems);
     expect(transport.size()).toBeLessThanOrEqual(80);
@@ -1135,15 +1159,20 @@ describe("organization onboarding with real Better Auth / Hono / SDK / PostgreSQ
     expectNoBrowserProblems(alternateProblems);
     await alternateContext.close();
 
-    const forget = await fetch(`${publicOrigin}/v1/auth/request-password-reset`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        email: registeredEmail,
-        redirectTo: "/reset-password",
-      }),
+    const resetRequestContext = await browser.newContext();
+    const resetRequestPage = await resetRequestContext.newPage();
+    await resetRequestPage.goto(publicOrigin);
+    await resetRequestPage.getByRole("button", { name: "Forgot password?" }).click();
+    await resetRequestPage.getByLabel("Email", { exact: true }).fill(registeredEmail);
+    expect(await resetRequestPage.getByLabel("Password", { exact: true }).count()).toBe(0);
+    await resetRequestPage.getByRole("button", { name: "Send reset link", exact: true }).click();
+    await resetRequestPage.getByText("If this email has an account,", { exact: false }).waitFor();
+    await expectNoAxeViolations(resetRequestPage, "body");
+    await resetRequestPage.screenshot({
+      path: `${EVIDENCE_DIR}/password-reset-request.png`,
+      fullPage: true,
     });
-    expect(forget.status).toBe(200);
+    await resetRequestContext.close();
     const resetEmail = await takeEmail("password_reset", registeredEmail);
     const resetUrl = new URL(firstUrl(resetEmail));
     expect(resetUrl.pathname.startsWith("/v1/auth/reset-password/")).toBe(true);


### PR DESCRIPTION
Staging QA found that ordinary workspace members received raw permission errors while starting sessions or opening Machines, and signed-out users had no password-recovery entry point.

This change gates GitHub, machine, and rig requests using workspace permissions, clears inaccessible cached resources, and gives restricted members an explanatory Machines state. Sign-in now offers Forgot password through the existing reset-email flow, with neutral confirmation and retry handling. Verification guidance identifies the email subject and next step. All stock rig catalog reads/retries and machine management controls follow their exact grants. Organization setup loads on demand so normal sessions stay below the existing bundle budget.

Validation:
- Real browser onboarding acceptance: 3 passing tests, 98 assertions, including member composer/Machines with no 403 responses and password reset requested through the UI through successful login.
- Password-recovery component test, onboarding component tests, focused auth/permissions/machine tests passed.
- Permission regressions: 2 tests / 29 assertions covering revocation, denied retries, read-only members, grant recovery, and stable denied-state callbacks.
- Production build passed existing bundle limits (direct session: 2,307,114 bytes against 2,314,240).
- Web TypeScript, web lint, workspace/billing guards, formatting and diff checks passed.
- Independent review approved exact head 9af0286e2 after fixing the related rig and machine-control findings.

Tracks OPE-448. QA observations about Personal-first invitation onboarding and verification requiring sign-in match the documented product behavior. Missing legal links require approved policy destinations; this PR does not invent those policies.
