### PR TITLE
Pass the prepared SDK history to the durability guard

### DIFF
--- a/apps/worker/src/activities/agent-turn/history-sink.ts
+++ b/apps/worker/src/activities/agent-turn/history-sink.ts
@@ -51,7 +51,7 @@ export type TurnHistorySinkDeps = {
 export class TurnHistorySink {
   private readonly prefix = new HistoryPrefixGuard();
 
-  seedHistory(input: unknown, count: number) {
+  seedHistory(input: string | readonly unknown[] | { readonly history: unknown[] }, count: number) {
     const items =
       typeof input === "string" && count === 0
         ? []

--- a/apps/worker/src/activities/agent-turn/stream-attempt.ts
+++ b/apps/worker/src/activities/agent-turn/stream-attempt.ts
@@ -471,7 +471,7 @@ export async function runTurnStreamAttempt(
       // prepareInput already sanitized the exact durable prefix represented
       // by state.history. Carry its count forward instead of loading and
       // retaining the full active transcript a second time beside runInput.
-      historySink.seedHistory(prepared.input, prepared.persistedHistoryCount);
+      historySink.seedHistory(prepared.input.input, prepared.persistedHistoryCount);
       preparedHistoryCount = prepared.persistedHistoryCount;
       const historyPositionStartedAt = performance.now();
       let historyPositionOutcome: "completed" | "failed" = "completed";

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,11 +201,7 @@ Canonical: `apps/worker/src/activities/agent-turn/`,
 `apps/worker/src/activities/session-state.ts`, and
 [`run-lifecycle.md`](run-lifecycle.md).
 
-Externally owned SDK history preserves retained messages across opaque compaction
-checkpoints in both provider input and returned history. The turn history sink
-checks the identities and order of its durable prefix before advancing its append
-cursor; database position conflicts succeed only for the same turn and exact
-canonical item. Provider dispatch and successful settlement require this check.
+External SDK history and append verification: [`run-lifecycle.md`](run-lifecycle.md).
 
 ### 3.4 Long runs are bounded by policy and intent, not arbitrary loop caps
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -9,6 +9,12 @@ over this doc; the canonical sources are `apps/worker/src/workflows/session.ts`,
 
 ## Turns
 
+Externally owned SDK history preserves retained messages across opaque compaction
+checkpoints in both provider input and returned history. The turn history sink
+checks the identities and order of its durable prefix before advancing its append
+cursor; database position conflicts succeed only for the same turn and exact
+canonical item. Provider dispatch and successful settlement require this check.
+
 A **turn** is one logical unit of agent work inside a session: a waiting
 human/API prompt, an approval or structured-input response, or one coalesced
 internal-update batch is processed until the agent reaches a natural stopping

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1387,8 +1387,14 @@ describe("worker activities integration", () => {
     });
     const runtime: OpenGeniRuntime = {
       ...baseRuntime,
-      runStream: async () =>
-        ({
+      runStream: async (_agent, prepared) => {
+        // The SDK preserves the exact prepared input under external ownership.
+        // Keep this transport-error fixture faithful to that contract.
+        const original = Array.isArray(prepared.input)
+          ? prepared.input
+          : [{ type: "message", role: "user", content: prepared.input }];
+        state.history = [...original, ...state.history.slice(1)] as typeof state.history;
+        return {
           toStream: () =>
             (async function* () {
               yield {
@@ -1422,7 +1428,8 @@ describe("worker activities integration", () => {
           interruptions: [],
           state,
           finalOutput: "",
-        }) as never,
+        } as never;
+      },
     };
     const activities = createWorkerActivities({
       settings: testSettings({
@@ -2041,7 +2048,17 @@ describe("worker activities integration", () => {
           toStream: () => (async function* () {})(),
           completed: Promise.resolve(),
           interruptions: [],
-          state: { toString: () => "resumed-state" },
+          state: {
+            history: [
+              { type: "message", role: "user", content: "approved" },
+              {
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "approved" }],
+              },
+            ],
+            toString: () => "resumed-state",
+          },
           finalOutput: "approved",
         } as never;
       },


### PR DESCRIPTION
The worker passes a PreparedAgentInput wrapper through turnInput. Seed the new history guard from its nested SDK input, and narrow the parameter type so passing the wrapper cannot compile.

Two recovery fixtures now expose the exact prepared/returned history promised by the real SDK, instead of manufacturing a different prefix or omitting history. Move detailed lifecycle documentation out of the architecture file to keep its orientation budget.

Validation: actual worker continuation passes; 53 worker integration cases passed in the full run and the two corrected recovery fixtures pass separately. Compaction activity and durability suites: 29 pass, 229 assertions. Worker typecheck and documentation guards pass. This follows PR #2260; no affected image has been deployed.

## Summary by Sourcery

Pass the prepared SDK history into the durability guard and align recovery fixtures and lifecycle documentation with the SDK contract.

Bug Fixes:
- Seed the durability guard from the nested SDK input so prepared agent wrappers cannot be passed as history input.

Enhancements:
- Narrow the history seeding contract to supported SDK input shapes.
- Move detailed external-history and append-verification lifecycle guidance into the run-lifecycle documentation.

Documentation:
- Relocate detailed SDK history lifecycle documentation from the architecture overview to the run-lifecycle guide.

Tests:
- Update recovery fixtures to preserve and expose the exact prepared and returned history expected from the SDK.