### PR TITLE
Fix oversized history continuation and command failure preservation

### DIFF
--- a/.changeset/bounded-history-review-fixes.md
+++ b/.changeset/bounded-history-review-fixes.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Correct oversized session-message continuation with bounded source slicing, preserve typed runner terminal failures during command observation, and keep retained command output readable when live refresh encounters a recognized temporary transport failure. Refresh fallback rechecks API authorization and explicitly marks unavailable freshness; it does not mask integrity or authorization errors.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -4870,7 +4870,7 @@ function registerWorkspaceOrchestrationTools(
       "session_events",
       {
         description:
-          "Read session history. Default view=conversation returns roughly ten complete user/assistant messages, including completed commentary, in a 16 KiB envelope; no token deltas or execution records. Prefer fewer complete messages; a single oversized message has fragment offsets and a lossless nextCursor continuation over retained source text. Pass cursor=nextCursor with sessionId, omitting other selectors; it binds the view, detail and direction. after/nextAfter and before/nextBefore only change position, never view or detail; use nextCursor when present to avoid skipping a message fragment. view=results returns final turn answers and actionable outcomes without duplicate message-completion text. view=tools returns compact call/result identities; includeArguments/includeOutput opt into one text or JSON-encoded value, and callId selects an exact call (sparse scans can return an empty advancing page). sourceExact=false identifies a legacy database projection whose original bytes cannot be reconstructed here. Conversation/results/tools omit never-claimed human/API prompts and stale duplicate events. view=debug exposes the existing authorized audit query with explicit type/class filters, mode=monitoring|forensic and payloadMode=none|summary|full; raw deltas and never-claimed prompts require mode=forensic. Explicit legacy audit selectors remain supported without view. latest is an exclusive semantic-class lookup; resultMode=compact requires latest. No read observes commands or changes append-only history. REST behavior is unchanged.",
+          "Read session history. Default view=conversation returns roughly ten complete user/assistant messages, including completed commentary, in a 16 KiB envelope; no token deltas or execution records. Prefer fewer complete messages; a single oversized message has fragment offsets and a lossless nextCursor continuation over retained source text, including large legacy rows. Fragment unit is codepoint for plain text or utf16 for codec text; pass the opaque v2 cursor unchanged (v1 cursors must restart). Pass cursor=nextCursor with sessionId, omitting other selectors; it binds the view, detail and direction. after/nextAfter and before/nextBefore only change position, never view or detail; use nextCursor when present to avoid skipping a message fragment. view=results returns final turn answers and actionable outcomes without duplicate message-completion text. view=tools returns compact call/result identities; includeArguments/includeOutput opt into one text or JSON-encoded value, and callId selects an exact call (sparse scans can return an empty advancing page). sourceExact=false and sourceOmitted identify oversized structured values that were omitted, never partial JSON presented as complete; scalar text remains resumable. Conversation/results/tools omit never-claimed human/API prompts and stale duplicate events. view=debug exposes the existing authorized audit query with explicit type/class filters, mode=monitoring|forensic and payloadMode=none|summary|full; raw deltas and never-claimed prompts require mode=forensic. Explicit legacy audit selectors remain supported without view. latest is an exclusive semantic-class lookup; resultMode=compact requires latest. No read observes commands or changes append-only history. REST behavior is unchanged.",
         inputSchema: {
           sessionId: z4.string().uuid(),
           view: z4.enum(["conversation", "results", "tools", "debug"]).optional(),
@@ -4972,6 +4972,7 @@ function registerWorkspaceOrchestrationTools(
         }
         if (view !== "debug" && !auditRequested) {
           const { readSessionEventView } = await import("./session-event-view");
+          const { listSessionEventSlices } = await import("@opengeni/db/session-event-slices");
           return json(
             await readSessionEventView(
               {
@@ -4986,7 +4987,7 @@ function registerWorkspaceOrchestrationTools(
                 direction: requestedDirection,
                 limit,
               },
-              (options) => listSessionEventPage(deps.db, grant.workspaceId, sessionId, options),
+              (options) => listSessionEventSlices(deps.db, grant.workspaceId, sessionId, options),
             ),
           );
         }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -4987,7 +4987,15 @@ function registerWorkspaceOrchestrationTools(
                 direction: requestedDirection,
                 limit,
               },
-              (options) => listSessionEventSlices(deps.db, grant.workspaceId, sessionId, options),
+              (options) =>
+                listSessionEventSlices(
+                  deps.db,
+                  grant.workspaceId,
+                  sessionId,
+                  options,
+                  (legacyOptions) =>
+                    listSessionEventPage(deps.db, grant.workspaceId, sessionId, legacyOptions),
+                ),
             ),
           );
         }

--- a/apps/api/src/mcp/session-event-view.ts
+++ b/apps/api/src/mcp/session-event-view.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import type { SessionEvent, SessionEventType } from "@opengeni/contracts";
-import type { ListSessionEventPageOptions, SessionEventPage } from "@opengeni/db";
+import type {
+  SessionEventSliceOptions,
+  SessionEventSlicePage,
+} from "@opengeni/db/session-event-slices";
 
 export const SESSION_EVENT_VIEW_MAX_BYTES = 16 * 1024;
 const selectionSchema = z.object({
@@ -21,10 +24,10 @@ const selectionSchema = z.object({
   before: z.number().int().positive().nullable(),
 });
 const cursorSchema = z.object({
-  v: z.literal(1),
+  v: z.union([z.literal(1), z.literal(2)]),
   selection: selectionSchema,
   sequence: z.number().int().positive().nullable(),
-  offset: z.number().int().nonnegative(),
+  offset: z.number().int().nonnegative().max(2_147_483_647),
 });
 type Selection = z.infer<typeof selectionSchema>;
 export type SessionEventViewInput = {
@@ -43,7 +46,7 @@ type Item = { sequence: number; turnId?: string; role?: string; text?: string } 
   string,
   unknown
 >;
-type ReadPage = (options: ListSessionEventPageOptions) => Promise<SessionEventPage>;
+type ReadPage = (options: SessionEventSliceOptions) => Promise<SessionEventSlicePage>;
 const types: Record<Selection["view"], SessionEventType[]> = {
   conversation: ["user.message", "agent.message.completed"],
   // Final turn output is authoritative: do not repeat message.completed text.
@@ -55,8 +58,8 @@ const record = (value: unknown): Record<string, unknown> =>
     ? (value as Record<string, unknown>)
     : {};
 const bytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
-const encode = (selection: Selection, sequence: number | null = null, offset = 0) =>
-  Buffer.from(JSON.stringify({ v: 1, selection, sequence, offset })).toString("base64url");
+const encode = (selection: Selection, sequence: number | null = null, offset = 0, v = 2) =>
+  Buffer.from(JSON.stringify({ v, selection, sequence, offset })).toString("base64url");
 
 /** A cursor is a bounded selector, never authority. The caller reauthorizes every read. */
 export function resolveSessionEventView(input: SessionEventViewInput) {
@@ -107,6 +110,14 @@ export function resolveSessionEventView(input: SessionEventViewInput) {
   ) {
     throw new Error("callId/includeArguments/includeOutput require view=tools");
   }
+  if (
+    continuation &&
+    ((continuation.sequence === null && continuation.offset !== 0) ||
+      (continuation.sequence !== null &&
+        (continuation.sequence <= selection.after ||
+          (selection.before !== null && continuation.sequence >= selection.before))))
+  )
+    throw new Error("Invalid session_events cursor position");
   return { selection, continuation };
 }
 
@@ -140,6 +151,7 @@ function project(event: SessionEvent, selection: Selection): Item | null {
     callId,
     kind: output ? "result" : "call",
     ...(typeof p.name === "string" ? { name: p.name } : {}),
+    ...(p.identityOmitted === true ? { identityOmitted: true } : {}),
     ...(p.isError === true || record(value).isError === true ? { isError: true } : {}),
     ...((output ? selection.includeOutput : selection.includeArguments) && value !== undefined
       ? {
@@ -167,6 +179,7 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
   let nextCursor: string | null = null;
   let sourceExact = true;
   let edge: number | null = null;
+  let legacyActive = continuation?.v === 1 && continuation.sequence !== null;
   const page = () => ({
     view: selection.view,
     direction: selection.direction,
@@ -179,10 +192,10 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
     ...(!sourceExact
       ? {
           sourceLoss: {
-            reason: "database_read_projection" as const,
+            reason: "structured_value_exceeds_budget" as const,
             completeTextAvailable: false as const,
             message:
-              "The database returned bounded audit previews for oversized legacy rows. Original text is unavailable through this read; conversation omits previews rather than presenting them as complete messages. Debug view can inspect the retained preview.",
+              "An oversized structured value was omitted. Scalar text remains retrievable through continuation; omitted structured values are not complete JSON results.",
           },
         }
       : {}),
@@ -190,30 +203,50 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
   });
   const resume = (sequence: number, offset = 0) => {
     hasMore = true;
-    nextCursor = encode({ ...selection, after, before }, sequence, offset);
+    nextCursor = encode(
+      { ...selection, after, before },
+      sequence,
+      offset,
+      legacyActive && sequence === continuation?.sequence ? 1 : 2,
+    );
   };
   // Bound work even when a sparse exact callId lookup matches nothing. The
   // returned cursor advances the scan without claiming the lookup is exhausted.
-  for (let scan = 0; scan < 8; scan += 1) {
+  for (let scan = 0; scan < 64; scan += 1) {
     const source = await read({
       after,
       ...(before === null ? {} : { before }),
       direction: selection.direction,
-      limit: 64,
+      limit: 8,
       includeTypes: types[selection.view],
       payloadMode: "full",
       excludeUnclaimedHumanPrompts: true,
       maxBytes: 1024 * 1024,
+      legacyUtf16: legacyActive,
+      view: selection.view,
+      includeArguments: selection.includeArguments,
+      includeOutput: selection.includeOutput,
+      ...(continuation?.sequence
+        ? { sourceSequence: continuation.sequence, sourceOffset: continuation.offset }
+        : {}),
     });
     sourceExact &&= source.fullPayloadsExact;
     const ordered = selection.direction === "before" ? [...source.events].reverse() : source.events;
     for (const event of ordered) {
+      const slice = source.slices?.[event.sequence];
       const item = project(event, selection);
       if (item) {
         const offset = continuation?.sequence === event.sequence ? continuation.offset : 0;
-        if (offset > (item.text?.length ?? 0))
+        if (slice?.omitted) {
+          delete item.text;
+          item.sourceOmitted = { reason: "structured_value_exceeds_budget", complete: false };
+        }
+        const advance = (text: string) =>
+          slice?.unit === "codepoint" ? Array.from(text).length : text.length;
+        if (!slice && offset > (item.text?.length ?? 0))
           throw new Error("Invalid message continuation offset");
         if (
+          !slice &&
           offset > 0 &&
           item.text &&
           /[\uD800-\uDBFF]/.test(item.text[offset - 1]!) &&
@@ -221,13 +254,13 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
         ) {
           throw new Error("Invalid message continuation offset: splits a surrogate pair");
         }
-        if (offset > 0 && item.text) item.text = item.text.slice(offset);
+        if (!slice && offset > 0 && item.text) item.text = item.text.slice(offset);
         events.push(item);
         // Reserve enough for the bounded cursor and fragment facts.
         if (bytes(page()) > SESSION_EVENT_VIEW_MAX_BYTES - 4096) {
           events.pop();
           if (events.length > 0) {
-            resume(event.sequence);
+            resume(event.sequence, offset);
             if (selection.direction === "before") events.reverse();
             return page();
           }
@@ -247,15 +280,33 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
           events.push({
             ...item,
             text: text.slice(0, low),
-            fragment: { offset, nextOffset: offset + low, complete: false },
+            fragment: {
+              offset,
+              nextOffset: offset + advance(text.slice(0, low)),
+              complete: false,
+              unit: slice?.unit ?? "utf16",
+            },
           });
-          resume(event.sequence, offset + low);
+          resume(event.sequence, offset + advance(text.slice(0, low)));
+          return page();
+        }
+        const nextOffset = offset + advance(item.text ?? "");
+        if (slice && !slice.omitted && nextOffset < slice.total) {
+          item.fragment = { offset, nextOffset, complete: false, unit: slice.unit };
+          resume(event.sequence, nextOffset);
+          if (selection.direction === "before") events.reverse();
           return page();
         }
         if (offset > 0)
-          item.fragment = { offset, nextOffset: offset + (item.text?.length ?? 0), complete: true };
+          item.fragment = {
+            offset,
+            nextOffset,
+            complete: true,
+            unit: slice?.unit ?? "utf16",
+          };
       }
       edge = event.sequence;
+      legacyActive = false;
       if (selection.direction === "after") after = event.sequence;
       else before = event.sequence;
       if (events.length >= limit) {
@@ -264,6 +315,12 @@ export async function readSessionEventView(input: SessionEventViewInput, read: R
         if (selection.direction === "before") events.reverse();
         return page();
       }
+    }
+    // Metadata selection can advance over stale/duplicate rows without a
+    // projected payload. Use its covered edge rather than repeating the page.
+    if (source.coveredSequence) {
+      if (selection.direction === "after") after = Math.max(after, source.coveredSequence.last);
+      else before = Math.min(before ?? Infinity, source.coveredSequence.first);
     }
     if (!source.hasMore) {
       hasMore = false;

--- a/apps/api/test/session-event-view.test.ts
+++ b/apps/api/test/session-event-view.test.ts
@@ -254,5 +254,23 @@ describe("session event content views", () => {
     await expect(readSessionEventView({ sessionId, cursor: "invalid" }, read)).rejects.toThrow(
       "Invalid",
     );
+    const cursor = JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString());
+    for (const change of [
+      { v: 3 },
+      { offset: -1 },
+      { offset: 2_147_483_648 },
+      { sequence: null, offset: 1 },
+      { sequence: cursor.selection.after },
+    ]) {
+      await expect(
+        readSessionEventView(
+          {
+            sessionId,
+            cursor: Buffer.from(JSON.stringify({ ...cursor, ...change })).toString("base64url"),
+          },
+          read,
+        ),
+      ).rejects.toThrow("Invalid");
+    }
   });
 });

--- a/apps/api/test/session-events-mcp.test.ts
+++ b/apps/api/test/session-events-mcp.test.ts
@@ -163,7 +163,7 @@ afterAll(async () => {
 }, 60_000);
 
 describe("session_events MCP model boundary (real PostgreSQL)", () => {
-  test("legacy messages above the database page budget explicitly report source loss", async () => {
+  test("legacy messages above the database page budget reconstruct through bounded source slices", async () => {
     const session = await createSession(client.db, {
       accountId: grant.accountId,
       workspaceId,
@@ -187,15 +187,12 @@ describe("session_events MCP model boundary (real PostgreSQL)", () => {
       nextCursor: string | null;
     };
     let page = await callMcpTool<Page>("session_events", { sessionId: session.id });
-    expect(page.sourceExact).toBe(false);
-    expect(page.sourceLoss).toMatchObject({
-      reason: "database_read_projection",
-      completeTextAvailable: false,
-    });
+    expect(page.sourceExact).toBe(true);
+    expect(page.sourceLoss).toBeUndefined();
     const parts: string[] = [];
     for (let count = 0; ; count++) {
-      expect(count).toBeLessThan(40);
-      expect(page.sourceExact).toBe(false);
+      expect(count).toBeLessThan(400);
+      expect(page.sourceExact).toBe(true);
       expect(Buffer.byteLength(JSON.stringify(page, null, 2))).toBeLessThanOrEqual(16 * 1024);
       parts.push(...page.events.map((event) => event.text));
       if (!page.nextCursor) break;
@@ -204,12 +201,9 @@ describe("session_events MCP model boundary (real PostgreSQL)", () => {
         cursor: page.nextCursor,
       });
     }
-    expect(parts.join("")).not.toBe(text);
-    // The database preview contains JSON head/tail, not a complete text field.
-    // Never misrepresent that audit preview as conversation or a lossless fragment.
-    expect(parts).toEqual([]);
+    expect(parts.join("")).toBe(text);
     expect(page.nextCursor).toBeNull();
-  });
+  }, 180_000);
   test("compact event-filter schema retains canonical runtime validation", async () => {
     const schema = (mcp as { _registeredTools: Record<string, { inputSchema: z.ZodType }> })
       ._registeredTools.session_events!.inputSchema;

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -1257,17 +1257,22 @@ export function connectedCommandProofFromStatus(
         throw new Error("Connected command completed without an exit record");
       }
       const failureCode = exit.failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128);
-      const reason = exit.cancelled
-        ? "op_cancelled"
-        : exit.timedOut
-          ? "op_timed_out"
-          : failureCode
-            ? `op_failure_${failureCode}`
+      const reason = failureCode
+        ? `op_failure_${failureCode}`
+        : exit.cancelled
+          ? "op_cancelled"
+          : exit.timedOut
+            ? "op_timed_out"
             : "op_exit";
       return {
         outcome: "exited",
         exitCode: exit.exitCode,
         reason,
+        ...(failureCode
+          ? {
+              failure: { code: failureCode, detail: exit.failureDetail, retryable: false as const },
+            }
+          : {}),
         observedAt,
       };
     }

--- a/apps/worker/src/sandbox-routing.ts
+++ b/apps/worker/src/sandbox-routing.ts
@@ -913,6 +913,7 @@ export function wrapTurnBoxWithRouting(
               outcome: command.outcome,
               exitCode: command.exitCode,
               reason: command.reason,
+              ...(command.failure ? { failure: command.failure } : {}),
             });
             if (settlement && bus) {
               await bus
@@ -1182,6 +1183,7 @@ export function wrapLazyTurnBoxWithRouting(
               outcome: command.outcome,
               exitCode: command.exitCode,
               reason: command.reason,
+              ...(command.failure ? { failure: command.failure } : {}),
             });
             if (settlement && bus) {
               await bus
@@ -1557,6 +1559,7 @@ export async function establishSelfhostedTurnSession(
         outcome: command.outcome,
         exitCode: command.exitCode,
         reason: command.reason,
+        ...(command.failure ? { failure: command.failure } : {}),
       });
       if (settlement && bus) {
         await bus

--- a/apps/worker/test/session-background-command-reconciliation.test.ts
+++ b/apps/worker/test/session-background-command-reconciliation.test.ts
@@ -60,6 +60,28 @@ function rpc(answer: OpStatus) {
 }
 
 describe("Connected Machine background-command reconciliation", () => {
+  test("runner failure remains typed with zero exit even when cancellation or timeout also occurred", () => {
+    for (const failureCode of ["OP_OVERFLOW", "OP_PIPE_IO", "OP_SPOOL_IO"]) {
+      expect(
+        connectedCommandProofFromStatus(
+          status(OpState.OP_STATE_COMPLETE, {
+            exit: {
+              exitCode: 0,
+              cancelled: true,
+              timedOut: true,
+              durationMs: "1",
+              totals: {},
+              digests: {},
+              failureCode,
+              failureDetail: { retained_bytes: "1024" },
+            },
+          }),
+          new Date(),
+        ),
+      ).toMatchObject({ outcome: "exited", exitCode: 0, reason: `op_failure_${failureCode}` });
+    }
+  });
+
   test("running commands query only the immutable launch subject with epoch zero", async () => {
     const { controlRpc, requests } = rpc(status(OpState.OP_STATE_RUNNING));
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,29 +173,25 @@ settlement advances that same outbox row in its settlement transaction. A
 workflow close or writer exit racing reconciliation cannot orphan recovery;
 repeated Pause re-arms a missing quiescence wake.
 
-A background command becomes session-owned only after its exact provider
-identity is durably adopted. Before adoption it remains attempt-owned. After
-adoption, ordinary turn completion and Steer detach from it, while explicit
-command cancellation, Pause, or terminal Cancel control its lifetime.
-An explicitly stopped, revoked, or replaced Connected Machine instance ends
-command tracking as `lost`; this never asserts operating-system process death.
-A temporary transport outage alone preserves tracking. Reconciliation drains
-a fixed due-time frontier in batches, sharing offline observations per instance.
-The historical retirement migration preserves command records without creating
-model input or waking old sessions.
-Terminal proof atomically settles the command and appends its audit event.
-Unobserved completion creates fallback input for nonterminal sessions. Terminal
-command reads suppress pending notifications, never history; running reads do
-not. Command interaction is separate from conversation-first history and explicit
-diagnostics. Failed/cancelled sessions retain event-only audit. Live fanout is
-post-commit and replaceable.
+A command is attempt-owned until durable adoption of its exact provider identity.
+Thereafter turn completion and Steer detach; command cancellation, Pause, and
+terminal Cancel control its lifetime. Instance stop/revocation/replacement makes
+Connected Machine tracking `lost`, not proof of process death. Temporary outages
+preserve tracking. Reconciliation batches a fixed due-time frontier, sharing
+per-instance offline observations. Historical retirement preserves records without
+input or wakes.
+Terminal proof commits settlement and audit together. Nonterminal sessions receive
+fallback input unless observed. Terminal reads suppress pending notifications,
+never history; running reads do not. Failed/cancelled sessions retain audit only.
+Fanout is replaceable and post-commit. Conversation history remains separate:
+sequence cursors bound traversal, and `packages/db/src/session-event-slices.ts`
+transfers large message scalars in bounded slices, not whole histories.
 
-A long external wait is likewise session state, not workflow memory or goal
-state. `wait_for_input` records the exact declaring turn and an absolute
-PostgreSQL deadline, then the agent ends its turn. The workflow closes while
-the wait is current and is restarted by durable input or the deadline outbox;
-timeout becomes typed machine input. `session_wait` and `command_wait` remain
-short in-turn reads and never hold an inference indefinitely.
+Long external waits are session state, not workflow memory or goals.
+`wait_for_input` records the declaring turn and absolute PostgreSQL deadline,
+then ends the turn and workflow. Durable input or the deadline outbox restarts
+it; timeout becomes typed input. `session_wait` and `command_wait` are short
+in-turn reads.
 
 Canonical: `apps/worker/src/activities/agent-turn/`,
 `apps/worker/src/activities/session-state.ts`, and

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1470,6 +1470,27 @@ calls and Codemode use this path; third-party lookalike tools do not. Outside
 that owning context, native reads and background reconciliation refresh the
 stored snapshot. An empty running snapshot can therefore precede capture of
 bytes already produced by the process.
+If a live refresh encounters a recognized temporary transport failure, the
+runtime reauthorizes and rereads the API instead of discarding retained output.
+A still-running result reports `freshness.status: "refresh_unavailable"` and
+`retryable: true`; this is a freshness warning, not proof of command failure or
+completion. No provider operation is retried by this fallback. Authorization,
+consent, fencing, integrity, and unclassified errors still fail closed.
+
+Typed runner failures are distinct from the process exit code: a runner may
+report an output/spool failure alongside exit code zero. Migration 0417 adds
+bounded `runner_failure` metadata to the command row so later reads and
+completion notifications preserve that distinction after the live reader is
+gone. Apply this rolling migration before starting readers that select the new
+field; do not infer successful completion from exit code alone.
+
+Repeated reads by the same live command client retain only an in-memory replay
+frontier, incremental integrity state, and UTF-8 decoder state after successful
+capture. They do not retain the full output prefix. Failed capture discards that
+optimization and permits replay of retained truth; it grants no runner garbage
+collection authority. A fresh client, including a new reconciliation claim,
+still replays the retained prefix and performs idempotent capture. Its work is
+proportional to retained command output, not bounded by the API output-page size.
 
 Connected Machine capture preserves stream identity. SDK native readers can
 return merged output; those retained chunks explicitly report merged stream

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7740,6 +7740,7 @@ export const SessionSystemUpdatePayload = z.discriminatedUnion("type", [
       state: z.enum(["exited", "lost"]),
       exitCode: z.number().int().nullable(),
       reason: boundedUtf8String(512),
+      failure: z.lazy(() => SessionCommandFailure).optional(),
       outputLocator: z
         .object({
           eventType: z.literal("sandbox.command.output.delta"),
@@ -11905,6 +11906,20 @@ export const SessionBackgroundCommandActivity = z
   .strict();
 export type SessionBackgroundCommandActivity = z.infer<typeof SessionBackgroundCommandActivity>;
 
+export const SessionCommandFailure = z
+  .object({
+    code: z.string().regex(/^[A-Za-z0-9_-]{1,128}$/),
+    detail: z.record(z.string().max(128), z.string().max(2048)).optional(),
+    retryable: z.literal(false),
+  })
+  .refine(
+    (failure) =>
+      Object.keys(failure.detail ?? {}).length <= 32 &&
+      new TextEncoder().encode(JSON.stringify(failure)).byteLength <= 4096,
+    "Command failure metadata exceeds its retained bound",
+  );
+export type SessionCommandFailure = z.infer<typeof SessionCommandFailure>;
+
 export const SessionBackgroundCommand = z
   .object({
     id: z.string().uuid(),
@@ -11916,6 +11931,7 @@ export const SessionBackgroundCommand = z
     cancelRequestedAt: z.string().nullable(),
     exitCode: z.number().int().nullable(),
     settlementReason: z.string().nullable(),
+    failure: SessionCommandFailure.optional(),
     startedAt: z.string(),
     settledAt: z.string().nullable(),
     completionObservedAt: z.string().nullable().optional(),
@@ -11941,8 +11957,17 @@ export const CommandReadResult = /* @__PURE__ */ (() =>
       commandId: z.string().uuid(),
       state: SessionBackgroundCommandState,
       exitCode: z.number().int().nullable(),
+      settlementReason: z.string().nullable().optional(),
+      // A physical zero exit is not success when runner output delivery failed.
+      failure: SessionCommandFailure.optional(),
       terminal: z.boolean(),
       completionObservedAt: z.string().nullable(),
+      freshness: z
+        .object({
+          status: z.literal("refresh_unavailable"),
+          retryable: z.literal(true),
+        })
+        .optional(),
       chunks: z
         .array(
           z.object({

--- a/packages/db/drizzle/0417_command_runner_failure_metadata.sql
+++ b/packages/db/drizzle/0417_command_runner_failure_metadata.sql
@@ -1,0 +1,17 @@
+-- deployment-mode: rolling
+-- A single retained field follows exact provider proof through settlement.
+-- No new delivery cursor or ACK authority is introduced.
+ALTER TABLE session_background_commands
+  ADD COLUMN runner_failure jsonb,
+  ADD CONSTRAINT session_background_commands_runner_failure_check CHECK (
+    runner_failure IS NULL OR (
+      provider = 'connected_machine'
+      AND jsonb_typeof(runner_failure) = 'object'
+      AND octet_length(runner_failure::text) <= 8192
+      AND runner_failure ?& ARRAY['code', 'retryable']
+      AND jsonb_typeof(runner_failure -> 'code') = 'string'
+      AND (runner_failure ->> 'code') ~ '^[A-Za-z0-9_-]{1,128}$'
+      AND runner_failure -> 'retryable' = 'false'::jsonb
+      AND (NOT (runner_failure ? 'detail') OR jsonb_typeof(runner_failure -> 'detail') = 'object')
+    )
+  );

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -59,6 +59,10 @@
       "types": "./src/session-tenancy.ts",
       "default": "./src/session-tenancy.ts"
     },
+    "./session-event-slices": {
+      "types": "./src/session-event-slices.ts",
+      "default": "./src/session-event-slices.ts"
+    },
     "./session-command-output": {
       "types": "./src/session-command-output.ts",
       "default": "./src/session-command-output.ts"

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -72884,6 +72884,7 @@ function backgroundCommandTerminalMutation(input: {
                 state: command.state,
                 exitCode: command.exitCode,
                 reason,
+                ...(command.failure ? { failure: command.failure } : {}),
                 settledAt: command.settledAt,
                 outputLocator,
               },
@@ -72913,10 +72914,13 @@ function backgroundCommandTerminalMutation(input: {
         return;
       }
       const classification: SystemUpdateClassification =
-        command.state === "exited" && command.exitCode === 0 ? "success" : "failure";
+        command.state === "exited" && command.exitCode === 0 && !command.failure
+          ? "success"
+          : "failure";
       const commandLabel = command.commandPreview || "Background command";
-      const summary =
-        command.state === "lost"
+      const summary = command.failure
+        ? `${commandLabel}: output delivery failed (${command.failure.code}); process exit code ${command.exitCode ?? "unknown"} is not a successful command result.`
+        : command.state === "lost"
           ? `${commandLabel}: result unavailable. Its exit status could not be confirmed.`
           : command.exitCode === 0
             ? `${commandLabel}: completed successfully.`
@@ -72927,6 +72931,7 @@ function backgroundCommandTerminalMutation(input: {
         state: command.state,
         exitCode: command.exitCode,
         reason,
+        ...(command.failure ? { failure: command.failure } : {}),
         outputLocator,
       };
       const [insertedUpdate] = await tx
@@ -73067,6 +73072,7 @@ export type SessionBackgroundCommandTerminalSettlement = {
 export async function settleConnectedMachineSessionBackgroundCommand(
   db: Database,
   input: {
+    failure?: SessionBackgroundCommand["failure"];
     accountId: string;
     workspaceId: string;
     sessionId: string;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -9713,6 +9713,8 @@ export const sessionBackgroundCommands = pgTable(
     cancelRequestedBy: text("cancel_requested_by"),
     exitCode: integer("exit_code"),
     settlementReason: text("settlement_reason"),
+    runnerFailure:
+      jsonb("runner_failure").$type<import("@opengeni/contracts").SessionCommandFailure>(),
     startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
     settledAt: timestamp("settled_at", { withTimezone: true }),
     completionObservedAt: timestamp("completion_observed_at", { withTimezone: true }),
@@ -9739,6 +9741,20 @@ export const sessionBackgroundCommands = pgTable(
       columns: [table.workspaceId, table.accountId],
       foreignColumns: [workspaces.id, workspaces.accountId],
     }).onDelete("cascade"),
+    runnerFailureCheck: check(
+      "session_background_commands_runner_failure_check",
+      sql`
+      ${table.runnerFailure} IS NULL OR (
+        ${table.provider} = 'connected_machine'
+        AND jsonb_typeof(${table.runnerFailure}) = 'object'
+        AND octet_length(${table.runnerFailure}::text) <= 8192
+        AND ${table.runnerFailure} ?& ARRAY['code', 'retryable']
+        AND jsonb_typeof(${table.runnerFailure} -> 'code') = 'string'
+        AND (${table.runnerFailure} ->> 'code') ~ '^[A-Za-z0-9_-]{1,128}$'
+        AND ${table.runnerFailure} -> 'retryable' = 'false'::jsonb
+        AND (NOT (${table.runnerFailure} ? 'detail') OR jsonb_typeof(${table.runnerFailure} -> 'detail') = 'object')
+      )`,
+    ),
     workspaceSession: foreignKey({
       name: "session_background_commands_session_fk",
       columns: [table.workspaceId, table.sessionId],

--- a/packages/db/src/session-background-commands.ts
+++ b/packages/db/src/session-background-commands.ts
@@ -2,6 +2,8 @@ import type {
   SessionBackgroundCommand,
   SessionBackgroundCommandActivity,
 } from "@opengeni/contracts";
+import { SessionCommandFailure } from "@opengeni/contracts";
+import { isDeepStrictEqual } from "node:util";
 import { and, asc, desc, eq, gte, inArray, sql } from "drizzle-orm";
 
 import type { Database, SessionActivityDatabase } from "./database";
@@ -14,6 +16,7 @@ export type ConnectedMachineBackgroundCommandProof = {
   outcome: "exited" | "lost";
   exitCode: number | null;
   reason: string;
+  failure?: SessionCommandFailure;
   observedAt: Date;
 };
 
@@ -79,6 +82,18 @@ function commandPreview(value: string): string {
 function mapCommand(
   row: typeof schema.sessionBackgroundCommands.$inferSelect,
 ): SessionBackgroundCommand {
+  const terminal = row.state === "exited" || row.state === "lost";
+  const legacyFailureCode =
+    row.provider === "connected_machine"
+      ? /^op_failure_([A-Za-z0-9_-]{1,128})$/.exec(row.settlementReason ?? "")?.[1]
+      : undefined;
+  const failure = !terminal
+    ? undefined
+    : row.runnerFailure
+      ? SessionCommandFailure.parse(row.runnerFailure)
+      : legacyFailureCode
+        ? { code: legacyFailureCode, retryable: false as const }
+        : undefined;
   return {
     id: row.id,
     workspaceId: row.workspaceId,
@@ -89,6 +104,7 @@ function mapCommand(
     cancelRequestedAt: row.cancelRequestedAt?.toISOString() ?? null,
     exitCode: row.exitCode ?? null,
     settlementReason: row.settlementReason ?? null,
+    ...(failure ? { failure } : {}),
     startedAt: row.startedAt.toISOString(),
     settledAt: row.settledAt?.toISOString() ?? null,
     completionObservedAt: row.completionObservedAt?.toISOString() ?? null,
@@ -388,10 +404,13 @@ export async function recordConnectedMachineBackgroundCommandProof(
     proof: ConnectedMachineBackgroundCommandProof;
   },
 ): Promise<void> {
+  const failure = input.proof.failure ? SessionCommandFailure.parse(input.proof.failure) : null;
   const reason = boundedSessionBackgroundCommandReason(
     input.proof.reason,
     "Connected command proof reason",
   );
+  if (failure && reason !== `op_failure_${failure.code}`)
+    throw new Error("Connected command failure code conflicts with proof reason");
   if (input.proof.outcome === "exited" && input.proof.exitCode === null) {
     throw new Error("Connected command exit proof requires an exit code");
   }
@@ -415,6 +434,7 @@ export async function recordConnectedMachineBackgroundCommandProof(
           current.reconcileProofOutcome !== input.proof.outcome ||
           current.reconcileProofExitCode !== input.proof.exitCode ||
           current.reconcileProofReason !== reason ||
+          !isDeepStrictEqual(current.runnerFailure, failure) ||
           observedAt !== input.proof.observedAt.getTime()
         ) {
           throw new Error("Connected command reconciliation proof conflicts with durable proof");
@@ -427,6 +447,7 @@ export async function recordConnectedMachineBackgroundCommandProof(
           reconcileProofOutcome: input.proof.outcome,
           reconcileProofExitCode: input.proof.exitCode,
           reconcileProofReason: reason,
+          runnerFailure: failure,
           reconcileProofObservedAt: input.proof.observedAt,
           lastReconcileOutcome: `proof_${input.proof.outcome}`,
           updatedAt: new Date(),
@@ -786,13 +807,17 @@ export async function settleConnectedMachineSessionBackgroundCommandWithMutation
     outcome: "exited" | "lost";
     exitCode: number | null;
     reason: string;
+    failure?: SessionCommandFailure | undefined;
   },
   mutateTerminal: SessionBackgroundCommandTerminalMutation,
 ): Promise<SessionBackgroundCommand | null> {
+  const failure = input.failure ? SessionCommandFailure.parse(input.failure) : null;
   const reason = boundedSessionBackgroundCommandReason(
     input.reason,
     "Connected command settlement reason",
   );
+  if (failure && reason !== `op_failure_${failure.code}`)
+    throw new Error("Connected command failure code conflicts with settlement reason");
   if (input.outcome === "exited" && input.exitCode === null) {
     throw new Error("Connected command exit settlement requires an exit code");
   }
@@ -811,6 +836,7 @@ export async function settleConnectedMachineSessionBackgroundCommandWithMutation
           state: input.outcome,
           exitCode: input.outcome === "exited" ? input.exitCode : null,
           settlementReason: reason,
+          runnerFailure: failure,
           settledAt,
           reconcileClaimId: null,
           reconcileClaimedAt: null,
@@ -831,6 +857,10 @@ export async function settleConnectedMachineSessionBackgroundCommandWithMutation
             eq(schema.sessionBackgroundCommands.enrollmentId, input.enrollmentId),
             eq(schema.sessionBackgroundCommands.connectionInstanceId, input.connectionInstanceId),
             eq(schema.sessionBackgroundCommands.opId, input.opId),
+            // A fast owner settlement cannot erase or replace metadata already
+            // checkpointed by the reconciler under the exact command identity.
+            sql`(${schema.sessionBackgroundCommands.runnerFailure} is null or
+              ${schema.sessionBackgroundCommands.runnerFailure} = ${failure ? JSON.stringify(failure) : null}::jsonb)`,
             inArray(schema.sessionBackgroundCommands.state, ["running", "stopping"]),
           ),
         )
@@ -1089,6 +1119,8 @@ export async function readSessionBackgroundCommandOutput(
     commandId: command.id,
     state: command.state,
     exitCode: command.exitCode,
+    settlementReason: command.settlementReason,
+    ...(command.failure ? { failure: command.failure } : {}),
     terminal,
     completionObservedAt: observed?.completionObservedAt ?? null,
     ...page,

--- a/packages/db/src/session-background-commands.ts
+++ b/packages/db/src/session-background-commands.ts
@@ -87,10 +87,26 @@ function mapCommand(
     row.provider === "connected_machine"
       ? /^op_failure_([A-Za-z0-9_-]{1,128})$/.exec(row.settlementReason ?? "")?.[1]
       : undefined;
+  // Application writes validate exact detail bounds. Older/restored rows may
+  // meet the wider storage envelope without meeting that contract: preserve
+  // failure truth and readable output rather than throwing on every read.
+  const storedFailure = row.runnerFailure
+    ? SessionCommandFailure.safeParse(row.runnerFailure)
+    : null;
   const failure = !terminal
     ? undefined
     : row.runnerFailure
-      ? SessionCommandFailure.parse(row.runnerFailure)
+      ? storedFailure?.success
+        ? storedFailure.data
+        : {
+            code: /^[A-Za-z0-9_-]{1,128}$/.test(row.runnerFailure.code)
+              ? row.runnerFailure.code
+              : "INVALID_RUNNER_FAILURE",
+            detail: {
+              metadata_error: "Stored runner failure details do not match the retained contract.",
+            },
+            retryable: false as const,
+          }
       : legacyFailureCode
         ? { code: legacyFailureCode, retryable: false as const }
         : undefined;

--- a/packages/db/src/session-event-slices.ts
+++ b/packages/db/src/session-event-slices.ts
@@ -1,8 +1,8 @@
 import { and, asc, desc, eq, gt, inArray, lt, notInArray, sql, type SQL } from "drizzle-orm";
 import { resolveSessionEventTypeFilters, type SessionEvent } from "@opengeni/contracts";
 import { rawRows, withWorkspaceRls, type Database } from "./database";
-import type { ListSessionEventPageOptions, SessionEventPage } from "./index";
-import { listSessionEventPage } from "./index";
+type ListSessionEventPageOptions = import("./index").ListSessionEventPageOptions;
+type SessionEventPage = import("./index").SessionEventPage;
 import { fromPostgresLosslessJson, LOSSLESS_JSON_STRING_PREFIX } from "./lossless-json";
 import * as schema from "./schema";
 
@@ -37,15 +37,18 @@ export async function listSessionEventSlices(
   workspaceId: string,
   sessionId: string,
   options: SessionEventSliceOptions,
+  legacyRead?: (options: ListSessionEventPageOptions) => Promise<SessionEventPage>,
 ): Promise<SessionEventSlicePage> {
   // Finish an already-issued UTF-16 cursor using its original bounded reader.
   // New messages use source slices; no cursor offset is silently reinterpreted.
-  if (options.legacyUtf16)
-    return listSessionEventPage(db, workspaceId, sessionId, {
+  if (options.legacyUtf16) {
+    if (!legacyRead) throw new Error("Legacy continuation requires its original bounded reader");
+    return legacyRead({
       ...options,
       limit: 1,
       maxBytes: 1024 * 1024,
     });
+  }
   const offset = options.sourceOffset ?? 0;
   if (!Number.isSafeInteger(offset) || offset < 0 || offset > 2_147_483_647)
     throw new Error("Invalid message continuation offset");

--- a/packages/db/src/session-event-slices.ts
+++ b/packages/db/src/session-event-slices.ts
@@ -1,0 +1,307 @@
+import { and, asc, desc, eq, gt, inArray, lt, notInArray, sql, type SQL } from "drizzle-orm";
+import { resolveSessionEventTypeFilters, type SessionEvent } from "@opengeni/contracts";
+import { rawRows, withWorkspaceRls, type Database } from "./database";
+import type { ListSessionEventPageOptions, SessionEventPage } from "./index";
+import { listSessionEventPage } from "./index";
+import { fromPostgresLosslessJson, LOSSLESS_JSON_STRING_PREFIX } from "./lossless-json";
+import * as schema from "./schema";
+
+export type SessionEventSliceOptions = ListSessionEventPageOptions & {
+  sourceSequence?: number;
+  sourceOffset?: number;
+  view?: "conversation" | "results" | "tools";
+  includeArguments?: boolean;
+  includeOutput?: boolean;
+  legacyUtf16?: boolean;
+};
+export type SessionEventSlice = {
+  offset: number;
+  total: number;
+  unit: "codepoint" | "utf16";
+  text: string;
+  omitted: boolean;
+};
+export type SessionEventSlicePage = SessionEventPage & {
+  slices?: Record<number, SessionEventSlice>;
+};
+const WINDOW = 8192;
+const STRUCTURED_BYTES = 1024 * 1024;
+
+/** Bounded transfer over retained scalar truth. JSONB extraction/detoasting still
+ * costs PostgreSQL work proportional to the individual source value, not history.
+ * This is a read projection, not authorization: the MCP caller must authorize the
+ * target on every request. Both metadata and scalar reads retain workspace RLS.
+ */
+export async function listSessionEventSlices(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+  options: SessionEventSliceOptions,
+): Promise<SessionEventSlicePage> {
+  // Finish an already-issued UTF-16 cursor using its original bounded reader.
+  // New messages use source slices; no cursor offset is silently reinterpreted.
+  if (options.legacyUtf16)
+    return listSessionEventPage(db, workspaceId, sessionId, {
+      ...options,
+      limit: 1,
+      maxBytes: 1024 * 1024,
+    });
+  const offset = options.sourceOffset ?? 0;
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > 2_147_483_647)
+    throw new Error("Invalid message continuation offset");
+  const direction = options.direction ?? (options.before === undefined ? "after" : "before");
+  const limit = options.sourceSequence ? 1 : Math.max(1, Math.min(options.limit ?? 8, 8));
+  const filters = resolveSessionEventTypeFilters(options);
+  const predicates: SQL[] = [
+    eq(schema.sessionEvents.workspaceId, workspaceId),
+    eq(schema.sessionEvents.sessionId, sessionId),
+    gt(schema.sessionEvents.sequence, Math.min(options.after ?? 0, 2_147_483_647)),
+    // Same indexed exclusion as the audit/discovery reader. Do not substitute
+    // turn status: terminal-before-claim prompts must remain excluded too.
+    sql`(${schema.sessionEvents.type} <> 'user.message' or not exists (
+      select 1 from ${schema.sessionTurns} unclaimed_prompt_turn
+      where unclaimed_prompt_turn.workspace_id = ${workspaceId}
+        and unclaimed_prompt_turn.workspace_id = ${schema.sessionEvents.workspaceId}
+        and unclaimed_prompt_turn.session_id = ${schema.sessionEvents.sessionId}
+        and unclaimed_prompt_turn.trigger_event_id = ${schema.sessionEvents.id}
+        and unclaimed_prompt_turn.source in ('user', 'api')
+        and unclaimed_prompt_turn.started_at is null
+    ))`,
+  ];
+  if (options.before !== undefined && options.before <= 2_147_483_647)
+    predicates.push(lt(schema.sessionEvents.sequence, options.before));
+  if (filters.includeTypes.length)
+    predicates.push(inArray(schema.sessionEvents.type, filters.includeTypes));
+  if (filters.excludeTypes.length)
+    predicates.push(notInArray(schema.sessionEvents.type, filters.excludeTypes));
+  // Unlike audit `none` mode, this identity query does not compute a payload
+  // projection merely to report its size. Only the selected scalar is extracted.
+  const identities = await withWorkspaceRls(db, workspaceId, (tx) =>
+    tx
+      .select({
+        id: schema.sessionEvents.id,
+        sequence: schema.sessionEvents.sequence,
+        type: sql<string>`case when octet_length(${schema.sessionEvents.type}) <= 256 then ${schema.sessionEvents.type} else 'session.event.envelope_omitted' end`,
+        turnId: schema.sessionEvents.turnId,
+        turnAssociation: sql<
+          string | null
+        >`case when ${schema.sessionEvents.turnAssociation} is null then null when ${schema.sessionEvents.turnAssociation} = 'current' then 'current' else 'late_rejected' end`,
+        duplicateOfEventId: schema.sessionEvents.duplicateOfEventId,
+      })
+      .from(schema.sessionEvents)
+      .where(and(...predicates))
+      .orderBy(
+        direction === "before"
+          ? desc(schema.sessionEvents.sequence)
+          : asc(schema.sessionEvents.sequence),
+      )
+      .limit(limit + 1),
+  );
+  const ordered = identities.slice(0, limit).map(
+    (identity) =>
+      ({
+        ...identity,
+        workspaceId,
+        sessionId,
+        payload: {},
+        occurredAt: "",
+      }) as SessionEvent,
+  );
+  const page: SessionEventPage = {
+    events: [],
+    hasMore: identities.length > limit,
+    bytes: 2,
+    fullPayloadsExact: true,
+    direction,
+    coveredSequence: null,
+    nextAfter: null,
+    nextBefore: null,
+    truncatedBy: identities.length > limit ? "count" : null,
+  };
+  const slices: Record<number, SessionEventSlice> = {};
+  const events: SessionEvent[] = [];
+  let consumed = 0;
+  await withWorkspaceRls(db, workspaceId, async (tx) => {
+    for (const event of ordered) {
+      consumed++;
+      if (
+        event.duplicateOfEventId ||
+        (event.turnAssociation && event.turnAssociation !== "current")
+      )
+        continue;
+      const p = schema.sessionEvents.payload;
+      const output = event.type === "agent.toolCall.output";
+      let value: SQL = sql`${p}->'text'`;
+      if (options.view === "tools")
+        value = output
+          ? sql`${p}->'output'`
+          : sql`coalesce(nullif(${p}->'arguments', 'null'::jsonb), ${p}->'args')`;
+      else if (options.view === "results")
+        value =
+          event.type === "turn.completed"
+            ? sql`coalesce(nullif(${p}->'output', 'null'::jsonb), ${p}->'result')`
+            : sql`${p}`;
+      const include =
+        options.view !== "tools" || (output ? options.includeOutput : options.includeArguments);
+      if (!include) value = sql`null::jsonb`;
+      const start = options.sourceSequence === event.sequence ? offset : 0;
+      const prefix = LOSSLESS_JSON_STRING_PREFIX;
+      const raw = sql`raw`;
+      const encoded = sql`encoded`;
+      // Match exactly the JS codec's canonical-base64/even-byte acceptance.
+      // A malformed active marker remains literal, just like the shared codec.
+      const tagged = sql`case when version = 1
+        and left(${raw}, ${prefix.length}) = ${prefix}
+        and length(${encoded}) > 0
+        and ${encoded} ~ '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'
+        then (length(${encoded}) / 4 * 3 - case when right(${encoded}, 2) = '==' then 2 when right(${encoded}, 1) = '=' then 1 else 0 end) % 2 = 0
+          and encode(decode(right(${encoded}, 4), 'base64'), 'base64') = right(${encoded}, 4)
+        else false end`;
+      // Aligned base64 windows represent groups of three UTF-16 units. Include
+      // one preceding and one following unit to validate/avoid pair splits.
+      const group = Math.floor(Math.max(0, start - 1) / 3);
+      const safeMetadata = (key: string) =>
+        sql`case when octet_length((${p}->${key})::text) <= 4096 then ${p}->${key} else null end`;
+      const callId = sql`coalesce(nullif(${p}->'callId', 'null'::jsonb), nullif(${p}->'call_id', 'null'::jsonb), ${p}->'id')`;
+      const metadataSql =
+        options.view === "tools"
+          ? sql`jsonb_strip_nulls(jsonb_build_object(
+          'callId', case when octet_length((${callId})::text) <= 4096 then ${callId} else null end,
+          'identityOmitted', case when octet_length((${callId})::text) > 4096 or octet_length((${p}->'name')::text) > 4096 then true else null end,
+          'name', ${safeMetadata("name")}, 'isError', case when ${p}->'isError' = 'true'::jsonb or (${output} and ${p}->'output'->'isError' = 'true'::jsonb) then true else null end,
+          'maintenance', case when ${p} ? 'maintenance' then true else null end,
+          'segmentLimit', case when ${p} ? 'segmentLimit' then true else null end))`
+          : options.view === "results" && event.type === "turn.completed"
+            ? sql`jsonb_strip_nulls(jsonb_build_object(
+            'maintenance', case when ${p} ? 'maintenance' then true else null end,
+            'segmentLimit', case when ${p} ? 'segmentLimit' then true else null end))`
+            : sql`'{}'::jsonb`;
+      const [row] = await rawRows<{
+        metadata: unknown;
+        version: number | null;
+        kind: string | null;
+        tagged: boolean;
+        total: number;
+        window: string | null;
+        structured: unknown;
+        omitted: boolean;
+      }>(
+        tx,
+        sql`with source as (
+        select ${value} as value, ${metadataSql} as metadata,
+          ${schema.sessionEvents.payloadCodecVersion} as version
+        from ${schema.sessionEvents}
+        where ${schema.sessionEvents.workspaceId} = ${workspaceId}
+          and ${schema.sessionEvents.sessionId} = ${sessionId}
+          and ${schema.sessionEvents.id} = ${event.id}
+          and (${schema.sessionEvents.turnAssociation} is null or ${schema.sessionEvents.turnAssociation} = 'current')
+          and ${schema.sessionEvents.duplicateOfEventId} is null
+        limit 1
+      ), scalar as (
+        select *, jsonb_typeof(value) as kind,
+          case when jsonb_typeof(value) = 'string' then value #>> '{}' else null end as raw,
+          case when jsonb_typeof(value) <> 'string' then octet_length(value::text) else 0 end as structured_bytes
+        from source offset 0
+      ), encoding as (
+        select *, case when version = 1 and left(raw, ${prefix.length}) = ${prefix}
+          then substring(raw from ${prefix.length + 1}::integer) else null end as encoded
+        from scalar offset 0
+      ), validated as (
+        select *, ${tagged} as tagged from encoding offset 0
+      )
+      select metadata, version, kind, tagged,
+        case when kind = 'string' then
+          case when tagged then (length(encoded) / 4 * 3 - case when right(encoded, 2) = '==' then 2 when right(encoded, 1) = '=' then 1 else 0 end) / 2
+          else length(raw) end else 0 end as total,
+        case when kind = 'string' then
+          case when tagged then substring(encoded from ${Math.min(group * 8 + 1, 2_147_483_647)}::integer for ${Math.ceil((WINDOW + 6) / 3) * 8}::integer)
+          else substring(raw from ${Math.min(start + 1, 2_147_483_647)}::integer for ${WINDOW}::integer) end else null end as window,
+        case when kind <> 'string' and structured_bytes <= ${STRUCTURED_BYTES} then value else null end as structured,
+        coalesce(kind <> 'string' and structured_bytes > ${STRUCTURED_BYTES}, false) as omitted
+      from validated`,
+      );
+      if (!row) continue;
+      const metadata = fromPostgresLosslessJson(row.metadata, row.version) as Record<
+        string,
+        unknown
+      >;
+      // Codec decoding can expand JSON escaping (notably NUL/lone surrogates).
+      // Keep identities bounded too, without falling back to a different alias.
+      for (const [key, budget] of [
+        ["callId", 4096],
+        ["name", 1024],
+      ] as const) {
+        if (
+          metadata[key] !== undefined &&
+          Buffer.byteLength(JSON.stringify(metadata[key]), "utf8") > budget
+        ) {
+          delete metadata[key];
+          metadata.identityOmitted = true;
+        }
+      }
+      let text = row.window ?? "";
+      if (row.tagged) {
+        // Window lengths are multiples of eight, so each partial block is also
+        // a complete canonical encoding accepted by the existing lossless codec.
+        text = fromPostgresLosslessJson(prefix + text, 1);
+        const local = start - group * 3;
+        if (
+          local > 0 &&
+          /[\uD800-\uDBFF]/.test(text[local - 1]!) &&
+          /[\uDC00-\uDFFF]/.test(text[local] ?? "")
+        )
+          throw new Error("Invalid message continuation offset: splits a surrogate pair");
+        text = text.slice(local, local + WINDOW);
+        if (start + text.length < row.total && /[\uD800-\uDBFF]/.test(text.at(-1)!))
+          text = text.slice(0, -1);
+      }
+      if (start > row.total && row.kind === "string")
+        throw new Error("Invalid message continuation offset");
+      const logical = row.omitted
+        ? {}
+        : row.kind === "string"
+          ? text
+          : fromPostgresLosslessJson(row.structured, row.version);
+      let payload: Record<string, unknown> = { ...metadata };
+      if (options.view === "tools") {
+        if (row.kind !== null) payload[output ? "output" : "arguments"] = logical;
+      } else if (options.view === "results") {
+        if (event.type === "turn.completed") payload.output = logical;
+        else payload = (logical as Record<string, unknown>) ?? {};
+      } else payload.text = logical;
+      if (row.omitted) payload = { ...payload, sourceOmitted: true };
+      if (row.kind === "string" || row.omitted)
+        slices[event.sequence] = {
+          offset: start,
+          total: row.total,
+          unit: row.tagged ? "utf16" : "codepoint",
+          text,
+          omitted: row.omitted,
+        };
+      events.push({ ...event, payload });
+      // One large structured value preserves the previous bounded JSON path,
+      // without accumulating several megabyte-sized values in one source page.
+      if (row.kind !== "string" && Buffer.byteLength(JSON.stringify(payload)) > WINDOW) break;
+      if (
+        row.kind === "string" &&
+        start + (row.tagged ? text.length : Array.from(text).length) < row.total
+      )
+        break;
+    }
+  });
+  // Preserve scan advancement even when every identity was excluded above.
+  return {
+    ...page,
+    events: events.sort((a, b) => a.sequence - b.sequence),
+    hasMore: page.hasMore || consumed < ordered.length,
+    coveredSequence: consumed
+      ? {
+          first: Math.min(ordered[0]!.sequence, ordered[consumed - 1]!.sequence),
+          last: Math.max(ordered[0]!.sequence, ordered[consumed - 1]!.sequence),
+        }
+      : null,
+    bytes: Buffer.byteLength(JSON.stringify(events), "utf8"),
+    fullPayloadsExact: !Object.values(slices).some((slice) => slice.omitted),
+    slices,
+  };
+}

--- a/packages/db/test/migration-0417-command-runner-failure-metadata.test.ts
+++ b/packages/db/test/migration-0417-command-runner-failure-metadata.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { SessionCommandFailure } from "@opengeni/contracts";
+
+test("0417 adds one bounded rolling failure field without delivery or ACK state", () => {
+  const source = readFileSync(
+    new URL("../drizzle/0417_command_runner_failure_metadata.sql", import.meta.url),
+    "utf8",
+  );
+  expect(source.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+  expect(source.match(/ADD COLUMN/g)).toHaveLength(1);
+  expect(source).toContain("ADD COLUMN runner_failure jsonb");
+  expect(source).toContain("octet_length(runner_failure::text) <= 8192");
+  expect(source).not.toContain("CREATE TABLE");
+});
+
+test("typed runner failure metadata has a bounded exact-detail contract", () => {
+  const value = {
+    code: "OP_OVERFLOW",
+    detail: { retained_bytes: "268435456" },
+    retryable: false as const,
+  };
+  expect(SessionCommandFailure.parse(value)).toEqual(value);
+  expect(
+    SessionCommandFailure.safeParse({ ...value, detail: { large: "x".repeat(2049) } }).success,
+  ).toBe(false);
+  expect(
+    SessionCommandFailure.safeParse({
+      ...value,
+      detail: Object.fromEntries(Array.from({ length: 33 }, (_, i) => [`key${i}`, "0"])),
+    }).success,
+  ).toBe(false);
+  expect(
+    SessionCommandFailure.safeParse({
+      ...value,
+      detail: { a: "x".repeat(2048), b: "x".repeat(2048) },
+    }).success,
+  ).toBe(false);
+});

--- a/packages/db/test/session-command-output.test.ts
+++ b/packages/db/test/session-command-output.test.ts
@@ -1,8 +1,26 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
-import { bootstrapWorkspace, createDb, createSession, type DbClient } from "../src";
+import { CommandReadResult } from "@opengeni/contracts";
+import {
+  bootstrapWorkspace,
+  createDb,
+  createSession,
+  settleConnectedMachineSessionBackgroundCommand,
+  settleClaimedConnectedMachineBackgroundCommand,
+  type DbClient,
+} from "../src";
 import { appendSessionCommandOutput } from "../src/session-command-output";
-import { readSessionBackgroundCommandOutput } from "../src/session-background-commands";
+import {
+  readSessionBackgroundCommandOutput,
+  recordConnectedMachineBackgroundCommandProof,
+} from "../src/session-background-commands";
+import { fromPostgresLosslessJson } from "../src/lossless-json";
+import {
+  FakeOpRunner,
+  InMemoryOpStreamTransport,
+} from "../../runtime/src/sandbox/selfhosted/op-testing";
+import { SelfhostedSession } from "../../runtime/src/sandbox/selfhosted/session";
+import { runWithToolCallCorrelation } from "../../runtime/src/sandbox/op-correlation";
 
 let shared: SharedTestDatabase;
 let client: DbClient;
@@ -42,7 +60,10 @@ afterAll(async () => {
   await shared?.release();
 }, 60_000);
 
-async function connected() {
+async function connected(
+  enrollmentId: string = crypto.randomUUID(),
+  opId: string = crypto.randomUUID(),
+) {
   const commandId = crypto.randomUUID();
   await shared.admin`insert into session_background_commands ${shared.admin({
     id: commandId,
@@ -52,12 +73,179 @@ async function connected() {
     provider: "connected_machine",
     state: "running",
     control_workspace_id: workspaceId,
-    enrollment_id: crypto.randomUUID(),
+    enrollment_id: enrollmentId,
     connection_instance_id: "launch",
-    op_id: commandId,
+    op_id: opId,
   })}`;
   return { accountId, workspaceId, sessionId, commandId };
 }
+
+test("native zero-exit failure persists exact details in pending notification and a fresh reader", async () => {
+  for (const failureCode of ["OP_OVERFLOW", "OP_PIPE_IO", "OP_SPOOL_IO"]) {
+    const enrollmentId = crypto.randomUUID();
+    const correlation = crypto.randomUUID();
+    const opId = `${correlation}:0`;
+    const identity = await connected(enrollmentId, opId);
+    const transport = new InMemoryOpStreamTransport();
+    const runner = new FakeOpRunner({
+      transport,
+      workspaceId,
+      agentId: enrollmentId,
+      connectionInstanceId: "launch",
+    });
+    const detail = { retained_bytes: "268435456", stdout_bytes: "7" };
+    runner.script(opId, {
+      live: true,
+      holdUntilCancel: true,
+      frames: [{ channel: "stdout", bytes: "partial" }],
+      exit: { exitCode: 0, failureCode, failureDetail: detail },
+    });
+    const session = new SelfhostedSession({
+      workspaceId,
+      workspaceRoot: "/home/user/project",
+      agentId: enrollmentId,
+      connectionInstanceId: "launch",
+      controlRpc: runner,
+      relay: { host: "relay.test" },
+      timeoutMs: 2000,
+      execTimeoutMs: 5000,
+      retryClock: { sleep: async () => {}, jitter: () => 0.5 },
+      opStream: { transport },
+      adoptBackgroundCommand: async () => ({ commandId: identity.commandId }),
+      captureBackgroundCommandOutput: async (_id, frames) => {
+        for (const frame of frames)
+          await appendSessionCommandOutput(client.db, {
+            ...identity,
+            ...frame,
+            chunkId: `op-frame:${frame.sequence}`,
+          });
+      },
+      settleBackgroundCommand: async (command) => {
+        await settleConnectedMachineSessionBackgroundCommand(client.db, {
+          ...identity,
+          ...command,
+        });
+      },
+    });
+    await runWithToolCallCorrelation(correlation, () =>
+      session.execCommand({ cmd: "work", yieldTimeMs: 1 }),
+    );
+    runner.runs.get(opId)!.script.holdUntilCancel = false;
+    await expect(session.refreshOwnedCommand(identity.commandId)).rejects.toMatchObject({
+      detail: { failure_code: failureCode, ...detail },
+    });
+    const [notification] =
+      await shared.admin`select classification, summary, payload, payload_codec_version, state from session_system_updates where session_id=${sessionId} and source_id=${identity.commandId} and kind='background_command_result'`;
+    expect(notification).toMatchObject({ classification: "failure", state: "pending" });
+    expect(notification!.summary).not.toContain("completed successfully");
+    expect(
+      fromPostgresLosslessJson(notification!.payload, notification!.payload_codec_version),
+    ).toMatchObject({ failure: { code: failureCode, detail, retryable: false } });
+    const newClient = createDb(shared.appUrl, { max: 1 });
+    try {
+      const read = await readSessionBackgroundCommandOutput(newClient.db, identity);
+      const parsed = CommandReadResult.parse({
+        ...read,
+        waitedMs: 0,
+        timedOut: false,
+        aborted: false,
+        liveFanout: false,
+      });
+      expect(parsed).toMatchObject({
+        exitCode: 0,
+        terminal: true,
+        failure: { code: failureCode, detail, retryable: false },
+      });
+      expect(parsed.chunks.map((chunk) => chunk.chunk).join("")).toBe("partial");
+    } finally {
+      await newClient.close();
+    }
+  }
+});
+
+test("checkpointed runner details survive settlement recovery and conflicting proof fails closed", async () => {
+  const enrollmentId = crypto.randomUUID();
+  const opId = crypto.randomUUID();
+  const identity = await connected(enrollmentId, opId);
+  const claimId = crypto.randomUUID();
+  await shared.admin`update session_background_commands set reconcile_claim_id=${claimId}, reconcile_claimed_at=now() where id=${identity.commandId}`;
+  const claim = {
+    ...identity,
+    enrollmentId,
+    opId,
+    claimId,
+    state: "running" as const,
+    controlWorkspaceId: workspaceId,
+    connectionInstanceId: "launch",
+    reconcileAttempts: 1,
+    proof: null,
+  };
+  const failure = {
+    code: "OP_OVERFLOW",
+    detail: { retained_bytes: "4096" },
+    retryable: false as const,
+  };
+  const proof = {
+    outcome: "exited" as const,
+    exitCode: 0,
+    reason: "op_failure_OP_OVERFLOW",
+    failure,
+    observedAt: new Date(),
+  };
+  await recordConnectedMachineBackgroundCommandProof(client.db, { claim, proof });
+  await expect(
+    recordConnectedMachineBackgroundCommandProof(client.db, {
+      claim,
+      proof: { ...proof, failure: { ...failure, detail: { retained_bytes: "8192" } } },
+    }),
+  ).rejects.toThrow("conflicts with durable proof");
+  expect(
+    await settleConnectedMachineSessionBackgroundCommand(client.db, {
+      ...identity,
+      controlWorkspaceId: workspaceId,
+      enrollmentId,
+      connectionInstanceId: "launch",
+      opId,
+      outcome: "exited",
+      exitCode: 0,
+      reason: proof.reason,
+      failure: { ...failure, detail: { retained_bytes: "8192" } },
+    }),
+  ).toBeNull();
+  const freshClient = createDb(shared.appUrl, { max: 1 });
+  try {
+    expect(
+      (await settleClaimedConnectedMachineBackgroundCommand(freshClient.db, { claim })).settled,
+    ).toBe(true);
+    const [notification] =
+      await shared.admin`select classification, payload, payload_codec_version from session_system_updates where session_id=${sessionId} and source_id=${identity.commandId} and kind='background_command_result'`;
+    expect(notification!.classification).toBe("failure");
+    expect(
+      fromPostgresLosslessJson(notification!.payload, notification!.payload_codec_version),
+    ).toMatchObject({ failure });
+    expect((await readSessionBackgroundCommandOutput(freshClient.db, identity)).failure).toEqual(
+      failure,
+    );
+  } finally {
+    await freshClient.close();
+  }
+});
+
+test("runner failure storage rejects malformed or oversized metadata without changing command state", async () => {
+  const identity = await connected();
+  for (const failure of [
+    { retryable: false },
+    { code: "OP_OVERFLOW", retryable: true },
+    { code: "OP_OVERFLOW", retryable: false, detail: { bytes: "x".repeat(9000) } },
+  ]) {
+    await expect(
+      (async () => {
+        await shared.admin`update session_background_commands set runner_failure=${JSON.stringify(failure)}::jsonb where id=${identity.commandId}`;
+      })(),
+    ).rejects.toThrow("session_background_commands_runner_failure_check");
+  }
+  expect((await readSessionBackgroundCommandOutput(client.db, identity)).state).toBe("running");
+});
 
 test("captured frames are idempotent, pageable while running, and do not observe completion", async () => {
   const identity = await connected();
@@ -110,6 +298,34 @@ test("unknown and cross-session command identities cannot publish output", async
       chunk: "no",
     }),
   ).rejects.toThrow();
+});
+
+test("already-settled zero-exit runner failures survive durable output read and public parsing", async () => {
+  for (const failureCode of ["OP_OVERFLOW", "OP_PIPE_IO", "OP_SPOOL_IO", ""]) {
+    const identity = await connected();
+    const reason = failureCode ? `op_failure_${failureCode}` : "op_exit";
+    await shared.admin`update session_background_commands set state='exited', exit_code=0, settlement_reason=${reason}, settled_at=now() where id=${identity.commandId}`;
+    await appendSessionCommandOutput(client.db, {
+      ...identity,
+      chunkId: "op-frame:1",
+      stream: "stdout",
+      chunk: "retained partial",
+    });
+    const page = await readSessionBackgroundCommandOutput(client.db, identity);
+    const parsed = CommandReadResult.parse({
+      ...page,
+      waitedMs: 0,
+      timedOut: false,
+      aborted: false,
+      liveFanout: false,
+    });
+    expect(parsed).toMatchObject({ terminal: true, exitCode: 0, settlementReason: reason });
+    expect(parsed.failure).toEqual(
+      failureCode ? { code: failureCode, retryable: false } : undefined,
+    );
+    expect(parsed.chunks.map((chunk) => chunk.chunk).join("")).toBe("retained partial");
+    expect(parsed.completionObservedAt).not.toBeNull();
+  }
 });
 
 test("managed initial output persists before background adoption", async () => {

--- a/packages/db/test/session-command-output.test.ts
+++ b/packages/db/test/session-command-output.test.ts
@@ -81,7 +81,13 @@ async function connected(
 }
 
 test("native zero-exit failure persists exact details in pending notification and a fresh reader", async () => {
-  for (const failureCode of ["OP_OVERFLOW", "OP_PIPE_IO", "OP_SPOOL_IO"]) {
+  for (const failureCode of [
+    "OP_OVERFLOW",
+    "OP_PIPE_IO",
+    "OP_SPOOL_IO",
+    "OP.BAD:" + "x".repeat(140),
+  ]) {
+    const persistedCode = failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128);
     const enrollmentId = crypto.randomUUID();
     const correlation = crypto.randomUUID();
     const opId = `${correlation}:0`;
@@ -140,7 +146,7 @@ test("native zero-exit failure persists exact details in pending notification an
     expect(notification!.summary).not.toContain("completed successfully");
     expect(
       fromPostgresLosslessJson(notification!.payload, notification!.payload_codec_version),
-    ).toMatchObject({ failure: { code: failureCode, detail, retryable: false } });
+    ).toMatchObject({ failure: { code: persistedCode, detail, retryable: false } });
     const newClient = createDb(shared.appUrl, { max: 1 });
     try {
       const read = await readSessionBackgroundCommandOutput(newClient.db, identity);
@@ -154,12 +160,34 @@ test("native zero-exit failure persists exact details in pending notification an
       expect(parsed).toMatchObject({
         exitCode: 0,
         terminal: true,
-        failure: { code: failureCode, detail, retryable: false },
+        failure: { code: persistedCode, detail, retryable: false },
       });
       expect(parsed.chunks.map((chunk) => chunk.chunk).join("")).toBe("partial");
     } finally {
       await newClient.close();
     }
+  }
+});
+
+test("restored failure detail outside the application contract does not hide retained output", async () => {
+  for (const detail of [{ count: 7 }, { text: "x".repeat(3000) }]) {
+    const identity = await connected();
+    await appendSessionCommandOutput(client.db, {
+      ...identity,
+      chunkId: "retained",
+      stream: "stdout",
+      chunk: "kept",
+    });
+    await shared.admin`update session_background_commands set state='exited', exit_code=0, settled_at=now(),
+      runner_failure=${shared.admin.json({ code: "OP_OVERFLOW", retryable: false, detail })}
+      where id=${identity.commandId}`;
+    const result = await readSessionBackgroundCommandOutput(client.db, identity);
+    expect(result?.failure).toMatchObject({
+      code: "OP_OVERFLOW",
+      retryable: false,
+      detail: { metadata_error: expect.any(String) },
+    });
+    expect(result?.chunks.map((part) => part.chunk).join("")).toBe("kept");
   }
 });
 

--- a/packages/db/test/session-event-slices.test.ts
+++ b/packages/db/test/session-event-slices.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
-import { bootstrapWorkspace, createDb, createSession } from "../src";
+import { bootstrapWorkspace, createDb, createSession, listSessionEventPage } from "../src";
 import { listSessionEventSlices } from "../src/session-event-slices";
 import { LOSSLESS_JSON_STRING_PREFIX, toPostgresLosslessJson } from "../src/lossless-json";
 import {
@@ -61,7 +61,13 @@ async function insert(
     values (${accountId}, ${workspaceId}, ${sessionId}, ${sequence}, ${type}, ${shared.admin.json(payload as never)}, ${version})`;
 }
 const read = async (options: Parameters<typeof listSessionEventSlices>[3]) => {
-  const page = await listSessionEventSlices(client.db, workspaceId, sessionId, options);
+  const page = await listSessionEventSlices(
+    client.db,
+    workspaceId,
+    sessionId,
+    options,
+    (legacyOptions) => listSessionEventPage(client.db, workspaceId, sessionId, legacyOptions),
+  );
   expect(Buffer.byteLength(JSON.stringify(page))).toBeLessThan(512 * 1024);
   return page;
 };

--- a/packages/db/test/session-event-slices.test.ts
+++ b/packages/db/test/session-event-slices.test.ts
@@ -1,0 +1,255 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { bootstrapWorkspace, createDb, createSession } from "../src";
+import { listSessionEventSlices } from "../src/session-event-slices";
+import { LOSSLESS_JSON_STRING_PREFIX, toPostgresLosslessJson } from "../src/lossless-json";
+import {
+  readSessionEventView,
+  SESSION_EVENT_VIEW_MAX_BYTES,
+} from "../../../apps/api/src/mcp/session-event-view";
+
+let shared: SharedTestDatabase;
+let client: ReturnType<typeof createDb>;
+let workspaceId: string;
+let accountId: string;
+let sessionId: string;
+let otherSessionId: string;
+beforeAll(async () => {
+  const acquired = await acquireSharedTestDatabase("session-event-slices");
+  if (!acquired) throw new Error("PostgreSQL test database unavailable");
+  shared = acquired;
+  client = createDb(shared.appUrl, { max: 2 });
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: crypto.randomUUID(),
+    accountName: "Slices",
+    workspaceExternalSource: "test",
+    workspaceExternalId: crypto.randomUUID(),
+    workspaceName: "Slices",
+    subjectId: crypto.randomUUID(),
+  });
+  ({ workspaceId, accountId } = access.workspaceGrants[0]!);
+  otherSessionId = (await makeSession()).id;
+}, 180_000);
+const makeSession = () =>
+  createSession(client.db, {
+    accountId,
+    workspaceId,
+    initialMessage: "slice fixture",
+    resources: [],
+    metadata: {},
+    model: "test",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+beforeEach(async () => {
+  sessionId = (await makeSession()).id;
+});
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+async function insert(
+  sequence: number,
+  type: string,
+  payload: unknown,
+  version: number | null = null,
+) {
+  await shared.admin`insert into session_events (account_id, workspace_id, session_id, sequence, type, payload, payload_codec_version)
+    values (${accountId}, ${workspaceId}, ${sessionId}, ${sequence}, ${type}, ${shared.admin.json(payload as never)}, ${version})`;
+}
+const read = async (options: Parameters<typeof listSessionEventSlices>[3]) => {
+  const page = await listSessionEventSlices(client.db, workspaceId, sessionId, options);
+  expect(Buffer.byteLength(JSON.stringify(page))).toBeLessThan(512 * 1024);
+  return page;
+};
+
+for (const direction of ["after", "before"] as const) {
+  test(`real PostgreSQL reconstructs >1MiB legacy and canonical scalar text (${direction})`, async () => {
+    const sequence = 1;
+    const legacy = "🙂界" + "x".repeat(1_048_577);
+    const canonical = "a\u0000🙂\ud800\\\n" + "x".repeat(1_048_577);
+    await insert(sequence, "agent.message.completed", { text: legacy });
+    await insert(
+      sequence + 1,
+      "agent.message.completed",
+      toPostgresLosslessJson({ text: canonical }),
+      1,
+    );
+    const reconstructed = new Map<number, string[]>();
+    let cursor: string | undefined;
+    for (let n = 0; ; n++) {
+      expect(n).toBeLessThan(5000);
+      const page = await readSessionEventView(
+        cursor
+          ? { sessionId, cursor }
+          : { sessionId, direction, after: sequence - 1, before: sequence + 2 },
+        read,
+      );
+      expect(Buffer.byteLength(JSON.stringify(page, null, 2))).toBeLessThanOrEqual(
+        SESSION_EVENT_VIEW_MAX_BYTES,
+      );
+      expect(page.sourceExact).toBe(true);
+      for (const item of page.events) {
+        const parts = reconstructed.get(item.sequence) ?? [];
+        parts.push(item.text!);
+        reconstructed.set(item.sequence, parts);
+      }
+      if (!page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+    expect(reconstructed.get(sequence)?.join("")).toBe(legacy);
+    expect(reconstructed.get(sequence + 1)?.join("")).toBe(canonical);
+  }, 180_000);
+}
+
+test("structured results keep the existing budget and legacy cursors keep UTF-16 offsets", async () => {
+  const output = { body: "structured".repeat(2000) };
+  await insert(1, "agent.toolCall.output", { callId: "structured", output });
+  let cursor: string | undefined;
+  let actual = "";
+  do {
+    const page = await readSessionEventView(
+      cursor
+        ? { sessionId, cursor }
+        : {
+            sessionId,
+            view: "tools",
+            includeOutput: true,
+            after: 0,
+          },
+      read,
+    );
+    expect(page.sourceExact).toBe(true);
+    actual += page.events.map((event) => event.text ?? "").join("");
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
+  expect(actual).toBe(JSON.stringify(output));
+  const text = "🙂prefix" + "x".repeat(20_000);
+  await insert(2, "agent.message.completed", { text });
+  const legacyCursor = Buffer.from(
+    JSON.stringify({
+      v: 1,
+      selection: {
+        sessionId,
+        view: "conversation",
+        includeArguments: false,
+        includeOutput: false,
+        callId: null,
+        direction: "after",
+        after: 1,
+        before: null,
+      },
+      sequence: 2,
+      offset: 8,
+    }),
+  ).toString("base64url");
+  const page = await readSessionEventView({ sessionId, cursor: legacyCursor }, read);
+  expect(page.events[0]?.text).toBe(text.slice(8, 8 + page.events[0]!.text!.length));
+  await insert(3, "agent.toolCall.output", {
+    callId: "error",
+    output: { isError: true, content: [] },
+  });
+  const compact = await readSessionEventView({ sessionId, view: "tools", after: 2 }, read);
+  expect(compact.events[0]?.isError).toBe(true);
+  expect(compact.events[0]?.text).toBeUndefined();
+});
+
+test("legacy marker remains literal, malformed canonical marker remains literal, and offsets are checked", async () => {
+  const literal = LOSSLESS_JSON_STRING_PREFIX + "YQA=";
+  const malformed = LOSSLESS_JSON_STRING_PREFIX + "YQB=";
+  await insert(1, "agent.message.completed", { text: literal });
+  await insert(2, "agent.message.completed", { text: malformed }, 1);
+  await insert(3, "agent.message.completed", toPostgresLosslessJson({ text: "🙂\u0000" }), 1);
+  const page = await read({
+    after: 0,
+    before: 4,
+    includeTypes: ["agent.message.completed"],
+    view: "conversation",
+  });
+  expect(page.events.map((event) => (event.payload as { text: string }).text)).toEqual([
+    literal,
+    malformed,
+    "🙂\u0000",
+  ]);
+  await expect(
+    read({ after: 2, before: 4, sourceSequence: 3, sourceOffset: 1, view: "conversation" }),
+  ).rejects.toThrow("surrogate pair");
+  await expect(
+    read({ after: 2, before: 4, sourceSequence: 3, sourceOffset: 99, view: "conversation" }),
+  ).rejects.toThrow("offset");
+  const other = await listSessionEventSlices(client.db, workspaceId, otherSessionId, {
+    after: 0,
+    sourceSequence: 3,
+    sourceOffset: 0,
+    view: "conversation",
+  });
+  expect(other.events).toEqual([]);
+});
+
+test("large result/tool scalar slots remain resumable; structured omissions are explicit", async () => {
+  const text = "result ".repeat(320_000);
+  await insert(1, "turn.completed", { output: text });
+  await insert(2, "agent.toolCall.output", { callId: "large", output: text });
+  await insert(3, "agent.toolCall.output", { callId: "structured", output: { body: text } });
+  for (const view of ["results", "tools"] as const) {
+    const page = await readSessionEventView(
+      {
+        sessionId,
+        view,
+        after: 0,
+        before: 3,
+        ...(view === "tools" ? { callId: "large", includeOutput: true } : {}),
+      },
+      read,
+    );
+    expect(page.events[0]!.text).toBe(text.slice(0, page.events[0]!.text!.length));
+    expect(page.nextCursor).not.toBeNull();
+    expect(page.sourceExact).toBe(true);
+  }
+  const omitted = await readSessionEventView(
+    { sessionId, view: "tools", after: 2, includeOutput: true },
+    read,
+  );
+  expect(omitted.events[0]!.text).toBeUndefined();
+  expect(omitted.events[0]!.sourceOmitted).toBeDefined();
+  expect(omitted.sourceExact).toBe(false);
+  await insert(4, "turn.completed", { output: { body: text } });
+  const structuredResult = await readSessionEventView(
+    { sessionId, view: "results", after: 3 },
+    read,
+  );
+  expect(structuredResult.events[0]!.sourceOmitted).toBeDefined();
+  expect(structuredResult.events[0]!.text).toBeUndefined();
+  await insert(5, "agent.toolCall.output", {
+    callId: "x".repeat(10_000),
+    id: "target",
+    output: "wrong",
+  });
+  const precedence = await readSessionEventView(
+    { sessionId, view: "tools", after: 4, callId: "target", includeOutput: true },
+    read,
+  );
+  expect(precedence.events).toEqual([]);
+  await insert(
+    6,
+    "agent.toolCall.output",
+    toPostgresLosslessJson({
+      callId: "\u0000".repeat(1000),
+      name: "\u0000".repeat(1000),
+      output: "readable",
+    }),
+    1,
+  );
+  const identity = await readSessionEventView(
+    { sessionId, view: "tools", after: 5, includeOutput: true },
+    read,
+  );
+  expect(identity.events[0]!.identityOmitted).toBe(true);
+  expect(identity.events[0]!.text).toBe("readable");
+  expect(Buffer.byteLength(JSON.stringify(identity, null, 2))).toBeLessThanOrEqual(
+    SESSION_EVENT_VIEW_MAX_BYTES,
+  );
+});

--- a/packages/db/tsup.config.ts
+++ b/packages/db/tsup.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     "session-tenancy": "src/session-tenancy.ts",
     "session-background-commands": "src/session-background-commands.ts",
     "session-command-output": "src/session-command-output.ts",
+    "session-event-slices": "src/session-event-slices.ts",
   },
   format: ["esm"],
   target: "es2022",

--- a/packages/runtime/src/command-read-refresh.ts
+++ b/packages/runtime/src/command-read-refresh.ts
@@ -1,4 +1,6 @@
 import type { AttemptToolResult } from "@opengeni/contracts";
+import { SelfhostedControlError } from "./sandbox/selfhosted/control-rpc";
+import { OpStreamUnavailableError } from "./sandbox/selfhosted/op-transport";
 
 /** First-party execution edge only. API reads authorize before provider access
  * and remain the sole terminal-observation authority. No background poller. */
@@ -25,7 +27,27 @@ export async function executeCommandReadWithRefresh(input: {
     const snapshot = commandSnapshot(result);
     if (!snapshot || snapshot.terminal || input.signal?.aborted)
       return finishReceipt(result, started, seconds);
-    if (!(await input.refresh(input.args.commandId))) {
+    let refreshedOwner: boolean;
+    try {
+      refreshedOwner = await input.refresh(input.args.commandId);
+    } catch (error) {
+      if (input.signal?.aborted || !isTransientRefreshFailure(error)) throw error;
+      // A failed live refresh must not hide durable output. Reauthorize and
+      // reread, rather than serving a cached receipt after authority changed.
+      // Do not retry the provider operation or turn this into observation logic.
+      const retained = await input.call({ ...input.args, waitSeconds: 0 });
+      const retainedSnapshot = commandSnapshot(retained);
+      return finishReceipt(
+        retainedSnapshot && !retainedSnapshot.terminal
+          ? patchReceipt(retained, {
+              freshness: { status: "refresh_unavailable", retryable: true },
+            })
+          : retained,
+        started,
+        seconds,
+      );
+    }
+    if (!refreshedOwner) {
       return finishReceipt(
         await input.call({
           ...input.args,
@@ -54,6 +76,55 @@ export async function executeCommandReadWithRefresh(input: {
   }
 }
 
+/** Fail closed for unknown faults, fencing, consent, and integrity errors.
+ * Neither exception text nor a generic retryable flag is sufficient evidence. */
+function isTransientRefreshFailure(error: unknown): boolean {
+  if (error instanceof SelfhostedControlError) {
+    return (
+      !error.fenced &&
+      !error.payloadTooLarge &&
+      (error.agentOffline || error.reason === "agent_reconnecting" || error.draining)
+    );
+  }
+  if (error instanceof OpStreamUnavailableError) return error.unavailableKind === "transport";
+  if (!(error instanceof Error)) return false;
+  const code = (error as Error & { code?: unknown }).code;
+  return (
+    typeof code === "string" &&
+    [
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ETIMEDOUT",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "EAI_AGAIN",
+    ].includes(code)
+  );
+}
+
+function patchReceipt(
+  result: AttemptToolResult,
+  fields: {
+    waitedMs?: number;
+    timedOut?: boolean;
+    freshness?: { status: "refresh_unavailable"; retryable: true };
+  },
+): AttemptToolResult {
+  const snapshot = commandSnapshot(result);
+  if (!snapshot) return result;
+  return {
+    ...result,
+    ...(result.structuredContent
+      ? { structuredContent: { ...result.structuredContent, ...fields } }
+      : {}),
+    content: result.content.map((part, index) =>
+      index === 0 && part.type === "text"
+        ? { ...part, text: JSON.stringify({ ...snapshot, ...fields }) }
+        : part,
+    ),
+  };
+}
+
 function finishReceipt(
   result: AttemptToolResult,
   started: number,
@@ -62,26 +133,15 @@ function finishReceipt(
   const snapshot = commandSnapshot(result);
   if (!snapshot) return result;
   const waitedMs = Date.now() - started;
-  return {
-    ...result,
-    content: result.content.map((part, index) =>
-      index === 0 && part.type === "text"
-        ? {
-            ...part,
-            text: JSON.stringify({
-              ...snapshot,
-              waitedMs,
-              timedOut:
-                seconds > 0 &&
-                waitedMs >= seconds * 1000 &&
-                !snapshot.terminal &&
-                !snapshot.chunks.length &&
-                !snapshot.hasMore,
-            }),
-          }
-        : part,
-    ),
-  };
+  return patchReceipt(result, {
+    waitedMs,
+    timedOut:
+      seconds > 0 &&
+      waitedMs >= seconds * 1000 &&
+      !snapshot.terminal &&
+      !snapshot.chunks.length &&
+      !snapshot.hasMore,
+  });
 }
 
 function commandSnapshot(

--- a/packages/runtime/src/sandbox/routing/backend-resolver.ts
+++ b/packages/runtime/src/sandbox/routing/backend-resolver.ts
@@ -134,6 +134,7 @@ export interface ActiveBackendResolverDeps {
     outcome: "exited" | "lost";
     exitCode: number | null;
     reason: string;
+    failure?: import("@opengeni/contracts").SessionCommandFailure;
   }) => void | Promise<void>;
   /**
    * The run's declared sandbox environment — the SAME `Record<string,string>` the

--- a/packages/runtime/src/sandbox/selfhosted/control-rpc.ts
+++ b/packages/runtime/src/sandbox/selfhosted/control-rpc.ts
@@ -397,6 +397,27 @@ export interface NatsRequestConnection {
  *  selfhosted control plane reads this as `agent_offline`, NEVER a NotFound. */
 const NATS_NO_RESPONDERS_CODE = "503";
 
+function natsAuthorizationFailure(error: unknown): SelfhostedControlError | null {
+  const code = (error as { code?: unknown } | null)?.code;
+  if (
+    typeof code !== "string" ||
+    ![
+      "PERMISSIONS_VIOLATION",
+      "AUTHORIZATION_VIOLATION",
+      "AUTHENTICATION_EXPIRED",
+      "BAD_AUTHENTICATION",
+    ].includes(code)
+  )
+    return null;
+  return new SelfhostedControlError({
+    code: ErrorCode.ERROR_CODE_PROTOCOL,
+    message: "Control transport authorization failed.",
+    reason: null,
+    retryable: false,
+    detail: { transport_error_code: code },
+  });
+}
+
 function isNoRespondersError(err: unknown): boolean {
   const code = (err as { code?: unknown })?.code;
   if (typeof code === "string" && code === NATS_NO_RESPONDERS_CODE) {
@@ -452,7 +473,11 @@ export class NatsControlRpc implements ControlRpc {
         }
         return connection;
       })
-      .catch(() => null)
+      .catch((error) => {
+        const denied = natsAuthorizationFailure(error);
+        if (denied) throw denied;
+        return null;
+      })
       .finally(() => {
         this.connecting = undefined;
       });
@@ -471,10 +496,12 @@ export class NatsControlRpc implements ControlRpc {
       return offlineControlResponse(req.requestId, true);
     }
     const payload = ControlRequest.encode(req).finish();
+    let reply: { data: Uint8Array };
     try {
-      const reply = await conn.request(subject, payload, { timeout: opts.timeoutMs });
-      return ControlResponse.decode(reply.data);
+      reply = await conn.request(subject, payload, { timeout: opts.timeoutMs });
     } catch (err) {
+      const denied = natsAuthorizationFailure(err);
+      if (denied) throw denied;
       // Re-allow a future request to re-dial if the cached conn was torn down.
       if (isNoRespondersError(err)) {
         // No subscriber on the subject at all → the request reached no responder and
@@ -490,6 +517,23 @@ export class NatsControlRpc implements ControlRpc {
       // surfaces agent_offline and the lease never cold-creates a rival.
       this.connection = undefined; // force a re-dial next time
       return offlineControlResponse(req.requestId);
+    }
+    // A received but malformed response is not evidence of an offline agent.
+    // Keep decoding outside the transport catch so corruption cannot become a
+    // retryable refresh outage (or license retry of an already-sent operation).
+    try {
+      return ControlResponse.decode(reply.data);
+    } catch {
+      return {
+        requestId: req.requestId,
+        error: {
+          code: ErrorCode.ERROR_CODE_PROTOCOL,
+          message: "The machine returned a malformed control response.",
+          retryable: false,
+          detail: {},
+        },
+        result: undefined,
+      };
     }
   }
 }

--- a/packages/runtime/src/sandbox/selfhosted/op-stream.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-stream.ts
@@ -147,6 +147,8 @@ export interface OpStreamExecClientDeps {
  *  telemetry the session folds into its op observation. */
 export interface OpStreamExecOutcome {
   response: ExecResponse;
+  /** Runner transport failure is independent of the process exit code. */
+  failure?: Pick<OpExit, "failureCode" | "failureDetail">;
   /** Attach/query heals that occurred after streaming began (gap replays,
    *  silence probes that re-attached). >0 marks the op `healed`. */
   heals: number;
@@ -260,6 +262,7 @@ export class OpStreamExecClient {
   private readonly deps: OpStreamExecClientDeps;
   private readonly settled: SettledOp[] = [];
   private readonly inFlight = new Set<string>();
+  private readonly readCheckpoints = new Map<string, OpReadCheckpoint>();
   private lastReadGeneration = 0n;
 
   constructor(deps: OpStreamExecClientDeps) {
@@ -379,13 +382,23 @@ export class OpStreamExecClient {
   }
 
   /** Observe an already-adopted operation. Never issues OpStart, cancellation,
-   * final ACK, or terminal model-observation acknowledgment. */
+   * final ACK, or terminal model-observation acknowledgment. Output is delivered
+   * through captureOutput, not accumulated in response stdout/stderr. Successful
+   * running reads reuse local integrity state; a new client replays from zero. */
   async readExisting(
     opId: string,
     yieldMs: number,
     captureOutput: (frames: OpStreamOutputFrame[]) => Promise<void>,
   ): Promise<OpStreamExecResult> {
-    const consumer = new OpConsumer(this.deps, opId, this.readGeneration());
+    if (this.inFlight.has(opId)) throw protocolError("op-stream read: duplicate concurrent op id");
+    const consumer = new OpConsumer(
+      this.deps,
+      opId,
+      this.readGeneration(),
+      this.readCheckpoints.get(opId),
+    );
+    this.inFlight.add(opId);
+    this.readCheckpoints.delete(opId);
     try {
       const result = await consumer.run(
         null,
@@ -397,11 +410,18 @@ export class OpStreamExecClient {
           captureOutput,
         },
       );
+      // Only a successful capture may advance this local replay optimization.
+      // A fresh client or failed persistence always replays retained truth.
+      consumer.teardown();
+      if (result.status === "running" && !result.terminal) {
+        this.readCheckpoints.set(opId, consumer.readCheckpoint());
+      }
       return result.status === "completed"
         ? { status: "completed", outcome: result.outcome }
         : result;
     } finally {
       consumer.teardown();
+      this.inFlight.delete(opId);
     }
   }
 
@@ -441,6 +461,14 @@ export class OpStreamExecClient {
   }
 }
 
+/** In-memory only: never licenses runner GC or substitutes for durable output. */
+type OpReadCheckpoint = {
+  lastApplied: bigint;
+  hashes: { stdout: ReturnType<typeof blake3.create>; stderr: ReturnType<typeof blake3.create> };
+  totals: { stdout: bigint; stderr: bigint };
+  decoders: { stdout: TextDecoder; stderr: TextDecoder };
+};
+
 /** Internal per-op consumer: subscription, reassembly, flow, liveness. */
 class OpConsumer {
   private readonly deps: OpStreamExecClientDeps;
@@ -458,6 +486,9 @@ class OpConsumer {
   };
   private readonly outputFrames: OpStreamOutputFrame[] = [];
   private readonly outputDecoders = { stdout: new TextDecoder(), stderr: new TextDecoder() };
+  private readonly hashes = { stdout: blake3.create(), stderr: blake3.create() };
+  private readonly totals = { stdout: 0n, stderr: 0n };
+  private captureOnly = false;
   private receivedPayloadBytes = 0n;
   private creditAtLastAck = 0n;
   private exit: OpExit | undefined;
@@ -472,12 +503,32 @@ class OpConsumer {
   private settleReject: ((error: unknown) => void) | undefined;
   private torn = false;
 
-  constructor(deps: OpStreamExecClientDeps, opId: string, generation: string) {
+  constructor(
+    deps: OpStreamExecClientDeps,
+    opId: string,
+    generation: string,
+    checkpoint?: OpReadCheckpoint,
+  ) {
     this.deps = deps;
     this.opId = opId;
     this.generation = generation;
     this.windowBytes = deps.windowBytes ?? OP_STREAM_DEFAULT_WINDOW_BYTES;
     this.lastFrameAt = Date.now();
+    if (checkpoint) {
+      this.lastApplied = checkpoint.lastApplied;
+      this.hashes = checkpoint.hashes;
+      this.totals = checkpoint.totals;
+      this.outputDecoders = checkpoint.decoders;
+    }
+  }
+
+  readCheckpoint(): OpReadCheckpoint {
+    return {
+      lastApplied: this.lastApplied,
+      hashes: this.hashes,
+      totals: this.totals,
+      decoders: this.outputDecoders,
+    };
   }
 
   private get ackIntervalMs(): number {
@@ -513,6 +564,7 @@ class OpConsumer {
       }
     | Extract<OpStreamExecResult, { status: "running" }>
   > {
+    this.captureOnly = exec === null;
     // Arm the settle promise FIRST: frames can start applying the moment the
     // attach below returns (replay is asynchronous), and a completion that
     // fires before the resolver exists would strand the op on its wall.
@@ -573,6 +625,10 @@ class OpConsumer {
           // receipt. A completion racing the transaction is handled below as
           // terminal proof for the adopted command, never returned inline too.
           if (this.exitSeq === undefined) {
+            // Freeze a read's exact local frontier before persistence can block.
+            // The runner retains later output; do not accumulate it while the
+            // database is slow. Foreground/adoption receipt behavior is unchanged.
+            if (this.captureOnly) this.teardown();
             await this.sendBackgroundCredit();
             const partial = this.snapshotOutput();
             await yieldOptions.captureOutput?.(this.outputFrames.splice(0));
@@ -600,12 +656,15 @@ class OpConsumer {
     // Settled: the exit frame and every frame before it are applied.
     const exit = this.exit as OpExit;
     const exitSeq = this.exitSeq as bigint;
-    if (exit.failureCode && exec !== null) {
+    if (exit.failureCode && exec !== null && !adopted) {
       throw runnerFailureToControlError(exit);
     }
     const { stdout, stderr } = this.assembleAndVerify(exit);
     if (adopted || exec === null) await yieldOptions?.captureOutput?.(this.outputFrames.splice(0));
     const outcome: OpStreamExecOutcome = {
+      ...(exit.failureCode
+        ? { failure: { failureCode: exit.failureCode, failureDetail: exit.failureDetail } }
+        : {}),
       response: {
         exitCode: exit.exitCode,
         stdout,
@@ -860,6 +919,7 @@ class OpConsumer {
   }
 
   private onFramePayload(payload: Uint8Array): void {
+    if (this.torn) return;
     let frame: OpFrame;
     try {
       frame = OpFrame.decode(payload);
@@ -919,7 +979,12 @@ class OpConsumer {
       case "data": {
         const channel = OP_CHANNEL_NAMES[body.data.channel];
         if (channel) {
-          this.chunks[channel].push(body.data.bytes);
+          if (this.captureOnly) {
+            this.hashes[channel].update(body.data.bytes);
+            this.totals[channel] += BigInt(body.data.bytes.byteLength);
+          } else {
+            this.chunks[channel].push(body.data.bytes);
+          }
           const chunk = this.outputDecoders[channel].decode(body.data.bytes, { stream: true });
           if (chunk) this.outputFrames.push({ sequence: frame.seq, stream: channel, chunk });
         }
@@ -1078,15 +1143,18 @@ class OpConsumer {
     for (const channel of ["stdout", "stderr"] as const) {
       const bytes = assembled[channel];
       const declaredTotal = exit.totals[channel];
-      if (declaredTotal !== undefined && BigInt(declaredTotal) !== BigInt(bytes.byteLength)) {
+      const total = this.captureOnly ? this.totals[channel] : BigInt(bytes.byteLength);
+      if (declaredTotal !== undefined && BigInt(declaredTotal) !== total) {
         throw protocolError(
-          `op-stream reassembly: ${channel} total mismatch (got ${bytes.byteLength}, ` +
+          `op-stream reassembly: ${channel} total mismatch (got ${total}, ` +
             `runner declared ${declaredTotal})`,
         );
       }
       const declaredDigest = exit.digests[channel];
       if (declaredDigest) {
-        const digest = bytesToHex(blake3(bytes));
+        const digest = bytesToHex(
+          this.captureOnly ? this.hashes[channel].clone().digest() : blake3(bytes),
+        );
         if (digest !== declaredDigest) {
           throw protocolError(
             `op-stream reassembly: ${channel} digest mismatch (got ${digest}, ` +
@@ -1149,7 +1217,9 @@ function lostToControlError(status: OpStatus): SelfhostedControlError {
  * output, redirect to a file, read it back in ranges — so it gets the same
  * actionable rendering, with the runner's exact counters in the detail.
  */
-function runnerFailureToControlError(exit: OpExit): SelfhostedControlError {
+export function runnerFailureToControlError(
+  exit: Pick<OpExit, "failureCode" | "failureDetail">,
+): SelfhostedControlError {
   if (exit.failureCode === "OP_OVERFLOW") {
     return new SelfhostedControlError({
       message:

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -60,7 +60,12 @@ import {
   notifyDurableOpOwnershipTransferStarted,
   notifyDurableOpOwnershipTransferred,
 } from "../op-correlation";
-import { OpStreamExecClient, type OpStreamJournal, type OpStreamOutputFrame } from "./op-stream";
+import {
+  OpStreamExecClient,
+  runnerFailureToControlError,
+  type OpStreamJournal,
+  type OpStreamOutputFrame,
+} from "./op-stream";
 import { OpStreamUnavailableError, type OpStreamTransport } from "./op-transport";
 import { connectedMachineWorkspaceRootsEqual, resolveConnectedMachinePath } from "./workspace-path";
 
@@ -348,6 +353,7 @@ export interface SelfhostedSessionDeps {
     outcome: "exited" | "lost";
     exitCode: number | null;
     reason: string;
+    failure?: import("@opengeni/contracts").SessionCommandFailure;
   }) => void | Promise<void>;
   /** The clock the bounded control-op retry loop drives (sleep + jitter). Injected
    *  so tests are deterministic; defaults to a real timer + `Math.random()`. */
@@ -1030,9 +1036,22 @@ export class SelfhostedSession {
                       opId,
                       outcome: "exited",
                       exitCode: terminal.outcome.response.exitCode,
-                      reason: "op_exit",
+                      reason: terminal.outcome.failure
+                        ? `op_failure_${terminal.outcome.failure.failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128)}`
+                        : "op_exit",
+                      ...(terminal.outcome.failure
+                        ? {
+                            failure: {
+                              code: terminal.outcome.failure.failureCode,
+                              detail: terminal.outcome.failure.failureDetail,
+                              retryable: false as const,
+                            },
+                          }
+                        : {}),
                     });
                     this.ownedCommandReaders.delete(adopted.commandId);
+                    if (terminal.outcome.failure)
+                      throw runnerFailureToControlError(terminal.outcome.failure);
                   }
                 });
                 notifyDurableOpOwnershipTransferred(opId);
@@ -1053,7 +1072,18 @@ export class SelfhostedSession {
               opId,
               outcome: "exited",
               exitCode: result.terminal.outcome.response.exitCode,
-              reason: "op_exit",
+              reason: result.terminal.outcome.failure
+                ? `op_failure_${result.terminal.outcome.failure.failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128)}`
+                : "op_exit",
+              ...(result.terminal.outcome.failure
+                ? {
+                    failure: {
+                      code: result.terminal.outcome.failure.failureCode,
+                      detail: result.terminal.outcome.failure.failureDetail,
+                      retryable: false as const,
+                    },
+                  }
+                : {}),
             }),
           ).catch(() => undefined);
         }
@@ -1091,7 +1121,18 @@ export class SelfhostedSession {
             opId,
             outcome: "exited",
             exitCode: outcome.response.exitCode,
-            reason: "op_exit",
+            reason: outcome.failure
+              ? `op_failure_${outcome.failure.failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128)}`
+              : "op_exit",
+            ...(outcome.failure
+              ? {
+                  failure: {
+                    code: outcome.failure.failureCode,
+                    detail: outcome.failure.failureDetail,
+                    retryable: false as const,
+                  },
+                }
+              : {}),
           }),
         ).catch(() => undefined);
       }

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -1042,7 +1042,9 @@ export class SelfhostedSession {
                       ...(terminal.outcome.failure
                         ? {
                             failure: {
-                              code: terminal.outcome.failure.failureCode,
+                              code: terminal.outcome.failure.failureCode
+                                .replace(/[^A-Za-z0-9_-]/g, "_")
+                                .slice(0, 128),
                               detail: terminal.outcome.failure.failureDetail,
                               retryable: false as const,
                             },
@@ -1078,7 +1080,9 @@ export class SelfhostedSession {
               ...(result.terminal.outcome.failure
                 ? {
                     failure: {
-                      code: result.terminal.outcome.failure.failureCode,
+                      code: result.terminal.outcome.failure.failureCode
+                        .replace(/[^A-Za-z0-9_-]/g, "_")
+                        .slice(0, 128),
                       detail: result.terminal.outcome.failure.failureDetail,
                       retryable: false as const,
                     },
@@ -1127,7 +1131,7 @@ export class SelfhostedSession {
             ...(outcome.failure
               ? {
                   failure: {
-                    code: outcome.failure.failureCode,
+                    code: outcome.failure.failureCode.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128),
                     detail: outcome.failure.failureDetail,
                     retryable: false as const,
                   },

--- a/packages/runtime/test/command-read-refresh.test.ts
+++ b/packages/runtime/test/command-read-refresh.test.ts
@@ -4,10 +4,234 @@ import { executeCommandReadWithRefresh } from "../src/command-read-refresh";
 import { createAttemptToolEnvironment } from "@opengeni/codemode";
 import { PrefixedMcpServer } from "../src/index";
 import type { MCPServer } from "@openai/agents";
+import { ControlRequest, ErrorCode } from "@opengeni/agent-proto";
+import {
+  SelfhostedControlError,
+  NatsControlRpc,
+  agentErrorToControlError,
+} from "../src/sandbox/selfhosted/control-rpc";
+import { OpStreamUnavailableError } from "../src/sandbox/selfhosted/op-transport";
 
 const commandId = "6cfa95ae-29cc-48cb-9ab1-2613d15f1dde";
 const receipt = (terminal = false, chunks: unknown[] = []): AttemptToolResult => ({
   content: [{ type: "text", text: JSON.stringify({ commandId, terminal, chunks }) }],
+});
+
+const snapshot = (result: AttemptToolResult) =>
+  JSON.parse((result.content[0] as { text: string }).text);
+
+test("temporary live transport failure preserves retained output after API reauthorization", async () => {
+  for (const error of [
+    new OpStreamUnavailableError("private transport detail"),
+    new SelfhostedControlError({
+      message: "offline",
+      code: ErrorCode.ERROR_CODE_AGENT_OFFLINE,
+      reason: "agent_offline",
+      retryable: false,
+      agentOffline: true,
+    }),
+    new SelfhostedControlError({
+      message: "timeout",
+      code: ErrorCode.ERROR_CODE_TIMEOUT,
+      reason: "agent_reconnecting",
+      retryable: true,
+    }),
+    new SelfhostedControlError({
+      message: "busy",
+      code: ErrorCode.ERROR_CODE_DRAINING,
+      reason: null,
+      retryable: true,
+      draining: true,
+    }),
+    Object.assign(new Error("connection reset"), { code: "ECONNRESET" }),
+  ]) {
+    const calls: string[] = [];
+    const args = { commandId, cursor: "unchanged", maxOutputBytes: 64, waitSeconds: 45 };
+    const result = await executeCommandReadWithRefresh({
+      toolName: "command_wait",
+      args,
+      call: async (readArgs) => {
+        calls.push("api");
+        expect(readArgs).toEqual({ ...args, waitSeconds: 0 });
+        const value = receipt(false, [{ stream: "stdout", chunk: "already durable" }]);
+        return { ...value, structuredContent: snapshot(value) };
+      },
+      refresh: async () => {
+        calls.push("refresh");
+        throw error;
+      },
+    });
+    expect(calls).toEqual(["api", "refresh", "api"]);
+    expect(snapshot(result)).toMatchObject({
+      terminal: false,
+      chunks: [{ stream: "stdout", chunk: "already durable" }],
+      freshness: { status: "refresh_unavailable", retryable: true },
+      timedOut: false,
+    });
+    expect(result.structuredContent).toEqual(snapshot(result));
+    expect(JSON.stringify(result)).not.toContain(error.message);
+  }
+});
+
+test("refresh fallback never hides revoked authorization or a failed API read", async () => {
+  let reads = 0;
+  const denied: AttemptToolResult = { content: [{ type: "text", text: "denied" }], isError: true };
+  const result = await executeCommandReadWithRefresh({
+    toolName: "command_read",
+    args: { commandId },
+    call: async () => (++reads === 1 ? receipt(false, ["sensitive retained output"]) : denied),
+    refresh: async () => {
+      throw new OpStreamUnavailableError("offline");
+    },
+  });
+  expect(result).toBe(denied);
+  reads = 0;
+  const failure = new Error("API authority unavailable");
+  await expect(
+    executeCommandReadWithRefresh({
+      toolName: "command_read",
+      args: { commandId },
+      call: async () => {
+        if (++reads > 1) throw failure;
+        return receipt();
+      },
+      refresh: async () => {
+        throw new OpStreamUnavailableError("offline");
+      },
+    }),
+  ).rejects.toBe(failure);
+});
+
+test("terminal API result after refresh failure stays authoritative without stale warning", async () => {
+  let reads = 0;
+  const result = await executeCommandReadWithRefresh({
+    toolName: "command_read",
+    args: { commandId },
+    call: async () => receipt(++reads > 1, ["tail"]),
+    refresh: async () => {
+      throw new OpStreamUnavailableError("offline");
+    },
+  });
+  expect(snapshot(result).terminal).toBe(true);
+  expect(snapshot(result).freshness).toBeUndefined();
+});
+
+test("integrity, consent, fencing, unsupported and unknown refresh errors still fail closed", async () => {
+  for (const error of [
+    new Error("provider temporarily offline"),
+    new OpStreamUnavailableError("unsupported", "runner"),
+    new SelfhostedControlError({
+      message: "bad digest",
+      code: ErrorCode.ERROR_CODE_PROTOCOL,
+      reason: null,
+      retryable: false,
+    }),
+    new SelfhostedControlError({
+      message: "fenced",
+      code: ErrorCode.ERROR_CODE_FENCED,
+      reason: null,
+      retryable: true,
+      fenced: true,
+    }),
+    new SelfhostedControlError({
+      message: "consent",
+      code: ErrorCode.ERROR_CODE_CONSENT_REQUIRED,
+      reason: "consent_required",
+      retryable: false,
+    }),
+  ]) {
+    let reads = 0;
+    await expect(
+      executeCommandReadWithRefresh({
+        toolName: "command_read",
+        args: { commandId },
+        call: async () => {
+          reads++;
+          return receipt(false, ["retained"]);
+        },
+        refresh: async () => {
+          throw error;
+        },
+      }),
+    ).rejects.toBe(error);
+    expect(reads).toBe(1);
+  }
+});
+
+test("real RPC decoder corruption remains a protocol failure, never a stale-output fallback", async () => {
+  const rpc = new NatsControlRpc(async () => ({
+    request: async () => ({ data: new Uint8Array([255]) }),
+  }));
+  const response = await rpc.request(
+    "test-control",
+    ControlRequest.fromPartial({ requestId: "corrupt" }),
+    { timeoutMs: 100 },
+  );
+  expect(response.error?.code).toBe(ErrorCode.ERROR_CODE_PROTOCOL);
+  expect(response.error?.retryable).toBe(false);
+  const fault = agentErrorToControlError(response.error!);
+  expect(fault.agentOffline).toBe(false);
+  expect(fault.neverSent).toBe(false);
+  let reads = 0;
+  await expect(
+    executeCommandReadWithRefresh({
+      toolName: "command_read",
+      args: { commandId },
+      call: async () => {
+        reads++;
+        return receipt(false, ["retained"]);
+      },
+      refresh: async () => {
+        throw fault;
+      },
+    }),
+  ).rejects.toBe(fault);
+  expect(reads).toBe(1);
+});
+
+test("NATS authorization failures during dial or request never become refresh outages", async () => {
+  for (const code of [
+    "PERMISSIONS_VIOLATION",
+    "AUTHORIZATION_VIOLATION",
+    "AUTHENTICATION_EXPIRED",
+    "BAD_AUTHENTICATION",
+  ]) {
+    for (const phase of ["connect", "request"]) {
+      const denied = Object.assign(new Error("private subject and credentials"), { code });
+      const rpc = new NatsControlRpc(async () => {
+        if (phase === "connect") throw denied;
+        return {
+          request: async () => {
+            throw denied;
+          },
+        };
+      });
+      let reads = 0;
+      const operation = executeCommandReadWithRefresh({
+        toolName: "command_read",
+        args: { commandId },
+        call: async () => {
+          reads++;
+          return receipt(false, ["retained"]);
+        },
+        refresh: async () => {
+          await rpc.request("test-control", ControlRequest.fromPartial({ requestId: "denied" }), {
+            timeoutMs: 100,
+          });
+          return true;
+        },
+      });
+      await expect(operation).rejects.toMatchObject({
+        name: "SelfhostedControlError",
+        code: ErrorCode.ERROR_CODE_PROTOCOL,
+        retryable: false,
+        agentOffline: false,
+        message: "Control transport authorization failed.",
+        detail: { transport_error_code: code },
+      });
+      expect(reads).toBe(1);
+    }
+  }
 });
 
 test("model and Codemode share the first-party catalog refresh executor", async () => {

--- a/packages/runtime/test/op-stream-exec.test.ts
+++ b/packages/runtime/test/op-stream-exec.test.ts
@@ -14,10 +14,12 @@ import { FakeOpRunner, InMemoryOpStreamTransport } from "../src/sandbox/selfhost
 import { SelfhostedSession } from "../src/sandbox/selfhosted/session";
 import {
   OpStreamExecClient,
+  OP_STREAM_DEFAULT_WINDOW_BYTES,
   type OpStreamJournal,
   type OpStreamOutputFrame,
 } from "../src/sandbox/selfhosted/op-stream";
 import { createTurnToolCancellationController } from "../src/sandbox/turn-tool-cancellation";
+import { executeCommandReadWithRefresh } from "../src/command-read-refresh";
 
 const WORKSPACE = "ws-1";
 const AGENT = "agent-1";
@@ -108,6 +110,223 @@ function buildRig(
 }
 
 describe("op-stream exec (fake runner)", () => {
+  for (const failureCode of ["OP_OVERFLOW", "OP_PIPE_IO", "OP_SPOOL_IO", ""]) {
+    test(`owner refresh preserves terminal classification with zero exit: ${failureCode || "normal"}`, async () => {
+      const events: string[] = [];
+      const settlements: unknown[] = [];
+      const { runner, session } = buildRig({
+        adoptBackgroundCommand: async () => ({ commandId: "typed-terminal" }),
+        captureBackgroundCommandOutput: async (_id, frames) => {
+          if (frames.length) events.push("capture");
+        },
+        settleBackgroundCommand: async (value) => {
+          events.push("settle");
+          settlements.push(value);
+        },
+      });
+      runner.script("typed_terminal:0", {
+        live: true,
+        holdUntilCancel: true,
+        frames: [{ channel: "stdout", bytes: "retained-prefix" }],
+        exit: { exitCode: 0, failureCode, failureDetail: { retained_bytes: "268435456" } },
+      });
+      const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+      await runWithToolCallCorrelation("typed_terminal", () =>
+        session.execCommand({ cmd: "work", yieldTimeMs: 1 }),
+      );
+      runner.runs.get("typed_terminal:0")!.script.holdUntilCancel = false;
+      if (failureCode) {
+        await expect(
+          executeCommandReadWithRefresh({
+            toolName: "command_read",
+            args: { commandId: "typed-terminal" },
+            refresh: (id) => session.refreshOwnedCommand(id),
+            call: async () => ({
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    commandId: "typed-terminal",
+                    terminal: false,
+                    chunks: [],
+                    hasMore: false,
+                  }),
+                },
+              ],
+            }),
+          }),
+        ).rejects.toMatchObject({
+          name: "SelfhostedControlError",
+          code:
+            failureCode === "OP_OVERFLOW"
+              ? ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE
+              : ErrorCode.ERROR_CODE_STREAM,
+          retryable: false,
+          payloadTooLarge: failureCode === "OP_OVERFLOW",
+          detail: { failure_code: failureCode, retained_bytes: "268435456" },
+        });
+      } else {
+        expect(await session.refreshOwnedCommand("typed-terminal")).toBe(true);
+      }
+      expect(events).toEqual(["capture", "settle"]);
+      expect(settlements).toEqual([
+        expect.objectContaining({
+          outcome: "exited",
+          exitCode: 0,
+          reason: failureCode ? `op_failure_${failureCode}` : "op_exit",
+        }),
+      ]);
+      expect(await session.refreshOwnedCommand("typed-terminal")).toBe(false);
+    });
+  }
+
+  for (const corruptDigest of [false, true]) {
+    test(`running reads bound replay, detach before capture, and preserve UTF-8/integrity (corrupt=${corruptDigest})`, async () => {
+      const { runner, transport, session } = buildRig({
+        adoptBackgroundCommand: async () => ({ commandId: "bounded-read" }),
+      });
+      const bytes = new TextEncoder().encode("🙂" + "x".repeat(128 * 1024));
+      runner.script("bounded_read:0", {
+        live: true,
+        holdUntilCancel: true,
+        frames: [
+          { channel: "stdout", bytes: bytes.slice(0, 2) },
+          { channel: "stdout", bytes: bytes.slice(2) },
+        ],
+      });
+      const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+      await runWithToolCallCorrelation("bounded_read", () =>
+        session.execCommand({ cmd: "work", yieldTimeMs: 1 }),
+      );
+      const run = runner.runs.get("bounded_read:0")!;
+      // The fake's retained log grows in stages, as a real still-running child does.
+      const allFrames = [...run.frames];
+      run.liveEmitted = true;
+      run.frames = allFrames.slice(0, 1);
+      const fromSeqs: string[] = [];
+      let delivered = 0;
+      let activeSubscriptions = 0;
+      let expectDetached = true;
+      const reader = new OpStreamExecClient({
+        workspaceId: WORKSPACE,
+        agentId: AGENT,
+        connectionInstanceId: CONNECTION_INSTANCE,
+        epoch: 0,
+        rpcSubject: `agent.${WORKSPACE}.${AGENT}.connection.${CONNECTION_INSTANCE}.rpc`,
+        controlRpc: {
+          request: async (subject, request, opts) => {
+            if (request.op?.$case === "opAttach") fromSeqs.push(request.op.opAttach.fromSeq);
+            return runner.request(subject, request, opts);
+          },
+        },
+        transport: {
+          subscribe: async (subject, handler) => {
+            const subscription = await transport.subscribe(subject, (payload) => {
+              delivered++;
+              handler(payload);
+            });
+            activeSubscriptions++;
+            return {
+              unsubscribe: () => {
+                activeSubscriptions--;
+                subscription.unsubscribe();
+              },
+            };
+          },
+          publish: (subject, payload) => transport.publish(subject, payload),
+        },
+        controlTimeoutMs: 1000,
+        ackIntervalMs: 2,
+        retryClock: { sleep: async () => {}, jitter: () => 0.5 },
+      });
+      const captured: OpStreamOutputFrame[] = [];
+      const capture = async (frames: OpStreamOutputFrame[]) => {
+        if (expectDetached) expect(activeSubscriptions).toBe(0);
+        captured.push(...frames);
+      };
+      expect((await reader.readExisting("bounded_read:0", 1, capture)).status).toBe("running");
+      expect(captured).toEqual([]); // split UTF-8 prefix lives in the checkpoint decoder
+      for (let i = 0; i < 5; i++) await reader.readExisting("bounded_read:0", 1, capture);
+      expect(fromSeqs).toEqual(["0", "1", "1", "1", "1", "1"]);
+      expect(delivered).toBe(1);
+      run.frames = allFrames.slice(0, 2);
+      await expect(
+        reader.readExisting("bounded_read:0", 1, async () => {
+          throw new Error("persistence failed");
+        }),
+      ).rejects.toThrow("persistence failed");
+      await reader.readExisting("bounded_read:0", 1, capture);
+      expect(fromSeqs.at(-1)).toBe("0");
+      expect(captured.map((frame) => frame.chunk).join("")).toBe(new TextDecoder().decode(bytes));
+      const afterCapture = delivered;
+      for (let i = 0; i < 5; i++) await reader.readExisting("bounded_read:0", 1, capture);
+      expect(delivered).toBe(afterCapture);
+      expect(captured).toHaveLength(1);
+      // No new bytes in this attachment: periodic credit must not include the
+      // retained prefix counted by the integrity checkpoint.
+      const priorAcks = transport.decodedAcks().length;
+      await reader.readExisting("bounded_read:0", 20, capture);
+      const currentAcks = transport
+        .decodedAcks()
+        .slice(priorAcks)
+        .filter((ack) => BigInt(ack.creditBytes) < 1_000_000_000n);
+      expect(currentAcks.length).toBeGreaterThan(0);
+      expect(
+        currentAcks.every((ack) => ack.creditBytes === String(OP_STREAM_DEFAULT_WINDOW_BYTES)),
+      ).toBe(true);
+      run.frames = allFrames;
+      expectDetached = false;
+      if (corruptDigest) {
+        const originalDigest = run.exit.digests.stdout!;
+        run.exit.digests.stdout = "invalid";
+        await expect(reader.readExisting("bounded_read:0", 100, capture)).rejects.toThrow(
+          "digest mismatch",
+        );
+        expect(captured).toHaveLength(1);
+        run.exit.digests.stdout = originalDigest;
+      }
+      expect((await reader.readExisting("bounded_read:0", 100, capture)).status).toBe("completed");
+      expect(fromSeqs.at(-1)).toBe(corruptDigest ? "0" : "2");
+      expect(captured).toHaveLength(corruptDigest ? 2 : 1);
+      expect(transport.decodedAcks().every((ack) => !ack.final && ack.ackedSeq === "0")).toBe(true);
+    });
+  }
+
+  test("a failure racing adoption is captured and settled as failure, never foreground success", async () => {
+    const events: string[] = [];
+    const settlements: unknown[] = [];
+    let session!: SelfhostedSession;
+    const rig = buildRig({
+      adoptBackgroundCommand: async ({ opId }) => {
+        await session.cancelExecCommand(opId);
+        return { commandId: "raced-failure" };
+      },
+      captureBackgroundCommandOutput: async (_id, frames) => {
+        if (frames.length) events.push("capture");
+      },
+      settleBackgroundCommand: async (value) => {
+        events.push("settle");
+        settlements.push(value);
+      },
+    });
+    session = rig.session;
+    rig.runner.script("raced_failure:0", {
+      live: true,
+      holdUntilCancel: true,
+      frames: [{ channel: "stdout", bytes: "partial" }],
+      exit: { failureCode: "OP_OVERFLOW", failureDetail: { retained_bytes: "7" } },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("raced_failure", () =>
+      session.execCommand({ cmd: "work", yieldTimeMs: 1 }),
+    );
+    expect(result).toContain("command ID raced-failure");
+    expect(events).toEqual(["capture", "settle"]);
+    expect(settlements).toEqual([
+      expect.objectContaining({ outcome: "exited", reason: "op_failure_OP_OVERFLOW" }),
+    ]);
+  });
+
   test("owner read uses a fresh attach after the reaper and stale consumers cannot replay", async () => {
     const captured: string[] = [];
     const settled: string[] = [];

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,7 +131,7 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe("0415_command_completion_observation.sql");
+    expect(completeSourceContract.latestMigration).toBe("0417_command_runner_failure_metadata.sql");
     const sandboxDeadlineIndex = completeSourceContract.migrations.findIndex(
       (migration) => migration.path === "0397_sandbox_deadline_rotation_preemption.sql",
     );
@@ -242,6 +242,9 @@ describe("release schema contract", () => {
     );
     const commandCompletionObservation = completeSourceContract.migrations.some(
       (migration) => migration.path === "0415_command_completion_observation.sql",
+    );
+    const commandRunnerFailureMetadata = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0417_command_runner_failure_metadata.sql",
     );
     const scheduledGeneratedProducerMaterialization = completeSourceContract.migrations.some(
       (migration) => migration.path === "0414_scheduled_generated_producer_materialization.sql",
@@ -673,6 +676,7 @@ describe("release schema contract", () => {
       "0413_session_filter_activity.sql",
       "0414_scheduled_generated_producer_materialization.sql",
       "0415_command_completion_observation.sql",
+      "0417_command_runner_failure_metadata.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -727,6 +731,7 @@ describe("release schema contract", () => {
         (newSessionDraftProjectProvenanceIndex ? 1 : 0) +
         (newSessionDraftProjectProvenanceBackfill ? 1 : 0) +
         (commandCompletionObservation ? 1 : 0) +
+        (commandRunnerFailureMetadata ? 1 : 0) +
         (scheduledGeneratedProducerMaterialization ? 1 : 0) +
         (newSessionDraftProjectProvenanceValidation ? 1 : 0) +
         (scheduledSessionTargetIndex ? 1 : 0) +
@@ -790,108 +795,110 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: commandCompletionObservation
-        ? "0415_command_completion_observation.sql"
-        : scheduledGeneratedProducerMaterialization
-          ? "0414_scheduled_generated_producer_materialization.sql"
-          : sessionFilterActivity
-            ? "0413_session_filter_activity.sql"
-            : newSessionDraftProjectProvenanceValidation
-              ? "0412_new_session_draft_project_provenance_validation.sql"
-              : newSessionDraftProjectProvenanceBackfill
-                ? "0411_new_session_draft_project_provenance_backfill.sql"
-                : newSessionDraftProjectProvenanceIndex
-                  ? "0410_new_session_draft_project_provenance_index.sql"
-                  : newSessionDraftProjectProvenance
-                    ? "0409_new_session_draft_project_provenance.sql"
-                    : scheduledSessionTargetIndex
-                      ? "0408_scheduled_session_target_index.sql"
-                      : connectedCommandTrackingRetirement
-                        ? "0407_connected_command_tracking_retirement.sql"
-                        : sandboxProviderDeadlineInteractionFollowup
-                          ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-                          : organizationModelProviderConnections
-                            ? "0390_organization_model_provider_connections.sql"
-                            : modelCatalogAndGatewayCustomModels
-                              ? "0389_model_catalog_and_gateway_custom_models.sql"
-                              : sandboxProviderDeadlineInteractions
-                                ? "0388_sandbox_provider_deadline_interactions.sql"
-                                : boundHostExportSessionPayloads
-                                  ? "0387_bound_host_export_session_payloads.sql"
-                                  : localOrganizationAdministration
-                                    ? "0386_local_organization_administration.sql"
-                                    : connectedMachineLegacyTildeWorkdirs
-                                      ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                                      : codexCooldownRevisionGuardPrivileges
-                                        ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                                        : codexCooldownReconciliation
-                                          ? "0383_codex_cooldown_reconciliation.sql"
-                                          : organizationApiKeyProvenance
-                                            ? "0382_organization_api_key_provenance.sql"
-                                            : organizationCodexSubscriptionInheritance
-                                              ? "0381_organization_codex_subscription_inheritance.sql"
-                                              : autonomousCompanyProfileAgentPolicy
-                                                ? "0380_autonomous_company_profile_agent_policy.sql"
-                                                : sessionEventRawLaneActivation
-                                                  ? "0379_session_event_raw_lane_activation.sql"
-                                                  : scopedRigHealthAuditTimestamp
-                                                    ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                                    : scopedRigHealthProjection
-                                                      ? "0377_scoped_rig_health_projection.sql"
-                                                      : organizationWorkspaceInventory
-                                                        ? "0376_organization_workspace_inventory.sql"
-                                                        : sessionRecoveryObservability
-                                                          ? "0375_session_recovery_observability.sql"
-                                                          : sessionEventCursors
-                                                            ? "0374_session_event_cursors.sql"
-                                                            : sandboxSharedPreparation
-                                                              ? "0373_sandbox_shared_preparation.sql"
-                                                              : orderedVariableSetRuntimeAuthority
-                                                                ? "0372_ordered_variable_set_runtime_authority.sql"
-                                                                : workspaceMemberCandidateInventory
-                                                                  ? "0371_workspace_member_candidate_inventory.sql"
-                                                                  : workspaceMemberManagementScope
-                                                                    ? "0370_workspace_member_management_scope.sql"
-                                                                    : localHumanPersonalAuthority
-                                                                      ? "0369_local_human_personal_authority.sql"
-                                                                      : sessionDiscoveryClaimSearchIndex
-                                                                        ? "0368_session_discovery_claim_search_index.sql"
-                                                                        : sessionDiscoveryGoalSearchIndex
-                                                                          ? "0367_session_discovery_goal_search_index.sql"
-                                                                          : sessionDiscoveryTitleSearchIndex
-                                                                            ? "0366_session_discovery_title_search_index.sql"
-                                                                            : permissionScopedWorkClaims
-                                                                              ? "0365_permission_scoped_work_claims.sql"
-                                                                              : workspaceLearningPolicySnapshotLockOrder
-                                                                                ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                                                : organizationRecoveryCustody
-                                                                                  ? "0363_organization_recovery_custody.sql"
-                                                                                  : managedAuthSessionSets
-                                                                                    ? "0362_managed_auth_session_sets.sql"
-                                                                                    : rememberKnowledgeMemoryMaterialization
-                                                                                      ? "0361_remember_knowledge_memory_materialization.sql"
-                                                                                      : organizationIdentityConfirmationPrompt
-                                                                                        ? "0360_organization_identity_confirmation_prompt.sql"
-                                                                                        : insightsForceRlsReadCapability
-                                                                                          ? "0359_insights_force_rls_read_capability.sql"
-                                                                                          : prReviewManagedGithubApp
-                                                                                            ? "0358_pr_review_managed_github_app.sql"
-                                                                                            : rigPlatformBaseOnly
-                                                                                              ? "0357_rig_platform_base_only.sql"
-                                                                                              : setBasedInsightsSessionVisibility
-                                                                                                ? "0356_set_based_insights_session_visibility.sql"
-                                                                                                : automaticSessionTitleQuarantine
-                                                                                                  ? "0355_automatic_session_title_quarantine.sql"
-                                                                                                  : automaticSessionTitleQuarantineIndex
-                                                                                                    ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                                                    : automaticSessionTitlePolicyFence
-                                                                                                      ? "0353_automatic_session_title_policy_fence.sql"
-                                                                                                      : sessionVariableSetAttachments
-                                                                                                        ? "0352_session_variable_set_attachments.sql"
-                                                                                                        : migrationsBeforeAutomaticSessionTitles.at(
-                                                                                                            -1,
-                                                                                                          )
-                                                                                                            ?.path,
+      latestMigration: commandRunnerFailureMetadata
+        ? "0417_command_runner_failure_metadata.sql"
+        : commandCompletionObservation
+          ? "0415_command_completion_observation.sql"
+          : scheduledGeneratedProducerMaterialization
+            ? "0414_scheduled_generated_producer_materialization.sql"
+            : sessionFilterActivity
+              ? "0413_session_filter_activity.sql"
+              : newSessionDraftProjectProvenanceValidation
+                ? "0412_new_session_draft_project_provenance_validation.sql"
+                : newSessionDraftProjectProvenanceBackfill
+                  ? "0411_new_session_draft_project_provenance_backfill.sql"
+                  : newSessionDraftProjectProvenanceIndex
+                    ? "0410_new_session_draft_project_provenance_index.sql"
+                    : newSessionDraftProjectProvenance
+                      ? "0409_new_session_draft_project_provenance.sql"
+                      : scheduledSessionTargetIndex
+                        ? "0408_scheduled_session_target_index.sql"
+                        : connectedCommandTrackingRetirement
+                          ? "0407_connected_command_tracking_retirement.sql"
+                          : sandboxProviderDeadlineInteractionFollowup
+                            ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+                            : organizationModelProviderConnections
+                              ? "0390_organization_model_provider_connections.sql"
+                              : modelCatalogAndGatewayCustomModels
+                                ? "0389_model_catalog_and_gateway_custom_models.sql"
+                                : sandboxProviderDeadlineInteractions
+                                  ? "0388_sandbox_provider_deadline_interactions.sql"
+                                  : boundHostExportSessionPayloads
+                                    ? "0387_bound_host_export_session_payloads.sql"
+                                    : localOrganizationAdministration
+                                      ? "0386_local_organization_administration.sql"
+                                      : connectedMachineLegacyTildeWorkdirs
+                                        ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                                        : codexCooldownRevisionGuardPrivileges
+                                          ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                                          : codexCooldownReconciliation
+                                            ? "0383_codex_cooldown_reconciliation.sql"
+                                            : organizationApiKeyProvenance
+                                              ? "0382_organization_api_key_provenance.sql"
+                                              : organizationCodexSubscriptionInheritance
+                                                ? "0381_organization_codex_subscription_inheritance.sql"
+                                                : autonomousCompanyProfileAgentPolicy
+                                                  ? "0380_autonomous_company_profile_agent_policy.sql"
+                                                  : sessionEventRawLaneActivation
+                                                    ? "0379_session_event_raw_lane_activation.sql"
+                                                    : scopedRigHealthAuditTimestamp
+                                                      ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                                      : scopedRigHealthProjection
+                                                        ? "0377_scoped_rig_health_projection.sql"
+                                                        : organizationWorkspaceInventory
+                                                          ? "0376_organization_workspace_inventory.sql"
+                                                          : sessionRecoveryObservability
+                                                            ? "0375_session_recovery_observability.sql"
+                                                            : sessionEventCursors
+                                                              ? "0374_session_event_cursors.sql"
+                                                              : sandboxSharedPreparation
+                                                                ? "0373_sandbox_shared_preparation.sql"
+                                                                : orderedVariableSetRuntimeAuthority
+                                                                  ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                                  : workspaceMemberCandidateInventory
+                                                                    ? "0371_workspace_member_candidate_inventory.sql"
+                                                                    : workspaceMemberManagementScope
+                                                                      ? "0370_workspace_member_management_scope.sql"
+                                                                      : localHumanPersonalAuthority
+                                                                        ? "0369_local_human_personal_authority.sql"
+                                                                        : sessionDiscoveryClaimSearchIndex
+                                                                          ? "0368_session_discovery_claim_search_index.sql"
+                                                                          : sessionDiscoveryGoalSearchIndex
+                                                                            ? "0367_session_discovery_goal_search_index.sql"
+                                                                            : sessionDiscoveryTitleSearchIndex
+                                                                              ? "0366_session_discovery_title_search_index.sql"
+                                                                              : permissionScopedWorkClaims
+                                                                                ? "0365_permission_scoped_work_claims.sql"
+                                                                                : workspaceLearningPolicySnapshotLockOrder
+                                                                                  ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                                  : organizationRecoveryCustody
+                                                                                    ? "0363_organization_recovery_custody.sql"
+                                                                                    : managedAuthSessionSets
+                                                                                      ? "0362_managed_auth_session_sets.sql"
+                                                                                      : rememberKnowledgeMemoryMaterialization
+                                                                                        ? "0361_remember_knowledge_memory_materialization.sql"
+                                                                                        : organizationIdentityConfirmationPrompt
+                                                                                          ? "0360_organization_identity_confirmation_prompt.sql"
+                                                                                          : insightsForceRlsReadCapability
+                                                                                            ? "0359_insights_force_rls_read_capability.sql"
+                                                                                            : prReviewManagedGithubApp
+                                                                                              ? "0358_pr_review_managed_github_app.sql"
+                                                                                              : rigPlatformBaseOnly
+                                                                                                ? "0357_rig_platform_base_only.sql"
+                                                                                                : setBasedInsightsSessionVisibility
+                                                                                                  ? "0356_set_based_insights_session_visibility.sql"
+                                                                                                  : automaticSessionTitleQuarantine
+                                                                                                    ? "0355_automatic_session_title_quarantine.sql"
+                                                                                                    : automaticSessionTitleQuarantineIndex
+                                                                                                      ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                                                      : automaticSessionTitlePolicyFence
+                                                                                                        ? "0353_automatic_session_title_policy_fence.sql"
+                                                                                                        : sessionVariableSetAttachments
+                                                                                                          ? "0352_session_variable_set_attachments.sql"
+                                                                                                          : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                                              -1,
+                                                                                                            )
+                                                                                                              ?.path,
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -1037,6 +1044,9 @@ describe("release schema contract", () => {
     );
     const commandCompletionObservation = completeSourceContract.migrations.some(
       (migration) => migration.path === "0415_command_completion_observation.sql",
+    );
+    const commandRunnerFailureMetadata = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0417_command_runner_failure_metadata.sql",
     );
     const scheduledGeneratedProducerMaterialization = completeSourceContract.migrations.some(
       (migration) => migration.path === "0414_scheduled_generated_producer_materialization.sql",
@@ -1345,6 +1355,7 @@ describe("release schema contract", () => {
       "0413_session_filter_activity.sql",
       "0414_scheduled_generated_producer_materialization.sql",
       "0415_command_completion_observation.sql",
+      "0417_command_runner_failure_metadata.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -1632,6 +1643,7 @@ describe("release schema contract", () => {
         (newSessionDraftProjectProvenanceIndex ? 1 : 0) +
         (newSessionDraftProjectProvenanceBackfill ? 1 : 0) +
         (commandCompletionObservation ? 1 : 0) +
+        (commandRunnerFailureMetadata ? 1 : 0) +
         (scheduledGeneratedProducerMaterialization ? 1 : 0) +
         (newSessionDraftProjectProvenanceValidation ? 1 : 0) +
         (scheduledSessionTargetIndex ? 1 : 0) +
@@ -1700,117 +1712,119 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: commandCompletionObservation
-        ? "0415_command_completion_observation.sql"
-        : scheduledGeneratedProducerMaterialization
-          ? "0414_scheduled_generated_producer_materialization.sql"
-          : sessionFilterActivity
-            ? "0413_session_filter_activity.sql"
-            : newSessionDraftProjectProvenanceValidation
-              ? "0412_new_session_draft_project_provenance_validation.sql"
-              : newSessionDraftProjectProvenanceBackfill
-                ? "0411_new_session_draft_project_provenance_backfill.sql"
-                : newSessionDraftProjectProvenanceIndex
-                  ? "0410_new_session_draft_project_provenance_index.sql"
-                  : newSessionDraftProjectProvenance
-                    ? "0409_new_session_draft_project_provenance.sql"
-                    : scheduledSessionTargetIndex
-                      ? "0408_scheduled_session_target_index.sql"
-                      : connectedCommandTrackingRetirement
-                        ? "0407_connected_command_tracking_retirement.sql"
-                        : sandboxProviderDeadlineInteractionFollowup
-                          ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-                          : organizationModelProviderConnections
-                            ? "0390_organization_model_provider_connections.sql"
-                            : modelCatalogAndGatewayCustomModels
-                              ? "0389_model_catalog_and_gateway_custom_models.sql"
-                              : sandboxProviderDeadlineInteractions
-                                ? "0388_sandbox_provider_deadline_interactions.sql"
-                                : boundHostExportSessionPayloads
-                                  ? "0387_bound_host_export_session_payloads.sql"
-                                  : localOrganizationAdministration
-                                    ? "0386_local_organization_administration.sql"
-                                    : connectedMachineLegacyTildeWorkdirs
-                                      ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                                      : codexCooldownRevisionGuardPrivileges
-                                        ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                                        : codexCooldownReconciliation
-                                          ? "0383_codex_cooldown_reconciliation.sql"
-                                          : organizationApiKeyProvenance
-                                            ? "0382_organization_api_key_provenance.sql"
-                                            : organizationCodexSubscriptionInheritance
-                                              ? "0381_organization_codex_subscription_inheritance.sql"
-                                              : autonomousCompanyProfileAgentPolicy
-                                                ? "0380_autonomous_company_profile_agent_policy.sql"
-                                                : sessionEventRawLaneActivation
-                                                  ? "0379_session_event_raw_lane_activation.sql"
-                                                  : scopedRigHealthAuditTimestamp
-                                                    ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                                    : scopedRigHealthProjection
-                                                      ? "0377_scoped_rig_health_projection.sql"
-                                                      : organizationWorkspaceInventory
-                                                        ? "0376_organization_workspace_inventory.sql"
-                                                        : sessionRecoveryObservability
-                                                          ? "0375_session_recovery_observability.sql"
-                                                          : sessionEventCursors
-                                                            ? "0374_session_event_cursors.sql"
-                                                            : sandboxSharedPreparation
-                                                              ? "0373_sandbox_shared_preparation.sql"
-                                                              : orderedVariableSetRuntimeAuthority
-                                                                ? "0372_ordered_variable_set_runtime_authority.sql"
-                                                                : workspaceMemberCandidateInventory
-                                                                  ? "0371_workspace_member_candidate_inventory.sql"
-                                                                  : workspaceMemberManagementScope
-                                                                    ? "0370_workspace_member_management_scope.sql"
-                                                                    : localHumanPersonalAuthority
-                                                                      ? "0369_local_human_personal_authority.sql"
-                                                                      : sessionDiscoveryClaimSearchIndex
-                                                                        ? "0368_session_discovery_claim_search_index.sql"
-                                                                        : sessionDiscoveryGoalSearchIndex
-                                                                          ? "0367_session_discovery_goal_search_index.sql"
-                                                                          : sessionDiscoveryTitleSearchIndex
-                                                                            ? "0366_session_discovery_title_search_index.sql"
-                                                                            : permissionScopedWorkClaims
-                                                                              ? "0365_permission_scoped_work_claims.sql"
-                                                                              : workspaceLearningPolicySnapshotLockOrder
-                                                                                ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                                                : organizationRecoveryCustody
-                                                                                  ? "0363_organization_recovery_custody.sql"
-                                                                                  : managedAuthSessionSets
-                                                                                    ? "0362_managed_auth_session_sets.sql"
-                                                                                    : sessionVariableSetAttachments
-                                                                                      ? "0352_session_variable_set_attachments.sql"
-                                                                                      : organizationUserSetupDelivery
-                                                                                        ? "0351_organization_user_setup_delivery.sql"
-                                                                                        : organizationSharedWorkspaceAdministration
-                                                                                          ? "0350_organization_shared_workspace_administration.sql"
-                                                                                          : greenfieldSessionTenancyActivation
-                                                                                            ? "0349_greenfield_session_tenancy_activation.sql"
-                                                                                            : namedSignupAndUserSetup
-                                                                                              ? "0348_named_signup_and_user_setup.sql"
-                                                                                              : connectionAuthorityConvergenceEvidence
-                                                                                                ? "0347_connection_authority_convergence_evidence.sql"
-                                                                                                : documentMigrationAuditSurface
-                                                                                                  ? "0346_document_migration_audit_surface.sql"
-                                                                                                  : tenantScopedSessionTenancyFence
-                                                                                                    ? "0345_tenant_scoped_session_tenancy_fence.sql"
-                                                                                                    : privateSessionVisibilityTransitionGate
-                                                                                                      ? "0344_private_session_visibility_transition_gate.sql"
-                                                                                                      : personalDocumentForceRlsRepair
-                                                                                                        ? "0343_personal_document_force_rls_lock_repair.sql"
-                                                                                                        : slackRoutePromptSinglePending
-                                                                                                          ? "0342_slack_route_prompt_single_pending.sql"
-                                                                                                          : slackRoutingProbeFence
-                                                                                                            ? "0341_slack_routing_probe_organization_fence.sql"
-                                                                                                            : tenancyBackfillActivationEvidence
-                                                                                                              ? "0340_tenancy_backfill_activation_evidence.sql"
-                                                                                                              : documentAuthorityReclassification
-                                                                                                                ? "0339_document_authority_reclassification.sql"
-                                                                                                                : atomicConnectedMachineAttachments
-                                                                                                                  ? "0338_atomic_connected_machine_attachments.sql"
-                                                                                                                  : routedSlackHandles
-                                                                                                                    ? "0337_slack_routed_action_handles.sql"
-                                                                                                                    : "0336_atomic_session_fork_visibility.sql",
+      latestMigration: commandRunnerFailureMetadata
+        ? "0417_command_runner_failure_metadata.sql"
+        : commandCompletionObservation
+          ? "0415_command_completion_observation.sql"
+          : scheduledGeneratedProducerMaterialization
+            ? "0414_scheduled_generated_producer_materialization.sql"
+            : sessionFilterActivity
+              ? "0413_session_filter_activity.sql"
+              : newSessionDraftProjectProvenanceValidation
+                ? "0412_new_session_draft_project_provenance_validation.sql"
+                : newSessionDraftProjectProvenanceBackfill
+                  ? "0411_new_session_draft_project_provenance_backfill.sql"
+                  : newSessionDraftProjectProvenanceIndex
+                    ? "0410_new_session_draft_project_provenance_index.sql"
+                    : newSessionDraftProjectProvenance
+                      ? "0409_new_session_draft_project_provenance.sql"
+                      : scheduledSessionTargetIndex
+                        ? "0408_scheduled_session_target_index.sql"
+                        : connectedCommandTrackingRetirement
+                          ? "0407_connected_command_tracking_retirement.sql"
+                          : sandboxProviderDeadlineInteractionFollowup
+                            ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+                            : organizationModelProviderConnections
+                              ? "0390_organization_model_provider_connections.sql"
+                              : modelCatalogAndGatewayCustomModels
+                                ? "0389_model_catalog_and_gateway_custom_models.sql"
+                                : sandboxProviderDeadlineInteractions
+                                  ? "0388_sandbox_provider_deadline_interactions.sql"
+                                  : boundHostExportSessionPayloads
+                                    ? "0387_bound_host_export_session_payloads.sql"
+                                    : localOrganizationAdministration
+                                      ? "0386_local_organization_administration.sql"
+                                      : connectedMachineLegacyTildeWorkdirs
+                                        ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                                        : codexCooldownRevisionGuardPrivileges
+                                          ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                                          : codexCooldownReconciliation
+                                            ? "0383_codex_cooldown_reconciliation.sql"
+                                            : organizationApiKeyProvenance
+                                              ? "0382_organization_api_key_provenance.sql"
+                                              : organizationCodexSubscriptionInheritance
+                                                ? "0381_organization_codex_subscription_inheritance.sql"
+                                                : autonomousCompanyProfileAgentPolicy
+                                                  ? "0380_autonomous_company_profile_agent_policy.sql"
+                                                  : sessionEventRawLaneActivation
+                                                    ? "0379_session_event_raw_lane_activation.sql"
+                                                    : scopedRigHealthAuditTimestamp
+                                                      ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                                      : scopedRigHealthProjection
+                                                        ? "0377_scoped_rig_health_projection.sql"
+                                                        : organizationWorkspaceInventory
+                                                          ? "0376_organization_workspace_inventory.sql"
+                                                          : sessionRecoveryObservability
+                                                            ? "0375_session_recovery_observability.sql"
+                                                            : sessionEventCursors
+                                                              ? "0374_session_event_cursors.sql"
+                                                              : sandboxSharedPreparation
+                                                                ? "0373_sandbox_shared_preparation.sql"
+                                                                : orderedVariableSetRuntimeAuthority
+                                                                  ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                                  : workspaceMemberCandidateInventory
+                                                                    ? "0371_workspace_member_candidate_inventory.sql"
+                                                                    : workspaceMemberManagementScope
+                                                                      ? "0370_workspace_member_management_scope.sql"
+                                                                      : localHumanPersonalAuthority
+                                                                        ? "0369_local_human_personal_authority.sql"
+                                                                        : sessionDiscoveryClaimSearchIndex
+                                                                          ? "0368_session_discovery_claim_search_index.sql"
+                                                                          : sessionDiscoveryGoalSearchIndex
+                                                                            ? "0367_session_discovery_goal_search_index.sql"
+                                                                            : sessionDiscoveryTitleSearchIndex
+                                                                              ? "0366_session_discovery_title_search_index.sql"
+                                                                              : permissionScopedWorkClaims
+                                                                                ? "0365_permission_scoped_work_claims.sql"
+                                                                                : workspaceLearningPolicySnapshotLockOrder
+                                                                                  ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                                  : organizationRecoveryCustody
+                                                                                    ? "0363_organization_recovery_custody.sql"
+                                                                                    : managedAuthSessionSets
+                                                                                      ? "0362_managed_auth_session_sets.sql"
+                                                                                      : sessionVariableSetAttachments
+                                                                                        ? "0352_session_variable_set_attachments.sql"
+                                                                                        : organizationUserSetupDelivery
+                                                                                          ? "0351_organization_user_setup_delivery.sql"
+                                                                                          : organizationSharedWorkspaceAdministration
+                                                                                            ? "0350_organization_shared_workspace_administration.sql"
+                                                                                            : greenfieldSessionTenancyActivation
+                                                                                              ? "0349_greenfield_session_tenancy_activation.sql"
+                                                                                              : namedSignupAndUserSetup
+                                                                                                ? "0348_named_signup_and_user_setup.sql"
+                                                                                                : connectionAuthorityConvergenceEvidence
+                                                                                                  ? "0347_connection_authority_convergence_evidence.sql"
+                                                                                                  : documentMigrationAuditSurface
+                                                                                                    ? "0346_document_migration_audit_surface.sql"
+                                                                                                    : tenantScopedSessionTenancyFence
+                                                                                                      ? "0345_tenant_scoped_session_tenancy_fence.sql"
+                                                                                                      : privateSessionVisibilityTransitionGate
+                                                                                                        ? "0344_private_session_visibility_transition_gate.sql"
+                                                                                                        : personalDocumentForceRlsRepair
+                                                                                                          ? "0343_personal_document_force_rls_lock_repair.sql"
+                                                                                                          : slackRoutePromptSinglePending
+                                                                                                            ? "0342_slack_route_prompt_single_pending.sql"
+                                                                                                            : slackRoutingProbeFence
+                                                                                                              ? "0341_slack_routing_probe_organization_fence.sql"
+                                                                                                              : tenancyBackfillActivationEvidence
+                                                                                                                ? "0340_tenancy_backfill_activation_evidence.sql"
+                                                                                                                : documentAuthorityReclassification
+                                                                                                                  ? "0339_document_authority_reclassification.sql"
+                                                                                                                  : atomicConnectedMachineAttachments
+                                                                                                                    ? "0338_atomic_connected_machine_attachments.sql"
+                                                                                                                    : routedSlackHandles
+                                                                                                                      ? "0337_slack_routed_action_handles.sql"
+                                                                                                                      : "0336_atomic_session_fork_visibility.sql",
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),


### PR DESCRIPTION
## Summary

- Slice oversized stored message text at the database boundary, preserving bounded responses, codec/Unicode correctness, keyset pagination, and old continuation cursors. No whole-session history cap is introduced.
- Persist bounded typed runner failures through proof, settlement, completion notifications, and subsequent command reads, including failures accompanied by process exit code zero.
- Preserve retained output during recognized temporary live-refresh failures after API reauthorization. Permission, protocol, and integrity failures remain errors.
- Avoid replaying and accumulating the entire output prefix on repeated reads by the same live client. Integrity state is in-memory only; capture failure forces safe replay and grants no final ACK authority.

## Verification

- Real PostgreSQL reconstruction of legacy and canonical messages above 1 MiB, in both directions, with bounded response sizes.
- Legacy UTF-16 cursor and structured-result compatibility regressions.
- Final targeted run: 80 tests, 827 assertions, zero failures.
- Separate periodic-credit replay regression: 2 tests, 58 assertions.
- API, worker, and DB typechecks; migration contract and documentation checks.

## Operational notes

Apply additive rolling migration 0417 before deploying readers selecting the new failure field. A fresh cross-process replay client still reads the retained prefix; no durable hash/consumption ledger or new runner protocol is added. Database scalar extraction/validation can scale with one message size, but does not scan the entire session history. The pre-existing bounded structured-JSON fallback is retained; scalar text is streamed through continuation.

Responsible agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/1c7d1a07-58e9-4d94-b8ac-eecf09a1d133

## Summary by Sourcery

Preserve complete oversized session history and typed command failure state while keeping live command output safe and readable during temporary refresh outages.

New Features:
- Support lossless continuation of oversized scalar session messages, including large legacy rows and codec-aware Unicode offsets.
- Expose bounded typed runner failure metadata through command state, notifications, settlement, and subsequent reads.
- Preserve retained command output with an explicit freshness warning when live refresh encounters an authorized temporary transport failure.

Bug Fixes:
- Prevent zero-exit runner failures from being classified or reported as successful commands.
- Avoid replaying and accumulating full retained output across repeated live reads while preserving integrity and safe fallback behavior.
- Keep authorization, protocol, integrity, fencing, and other non-transient refresh failures fail-closed.

Enhancements:
- Add bounded database-side session event slicing with compatibility for legacy UTF-16 cursors and explicit omission of oversized structured values.
- Validate and persist runner failure metadata with backward-compatible reconstruction from legacy settlement reasons.

Deployment:
- Add rolling migration 0417 for bounded connected-machine runner failure metadata before deploying readers that select the new field.

Documentation:
- Document bounded history slicing, typed runner failures, refresh fallback semantics, and in-memory live-read replay state.

Tests:
- Add PostgreSQL coverage for reconstructing oversized legacy and canonical scalar messages in both directions, cursor compatibility, structured-value omission, and tenant isolation.
- Add runtime and database coverage for typed zero-exit failures, settlement recovery, retained output preservation, refresh failure classification, replay bounds, and integrity handling.