### PR TITLE
fix: stop automatically forwarding uploads to child agents

### DIFF
--- a/.changeset/child-file-inheritance.md
+++ b/.changeset/child-file-inheritance.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/core": patch
+"@opengeni/api-router": patch
+---
+
+Inherit only repository resources when spawning child sessions. File attachments now require explicit selection; document this in the session creation tool.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -5240,7 +5240,12 @@ function registerWorkspaceOrchestrationTools(
           ),
         instructions: z4.string().min(1).max(SESSION_INSTRUCTIONS_MAX_CHARACTERS).optional(),
         goal: z4.unknown().optional(),
-        resources: z4.array(z4.unknown()).optional(),
+        resources: z4
+          .array(z4.unknown())
+          .optional()
+          .describe(
+            "Omit to inherit parent repositories only. Files are never inherited automatically; explicitly include file resources to attach them. An empty array inherits no resources.",
+          ),
         tools: z4.array(z4.unknown()).optional(),
         mcpServers: z4.array(z4.unknown()).optional(),
         variableSetId: z4.string().uuid().optional(),

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -239,6 +239,56 @@ describe("P1.4 shared-sandbox create resolution (real createSessionForRequest + 
     expect(b.id).not.toBe(a.id);
   }, 60_000);
 
+  test("child resource defaults exclude parent uploads and preserve explicit overrides", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const bus = new MemoryEventBus();
+    const parent = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId),
+      workspaceId,
+      {
+        initialMessage: "parent with repository",
+        resources: [
+          { kind: "repository", uri: "https://github.com/acme/project.git", ref: "main" },
+        ],
+      },
+    );
+    const file = { kind: "file" as const, fileId: crypto.randomUUID() };
+    // Seed an existing upload reference without an object-storage fixture. An
+    // implicit child must not resolve it or require storage to be configured.
+    await admin`update sessions set resources = ${JSON.stringify([...parent.resources, file])}::jsonb where id = ${parent.id}`;
+    for (const sandbox of [undefined, "new"] as const) {
+      const child = await createSessionForRequest(
+        deps(bus),
+        grant(accountId, workspaceId, parent.id),
+        workspaceId,
+        { initialMessage: "child", ...(sandbox ? { sandbox } : {}) },
+      );
+      expect(child.resources).toEqual(parent.resources);
+      const messages = (await listSessionEvents(db, workspaceId, child.id)).filter(
+        (event) => event.type === "user.message",
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0]!.payload.resources).toEqual(parent.resources);
+    }
+    const empty = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId, parent.id),
+      workspaceId,
+      { initialMessage: "no resources", resources: [] },
+    );
+    expect(empty.resources).toEqual([]);
+    // Explicit file selection still enters normal file validation, rather than
+    // being silently filtered by the repository-only inheritance policy.
+    await expect(
+      createSessionForRequest(deps(bus), grant(accountId, workspaceId, parent.id), workspaceId, {
+        initialMessage: "explicit upload",
+        resources: [file],
+      }),
+    ).rejects.toThrow("object storage is not configured");
+  }, 60_000);
+
   test("a child inherits omitted mixed-provider repositories, tools, and encrypted MCP context", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -766,7 +766,9 @@ These producers all converge on the ordinary session/turn runtime:
 - an **automation** authenticates an external event, freezes the matching
   trigger revision, and creates an ordinary session/run; and
 - a **child session** is a normal session with explicit lineage, depth, compute,
-  visibility, and initiating-authority rules.
+  visibility, and initiating-authority rules. Omitted child resources inherit
+  repositories only; file attachments require explicit selection (see
+  [`nested-agent-depth.md`](nested-agent-depth.md)).
 
 Session header and sidebar schedule indicators use `Session.hasSchedules`, derived by one batched indexed lookup of non-deleted `scheduled_tasks.reusable_session_id` targets after session authorization. Paused schedules remain linked. Creation metadata is only historical run-grouping provenance. The schedules list accepts a server-side `sessionId` filter; the web route passes `targetSessionId` on navigation.
 The existing lineage refresh also carries `sessionHasSchedules` for the open header and schedule flags for its nodes, so external schedule mutations converge through the existing 30-second header / 15-second sidebar refreshes without a new polling loop or event protocol.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -734,7 +734,7 @@ disable it for embedded products that require a narrower model-visible surface.
 An agent-created child normally needs the same working context as its manager,
 even when the two conversations are separate. When the creating grant carries
 the worker-signed parent `sessionId`, `createSessionForRequest` treats omitted
-`resources`, `skills`, `tools`, and `mcpServers` as inheritance from that trusted immediate
+`resources` (repositories only), `skills`, `tools`, and `mcpServers` as inheritance from that trusted immediate
 parent. The snapshot preserves inline session skills, mixed GitHub, GitLab, and Azure DevOps repository
 resources, multiple credential bindings for one provider, selected MCP tool
 refs, full per-session MCP policy, connection refs, and static credential

--- a/docs/nested-agent-depth.md
+++ b/docs/nested-agent-depth.md
@@ -10,6 +10,15 @@ exists, a live agent may address peer workspace sessions; see
 same-root for agents, and `user_private` still requires the initiating human as
 owner. Nested-agent depth does not restore a parent/child access lock.
 
+## Resource inheritance
+
+A child that omits `resources` inherits only the parent's repositories. Uploaded
+files are not automatically attached to its initial message. Explicit `resources`
+replaces inheritance (including `[]`); include selected file references to attach
+them, or pass a file ID in the task for on-demand retrieval. Shared sandbox files
+remain accessible on disk; this rule controls session attachments, not filesystem
+isolation.
+
 ## Depth and precedence
 
 - A root session has depth `0` and its `rootSessionId` is its own id.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14543,7 +14543,8 @@ export const CreateSessionRequest = withVariableSetIdAlias(
     // compatibility fallback by omitting this field.
     policyRole: WorkspaceInstructionPolicyRoleKeyInput.optional(),
     // For an agent-created child, omission inherits the trusted immediate
-    // parent's repository/file context. An explicit array, including [], is
+    // parent's repositories only; files require explicit selection. An explicit
+    // array, including [], is
     // authoritative. Top-level omission remains []. Presence is resolved from
     // the raw request because this Zod default erases absent-vs-empty.
     resources: z.array(ResourceRef).default([]),

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1715,8 +1715,9 @@ export async function postUserMessageTurn(
  * `session_create` tool: payload validation, resource/tool/variableSet
  * checks, usage limits, session start, and usage recording. `rawPayload` is
  * the unparsed request body so absent-vs-empty execution-context fields keep
- * their meaning: a child inherits omitted resources/tools/mcpServers from its
- * trusted immediate parent, while explicit arrays (including []) win. A
+ * their meaning: a child inherits repositories (never files), tools, and MCP
+ * servers from its trusted immediate parent when omitted; explicit arrays
+ * (including []) win. A
  * top-level create with omitted tools applies workspace-default capability MCPs.
  */
 export function resolveChildGoalFromAcceptedSnapshot(
@@ -2102,7 +2103,8 @@ export async function createSessionForRequestWithOutcome(
   const resources = normalizeResources(
     hasOwnProperty(rawPayload, "resources")
       ? payload.resources
-      : (parentSession?.resources ?? payload.resources),
+      : (parentSession?.resources.filter((resource) => resource.kind === "repository") ??
+          payload.resources),
   );
   const inheritedOrSubmittedSkills = hasOwnProperty(rawPayload, "skills")
     ? payload.skills


### PR DESCRIPTION
Children previously inherited every parent resource when session_create omitted resources, automatically forwarding uploads into their initial message. Omission now inherits repositories only; explicit file resources and empty-array overrides retain their existing behavior. Shared sandbox files remain accessible.

Validation: database-backed focused suite 35 passed (one opt-in Modal test skipped); all 32 typecheck projects, docs-reference checks, and targeted lint passed. Independent review passed at 9e54c583e.

Full local check was stopped after missing Docker-image fixtures and cross-test mock interference; affected consent/deferred suites pass in isolation. GitHub browser, E2E, real-service, source/type, package, and all six unit shards passed. Unit shards required one retry after an unrelated instruction-editor timing failure (also passes locally). Latest-main merge-tree compatibility verified without rebasing the reviewed commit.
