### PR TITLE
fix(db): retain preclaim failure evidence

### DIFF
--- a/.changeset/preclaim-failure-evidence.md
+++ b/.changeset/preclaim-failure-evidence.md
@@ -1,6 +1,6 @@
 ---
 "@opengeni/db": patch
-"@opengeni/worker": patch
+"@opengeni/worker-bundle": patch
 ---
 
 Preserve the supplied admission failure message and classified cause on the durable session failure event when no turn could be claimed.

--- a/.changeset/preclaim-failure-evidence.md
+++ b/.changeset/preclaim-failure-evidence.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker": patch
+---
+
+Preserve the supplied admission failure message and classified cause on the durable session failure event when no turn could be claimed.

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -160,6 +160,7 @@ export function createSessionStateActivities(
           workflowId,
           trigger: input.trigger,
           error: input.error ?? "Agent turn admission failed before attempt claim.",
+          ...(input.preClaimFailure ? { admissionFailure: input.preClaimFailure } : {}),
         });
         if (failed.action === "terminal") return { action: "terminal" };
         if (failed.action === "stale") return { action: "stale" };

--- a/apps/worker/test/session-state-failure-dedupe.test.ts
+++ b/apps/worker/test/session-state-failure-dedupe.test.ts
@@ -422,12 +422,21 @@ describe("failSessionAttempt child-terminal identity", () => {
       attemptId: "attempt-never-created",
       workflowId: "session-child-1",
       preClaimFailureDisposition: "permanent",
+      preClaimFailure: { disposition: "permanent", code: "claim_invariant" },
       trigger: { kind: "next" },
       error: "Agent turn admission failed before attempt claim.",
     });
 
     expect(result).toEqual({ action: "failed" });
     expect(terminalSettlement).toHaveBeenCalledTimes(1);
+    expect(terminalSettlement).toHaveBeenCalledWith(
+      expect.anything(),
+      "workspace-1",
+      expect.objectContaining({
+        error: "Agent turn admission failed before attempt claim.",
+        admissionFailure: { disposition: "permanent", code: "claim_invariant" },
+      }),
+    );
     expect(enqueue).not.toHaveBeenCalled();
     expect(publishCalls).toHaveLength(1);
     expect(parentWakeCalls).toHaveLength(1);

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -432,6 +432,12 @@ The same database-owned transition covers a lost claim commit response: if the
 activity reports retryable pre-claim failure but the control lane finds its
 exact active attempt, that durable attempt wins and is recovered.
 
+A permanent admission failure with no claimed turn records the supplied failure
+message and, when available, its classified admission cause on the durable
+`session.status.changed` event. The absence of a `turn.failed` event must not
+discard those diagnostics. Older events remain unchanged; missing historical
+details cannot be reconstructed from the failure code alone.
+
 SuperGrok/xAI connected-subscription work separately freezes an identifier-free
 `workspace | user` provider-account authority snapshot. Workspace is the
 default shared pool. User scope is explicit/private and remains bound to the

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -66572,6 +66572,11 @@ export type FailSessionWorkBeforeAttemptClaimInput = {
   workflowId: string;
   trigger: SessionWorkTrigger;
   error: string;
+  /** Already-classified admission facts from the failed worker activity. */
+  admissionFailure?: {
+    disposition: "retryable" | "permanent";
+    code: "db_deadlock" | "db_serialization_failure" | "db_failure" | "claim_invariant";
+  };
 };
 
 export type FailSessionWorkBeforeAttemptClaimResult =
@@ -66955,6 +66960,8 @@ export async function failSessionWorkBeforeAttemptClaim(
             payload: {
               status: "failed",
               code: "pre_claim_failure",
+              error: input.error,
+              ...(input.admissionFailure ? { admissionFailure: input.admissionFailure } : {}),
               ...(!turn ? { failedSystemUpdateIds } : {}),
             },
             turnId: turn?.id ?? null,

--- a/packages/db/test/child-read-acknowledgment.test.ts
+++ b/packages/db/test/child-read-acknowledgment.test.ts
@@ -459,6 +459,7 @@ describe("child read acknowledgment on parent consumption", () => {
       workflowId: `session-${parent.session.id}`,
       trigger: { kind: "next" },
       error: "Agent turn admission failed before attempt claim.",
+      admissionFailure: { disposition: "permanent", code: "claim_invariant" },
     });
     expect(failed.action).toBe("failed");
     const failedSequence = await lastSequence(parent.session.id);
@@ -476,6 +477,8 @@ describe("child read acknowledgment on parent consumption", () => {
       payload: {
         status: "failed",
         code: "pre_claim_failure",
+        error: "Agent turn admission failed before attempt claim.",
+        admissionFailure: { disposition: "permanent", code: "claim_invariant" },
         failedSystemUpdateIds: [pendingUpdate.id],
       },
       turnId: null,

--- a/packages/db/test/child-read-acknowledgment.test.ts
+++ b/packages/db/test/child-read-acknowledgment.test.ts
@@ -465,7 +465,13 @@ describe("child read acknowledgment on parent consumption", () => {
     const failedSequence = await lastSequence(parent.session.id);
     const [failureEvent] = await shared.admin<
       Array<{
-        payload: { status: string; code: string; failedSystemUpdateIds?: string[] };
+        payload: {
+          status: string;
+          code: string;
+          error: string;
+          admissionFailure?: { disposition: string; code: string };
+          failedSystemUpdateIds?: string[];
+        };
         turnId: string | null;
       }>
     >`


### PR DESCRIPTION
An admission failure before a turn exists currently leaves only `pre_claim_failure` in the session timeline, dropping the supplied message and already-classified cause. Preserve both on the durable status event so the session API and failure UI can report the evidence available at settlement.

This does not reconstruct historical errors, change retry policy, or change Temporal commands. It addresses OPE-451, separate from the earlier OPE-439 failure display fix.

Validation: reproduced missing message in a fresh PostgreSQL event read; 22 DB/worker tests pass (147 assertions), full repository typecheck and all 11 source guards pass, including formatting, schema contracts and published package closure.
