### PR TITLE
Clarify exact-head CI and evidence before retries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,16 @@ bun run test:e2e
 - Treat candidate/version labels as substantive source revisions. Base-only
   evidence refreshes stay on the same head. Change the head only for a source
   defect, actual conflict, or material semantic incompatibility.
+- PR CI in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) checks out
+  the exact PR head, not GitHub's synthetic merge commit. Closing and reopening
+  an unchanged PR starts another run of the same source; it does not incorporate
+  fixes from a newer base. Keep current-main integration evidence separate from
+  exact-head CI evidence.
+- Before retrying a failed check, inspect its failing leaf and checkout SHA.
+  If the candidate contains a real defect already fixed on `main`, apply the
+  necessary scoped correction to the candidate and run review and CI on that new
+  head. An unchanged-head retry needs evidence of a transient failure, not an
+  expectation that moving `main` changed the tested source.
 
 ## Keeping Docs True
 


### PR DESCRIPTION
PR CI checks out the exact candidate head. Clarify that closing and reopening cannot incorporate fixes from a newer base, and require failing-leaf/checkout evidence before retries. This addresses the unnecessary unchanged-head CI cycle observed during #2263 delivery.

Tracking: https://linear.app/cloudgeni/issue/OPE-92/eliminate-review-churn-and-drain-merge-ready-work-continuously
Validation: docs references and architecture-map guard; git diff --check. Workflow source unchanged.

## Summary by Sourcery

Clarify exact-head CI behavior and establish evidence-based guidance for correcting candidates and retrying failed checks.

Enhancements:
- Clarify that exact-head PR CI reruns unchanged source and does not incorporate fixes from a newer base.
- Require inspection of the failing leaf and checkout SHA, plus evidence of transient failure, before retrying unchanged-head CI.

Documentation:
- Document the distinction between exact-head CI evidence and current-main integration evidence, along with candidate correction and retry guidance.