### PR TITLE
fix(react): clarify child result receipts and open their source sessions

### DIFF
--- a/.changeset/clear-child-result-receipts.md
+++ b/.changeset/clear-child-result-receipts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Label child-result receipts without claiming task completion, explain pending input, and let hosts open the exact child from incoming and delivered updates.

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -2027,6 +2027,7 @@ function SessionChatPane(props: {
         <div className="mx-auto w-full max-w-3xl">
           <SessionChrome
             compact
+            onOpenSession={props.onOpenSession}
             queue={props.queue}
             composer={terminal ? undefined : composer}
             goal={props.goal}

--- a/packages/react/src/components/child-session-link.tsx
+++ b/packages/react/src/components/child-session-link.tsx
@@ -1,0 +1,27 @@
+import type { MachineInputMember } from "../timeline/types";
+
+/** Source IDs are routing coordinates only for typed child updates, never parsed from prose. */
+export function ChildSessionLink({
+  kind,
+  sourceId,
+  onOpenSession,
+}: Pick<MachineInputMember, "kind" | "sourceId"> & {
+  onOpenSession?: ((sessionId: string) => void) | undefined;
+}) {
+  if (
+    !onOpenSession ||
+    !kind.startsWith("child_") ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sourceId)
+  ) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenSession(sourceId)}
+      className="mt-1 rounded-og-sm text-og-xs font-medium text-og-accent underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-og-accent"
+    >
+      View session
+    </button>
+  );
+}

--- a/packages/react/src/components/machine-input-display.ts
+++ b/packages/react/src/components/machine-input-display.ts
@@ -7,7 +7,7 @@ export const MACHINE_INPUT_META: Record<MachineInputMember["kind"], string> = {
   session_wait_timeout: "Wait ended",
   agent_message: "Agent update",
   agent_steer_instruction: "Agent direction",
-  child_terminal_result: "Agent finished",
+  child_terminal_result: "Agent result received",
   media_generation_result: "Video update",
   child_requires_action: "Agent needs input",
   child_requires_action_resolved: "Agent unblocked",
@@ -35,7 +35,7 @@ export function machineInputBatchLabel(members: readonly MachineInputMember[]): 
       case "session_wait_timeout":
         return n === 1 ? "Wait ended" : `${n} waits ended`;
       case "child_terminal_result":
-        return n === 1 ? "Agent finished" : `${n} agents finished`;
+        return n === 1 ? "Agent result received" : `${n} agent results received`;
       case "goal_continuation":
         return n === 1 ? "Goal continued" : `${n} goal continuations`;
       case "scheduled_occurrence":

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1,3 +1,4 @@
+import { ChildSessionLink } from "./child-session-link";
 import type {
   DraftTimelineAnnotation,
   MediaGenerationResult,
@@ -2847,7 +2848,11 @@ export function TimelineRow({
       return <GoalRow item={item} />;
     case "machine-input-batch":
       return (
-        <MachineInputBatchRow item={item} loadVideoArtifactPlayback={loadVideoArtifactPlayback} />
+        <MachineInputBatchRow
+          item={item}
+          onOpenSession={onOpenSession}
+          loadVideoArtifactPlayback={loadVideoArtifactPlayback}
+        />
       );
     case "notice":
       return <NoticeRow item={item} />;
@@ -3460,9 +3465,11 @@ function GoalRow({ item }: { item: GoalItem }) {
 
 function MachineInputBatchRow({
   item,
+  onOpenSession,
   loadVideoArtifactPlayback,
 }: {
   item: MachineInputBatchItem;
+  onOpenSession?: ((sessionId: string) => void) | undefined;
   loadVideoArtifactPlayback?: VideoArtifactPlaybackLoader | undefined;
 }) {
   const enter = useEntranceAnimation();
@@ -3509,6 +3516,7 @@ function MachineInputBatchRow({
             <MachineInputRow
               key={member.id}
               member={member}
+              onOpenSession={onOpenSession}
               loadVideoArtifactPlayback={loadVideoArtifactPlayback}
             />
           ))}
@@ -3525,9 +3533,11 @@ function MachineInputBatchRow({
 
 function MachineInputRow({
   member,
+  onOpenSession,
   loadVideoArtifactPlayback,
 }: {
   member: MachineInputBatchItem["members"][number];
+  onOpenSession?: ((sessionId: string) => void) | undefined;
   loadVideoArtifactPlayback?: VideoArtifactPlaybackLoader | undefined;
 }) {
   if (member.kind === "media_generation_result" && member.result) {
@@ -3554,6 +3564,11 @@ function MachineInputRow({
             {truncate(summary, 320)}
           </p>
         ) : null}
+        <ChildSessionLink
+          kind={member.kind}
+          sourceId={member.sourceId}
+          onOpenSession={onOpenSession}
+        />
       </div>
     </div>
   );

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -1,3 +1,4 @@
+import { ChildSessionLink } from "./child-session-link";
 /**
  * SessionChrome — compact merged session signals above the composer.
  *
@@ -105,6 +106,8 @@ export type SessionChromeProps = {
    * (and the gallery) may still pass a handler so the action is visible.
    */
   onDismissIncoming?: ((inputId: string) => void) | undefined;
+  /** Open a typed child update's source through the host's normal authorized route. */
+  onOpenSession?: ((sessionId: string) => void) | undefined;
   readOnly?: boolean | undefined;
   className?: string | undefined;
   /** Controlled active segment; omit for uncontrolled. */
@@ -419,6 +422,7 @@ export function SessionChrome({
   commandsCount = 0,
   agentsSignal,
   onDismissIncoming,
+  onOpenSession,
   readOnly = false,
   className,
   active: activeControlled,
@@ -751,7 +755,11 @@ export function SessionChrome({
 
   const panelBody =
     active === "incoming" ? (
-      <IncomingPanel inputs={incoming} onDismiss={onDismissIncoming} />
+      <IncomingPanel
+        inputs={incoming}
+        onDismiss={onDismissIncoming}
+        onOpenSession={onOpenSession}
+      />
     ) : active === "queue" ? (
       <QueuePanel
         turns={queuedTurns}
@@ -1221,47 +1229,59 @@ export function SessionChrome({
 function IncomingPanel({
   inputs,
   onDismiss,
+  onOpenSession,
 }: {
   inputs: SessionPendingInputPreview[];
   onDismiss?: ((inputId: string) => void) | undefined;
+  onOpenSession?: ((sessionId: string) => void) | undefined;
 }) {
   return (
-    <ul
-      className="flex flex-col gap-0.5"
-      aria-label="Incoming updates"
-      data-og-session-chrome-panel="incoming"
-    >
-      {inputs.map((input) => (
-        <li
-          key={input.id}
-          className="group flex items-start gap-1.5 rounded-og-sm px-1.5 py-1 transition-colors hover:bg-[var(--_og-session-chrome-row-hover)]"
-        >
-          <span
-            className={cn(
-              "mt-px shrink-0 rounded px-1 py-px text-[10px] font-medium leading-4",
-              input.classification === "action_required" || input.classification === "failure"
-                ? "bg-og-status-waiting/12 text-og-status-waiting"
-                : "bg-og-surface-3/80 text-og-fg-muted",
-            )}
+    <div>
+      <p className="mb-2 text-og-xs text-og-fg-subtle">Waiting to be included in an agent turn.</p>
+      <ul
+        className="flex flex-col gap-0.5"
+        aria-label="Incoming updates"
+        data-og-session-chrome-panel="incoming"
+      >
+        {inputs.map((input) => (
+          <li
+            key={input.id}
+            className="group flex items-start gap-1.5 rounded-og-sm px-1.5 py-1 transition-colors hover:bg-[var(--_og-session-chrome-row-hover)]"
           >
-            {pendingKindLabel(input.kind)}
-          </span>
-          <p className="min-w-0 flex-1 text-og-xs leading-4 text-og-fg">{input.summary}</p>
-          {onDismiss ? (
-            <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 max-sm:opacity-100">
-              <IconAction
-                label={`Dismiss incoming ${pendingKindLabel(input.kind)}`}
-                tip="Dismiss"
-                onClick={() => onDismiss(input.id)}
-                danger
-              >
-                <Trash2Icon className="size-3" />
-              </IconAction>
+            <span
+              className={cn(
+                "mt-px shrink-0 rounded px-1 py-px text-[10px] font-medium leading-4",
+                input.classification === "action_required" || input.classification === "failure"
+                  ? "bg-og-status-waiting/12 text-og-status-waiting"
+                  : "bg-og-surface-3/80 text-og-fg-muted",
+              )}
+            >
+              {pendingKindLabel(input.kind)}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="break-words text-og-xs leading-4 text-og-fg">{input.summary}</p>
+              <ChildSessionLink
+                kind={input.kind}
+                sourceId={input.sourceId}
+                onOpenSession={onOpenSession}
+              />
             </div>
-          ) : null}
-        </li>
-      ))}
-    </ul>
+            {onDismiss ? (
+              <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 max-sm:opacity-100">
+                <IconAction
+                  label={`Dismiss incoming ${pendingKindLabel(input.kind)}`}
+                  tip="Dismiss"
+                  onClick={() => onDismiss(input.id)}
+                  danger
+                >
+                  <Trash2Icon className="size-3" />
+                </IconAction>
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -2893,6 +2893,9 @@
 :where(.og-root).underline-offset-2,:where(.og-root) .underline-offset-2 {
     text-underline-offset: 2px;
   }
+:where(.og-root).underline-offset-4,:where(.og-root) .underline-offset-4 {
+    text-underline-offset: 4px;
+  }
 :where(.og-root).accent-og-accent,:where(.og-root) .accent-og-accent {
     accent-color: var(--og-color-accent);
   }
@@ -4157,6 +4160,22 @@
         outline: 2px solid transparent;
         outline-offset: 2px;
       }
+    }
+  }
+:where(.og-root).focus-visible\:outline-2,:where(.og-root) .focus-visible\:outline-2 {
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+  }
+:where(.og-root).focus-visible\:outline-offset-2,:where(.og-root) .focus-visible\:outline-offset-2 {
+    &:focus-visible {
+      outline-offset: 2px;
+    }
+  }
+:where(.og-root).focus-visible\:outline-og-accent,:where(.og-root) .focus-visible\:outline-og-accent {
+    &:focus-visible {
+      outline-color: var(--og-color-accent);
     }
   }
 :where(.og-root).focus-visible\:ring-inset,:where(.og-root) .focus-visible\:ring-inset {

--- a/packages/react/test/machine-input-display.test.ts
+++ b/packages/react/test/machine-input-display.test.ts
@@ -21,14 +21,14 @@ function member(
 }
 
 describe("machineInputBatchLabel", () => {
-  test("pluralizes identical agent-finished members", () => {
+  test("counts result receipts without claiming their agents finished", () => {
     expect(
       machineInputBatchLabel([
         member("child_terminal_result", "", "a"),
         member("child_terminal_result", "", "b"),
         member("child_terminal_result", "", "c"),
       ]),
-    ).toBe("3 agents finished");
+    ).toBe("3 agent results received");
   });
 
   test("labels child lifecycle notices", () => {
@@ -61,7 +61,7 @@ describe("machineInputBatchLabel", () => {
         member("agent_message", "", "a"),
         member("child_terminal_result", "", "b"),
       ]),
-    ).toBe("2 updates · Agent update, Agent finished");
+    ).toBe("2 updates · Agent update, Agent result received");
   });
 
   test("single member uses the typed meta label", () => {

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -836,6 +836,55 @@ describe("SessionChrome", () => {
     ).toBe(true);
   });
 
+  test("explains pending child receipts and opens only their typed source", async () => {
+    const childId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const opened: string[] = [];
+    const inputs = [
+      {
+        ...pendingInput(),
+        id: "pending-1",
+        kind: "child_terminal_result" as const,
+        sourceId: childId,
+        summary: "Waiting for CI.",
+      },
+      {
+        ...pendingInput(),
+        id: "pending-2",
+        kind: "child_terminal_result" as const,
+        sourceId: childId,
+        summary: "PR merged; parent has not consumed this result.",
+      },
+      { ...pendingInput(), id: "pending-3", sourceId: childId },
+      {
+        ...pendingInput(),
+        id: "pending-4",
+        kind: "child_terminal_result" as const,
+        sourceId: "invalid",
+      },
+    ];
+    mounted = await renderComponent(
+      <SessionChrome
+        readOnly
+        defaultActive="incoming"
+        queue={queue({ queue: [], pendingInputs: inputs })}
+        onOpenSession={(id) => opened.push(id)}
+      />,
+    );
+    expect(mounted.container.textContent).toContain("Waiting to be included in an agent turn.");
+    const panel = mounted.container.querySelector('[data-og-session-chrome-panel="incoming"]')!;
+    const links = [...panel.querySelectorAll("button")].filter(
+      (button) => button.textContent === "View session",
+    );
+    expect(links).toHaveLength(2);
+    await act(async () => {
+      links[0]?.click();
+      links[1]?.click();
+    });
+    expect(opened).toEqual([childId, childId]);
+    expect(panel.textContent).toContain(inputs[1]!.summary);
+    expect(panel.querySelectorAll("li")).toHaveLength(4);
+  });
+
   test("inbox dismiss action appears when onDismissIncoming is provided", async () => {
     const dismissed: string[] = [];
     mounted = await renderComponent(

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -326,6 +326,61 @@ describe("provider MCP unavailable rendering", () => {
 });
 
 describe("durable machine-input timeline", () => {
+  test("opens the typed child source without treating receipt delivery as work completion", async () => {
+    resetTimelineEvents();
+    const childId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const opened: string[] = [];
+    const r = await renderComponent(
+      <MessageTimeline
+        onOpenSession={(id) => opened.push(id)}
+        events={[
+          timelineEvent("system.update.delivered", {
+            historyItemId: "history-results",
+            count: 3,
+            members: [
+              {
+                id: "result-1",
+                kind: "child_terminal_result",
+                classification: "success",
+                sourceId: childId,
+                summary: "The worker went idle while waiting for CI.",
+              },
+              {
+                id: "result-2",
+                kind: "child_terminal_result",
+                classification: "failure",
+                sourceId: childId,
+                summary: "A later turn failed.",
+              },
+              {
+                id: "result-3",
+                kind: "child_terminal_result",
+                classification: "success",
+                sourceId: "not-a-session",
+                summary: "Merged after verification.",
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+    await flush();
+    expect(r.container.textContent).toContain("3 agent results received");
+    expect(r.container.textContent).not.toContain("agents finished");
+    const links = [...r.container.querySelectorAll("button")].filter(
+      (button) => button.textContent === "View session",
+    );
+    expect(links).toHaveLength(2);
+    await act(async () => {
+      links[0]?.click();
+      links[1]?.click();
+    });
+    expect(opened).toEqual([childId, childId]);
+    expect(r.container.textContent).toContain("A later turn failed.");
+    expect(r.container.textContent).toContain("Merged after verification.");
+    await r.unmount();
+  });
+
   test("renders a collapsed landmark pill; details hold typed members", async () => {
     resetTimelineEvents();
     const r = await renderComponent(
@@ -355,7 +410,7 @@ describe("durable machine-input timeline", () => {
       />,
     );
     await flush();
-    expect(r.container.textContent).toContain("2 updates · Agent update, Agent finished");
+    expect(r.container.textContent).toContain("2 updates · Agent update, Agent result received");
     expect(r.container.textContent).not.toContain("updates joined this turn");
     expect(r.container.textContent).not.toContain("Input batch");
     expect(r.container.textContent).not.toContain('"sourceId"');
@@ -367,11 +422,11 @@ describe("durable machine-input timeline", () => {
     // Detail rows stay in the DOM for expand-on-demand audit.
     expect(r.container.textContent).toContain("verification-agent");
     expect(r.container.textContent).toContain("Cache verification completed.");
-    expect(r.container.textContent).toContain("Agent finished");
+    expect(r.container.textContent).toContain("Agent result received");
     await r.unmount();
   });
 
-  test("identical agent-finished members collapse to one plural pill", async () => {
+  test("result receipts collapse to a neutral count", async () => {
     resetTimelineEvents();
     const members = Array.from({ length: 15 }, (_, index) => ({
       id: `update-${index}`,
@@ -392,7 +447,7 @@ describe("durable machine-input timeline", () => {
       />,
     );
     await flush();
-    expect(r.container.textContent).toContain("15 agents finished");
+    expect(r.container.textContent).toContain("15 agent results received");
     expect(r.container.textContent).not.toContain("updates joined this turn");
     expect(
       (

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1805,17 +1805,41 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         await incoming.getByRole("button", { name: "View session", exact: true }).count(),
       ).toBe(9);
       expect(await page.getByTestId("failed-session-banner").isVisible()).toBe(true);
-      await page.setViewportSize({ width: 375, height: 812 });
-      await incoming.scrollIntoViewIfNeeded();
-      expect(
-        await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
-      ).toBe(true);
-      await page.screenshot({
-        path: `${process.env.TMPDIR ?? "/tmp"}/opengeni-child-results-mobile.png`,
+      const mobileContext = await configuredContext(browser, {
+        viewport: { width: 375, height: 812 },
+        extraHTTPHeaders: ownerHeaders,
       });
-      await incoming.getByRole("button", { name: "View session", exact: true }).last().click();
-      await page.waitForURL(`**/sessions/${child.id}`);
-      expect(new URL(page.url()).pathname.endsWith(child.id)).toBe(true);
+      try {
+        const mobilePage = await mobileContext.newPage();
+        mobilePage.on("pageerror", (error) => errors.push(error.message));
+        await mobilePage.goto(parentUrl);
+        await mobilePage.getByTestId("failed-session-banner").waitFor();
+        await mobilePage.getByRole("button", { name: "Session activity", exact: true }).click();
+        const mobileIncoming = mobilePage.getByRole("list", {
+          name: "Incoming updates",
+          exact: true,
+        });
+        await mobileIncoming.waitFor();
+        await mobilePage
+          .getByText("Waiting to be included in an agent turn.", { exact: true })
+          .scrollIntoViewIfNeeded();
+        expect(
+          await mobilePage.evaluate(
+            () => document.documentElement.scrollWidth <= window.innerWidth,
+          ),
+        ).toBe(true);
+        await mobilePage.screenshot({
+          path: `${process.env.TMPDIR ?? "/tmp"}/opengeni-child-results-mobile.png`,
+        });
+        await mobileIncoming
+          .getByRole("button", { name: "View session", exact: true })
+          .last()
+          .click();
+        await mobilePage.waitForURL(`**/sessions/${child.id}`);
+        expect(new URL(mobilePage.url()).pathname.endsWith(child.id)).toBe(true);
+      } finally {
+        await mobileContext.close();
+      }
       expect(errors).toEqual([]);
     } finally {
       await context.close();

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import AxeBuilder from "@axe-core/playwright";
 import {
   appendSessionEventsAndUpdateSession,
+  addSessionSystemUpdate,
   createDb,
   appendSessionEvents,
   createSession,
@@ -1702,6 +1703,124 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       await context.close();
     }
   }, 60_000);
+
+  test("opens the exact child from pending and delivered results without claiming the failed parent completed", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    const page = await context.newPage();
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    try {
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const parent = await createSessionThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        "Failed result parent",
+      );
+      const child = await createTitledSession(dbClient.db, {
+        accountId: parent.accountId,
+        workspaceId,
+        initialMessage: "Child with verified PR result",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sandboxBackend: "none",
+        parentSessionId: parent.id,
+        createdBy: { kind: "subject", subjectId: "sessionpin-owner" },
+      });
+      // Historical delivered receipts and current pending receipts are distinct.
+      // Both travel through the actual API and event projection in the browser.
+      await appendSessionEvents(dbClient.db, workspaceId, parent.id, [
+        {
+          type: "system.update.delivered",
+          payload: {
+            historyItemId: crypto.randomUUID(),
+            count: 2,
+            members: [0, 1].map((index) => ({
+              id: crypto.randomUUID(),
+              kind: "child_terminal_result",
+              classification: index === 0 ? "success" : "failure",
+              sourceId: child.id,
+              summary:
+                index === 0
+                  ? "Earlier turn went idle waiting for CI."
+                  : "Earlier review turn failed.",
+            })),
+          },
+        },
+      ]);
+      for (let index = 0; index < 9; index += 1) {
+        await addSessionSystemUpdate(dbClient.db, {
+          accountId: parent.accountId,
+          workspaceId,
+          sessionId: parent.id,
+          kind: "child_terminal_result",
+          classification: "success",
+          sourceId: child.id,
+          dedupeKey: `child-result-browser:${parent.id}:${index}`,
+          summary:
+            index === 8
+              ? "The child reports that its PR merged after review and green CI."
+              : "The child went idle while waiting for CI; its goal is not complete.",
+          payload: { type: "child_terminal_result", childSessionId: child.id, status: "idle" },
+        });
+      }
+      await appendSessionEventsAndUpdateSession(
+        dbClient.db,
+        workspaceId,
+        parent.id,
+        [
+          {
+            type: "session.status.changed",
+            payload: { status: "failed", code: "pre_claim_failure" },
+          },
+        ],
+        { status: "failed" },
+      );
+      const parentUrl = `${webBaseUrl}/workspaces/${workspaceId}/sessions/${parent.id}`;
+      await page.goto(parentUrl);
+      await page.getByTestId("failed-session-banner").waitFor();
+      const delivered = page.locator("details[data-og-machine-input-batch]");
+      await delivered.getByText("2 agent results received", { exact: true }).click();
+      expect(
+        await delivered.getByRole("button", { name: "View session", exact: true }).count(),
+      ).toBe(2);
+      await delivered.getByRole("button", { name: "View session", exact: true }).first().click();
+      await page.waitForURL(`**/sessions/${child.id}`);
+      expect(new URL(page.url()).pathname.endsWith(child.id)).toBe(true);
+      await page.goBack();
+      await page.getByTestId("failed-session-banner").waitFor();
+      await page.getByRole("button", { name: "Session activity", exact: true }).click();
+      const incoming = page.getByRole("list", { name: "Incoming updates", exact: true });
+      await incoming.waitFor();
+      await page.getByText("Waiting to be included in an agent turn.", { exact: true }).waitFor();
+      expect(await incoming.getByRole("listitem").count()).toBe(9);
+      expect(
+        await incoming.getByRole("button", { name: "View session", exact: true }).count(),
+      ).toBe(9);
+      expect(await page.getByTestId("failed-session-banner").isVisible()).toBe(true);
+      await page.setViewportSize({ width: 375, height: 812 });
+      await incoming.scrollIntoViewIfNeeded();
+      expect(
+        await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+      ).toBe(true);
+      await page.screenshot({
+        path: `${process.env.TMPDIR ?? "/tmp"}/opengeni-child-results-mobile.png`,
+      });
+      await incoming.getByRole("button", { name: "View session", exact: true }).last().click();
+      await page.waitForURL(`**/sessions/${child.id}`);
+      expect(new URL(page.url()).pathname.endsWith(child.id)).toBe(true);
+      expect(errors).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  }, 90_000);
 
   test("opens waiting descendants at every depth from a failed parent in For you", async () => {
     const context = await configuredContext(browser, {


### PR DESCRIPTION
Child result batches currently say “agents finished” even when several receipts came from one child that was only idle between CI checks. Label them as result receipts, explain that incoming updates are waiting to be included in an agent turn, and provide View session on valid typed child sources in both incoming and delivered rows.

Navigation uses the host’s existing session callback and UUID coordinates. Historical summaries, parent execution status, and goal authority remain intact.

Validation: 138 component/projection tests with 519 assertions; actual authenticated API and non-superuser PostgreSQL browser acceptance (desktop and fresh mobile context), 1 test/8 assertions; mobile screenshot inspected; full repository typecheck, lint and formatting; production bundle within existing limits.

Tracks [OPE-450](https://linear.app/cloudgeni/issue/OPE-450/distinguish-child-result-receipts-from-completed-work-and-link-their).

## Summary by Sourcery

Distinguish child-result receipts from completed work and enable hosts to open their source sessions.

New Features:
- Add View session links for valid typed child sources in both incoming updates and delivered timeline rows.

Bug Fixes:
- Clarify that child terminal updates are result receipts rather than proof that an agent completed its work.

Enhancements:
- Explain that incoming updates are waiting to be included in an agent turn while preserving existing navigation, execution status, and historical summaries.

Tests:
- Add component, timeline, and authenticated browser coverage for receipt labeling, source-session navigation, parent failure status, and mobile layout.