### PR TITLE
fix(ci): stop superseded work on normal cancellation

### DIFF
--- a/.changeset/ci-cancellation.md
+++ b/.changeset/ci-cancellation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Allow superseded CI jobs to stop on normal cancellation while retaining bounded diagnostics and final check reporting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ concurrency:
 permissions:
   contents: read
 
+# Substantive jobs must use !cancelled(), not always(): GitHub reevaluates
+# job conditions on cancellation. Keep bounded final reports and cleanup able
+# to run, while superseded heads release their test/build capacity promptly.
 jobs:
   automation-admission:
     name: Admit automation Version PR
@@ -138,7 +141,7 @@ jobs:
   plan:
     name: Explain change impact
     needs: automation-admission
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -272,7 +275,7 @@ jobs:
   source-contracts:
     name: Source and type contracts
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -407,7 +410,7 @@ jobs:
   unit-shards:
     name: Unit tests (shard ${{ matrix.number }}/${{ matrix.total }})
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.unit_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.unit_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -468,7 +471,7 @@ jobs:
   integration-shards:
     name: Real-service shard ${{ matrix.number }}/${{ matrix.total }}
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.integration_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.integration_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -520,7 +523,7 @@ jobs:
   e2e-shards:
     name: Impacted E2E shard ${{ matrix.number }}/${{ matrix.total }}
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.e2e_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.e2e_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -610,7 +613,7 @@ jobs:
   test-suite:
     name: Real-service and recovery tests
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -667,7 +670,7 @@ jobs:
   browser-acceptance:
     name: Browser and visual acceptance (${{ matrix.lane }})
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.browser_lane_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.browser_lane_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -959,7 +962,7 @@ jobs:
   package-contracts:
     name: Package and bundle contracts
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.build_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.build_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 55
     steps:
@@ -1133,7 +1136,7 @@ jobs:
   deployment:
     name: Deployment artifacts
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1351,7 +1354,7 @@ jobs:
   artifact-runtime:
     name: Build exact artifact runtime inputs
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.artifact_runtime_required == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.artifact_runtime_required == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     uses: ./.github/workflows/artifact-runtime.yml
     with:
       source_sha: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -1359,7 +1362,7 @@ jobs:
   api-image:
     name: Build API workload image
     needs: [automation-admission, plan, artifact-runtime]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -1441,7 +1444,7 @@ jobs:
   worker-image:
     name: Build worker workload image
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -1490,7 +1493,7 @@ jobs:
   web-image:
     name: Build web workload image
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -1540,7 +1543,7 @@ jobs:
   artifact-materializer-image:
     name: Build artifact materializer workload image
     needs: [automation-admission, plan, artifact-runtime]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -1595,7 +1598,7 @@ jobs:
   artifact-outbox-dispatcher-image:
     name: Build artifact outbox dispatcher workload image
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -1644,7 +1647,7 @@ jobs:
   relay-image:
     name: Build relay workload image
     needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -1689,7 +1692,7 @@ jobs:
   sandbox-image:
     name: Build headless sandbox workload image
     needs: [automation-admission, plan, artifact-runtime]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3660,6 +3660,96 @@ describe("workflow contracts", () => {
   const seal = Bun.YAML.parse(sealText) as any;
   const retainController = Bun.YAML.parse(retainControllerText) as any;
 
+  test("substantive CI work remains selectable through skipped dependencies but stops on cancellation", () => {
+    const reports = new Set(["test", "images", "automation-report"]);
+    const needs = {
+      plan: {
+        result: "success",
+        outputs: {
+          mode: "full",
+          unit_count: "1",
+          integration_count: "1",
+          e2e_count: "1",
+          browser_lane_count: "1",
+          build_count: "1",
+          artifact_runtime_required: "true",
+          bake_images: "true",
+        },
+      },
+      "automation-admission": { result: "skipped" },
+      "artifact-runtime": { result: "success" },
+    };
+    for (const [name, job] of Object.entries(ci.jobs) as [string, { if: string }][]) {
+      if (reports.has(name) || name === "automation-admission") continue;
+      // Execute the checked-in boolean predicate with GitHub's documented
+      // status-function values, including an unrelated skipped dependency.
+      const expression = job.if
+        .slice(3, -2)
+        .replace(/needs\.([a-z-]+)/g, (_match, key: string) => `needs[${JSON.stringify(key)}]`);
+      const select = new Function(
+        "github",
+        "needs",
+        "always",
+        "cancelled",
+        `return (${expression});`,
+      ) as (
+        github: { event_name: string },
+        needs: object,
+        always: () => boolean,
+        cancelled: () => boolean,
+      ) => boolean;
+      for (const event of ["pull_request", "push", "schedule", "workflow_dispatch"]) {
+        needs["automation-admission"].result =
+          event === "workflow_dispatch" ? "success" : "skipped";
+        expect(
+          select(
+            { event_name: event },
+            needs,
+            () => true,
+            () => false,
+          ),
+          `${name}/${event}`,
+        ).toBe(true);
+        expect(
+          select(
+            { event_name: event },
+            needs,
+            () => true,
+            () => true,
+          ),
+          `${name}/${event}/cancelled`,
+        ).toBe(false);
+      }
+      needs["automation-admission"].result = "failure";
+      expect(
+        select(
+          { event_name: "workflow_dispatch" },
+          needs,
+          () => true,
+          () => false,
+        ),
+        `${name}/admission`,
+      ).toBe(false);
+    }
+  });
+
+  test("cancellation preserves bounded final reports and diagnostic cleanup", () => {
+    for (const name of ["test", "images", "automation-report"]) {
+      expect(ci.jobs[name].if).toContain("always()");
+      expect(ci.jobs[name]["timeout-minutes"]).toBe(10);
+    }
+    expect(
+      ci.jobs.test.steps.find((step: any) => step.name === "Require every split CI lane").run,
+    ).toContain("scripts/ci/required-results.jq");
+    expect(ci.jobs["automation-report"].steps.at(-1).env.AUTOMATION_CHECK_CONCLUSION).toContain(
+      "&& 'success' || 'failure'",
+    );
+    expect(
+      ci.jobs["browser-acceptance"].steps.filter((step: any) => step.if?.includes("always()"))
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
   test("uses only the scoped token for Changesets and grants narrow dispatch rights", () => {
     expect(releaseText).not.toContain("RELEASE_PAT");
     const versionChangesets = release.jobs.version.steps.find(
@@ -3700,7 +3790,7 @@ describe("workflow contracts", () => {
     );
     expect(release.on.schedule).toBeUndefined();
     expect(ci.jobs.deployment.if).toBe(
-      "${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+      "${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
     );
     expect(ci.jobs.images.if).toBe(
       "${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
@@ -3720,7 +3810,7 @@ describe("workflow contracts", () => {
       "artifact-outbox-dispatcher-image",
       "relay-image",
     ]) {
-      expect(ci.jobs[jobName].if).toBe(ci.jobs.images.if);
+      expect(ci.jobs[jobName].if).toBe(ci.jobs.images.if.replace("always()", "!cancelled()"));
     }
     for (const jobName of ["api-image", "artifact-materializer-image", "sandbox-image"]) {
       expect(ci.jobs[jobName].if).toContain("needs.plan.outputs.bake_images == 'true'");
@@ -3834,7 +3924,7 @@ describe("workflow contracts", () => {
     expect(plan.name).toBe("Explain change impact");
     expect(plan.needs).toBe("automation-admission");
     expect(plan.if).toBe(
-      "${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+      "${{ !cancelled() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
     );
     expect(plan.outputs).toEqual(
       expect.objectContaining({

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -777,7 +777,9 @@ describe("release image workflow contract", () => {
     ]) {
       expect(parsed.jobs[jobName]?.if).toBe(parsed.jobs["worker-image"]?.if);
     }
-    expect(parsed.jobs.images?.if).toBe(parsed.jobs["worker-image"]?.if);
+    expect(parsed.jobs.images?.if).toBe(
+      "${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+    );
     expect(images.match(/packages: write/g)).toHaveLength(7);
     for (const jobName of leafNames) {
       const login = parsed.jobs[jobName]?.steps?.find((step) => step.name === "Log in to GHCR");

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "path": ".github/workflows/ci.yml",
-      "sha256": "40021a0593f096800af7a7091360ccb18b86a2c473a3520bb3f7f0243c14b956"
+      "sha256": "f8e82313d21eba3e032f52a31ec3d47b970ce678a2ae097278546493522ec0ca"
     },
     {
       "path": ".github/workflows/desktop-e2e.yml",


### PR DESCRIPTION
Superseded CI runs kept substantial jobs running after normal cancellation because their job-level `always()` conditions still evaluated true. Run34148444970 demonstrated the problem: four heavy jobs ended only when force-cancelled at17:47:12Z, after blocking capacity for its corrected candidate.

Use `!cancelled()` for the17 substantive planning/test/build job predicates. This explicit status function preserves selection when the automation admission dependency is intentionally skipped on ordinary PRs, while allowing cancellation to stop superseded work. Bounded final aggregate/check reporting and diagnostic cleanup retain their existing `always()` behavior. Check selection, admission fences, concurrency groups and release policy stay intact.

Validation: the original checked-in predicate failed the cancellation regression; corrected predicates pass across PR/push/schedule/dispatch, skipped dependencies, failed admission and cancellation.155 tests/1113 assertions passed across release automation, source admission, split-workflow and impact contracts. Lint, formatting and changeset validation passed. Independently reviewed exact source before publication.

Tracks OPE-453, related to OPE-27/OPE-92. Official behavior: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation . No unrelated runs were cancelled as part of this implementation.

## Summary by Sourcery

Ensure normally cancelled CI runs terminate substantive work without suppressing required final reporting.

Bug Fixes:
- Allow superseded CI runs to stop substantive planning, testing, and build jobs during normal cancellation, releasing capacity promptly.

Enhancements:
- Preserve bounded final reporting and diagnostic cleanup behavior while retaining existing workflow admission, selection, concurrency, and release policies.

CI:
- Update CI workflow contract coverage to verify cancellation behavior across event types, skipped dependencies, and failed admission conditions.

Tests:
- Add regression tests covering cancellation of substantive jobs and continued execution of bounded aggregate reports and cleanup.