### PR TITLE
Fix responsive composer overflow and failed-session goal wording

### DIFF
--- a/.changeset/truthful-failed-goal-and-responsive-composer.md
+++ b/.changeset/truthful-failed-goal-and-responsive-composer.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep hidden composer height measurement out of document overflow after responsive resizing. Allow session chrome hosts to identify an active goal blocked by failed session execution without changing the goal state.

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -2026,6 +2026,7 @@ function SessionChatPane(props: {
       <div className="mb-2 w-full shrink-0 px-4 sm:px-6">
         <div className="mx-auto w-full max-w-3xl">
           <SessionChrome
+            sessionStatus={props.session.status}
             compact
             queue={props.queue}
             composer={terminal ? undefined : composer}

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -281,7 +281,7 @@ function measureComposerContentHeight(textarea: HTMLTextAreaElement): number {
     mirror.tabIndex = -1;
     mirror.rows = 1;
     mirror.style.cssText =
-      "position:absolute;top:0;left:0;visibility:hidden;pointer-events:none;height:auto;min-height:0;max-height:none;overflow:hidden;z-index:-1;";
+      "position:fixed;top:0;left:-100000px;visibility:hidden;pointer-events:none;height:auto;min-height:0;max-height:none;overflow:hidden;z-index:-1;";
     composerHeightMirror = mirror;
   }
 

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -39,7 +39,12 @@
  * shell uses one CSS grid-track transition for deliberate open/close actions;
  * live queue reconciliation never feeds measurements back into layout.
  */
-import type { SessionGoal, SessionPendingInputPreview, SessionTurn } from "@opengeni/sdk";
+import type {
+  SessionGoal,
+  SessionPendingInputPreview,
+  SessionStatus,
+  SessionTurn,
+} from "@opengeni/sdk";
 import {
   ActivityIcon,
   AudioLinesIcon,
@@ -89,6 +94,8 @@ export type SessionChromeAgentsSignal = {
 
 export type SessionChromeProps = {
   compact?: boolean;
+  /** Authoritative execution status; omitted by older embedding hosts. */
+  sessionStatus?: SessionStatus | undefined;
   queue: UseTurnQueueResult;
   /** Needed for queue edit → composer checkout. Omit with `readOnly`. */
   composer?: ComposerState | undefined;
@@ -117,6 +124,7 @@ type GoalPillState =
   | "pursuing"
   | "waiting"
   | "scheduled"
+  | "session_failed"
   | "blocked"
   | "held"
   | "paused"
@@ -133,6 +141,7 @@ const GOAL_LABEL: Record<GoalPillState, string> = {
   waiting: "Waiting",
   scheduled: "Waiting",
   blocked: "Blocked",
+  session_failed: "Blocked by session failure",
   held: "Held",
   paused: "Paused",
   invariant_broken: "Needs attention",
@@ -187,6 +196,9 @@ export function sessionChromeGoalPillExplanation(
   record: GoalPillRecord | null | undefined,
 ): string | null {
   const continuation = record?.continuation ?? null;
+  if (state === "session_failed") {
+    return "Resolve the session failure, then use Continue or send a message to continue this active goal.";
+  }
   if (state === "paused") {
     return record?.pausedReason
       ? (GOAL_PAUSED_REASON_EXPLANATION[record.pausedReason] ?? null)
@@ -309,9 +321,11 @@ function objectValue(value: unknown): Record<string, unknown> | null {
 export function sessionChromeGoalPillState(
   goalStatus: "active" | "paused" | "completed",
   continuation: SessionGoal["continuation"] | null | undefined,
+  sessionStatus?: SessionStatus,
 ): GoalPillState {
   if (goalStatus === "completed") return "completed";
   if (goalStatus === "paused") return "paused";
+  if (sessionStatus === "failed") return "session_failed";
   if (!continuation) return "invariant_broken";
   if (continuation.state === "running") {
     return continuation.reason === "goal_turn_running"
@@ -411,6 +425,7 @@ function toneClass(tone: SessionChromeSignalTone, selected: boolean): string {
 
 export function SessionChrome({
   compact = false,
+  sessionStatus,
   queue,
   composer,
   goal,
@@ -458,7 +473,9 @@ export function SessionChrome({
   const canMutateQueue = !readOnly && composer !== undefined;
 
   const elapsed = useLiveElapsed(record?.createdAt, Boolean(record));
-  const goalState = record ? sessionChromeGoalPillState(record.status, record.continuation) : null;
+  const goalState = record
+    ? sessionChromeGoalPillState(record.status, record.continuation, sessionStatus)
+    : null;
 
   const initialAuthoritativeQueuedCount = countAuthoritativeQueuedTurns(
     queue.queue,
@@ -571,6 +588,7 @@ export function SessionChrome({
       const waiting =
         goalState === "waiting" ||
         goalState === "blocked" ||
+        goalState === "session_failed" ||
         goalState === "held" ||
         goalState === "paused";
       const explanation = sessionChromeGoalPillExplanation(goalState, record);

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -1469,3 +1469,43 @@ test("controlled compact command selection exposes activity navigation", async (
   ).toBe("true");
   expect(mounted.container.textContent).toContain("Controlled command body");
 });
+
+test("a failed session blocks only active goal presentation", () => {
+  const continuation = goal().goal!.continuation;
+  const failedState = sessionChromeGoalPillState("active", continuation, "failed");
+  expect(sessionChromeGoalPillLabel(failedState, goal().goal)).toBe("Blocked by session failure");
+  expect(sessionChromeGoalPillExplanation(failedState, goal().goal)).toContain("Continue");
+  expect(sessionChromeGoalPillState("completed", continuation, "failed")).toBe("completed");
+  expect(sessionChromeGoalPillState("paused", continuation, "failed")).toBe("paused");
+  expect(sessionChromeGoalPillState("active", continuation, "idle")).toBe(
+    sessionChromeGoalPillState("active", continuation),
+  );
+});
+
+test("failed-session goal chip and panel explain the block without changing the goal", async () => {
+  const activeGoal = goal({
+    continuation: {
+      state: "scheduled",
+      reason: "wake_pending",
+      wakeRevision: 3,
+      observedRevision: 2,
+      nextAttemptAt: null,
+      lastError: null,
+    },
+  });
+  mounted = await renderComponent(
+    <SessionChrome
+      compact
+      sessionStatus="failed"
+      queue={queue({ queue: [] })}
+      goal={activeGoal}
+      defaultActive="goal"
+    />,
+  );
+  expect(mounted.container.textContent).toContain("Goal · Blocked by session failure");
+  expect(
+    mounted.container.querySelector("[data-og-session-chrome-goal-explanation]")?.textContent,
+  ).toContain("use Continue or send a message");
+  expect(mounted.container.textContent).not.toContain("Waiting to continue automatically");
+  expect(activeGoal.goal?.status).toBe("active");
+});

--- a/test/e2e/composer-responsive.browser.e2e.ts
+++ b/test/e2e/composer-responsive.browser.e2e.ts
@@ -50,6 +50,42 @@ describe("container-responsive public composer demo", () => {
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 30_000);
 
+  test("desktop measurement does not widen the document after a mobile resize", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 1000 },
+      reducedMotion: "reduce",
+    });
+    try {
+      const page = await context.newPage();
+      await page.goto(`${baseUrl}/composer-responsive.html?width=768`, {
+        waitUntil: "networkidle",
+      });
+      const textarea = page.getByRole("textbox", { name: "Message the agent" });
+      await textarea.fill("A multiline draft that creates a desktop measurement. ".repeat(30));
+      await textarea.fill("Short draft");
+      await page.setViewportSize({ width: 375, height: 812 });
+      await page.waitForFunction(
+        () =>
+          (document.querySelector("[data-composer-panel]")?.getBoundingClientRect().width ??
+            Infinity) <= innerWidth,
+      );
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        375,
+      );
+      const shortHeight = await textarea.evaluate((node) => node.getBoundingClientRect().height);
+      await textarea.fill("A multiline draft remains editable after resizing. ".repeat(30));
+      expect(
+        await textarea.evaluate((node) => node.getBoundingClientRect().height),
+      ).toBeGreaterThan(shortHeight);
+      await textarea.fill("Short again");
+      expect(
+        await textarea.evaluate((node) => node.getBoundingClientRect().height),
+      ).toBeLessThanOrEqual(shortHeight + 1);
+    } finally {
+      await context.close();
+    }
+  }, 30_000);
+
   test("a wide viewport follows the child panel across the full width matrix", async () => {
     const context = await browser.newContext({
       viewport: { width: 1440, height: 1000 },


### PR DESCRIPTION
A desktop-sized hidden composer measurement textarea could keep the document wider than a mobile viewport after resize. Keep that measurement fixed outside the scrollable layout while preserving the existing autosize measurement.

An active goal could also say it would continue automatically while session execution was Failed. The stock host now supplies authoritative session status; SessionChrome presents “Blocked by session failure” for that combination and points to the existing continuation flow. The optional prop preserves older embedding hosts. Durable goal state and action authority are unchanged.

Validation:
- Actual Chromium regression reproduced 742px document width at375px before the fix; full responsive suite3 tests46 assertions passes, including growth/shrink and accessibility checks.
- SessionChrome50 tests186 assertions, including failed active goal chip/panel and completed/paused/omitted-status compatibility.
- Repository types, lint, formatting and production web/demo bundle checks pass without budget changes.
- Real component mobile fixture shows the full label and wrapped explanation at375px with no overflow or browser errors.

Fixes https://linear.app/cloudgeni/issue/OPE-454/prevent-hidden-composer-measurement-from-overflowing-after-desktop-to
Fixes https://linear.app/cloudgeni/issue/OPE-455/qualify-active-goal-waiting-claims-when-session-execution-has-failed

No deployment or live session mutations.

## Summary by Sourcery

Keep responsive composer layouts within the viewport and accurately communicate when active goals are blocked by failed session execution.

Bug Fixes:
- Prevent hidden composer autosize measurements from widening the document after responsive viewport resizing.
- Show active goals as blocked by session failure when execution has failed, with guidance to resolve the failure and continue.

Enhancements:
- Preserve compatibility for embedding hosts that do not provide session status and leave durable goal state and action authority unchanged.

Tests:
- Add responsive browser coverage for mobile overflow prevention and composer growth/shrink behavior.
- Add SessionChrome coverage for failed-session goal presentation and status compatibility.