### PR TITLE
Preserve human authority for command and timeout continuations

### DIFF
--- a/.changeset/command-causal-authority.md
+++ b/.changeset/command-causal-authority.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Preserve exact command-launch and wait-timeout causal authority, keep separate humans in separate claims, and recover only proven unconsumed pre-claim failures without extending personal grants.

--- a/apps/api/test/command-causal-authority.test.ts
+++ b/apps/api/test/command-causal-authority.test.ts
@@ -1,0 +1,222 @@
+import { test, expect } from "bun:test";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  freePort,
+} from "@opengeni/testing";
+import {
+  createDb,
+  claimSessionWorkForAttempt,
+  applySessionTurnSettlement,
+  adoptConnectedMachineSessionBackgroundCommand,
+  settleConnectedMachineSessionBackgroundCommand,
+  waitForSessionInputWithEvent,
+  settleSessionInputWait,
+} from "@opengeni/db";
+import { createApp } from "../src/app";
+
+test("managed HTTP session retains personal authority across command and timeout successors", async () => {
+  const shared = await acquireSharedTestDatabase("api-command-causal-authority");
+  if (!shared) throw new Error("PostgreSQL test database unavailable");
+  const client = createDb(shared.appUrl);
+  const port = await freePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const noop = async () => undefined;
+  const app = createApp({
+    db: client.db,
+    bus: new MemoryEventBus(),
+    workflowClient: {
+      signalUserMessage: noop,
+      wakeSessionWorkflow: noop,
+      requestSessionWorkflowWakeDispatch: noop,
+      signalApprovalDecision: noop,
+      signalSessionControl: noop,
+      syncScheduledTask: noop,
+      deleteScheduledTaskSchedule: noop,
+      triggerScheduledTask: noop,
+    },
+    settings: testSettings({
+      databaseUrl: shared.appUrl,
+      productAccessMode: "managed",
+      publicBaseUrl: origin,
+      betterAuthSecret: "command-authority-test-secret-32-bytes",
+      environmentsEncryptionKey: Buffer.alloc(32, 41).toString("base64"),
+    }),
+  });
+  const server = Bun.serve({ hostname: "127.0.0.1", port, fetch: app.fetch });
+  let cookie = "";
+  const request = (path: string, body?: unknown) =>
+    fetch(origin + path, {
+      method: body === undefined ? "GET" : "POST",
+      headers: { cookie, origin, "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  try {
+    const email = `command-${crypto.randomUUID()}@example.test`,
+      password = "test-password-only-1234";
+    const signup = await request("/v1/auth/sign-up/email", {
+      name: "Command owner",
+      email,
+      password,
+    });
+    expect(signup.status).toBeLessThan(300);
+    await shared.admin`update auth_users set email_verified=true where email=${email}`;
+    const signin = await request("/v1/auth/sign-in/email", { email, password, rememberMe: true });
+    expect(signin.status).toBe(200);
+    cookie = signin.headers
+      .getSetCookie()
+      .map((value) => value.split(";")[0])
+      .join("; ");
+    expect(cookie.length).toBeGreaterThan(0);
+    const onboard = await request("/v1/auth/organization-onboarding", {
+      organizationName: "Command authority",
+      operationId: crypto.randomUUID(),
+    });
+    expect(onboard.status).toBe(200);
+    const access = await request("/v1/access/me");
+    expect(access.status).toBe(200);
+    const context = (await access.json()) as {
+      defaultAccountId: string;
+      defaultWorkspaceId: string;
+    };
+    await shared.admin`insert into session_tenancy_activations(account_id,activation_version,inventory_digest,parity_digest,activated_by)
+      values (${context.defaultAccountId},1,${"a".repeat(64)},${"b".repeat(64)},'command-api-test') on conflict(account_id) do nothing`;
+    const workspaceResponse = await request("/v1/workspaces", {
+      accountId: context.defaultAccountId,
+      name: "Shared command workspace",
+    });
+    expect(workspaceResponse.status).toBe(201);
+    const workspace = (await workspaceResponse.json()) as { id: string };
+    const personalSetResponse = await request(
+      `/v1/workspaces/${context.defaultWorkspaceId}/variable-sets`,
+      {
+        scope: "user",
+        name: "Personal command fixture",
+        variables: [{ name: "FIXTURE_TOKEN", value: "test-only" }],
+      },
+    );
+    expect(personalSetResponse.status).toBe(201);
+    const variableSet = (await personalSetResponse.json()) as { id: string };
+    const base = `/v1/workspaces/${workspace.id}`;
+    for (const kind of ["command", "timeout"] as const) {
+      const created = await request(base + "/sessions", {
+        initialMessage: `Run ${kind} fixture`,
+        sandboxBackend: "none",
+        tools: [],
+        resources: [],
+        variableSetIds: [variableSet.id],
+        personalResourceAttachment: {
+          mode: "session",
+          workspaceSharedAcknowledged: true,
+          sharedOutputWarningVersion: 1,
+        },
+      });
+      expect(created.status).toBe(202);
+      const session = (await created.json()) as { id: string };
+      const claim = async () => {
+        const attemptId = crypto.randomUUID();
+        const result = await claimSessionWorkForAttempt(client.db, workspace.id, {
+          sessionId: session.id,
+          workflowId: `session-${session.id}`,
+          workflowRunId: crypto.randomUUID(),
+          attemptId,
+          dispatchId: crypto.randomUUID(),
+          trigger: { kind: "next" },
+        });
+        if (result.action !== "claimed") throw new Error(`expected claim, got ${result.action}`);
+        return { ...result, attemptId };
+      };
+      const initial = await claim();
+      const command = {
+        accountId: context.defaultAccountId,
+        workspaceId: workspace.id,
+        sessionId: session.id,
+        turnId: initial.turn.id,
+        attemptId: initial.attemptId,
+        executionGeneration: initial.turn.executionGeneration,
+      };
+      const provider = {
+        commandId: crypto.randomUUID(),
+        controlWorkspaceId: workspace.id,
+        enrollmentId: crypto.randomUUID(),
+        connectionInstanceId: crypto.randomUUID(),
+        opId: crypto.randomUUID(),
+      };
+      if (kind === "command") {
+        await adoptConnectedMachineSessionBackgroundCommand(client.db, {
+          ...command,
+          ...provider,
+          command: "printf done",
+        });
+      } else {
+        await waitForSessionInputWithEvent(client.db, workspace.id, session.id, {
+          reason: "waiting for command evidence",
+          timeoutSeconds: 30,
+          command: {
+            accountId: context.defaultAccountId,
+            operationKey: crypto.randomUUID(),
+            actor: {
+              type: "agent_attempt",
+              sessionId: session.id,
+              turnId: initial.turn.id,
+              attemptId: initial.attemptId,
+              executionGeneration: initial.turn.executionGeneration,
+            },
+          },
+        });
+      }
+      await applySessionTurnSettlement(client.db, workspace.id, {
+        sessionId: session.id,
+        turnId: initial.turn.id,
+        triggerEventId: initial.turn.triggerEventId,
+        attemptId: initial.attemptId,
+        turnStatus: "completed",
+        sessionStatus: "idle",
+        activeTurnId: null,
+        events: [{ type: "turn.completed", payload: { reason: "fixture" } }],
+      });
+      if (kind === "command") {
+        await settleConnectedMachineSessionBackgroundCommand(client.db, {
+          ...command,
+          ...provider,
+          outcome: "exited",
+          exitCode: 0,
+          reason: "done",
+        });
+      } else {
+        await shared.admin`update sessions set input_wait_until=now()-interval '1 second' where id=${session.id}`;
+        await settleSessionInputWait(client.db, {
+          accountId: context.defaultAccountId,
+          workspaceId: workspace.id,
+          sessionId: session.id,
+          waitTurnId: initial.turn.id,
+          disposition: "timeout",
+        });
+      }
+      const successor = await claim();
+      expect(successor.turn.initiatingHumanSubjectId).toBe(initial.turn.initiatingHumanSubjectId);
+      const [receipt] =
+        await shared.admin`select resource_count from session_attempt_personal_resource_admissions where attempt_id=${successor.attemptId}`;
+      expect(receipt?.resource_count).toBe(1);
+      const visible = await request(base + `/sessions/${session.id}`);
+      expect(visible.status).toBe(200);
+      expect(await visible.json()).toMatchObject({ id: session.id, status: "running" });
+      const events = await request(base + `/sessions/${session.id}/events?limit=1000`);
+      expect(events.status).toBe(200);
+      const timeline = (await events.json()) as Array<{ type: string; payload: { kind?: string } }>;
+      expect(
+        timeline.some(
+          (event) =>
+            event.type === "system.update.pending" &&
+            event.payload.kind ===
+              (kind === "command" ? "background_command_result" : "session_wait_timeout"),
+        ),
+      ).toBe(true);
+    }
+  } finally {
+    await server.stop(true);
+    await client.close();
+    await shared.release();
+  }
+}, 180_000);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -833,12 +833,11 @@ custom row, so they do not enter this fence. Custom-model retirement holds the
 exclusive counterpart; already accepted work, exact occurrence replay,
 same-model/existing-session continuations, and administrative-only task,
 trigger, or binding edits use retained definitions instead of reopening
-fresh-selection authority. A committed keyed session shell is also replayed as
-retained before active-only catalog checks so initialization remains repairable.
+fresh-selection authority. Committed keyed session shells replay before
+active-only catalog checks, preserving repairable initialization.
 
-Preference snapshots skip service-only turns; continuations and legacy subject
-turns retain their frozen human. Command and wait-timeout successors preserve
-exact causal turns, immutable receipts, separate claims, and live personal-grant
+Human preferences require frozen causal identity. Command/timeout successors
+preserve immutable receipts, separate causal claims and live personal-grant
 admission; see [run lifecycle](run-lifecycle.md).
 
 Tool disclosure is progressive, but authority is not. A tool may be eager or

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -836,9 +836,10 @@ trigger, or binding edits use retained definitions instead of reopening
 fresh-selection authority. A committed keyed session shell is also replayed as
 retained before active-only catalog checks so initialization remains repairable.
 
-Human preference snapshots require an exact causal human. Service-only turns
-with no causal human skip that human-bound capability; service continuations
-and legacy subject turns use only their already-frozen causal human.
+Preference snapshots skip service-only turns; continuations and legacy subject
+turns retain their frozen human. Command and wait-timeout successors preserve
+exact causal turns, immutable receipts, separate claims, and live personal-grant
+admission; see [run lifecycle](run-lifecycle.md).
 
 Tool disclosure is progressive, but authority is not. A tool may be eager or
 lazy, local or MCP-backed, direct-model or Codemode-accessible; every invocation

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3018,3 +3018,15 @@ A deployment is not acceptable until it proves:
 Use `bun run deployment:stack`, `bun run deployment:preflight`, provider
 Terraform validation, Helm rendering, and this conformance suite as the merge
 and release gate for deployment changes.
+
+
+### Background-command launch authority (0419)
+
+Migration `0419_background_command_launch_authority.sql` is rolling: nullable
+launch turn/attempt/generation columns and an immutable identity fence let older
+adoption writers remain compatible. New writers stamp the existing accepted
+attempt; terminal commands use that receipt without creating a personal grant.
+Historical managed rows may derive it from their exact retained process, while
+unattributed Connected Machine rows remain service-owned. Deploy the new API and
+worker together to enable command and wait-timeout causal admission; this source
+change does not itself deploy or authorize pre-claim recovery.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1467,6 +1467,23 @@ stdin is a separate capability, explicitly unsupported when the provider has no
 interactive transport. A longer wait uses session-level `wait_for_input`,
 whose timeout never cancels the command.
 
+Migration 0419 records the exact launch turn, attempt, and execution generation
+when either provider adopts a background command under the existing attempt
+fence. Terminal results resolve that immutable receipt, copy only eligible
+same-session successor delegations, and retain the causal human for normal
+personal-resource admission. Legacy managed commands can prove the same tuple
+through their retained process; legacy Connected Machine commands with no receipt
+remain unattributed. A timeout similarly inherits its exact waiting turn.
+Different causal turns claim separately. No path substitutes the newest human,
+extends a once grant, or bypasses live revocation.
+
+The existing exact-set pre-claim recovery can restore unconsumed root command
+results and wait timeouts only after verifying their retained launch or timeout
+receipt, completed causal human turn, failure frontier, and unchanged failed
+update set. It repairs typed authority, preserves message/event content, and is
+idempotent; it does not replay a previously accepted turn or recover a nested
+session with parent-facing terminal truth.
+
 Both command readers accept `commandId`, an optional opaque `cursor`,
 `waitSeconds` (0–50; defaults 0 for read and 45 for wait), and `maxOutputBytes`
 (4–65,536; default 16,384 UTF-8 output bytes). They return ordered stdout/stderr

--- a/packages/db/drizzle/0419_background_command_launch_authority.sql
+++ b/packages/db/drizzle/0419_background_command_launch_authority.sql
@@ -1,0 +1,56 @@
+-- deployment-mode: rolling
+-- New adoption writers freeze their already-fenced launch attempt. Older
+-- writers leave this tuple absent; never invent authority for legacy commands.
+ALTER TABLE session_background_commands
+  ADD COLUMN launch_turn_id uuid,
+  ADD COLUMN launch_attempt_id uuid,
+  ADD COLUMN launch_execution_generation integer,
+  ADD CONSTRAINT session_background_commands_launch_identity_check CHECK (
+    (launch_turn_id IS NULL AND launch_attempt_id IS NULL AND launch_execution_generation IS NULL)
+    OR (launch_turn_id IS NOT NULL AND launch_attempt_id IS NOT NULL AND launch_execution_generation IS NOT NULL AND launch_execution_generation > 0)
+  );
+
+CREATE FUNCTION fence_background_command_launch_identity()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, public AS $$
+DECLARE matches_launch boolean;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF ROW(NEW.launch_turn_id, NEW.launch_attempt_id, NEW.launch_execution_generation,
+           NEW.account_id, NEW.workspace_id, NEW.session_id, NEW.provider,
+           NEW.retained_process_id, NEW.control_workspace_id, NEW.enrollment_id,
+           NEW.connection_instance_id, NEW.op_id)
+       IS DISTINCT FROM
+       ROW(OLD.launch_turn_id, OLD.launch_attempt_id, OLD.launch_execution_generation,
+           OLD.account_id, OLD.workspace_id, OLD.session_id, OLD.provider,
+           OLD.retained_process_id, OLD.control_workspace_id, OLD.enrollment_id,
+           OLD.connection_instance_id, OLD.op_id) THEN
+      RAISE EXCEPTION 'background command launch identity is immutable' USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF NEW.launch_turn_id IS NOT NULL AND NEW.launch_attempt_id IS NOT NULL
+     AND NEW.launch_execution_generation IS NOT NULL THEN
+    -- The migrator also supports dedicated data schemas. Never resolve an
+    -- unrelated public table when this trigger belongs to another schema.
+    EXECUTE format(
+      'SELECT EXISTS (
+        SELECT 1 FROM %I.session_turn_attempts a
+        JOIN %I.session_turns t ON t.id = a.turn_id AND t.workspace_id = a.workspace_id
+          AND t.session_id = a.session_id AND t.account_id = a.account_id
+        WHERE a.id = $1 AND a.turn_id = $2
+          AND a.workspace_id = $3 AND a.session_id = $4
+          AND a.account_id = $5 AND a.execution_generation = $6
+      )', TG_TABLE_SCHEMA, TG_TABLE_SCHEMA
+    ) INTO matches_launch USING NEW.launch_attempt_id, NEW.launch_turn_id,
+      NEW.workspace_id, NEW.session_id, NEW.account_id, NEW.launch_execution_generation;
+    IF NOT matches_launch THEN
+      RAISE EXCEPTION 'background command launch attempt does not match session' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION fence_background_command_launch_identity() FROM PUBLIC;
+CREATE TRIGGER session_background_commands_launch_identity_fence
+BEFORE INSERT OR UPDATE ON session_background_commands
+FOR EACH ROW EXECUTE FUNCTION fence_background_command_launch_identity();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -38395,6 +38395,9 @@ export async function adoptManagedSessionBackgroundCommand(
           commandId: input.processId,
           retainedProcessId: input.processId,
           command: input.command,
+          turnId: input.turnId,
+          attemptId: input.attemptId,
+          executionGeneration: input.executionGeneration,
         });
       }),
   );
@@ -61784,7 +61787,9 @@ function systemUpdateCausalHumanTurnId(
       : null;
   const value = isChildLifecycleSystemUpdateKind(update.kind)
     ? lineage?.parentTurnId
-    : update.kind === "goal_continuation"
+    : update.kind === "goal_continuation" ||
+        update.kind === "background_command_result" ||
+        update.kind === "session_wait_timeout"
       ? lineage?.causalTurnId
       : null;
   if (typeof value !== "string" || !/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/iu.test(value)) {
@@ -61829,7 +61834,12 @@ function systemUpdateCausalExecutionKey(
 ): string | null {
   const targetTurnId = systemUpdateCausalHumanTurnId(update);
   if (targetTurnId) return `target-turn:${targetTurnId}`;
-  if (isChildLifecycleSystemUpdateKind(update.kind) || update.kind === "goal_continuation") {
+  if (
+    isChildLifecycleSystemUpdateKind(update.kind) ||
+    update.kind === "goal_continuation" ||
+    update.kind === "background_command_result" ||
+    update.kind === "session_wait_timeout"
+  ) {
     // Malformed historical authority-bearing rows still own distinct claims.
     // They may carry ordinary authority-neutral context, but they must never
     // borrow another child, goal, or Steer's causal principal.
@@ -66376,6 +66386,10 @@ async function settleSessionInputWaitInActivity(
     }
     const deadlineAt = expected.inputWaitUntil.toISOString();
     const reason = expected.inputWaitReason;
+    const causalAuthority = await sameSessionCausalAuthorityTx(db as unknown as Database, {
+      ...input,
+      turnId: input.waitTurnId,
+    });
     try {
       const result = await addSessionSystemUpdateWithSourceMutation(
         db,
@@ -66384,6 +66398,11 @@ async function settleSessionInputWaitInActivity(
           workspaceId: input.workspaceId,
           sessionId: input.sessionId,
           kind: "session_wait_timeout",
+          personalConnectionDelegations: causalAuthority?.personalConnectionDelegations ?? [],
+          xaiProviderAccountAuthoritySnapshot:
+            causalAuthority?.xaiProviderAccountAuthoritySnapshot ??
+            WORKSPACE_XAI_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1,
+          lineage: causalAuthority?.lineage ?? {},
           classification: "info",
           sourceId: input.waitTurnId,
           dedupeKey: `session-input-wait-timeout:${input.waitTurnId}`,
@@ -67284,6 +67303,8 @@ export async function recoverSessionWorkFailedBeforeAttemptClaim(
           .select({
             id: schema.sessionSystemUpdates.id,
             kind: schema.sessionSystemUpdates.kind,
+            sourceId: schema.sessionSystemUpdates.sourceId,
+            dedupeKey: schema.sessionSystemUpdates.dedupeKey,
             lineage: schema.sessionSystemUpdates.lineage,
             deliveredTurnId: schema.sessionSystemUpdates.deliveredTurnId,
             deliveredHistoryItemId: schema.sessionSystemUpdates.deliveredHistoryItemId,
@@ -67388,22 +67409,71 @@ export async function recoverSessionWorkFailedBeforeAttemptClaim(
         }
 
         const causalTurnIds = new Set<string>();
+        const repairedAuthorities = new Map<
+          string,
+          NonNullable<Awaited<ReturnType<typeof sameSessionCausalAuthorityTx>>>
+        >();
         for (const update of failedUpdates) {
-          const causalTurnId = systemUpdateCausalHumanTurnId(update);
+          let causalTurnId = systemUpdateCausalHumanTurnId(update);
           const lineage =
             update.lineage && typeof update.lineage === "object" && !Array.isArray(update.lineage)
               ? (update.lineage as Record<string, unknown>)
               : null;
           if (
-            !isChildLifecycleSystemUpdateKind(update.kind) ||
-            !causalTurnId ||
-            lineage?.parentSessionId !== input.sessionId ||
             update.deliveredTurnId !== null ||
             update.deliveredHistoryItemId !== null ||
             update.deliveredAt !== null
-          ) {
+          )
             return { action: "stale", event: null } as const;
-          }
+          if (isChildLifecycleSystemUpdateKind(update.kind)) {
+            if (!causalTurnId || lineage?.parentSessionId !== input.sessionId) {
+              return { action: "stale", event: null } as const;
+            }
+          } else if (update.kind === "background_command_result") {
+            if (
+              !update.sourceId ||
+              !UUID_PATTERN.test(update.sourceId) ||
+              update.dedupeKey !== `background-command-result:${update.sourceId}`
+            ) {
+              return { action: "stale", event: null } as const;
+            }
+            const authority = await backgroundCommandCausalAuthorityTx(tx as unknown as Database, {
+              accountId: session.accountId,
+              workspaceId,
+              sessionId: input.sessionId,
+              commandId: update.sourceId,
+            });
+            if (!authority) return { action: "stale", event: null } as const;
+            repairedAuthorities.set(update.id, authority);
+            causalTurnId = authority.lineage.causalTurnId;
+          } else if (update.kind === "session_wait_timeout") {
+            if (
+              !update.sourceId ||
+              !UUID_PATTERN.test(update.sourceId) ||
+              update.dedupeKey !== `session-input-wait-timeout:${update.sourceId}`
+            ) {
+              return { action: "stale", event: null } as const;
+            }
+            const [timeoutProof] = await tx.execute(sql`
+              select id from session_events
+              where workspace_id = ${workspaceId} and session_id = ${input.sessionId}
+                and type = 'session.wait.finished'
+                and payload ->> 'waitTurnId' = ${update.sourceId}
+                and payload ->> 'outcome' = 'timeout'
+                and sequence < ${input.expectedFailureEventSequence}
+              limit 1`);
+            if (!timeoutProof) return { action: "stale", event: null } as const;
+            const authority = await sameSessionCausalAuthorityTx(tx as unknown as Database, {
+              accountId: session.accountId,
+              workspaceId,
+              sessionId: input.sessionId,
+              turnId: update.sourceId,
+            });
+            if (!authority) return { action: "stale", event: null } as const;
+            repairedAuthorities.set(update.id, authority);
+            causalTurnId = authority.lineage.causalTurnId;
+          } else return { action: "stale", event: null } as const;
+          if (!causalTurnId) return { action: "stale", event: null } as const;
           causalTurnIds.add(causalTurnId);
         }
         const causalTurns = await tx
@@ -67432,6 +67502,27 @@ export async function recoverSessionWorkFailedBeforeAttemptClaim(
           return { action: "stale", event: null } as const;
         }
 
+        // Only after every exact failed member and causal receipt passes do
+        // we repair typed authority; message/event content is never rewritten.
+        for (const update of failedUpdates) {
+          const authority = repairedAuthorities.get(update.id);
+          if (!authority) continue;
+          await tx
+            .update(schema.sessionSystemUpdates)
+            .set({
+              personalConnectionDelegations: authority.personalConnectionDelegations,
+              xaiProviderAccountAuthoritySnapshot: authority.xaiProviderAccountAuthoritySnapshot,
+              lineage: { ...update.lineage, ...authority.lineage },
+            })
+            .where(
+              and(
+                eq(schema.sessionSystemUpdates.id, update.id),
+                eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
+                eq(schema.sessionSystemUpdates.sessionId, input.sessionId),
+                eq(schema.sessionSystemUpdates.state, "failed"),
+              ),
+            );
+        }
         const restored = await tx
           .update(schema.sessionSystemUpdates)
           .set({ state: "pending" })
@@ -72799,6 +72890,129 @@ export async function addSessionSystemUpdateWithSourceMutation<
   )) as AddSessionSystemUpdateResult<RequireIdleSession>;
 }
 
+async function sameSessionCausalAuthorityTx(
+  tx: Database,
+  input: { accountId: string; workspaceId: string; sessionId: string; turnId: string },
+) {
+  const [turn] = await tx
+    .select()
+    .from(schema.sessionTurns)
+    .where(
+      and(
+        eq(schema.sessionTurns.accountId, input.accountId),
+        eq(schema.sessionTurns.workspaceId, input.workspaceId),
+        eq(schema.sessionTurns.sessionId, input.sessionId),
+        eq(schema.sessionTurns.id, input.turnId),
+      ),
+    )
+    .limit(1);
+  if (!turn) return null;
+  const personalConnectionDelegations = personalConnectionDelegationsForSameSessionSuccessor(
+    parsedPersonalConnectionDelegations(
+      turn.personalConnectionDelegations,
+      `session_turns:${turn.id}`,
+    ),
+    input.sessionId,
+  );
+  const xaiProviderAccountAuthoritySnapshot = XaiProviderAccountAuthoritySnapshotV1.parse(
+    turn.xaiProviderAccountAuthoritySnapshot,
+  );
+  const human =
+    turn.initiatingHumanSubjectId ??
+    (turn.initiatorKind === "subject" ? turn.initiatorSubjectId : null);
+  if (
+    !human &&
+    (personalConnectionDelegations.some((d) => d.userDelegation) ||
+      xaiProviderAccountAuthoritySnapshot.scope === "user")
+  ) {
+    throw new SessionControlInvariantError("Causal turn lost its personal execution authority");
+  }
+  return {
+    personalConnectionDelegations,
+    xaiProviderAccountAuthoritySnapshot,
+    lineage: {
+      causalTurnId: turn.id,
+      ...(human && personalConnectionDelegations.some((d) => d.userDelegation)
+        ? { connectionAuthoritySubjectId: human }
+        : {}),
+      ...(human && xaiProviderAccountAuthoritySnapshot.scope === "user"
+        ? { xaiAuthoritySubjectId: human }
+        : {}),
+    },
+  };
+}
+
+/** Resolve only the immutable launch receipt, including pre-0419 managed rows.
+ * Legacy Connected Machine rows have no durable launch identity and stay
+ * unattributed. Neither a current session owner nor its latest turn is a substitute. */
+async function backgroundCommandCausalAuthorityTx(
+  tx: Database,
+  input: { accountId: string; workspaceId: string; sessionId: string; commandId: string },
+) {
+  const [command] = await tx
+    .select()
+    .from(schema.sessionBackgroundCommands)
+    .where(
+      and(
+        eq(schema.sessionBackgroundCommands.accountId, input.accountId),
+        eq(schema.sessionBackgroundCommands.workspaceId, input.workspaceId),
+        eq(schema.sessionBackgroundCommands.sessionId, input.sessionId),
+        eq(schema.sessionBackgroundCommands.id, input.commandId),
+      ),
+    )
+    .limit(1);
+  if (!command || !["exited", "lost"].includes(command.state) || !command.settledAt) return null;
+  let turnId = command.launchTurnId;
+  let attemptId = command.launchAttemptId;
+  let generation = command.launchExecutionGeneration;
+  if (!turnId && command.provider === "managed" && command.retainedProcessId) {
+    const [process] = await tx
+      .select()
+      .from(schema.sandboxRetainedProcesses)
+      .where(
+        and(
+          eq(schema.sandboxRetainedProcesses.id, command.retainedProcessId),
+          eq(schema.sandboxRetainedProcesses.accountId, input.accountId),
+          eq(schema.sandboxRetainedProcesses.workspaceId, input.workspaceId),
+          eq(schema.sandboxRetainedProcesses.sessionId, input.sessionId),
+        ),
+      )
+      .limit(1);
+    if (process?.ownerActorKind === "turn" && process.ownerActorId === process.ownerAttemptId) {
+      turnId = process.ownerTurnId;
+      attemptId = process.ownerAttemptId;
+      generation = process.ownerExecutionGeneration;
+    }
+  }
+  if (!turnId || !attemptId || !generation) return null;
+  const [attempt] = await tx
+    .select({ id: schema.sessionTurnAttempts.id })
+    .from(schema.sessionTurnAttempts)
+    .where(
+      and(
+        eq(schema.sessionTurnAttempts.id, attemptId),
+        eq(schema.sessionTurnAttempts.accountId, input.accountId),
+        eq(schema.sessionTurnAttempts.workspaceId, input.workspaceId),
+        eq(schema.sessionTurnAttempts.sessionId, input.sessionId),
+        eq(schema.sessionTurnAttempts.turnId, turnId),
+        eq(schema.sessionTurnAttempts.executionGeneration, generation),
+      ),
+    )
+    .limit(1);
+  if (!attempt) return null;
+  const authority = await sameSessionCausalAuthorityTx(tx, { ...input, turnId });
+  return authority
+    ? {
+        ...authority,
+        lineage: {
+          ...authority.lineage,
+          causalAttemptId: attemptId,
+          causalExecutionGeneration: generation,
+        },
+      }
+    : null;
+}
+
 function backgroundCommandTerminalMutation(input: {
   accountId: string;
   workspaceId: string;
@@ -72934,6 +73148,10 @@ function backgroundCommandTerminalMutation(input: {
         ...(command.failure ? { failure: command.failure } : {}),
         outputLocator,
       };
+      const causalAuthority = await backgroundCommandCausalAuthorityTx(tx as unknown as Database, {
+        ...input,
+        commandId: command.id,
+      });
       const [insertedUpdate] = await tx
         .insert(schema.sessionSystemUpdates)
         .values(
@@ -72949,7 +73167,15 @@ function backgroundCommandTerminalMutation(input: {
                 dedupeKey: `background-command-result:${command.id}`,
                 summary,
                 payload,
-                lineage: { commandId: command.id, provider: command.provider },
+                personalConnectionDelegations: causalAuthority?.personalConnectionDelegations ?? [],
+                xaiProviderAccountAuthoritySnapshot:
+                  causalAuthority?.xaiProviderAccountAuthoritySnapshot ??
+                  WORKSPACE_XAI_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1,
+                lineage: {
+                  commandId: command.id,
+                  provider: command.provider,
+                  ...causalAuthority?.lineage,
+                },
                 state: "pending",
               },
               "summary",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -9737,6 +9737,10 @@ export const sessionBackgroundCommands = pgTable(
       .notNull()
       .default("running"),
     retainedProcessId: uuid("retained_process_id"),
+    // Exact launch receipt, never inferred from a later turn or session owner.
+    launchTurnId: uuid("launch_turn_id"),
+    launchAttemptId: uuid("launch_attempt_id"),
+    launchExecutionGeneration: integer("launch_execution_generation"),
     controlWorkspaceId: uuid("control_workspace_id"),
     enrollmentId: uuid("enrollment_id"),
     connectionInstanceId: text("connection_instance_id"),
@@ -9815,6 +9819,12 @@ export const sessionBackgroundCommands = pgTable(
     stopping: index("session_background_commands_stopping_idx")
       .on(table.reconcileAfter, table.cancelRequestedAt, table.id)
       .where(sql`${table.state} in ('running', 'stopping')`),
+    launchIdentityValid: check(
+      "session_background_commands_launch_identity_check",
+      sql`(${table.launchTurnId} is null and ${table.launchAttemptId} is null and ${table.launchExecutionGeneration} is null)
+        or (${table.launchTurnId} is not null and ${table.launchAttemptId} is not null
+          and ${table.launchExecutionGeneration} is not null and ${table.launchExecutionGeneration} > 0)`,
+    ),
     providerValid: check(
       "session_background_commands_provider_check",
       sql`${table.provider} in ('managed', 'connected_machine')`,

--- a/packages/db/src/session-background-commands.ts
+++ b/packages/db/src/session-background-commands.ts
@@ -205,6 +205,9 @@ export async function insertManagedSessionBackgroundCommandInTransaction(
     commandId: string;
     retainedProcessId: string;
     command: string;
+    turnId?: string;
+    attemptId?: string;
+    executionGeneration?: number;
   },
 ): Promise<SessionBackgroundCommand> {
   const [process] = await db
@@ -213,6 +216,11 @@ export async function insertManagedSessionBackgroundCommandInTransaction(
       workspaceId: schema.sandboxRetainedProcesses.workspaceId,
       sessionId: schema.sandboxRetainedProcesses.sessionId,
       state: schema.sandboxRetainedProcesses.state,
+      ownerActorKind: schema.sandboxRetainedProcesses.ownerActorKind,
+      ownerActorId: schema.sandboxRetainedProcesses.ownerActorId,
+      ownerTurnId: schema.sandboxRetainedProcesses.ownerTurnId,
+      ownerAttemptId: schema.sandboxRetainedProcesses.ownerAttemptId,
+      ownerExecutionGeneration: schema.sandboxRetainedProcesses.ownerExecutionGeneration,
     })
     .from(schema.sandboxRetainedProcesses)
     .where(eq(schema.sandboxRetainedProcesses.id, input.retainedProcessId))
@@ -238,6 +246,9 @@ export async function insertManagedSessionBackgroundCommandInTransaction(
       state: "running",
       retainedProcessId: input.retainedProcessId,
       commandPreview: commandPreview(input.command),
+      launchTurnId: input.turnId ?? null,
+      launchAttemptId: input.attemptId ?? null,
+      launchExecutionGeneration: input.executionGeneration ?? null,
     })
     .onConflictDoUpdate({
       target: schema.sessionBackgroundCommands.retainedProcessId,
@@ -246,10 +257,23 @@ export async function insertManagedSessionBackgroundCommandInTransaction(
     })
     .returning();
   if (!row) throw new Error("Managed background command adoption returned no row");
+  const legacyReplayMatches =
+    row.launchTurnId === null &&
+    row.launchAttemptId === null &&
+    row.launchExecutionGeneration === null &&
+    process.ownerActorKind === "turn" &&
+    process.ownerActorId === input.attemptId &&
+    process.ownerTurnId === input.turnId &&
+    process.ownerAttemptId === input.attemptId &&
+    process.ownerExecutionGeneration === input.executionGeneration;
   if (
     row.accountId !== input.accountId ||
     row.workspaceId !== input.workspaceId ||
     row.sessionId !== input.sessionId ||
+    (!legacyReplayMatches &&
+      (row.launchTurnId !== (input.turnId ?? null) ||
+        row.launchAttemptId !== (input.attemptId ?? null) ||
+        row.launchExecutionGeneration !== (input.executionGeneration ?? null))) ||
     row.provider !== "managed" ||
     row.retainedProcessId !== input.retainedProcessId
   ) {
@@ -271,6 +295,9 @@ export async function insertConnectedMachineSessionBackgroundCommandInTransactio
     connectionInstanceId: string;
     opId: string;
     command: string;
+    turnId?: string;
+    attemptId?: string;
+    executionGeneration?: number;
   },
 ): Promise<SessionBackgroundCommand> {
   const [row] = await db
@@ -287,6 +314,9 @@ export async function insertConnectedMachineSessionBackgroundCommandInTransactio
       connectionInstanceId: input.connectionInstanceId,
       opId: input.opId,
       commandPreview: commandPreview(input.command),
+      launchTurnId: input.turnId ?? null,
+      launchAttemptId: input.attemptId ?? null,
+      launchExecutionGeneration: input.executionGeneration ?? null,
     })
     .onConflictDoUpdate({
       target: [
@@ -304,6 +334,9 @@ export async function insertConnectedMachineSessionBackgroundCommandInTransactio
     row.accountId !== input.accountId ||
     row.workspaceId !== input.workspaceId ||
     row.sessionId !== input.sessionId ||
+    row.launchTurnId !== (input.turnId ?? null) ||
+    row.launchAttemptId !== (input.attemptId ?? null) ||
+    row.launchExecutionGeneration !== (input.executionGeneration ?? null) ||
     row.provider !== "connected_machine" ||
     row.controlWorkspaceId !== input.controlWorkspaceId ||
     row.enrollmentId !== input.enrollmentId ||

--- a/packages/db/test/child-read-acknowledgment.test.ts
+++ b/packages/db/test/child-read-acknowledgment.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
@@ -5,6 +6,12 @@ import {
   addSessionSystemUpdateWithSourceMutation,
   applySessionTurnSettlement,
   bootstrapWorkspace,
+  settleRetainedProcess,
+  adoptConnectedMachineSessionBackgroundCommand,
+  adoptManagedSessionBackgroundCommand,
+  settleConnectedMachineSessionBackgroundCommand,
+  waitForSessionInputWithEvent,
+  settleSessionInputWait,
   claimPendingSessionSystemUpdateOutbox,
   claimSessionWorkForAttempt,
   configureChildLifecycleNotices,
@@ -131,7 +138,13 @@ async function member(grant: Grant, control = false): Promise<string> {
 
 async function startSession(
   grant: Grant,
-  input: { parent?: Started; goal?: boolean; message: string; personalVariableSetId?: string },
+  input: {
+    parent?: Started;
+    goal?: boolean;
+    message: string;
+    personalVariableSetId?: string;
+    personalMode?: "once" | "session" | "always";
+  },
 ) {
   const session = await createSession(client.db, {
     accountId: grant.accountId,
@@ -163,7 +176,7 @@ async function startSession(
           variableSetIds: [input.personalVariableSetId],
           variableSetId: input.personalVariableSetId,
           initialPersonalResourceAttachmentIntent: {
-            mode: "session" as const,
+            mode: input.personalMode ?? ("session" as const),
             workspaceSharedAcknowledged: true,
             sharedOutputWarningVersion: 1 as const,
           },
@@ -981,5 +994,444 @@ describe("child read acknowledgment on parent consumption", () => {
 
     expect(await pinRowCount(stranger.session.id)).toBe(0);
     expect(await pinRowCount(child.session.id)).toBe(0);
+  });
+});
+
+test.each(["legacy", "current", "legacy-replay"] as const)(
+  "a %s retained command result preserves exact causal human for personal resources",
+  async (version) => {
+    const { grant, variableSetId } = await managedWorkspaceWithPersonalVariableSet();
+    const parent = await startSession(grant, {
+      message: "run background work",
+      personalVariableSetId: variableSetId,
+    });
+    const { accountId, workspaceId } = grant;
+    const sessionId = parent.session.id,
+      sandboxGroupId = parent.session.sandboxGroupId;
+    const commandId = crypto.randomUUID(),
+      leaseId = crypto.randomUUID(),
+      admissionId = crypto.randomUUID();
+    const actorId = parent.attemptId;
+    await shared.admin`insert into sandbox_leases ${shared.admin({ id: leaseId, account_id: accountId, workspace_id: workspaceId, sandbox_group_id: sandboxGroupId, backend: "local", instance_id: "test-instance", expires_at: new Date(Date.now() + 60_000) })}`;
+    await shared.admin`insert into sandbox_lease_holders ${shared.admin({ account_id: accountId, workspace_id: workspaceId, lease_id: leaseId, kind: "process", holder_id: `process:${commandId}`, subject_id: sessionId })}`;
+    await shared.admin`insert into sandbox_workspace_mutation_admissions ${shared.admin({ id: admissionId, account_id: accountId, workspace_id: workspaceId, lease_id: leaseId, sandbox_group_id: sandboxGroupId, session_id: sessionId, actor_kind: "turn", actor_id: actorId, turn_id: parent.turn.id, attempt_id: parent.attemptId, execution_generation: parent.turn.executionGeneration, holder_kind: "turn", holder_id: `turn:${parent.turn.id}`, lease_epoch: 0, provider_backend: "local", provider_instance_id: "test-instance", route_kind: "active", route_epoch: 0, workspace_generation: 1, operation: "terminalExec", provider_outcome: "retained" })}`;
+    await shared.admin`insert into sandbox_retained_processes ${shared.admin({ id: commandId, account_id: accountId, workspace_id: workspaceId, session_id: sessionId, lease_id: leaseId, sandbox_group_id: sandboxGroupId, parent_admission_id: admissionId, holder_id: `process:${commandId}`, owner_actor_kind: "turn", owner_actor_id: actorId, owner_turn_id: parent.turn.id, owner_attempt_id: parent.attemptId, owner_execution_generation: parent.turn.executionGeneration, lease_epoch: 0, provider_backend: "local", provider_instance_id: "test-instance", route_kind: "active", route_epoch: 0, provider_session_id: 1 })}`;
+    await shared.admin`insert into session_background_commands ${shared.admin({ id: commandId, account_id: accountId, workspace_id: workspaceId, session_id: sessionId, provider: "managed", state: "running", retained_process_id: commandId })}`;
+    if (version !== "legacy") {
+      if (version === "current") {
+        await shared.admin`delete from session_background_commands where id=${commandId}`;
+      }
+      await adoptManagedSessionBackgroundCommand(client.db, {
+        accountId,
+        workspaceId,
+        sessionId,
+        processId: commandId,
+        turnId: parent.turn.id,
+        attemptId: parent.attemptId,
+        executionGeneration: parent.turn.executionGeneration,
+        command: "printf done",
+        expected: {
+          leaseId,
+          sandboxGroupId,
+          parentAdmissionId: admissionId,
+          holderId: `process:${commandId}`,
+          leaseEpoch: 0,
+          providerBackend: "local",
+          providerInstanceId: "test-instance",
+          routeKind: "active",
+          routeTargetId: null,
+          routeEpoch: 0,
+          providerSessionId: 1,
+        },
+      });
+    }
+    if (version === "current") {
+      await shared.admin`insert into session_background_commands ${shared.admin({
+        id: commandId,
+        account_id: accountId,
+        workspace_id: workspaceId,
+        session_id: sessionId,
+        provider: "managed",
+        state: "running",
+        retained_process_id: commandId,
+      })} on conflict (retained_process_id) where retained_process_id is not null
+        do update set updated_at=now()`;
+    }
+    const [launch] =
+      await shared.admin`select launch_turn_id from session_background_commands where id=${commandId}`;
+    expect(launch?.launch_turn_id).toBe(version === "current" ? parent.turn.id : null);
+    await settleIdle(grant, parent);
+    await settleRetainedProcess(client.db, {
+      accountId,
+      workspaceId,
+      sessionId,
+      processId: commandId,
+      expected: {
+        leaseId,
+        sandboxGroupId,
+        parentAdmissionId: admissionId,
+        holderId: `process:${commandId}`,
+        leaseEpoch: 0,
+        providerBackend: "local",
+        providerInstanceId: "test-instance",
+        routeKind: "active",
+        routeTargetId: null,
+        routeEpoch: 0,
+        providerSessionId: 1,
+      },
+      outcome: "exited",
+      exitCode: 0,
+      reason: "process exited",
+      idleGraceMs: 0,
+    });
+    const [pending] =
+      await shared.admin`select kind, lineage, state from session_system_updates where source_id=${commandId}`;
+    expect(pending).toMatchObject({ state: "pending", lineage: { causalTurnId: parent.turn.id } });
+    await recoverLegacyCausalUpdate(grant, parent, commandId);
+    const claimed = await claim(grant, sessionId);
+    expect(claimed.action).toBe("claimed");
+    if (claimed.action === "claimed")
+      expect(claimed.turn.initiatingHumanSubjectId).toBe(grant.subjectId);
+  },
+);
+
+test("an input wait timeout preserves exact waiting human for personal resources", async () => {
+  const { grant, variableSetId } = await managedWorkspaceWithPersonalVariableSet();
+  const parent = await startSession(grant, {
+    message: "wait for work",
+    personalVariableSetId: variableSetId,
+  });
+  await waitForSessionInputWithEvent(client.db, grant.workspaceId, parent.session.id, {
+    reason: "waiting for CI",
+    timeoutSeconds: 30,
+    command: {
+      accountId: grant.accountId,
+      operationKey: crypto.randomUUID(),
+      actor: {
+        type: "agent_attempt",
+        sessionId: parent.session.id,
+        turnId: parent.turn.id,
+        attemptId: parent.attemptId,
+        executionGeneration: parent.turn.executionGeneration,
+      },
+    },
+  });
+  await settleIdle(grant, parent);
+  await shared.admin`update sessions set input_wait_until=now()-interval '1 second' where id=${parent.session.id}`;
+  const result = await settleSessionInputWait(client.db, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    sessionId: parent.session.id,
+    waitTurnId: parent.turn.id,
+    disposition: "timeout",
+  });
+  expect(result.action).toBe("timeout");
+  await recoverLegacyCausalUpdate(grant, parent, parent.turn.id);
+  const claimed = await claim(grant, parent.session.id);
+  expect(claimed.action).toBe("claimed");
+});
+
+async function connectedCommand(grant: Grant, parent: Started) {
+  const identity = {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    sessionId: parent.session.id,
+    commandId: crypto.randomUUID(),
+    controlWorkspaceId: grant.workspaceId,
+    enrollmentId: crypto.randomUUID(),
+    connectionInstanceId: crypto.randomUUID(),
+    opId: crypto.randomUUID(),
+  };
+  const input = {
+    ...identity,
+    turnId: parent.turn.id,
+    attemptId: parent.attemptId,
+    executionGeneration: parent.turn.executionGeneration,
+    command: "printf done",
+  };
+  await adoptConnectedMachineSessionBackgroundCommand(client.db, input);
+  return {
+    identity,
+    input,
+    finish: () =>
+      settleConnectedMachineSessionBackgroundCommand(client.db, {
+        ...identity,
+        outcome: "exited",
+        exitCode: 0,
+        reason: "process exited",
+      }),
+  };
+}
+
+test.each(["session", "always"] as const)(
+  "a Connected Machine result inherits only its %s personal grant",
+  async (mode) => {
+    const { grant, variableSetId } = await managedWorkspaceWithPersonalVariableSet();
+    const parent = await startSession(grant, {
+      message: "start command",
+      personalVariableSetId: variableSetId,
+      personalMode: mode,
+    });
+    const command = await connectedCommand(grant, parent);
+    await adoptConnectedMachineSessionBackgroundCommand(client.db, command.input);
+    // Exact old-writer upsert omits the new columns; conflict replay must
+    // preserve the new writer's immutable receipt.
+    await shared.admin`insert into session_background_commands ${shared.admin({
+      id: command.identity.commandId,
+      account_id: grant.accountId,
+      workspace_id: grant.workspaceId,
+      session_id: parent.session.id,
+      provider: "connected_machine",
+      state: "running",
+      control_workspace_id: command.identity.controlWorkspaceId,
+      enrollment_id: command.identity.enrollmentId,
+      connection_instance_id: command.identity.connectionInstanceId,
+      op_id: command.identity.opId,
+    })} on conflict (control_workspace_id,enrollment_id,connection_instance_id,op_id)
+      where provider='connected_machine' do update set updated_at=now()`;
+    const [launch] =
+      await shared.admin`select launch_turn_id,launch_attempt_id from session_background_commands where id=${command.identity.commandId}`;
+    expect(launch).toEqual({ launch_turn_id: parent.turn.id, launch_attempt_id: parent.attemptId });
+    await settleIdle(grant, parent);
+    await command.finish();
+    await command.finish();
+    const result = await claim(grant, parent.session.id);
+    expect(result.action).toBe("claimed");
+    if (result.action !== "claimed") throw new Error("command result was not claimed");
+    expect(result.turn.initiatingHumanSubjectId).toBe(grant.subjectId);
+    const [receipt] =
+      await shared.admin`select resource_count from session_attempt_personal_resource_admissions where attempt_id=${result.attemptId}`;
+    expect(receipt?.resource_count).toBe(1);
+    const [count] =
+      await shared.admin`select count(*)::int as count from session_system_updates where source_id=${command.identity.commandId}`;
+    expect(count?.count).toBe(1);
+  },
+);
+
+test("a command successor cannot extend a once personal grant", async () => {
+  const { grant, variableSetId } = await managedWorkspaceWithPersonalVariableSet();
+  const parent = await startSession(grant, {
+    message: "start command",
+    personalVariableSetId: variableSetId,
+    personalMode: "once",
+  });
+  const command = await connectedCommand(grant, parent);
+  await settleIdle(grant, parent);
+  await command.finish();
+  await expect(claim(grant, parent.session.id)).rejects.toThrow();
+});
+
+test("commands launched by different humans never coalesce or borrow the latest human", async () => {
+  const owner = await workspace();
+  const other = { ...owner, subjectId: await member(owner) };
+  const first = await startSession(owner, { message: "first command" });
+  const firstCommand = await connectedCommand(owner, first);
+  await settleIdle(owner, first);
+  await enqueueHumanTurn(other, first.session.id);
+  const secondClaim = await claim(other, first.session.id);
+  if (secondClaim.action !== "claimed") throw new Error("second human was not claimed");
+  const second = {
+    session: first.session,
+    turn: secondClaim.turn,
+    attemptId: secondClaim.attemptId,
+  };
+  const secondCommand = await connectedCommand(other, second);
+  await settleIdle(other, second);
+  await firstCommand.finish();
+  await secondCommand.finish();
+  const firstResult = await claim(owner, first.session.id);
+  if (firstResult.action !== "claimed") throw new Error("first result was not claimed");
+  expect(firstResult.turn.initiatingHumanSubjectId).toBe(owner.subjectId);
+  const [pending] =
+    await shared.admin`select count(*)::int as count from session_system_updates where session_id=${first.session.id} and state='pending'`;
+  expect(pending?.count).toBe(1);
+  await settleIdle(owner, { ...first, turn: firstResult.turn, attemptId: firstResult.attemptId });
+  const secondResult = await claim(other, first.session.id);
+  if (secondResult.action !== "claimed") throw new Error("second result was not claimed");
+  expect(secondResult.turn.initiatingHumanSubjectId).toBe(other.subjectId);
+});
+
+test("command launch identity rejects another session, attempt and later rewrites", async () => {
+  const grant = await workspace();
+  const first = await startSession(grant, { message: "command" });
+  const other = await startSession(grant, { message: "other" });
+  const command = await connectedCommand(grant, first);
+  await expect(
+    adoptConnectedMachineSessionBackgroundCommand(client.db, {
+      ...command.input,
+      attemptId: other.attemptId,
+    }),
+  ).rejects.toThrow();
+  await expect(
+    adoptConnectedMachineSessionBackgroundCommand(client.db, {
+      ...command.input,
+      sessionId: other.session.id,
+    }),
+  ).rejects.toThrow();
+  await expect(
+    Promise.resolve(
+      shared.admin`update session_background_commands set launch_turn_id=${other.turn.id} where id=${command.identity.commandId}`,
+    ),
+  ).rejects.toThrow("immutable");
+});
+
+async function recoverLegacyCausalUpdate(grant: Grant, parent: Started, sourceId: string) {
+  // Simulate pre-fix producer authority fields while retaining exact payload,
+  // source receipt, pending event and lifecycle history.
+  await shared.admin`update session_system_updates set lineage = lineage - 'causalTurnId' - 'causalAttemptId' - 'causalExecutionGeneration' where session_id=${parent.session.id} and source_id=${sourceId}`;
+  const [update] =
+    await shared.admin`select id from session_system_updates where session_id=${parent.session.id} and source_id=${sourceId} and state='pending'`;
+  expect(update).toBeDefined();
+  await failSessionWorkBeforeAttemptClaim(client.db, grant.workspaceId, {
+    accountId: grant.accountId,
+    sessionId: parent.session.id,
+    workflowId: `session-${parent.session.id}`,
+    trigger: { kind: "next" },
+    error: "Agent turn admission failed before attempt claim.",
+  });
+  const failureSequence = await lastSequence(parent.session.id);
+  const input = {
+    accountId: grant.accountId,
+    sessionId: parent.session.id,
+    workflowId: `session-${parent.session.id}`,
+    operationId: crypto.randomUUID(),
+    expectedFailureEventSequence: failureSequence,
+    expectedLastSequence: failureSequence,
+    failedUpdateIds: [String(update!.id)],
+  };
+  expect(
+    await recoverSessionWorkFailedBeforeAttemptClaim(client.db, grant.workspaceId, {
+      ...input,
+      failedUpdateIds: [crypto.randomUUID()],
+    }),
+  ).toEqual({ action: "stale", event: null });
+  expect(
+    await recoverSessionWorkFailedBeforeAttemptClaim(client.db, grant.workspaceId, input),
+  ).toMatchObject({ action: "recovered", restoredUpdateIds: input.failedUpdateIds });
+  expect(
+    await recoverSessionWorkFailedBeforeAttemptClaim(client.db, grant.workspaceId, input),
+  ).toMatchObject({ action: "already_recovered" });
+}
+
+test("a command successor cannot revive a revoked personal grant", async () => {
+  const { grant, variableSetId } = await managedWorkspaceWithPersonalVariableSet();
+  const parent = await startSession(grant, {
+    message: "start command",
+    personalVariableSetId: variableSetId,
+  });
+  const command = await connectedCommand(grant, parent);
+  await settleIdle(grant, parent);
+  await shared.admin`update organization_user_resource_grants set status='revoked', revoked_at=clock_timestamp(), generation=generation+1 where id in (select grant_id from session_attempt_personal_resource_snapshots where attempt_id=${parent.attemptId})`;
+  await command.finish();
+  await expect(claim(grant, parent.session.id)).rejects.toThrow();
+});
+
+test("legacy unattributed commands cannot borrow a coalesced command human", async () => {
+  const grant = await workspace();
+  const parent = await startSession(grant, { message: "start command" });
+  const good = await connectedCommand(grant, parent);
+  const legacy = { ...good.identity, commandId: crypto.randomUUID(), opId: crypto.randomUUID() };
+  await shared.admin`insert into session_background_commands ${shared.admin({
+    id: legacy.commandId,
+    account_id: grant.accountId,
+    workspace_id: grant.workspaceId,
+    session_id: parent.session.id,
+    provider: "connected_machine",
+    state: "running",
+    control_workspace_id: grant.workspaceId,
+    enrollment_id: legacy.enrollmentId,
+    connection_instance_id: legacy.connectionInstanceId,
+    op_id: legacy.opId,
+  })}`;
+  await expect(
+    adoptConnectedMachineSessionBackgroundCommand(client.db, {
+      ...good.input,
+      ...legacy,
+    }),
+  ).rejects.toThrow("another identity");
+  const [legacyReceipt] =
+    await shared.admin`select launch_turn_id from session_background_commands where id=${legacy.commandId}`;
+  expect(legacyReceipt?.launch_turn_id).toBeNull();
+  await settleIdle(grant, parent);
+  await good.finish();
+  await settleConnectedMachineSessionBackgroundCommand(client.db, {
+    ...legacy,
+    outcome: "exited",
+    exitCode: 0,
+    reason: "done",
+  });
+  const goodResult = await claim(grant, parent.session.id);
+  if (goodResult.action !== "claimed") throw new Error("good command not claimed");
+  expect(goodResult.turn.initiatingHumanSubjectId).toBe(grant.subjectId);
+  await settleIdle(grant, { ...parent, turn: goodResult.turn, attemptId: goodResult.attemptId });
+  const legacyResult = await claim(grant, parent.session.id);
+  if (legacyResult.action !== "claimed") throw new Error("legacy command not claimed");
+  expect(legacyResult.turn.initiatingHumanSubjectId).toBeNull();
+});
+
+test("migration rejects a mismatched launch receipt and a partial identity", async () => {
+  const grant = await workspace();
+  const parent = await startSession(grant, { message: "parent" });
+  const other = await startSession(grant, { message: "other" });
+  const row = {
+    id: crypto.randomUUID(),
+    account_id: grant.accountId,
+    workspace_id: grant.workspaceId,
+    session_id: parent.session.id,
+    provider: "connected_machine",
+    state: "running",
+    control_workspace_id: grant.workspaceId,
+    enrollment_id: crypto.randomUUID(),
+    connection_instance_id: crypto.randomUUID(),
+    op_id: crypto.randomUUID(),
+    launch_turn_id: other.turn.id,
+    launch_attempt_id: other.attemptId,
+    launch_execution_generation: other.turn.executionGeneration,
+  };
+  await expect(
+    Promise.resolve(shared.admin`insert into session_background_commands ${shared.admin(row)}`),
+  ).rejects.toThrow("launch attempt does not match session");
+  await expect(
+    Promise.resolve(
+      shared.admin`insert into session_background_commands ${shared.admin({
+        ...row,
+        launch_turn_id: parent.turn.id,
+        launch_attempt_id: parent.attemptId,
+        launch_execution_generation: null,
+      })}`,
+    ),
+  ).rejects.toThrow("launch_identity_check");
+});
+
+test("0419 launch validation resolves its dedicated data schema", async () => {
+  const schemaName = `command_launch_${crypto.randomUUID().replaceAll("-", "")}`;
+  const migration = await readFile(
+    new URL("../drizzle/0419_background_command_launch_authority.sql", import.meta.url),
+    "utf8",
+  );
+  await shared.admin.begin(async (tx) => {
+    await tx.unsafe(`create schema "${schemaName}"`);
+    await tx`select set_config('search_path', ${schemaName}, true)`;
+    await tx.unsafe(`
+      create table session_turns (id uuid, workspace_id uuid, session_id uuid, account_id uuid);
+      create table session_turn_attempts (id uuid, turn_id uuid, workspace_id uuid, session_id uuid, account_id uuid, execution_generation int);
+      create table session_background_commands (
+        id uuid, account_id uuid, workspace_id uuid, session_id uuid, provider text,
+        retained_process_id uuid, control_workspace_id uuid, enrollment_id uuid,
+        connection_instance_id text, op_id text
+      );`);
+    await tx.unsafe(migration);
+    const account = crypto.randomUUID(),
+      dataWorkspaceId = crypto.randomUUID(),
+      session = crypto.randomUUID(),
+      turn = crypto.randomUUID(),
+      attempt = crypto.randomUUID();
+    await tx`insert into session_turns values (${turn},${dataWorkspaceId},${session},${account})`;
+    await tx`insert into session_turn_attempts values (${attempt},${turn},${dataWorkspaceId},${session},${account},1)`;
+    await tx`insert into session_background_commands (id,account_id,workspace_id,session_id,provider,launch_turn_id,launch_attempt_id,launch_execution_generation)
+      values (${crypto.randomUUID()},${account},${dataWorkspaceId},${session},'connected_machine',${turn},${attempt},1)`;
+    const [count] = await tx`select count(*)::int as count from session_background_commands`;
+    expect(count?.count).toBe(1);
+    await tx.unsafe(`drop schema "${schemaName}" cascade`);
   });
 });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,7 +131,9 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe("0418_site_direct_uploads.sql");
+    expect(completeSourceContract.latestMigration).toBe(
+      "0419_background_command_launch_authority.sql",
+    );
     const sandboxDeadlineIndex = completeSourceContract.migrations.findIndex(
       (migration) => migration.path === "0397_sandbox_deadline_rotation_preemption.sql",
     );
@@ -248,6 +250,9 @@ describe("release schema contract", () => {
     );
     const siteDirectUploads = completeSourceContract.migrations.some(
       (migration) => migration.path === "0418_site_direct_uploads.sql",
+    );
+    const backgroundCommandLaunchAuthority = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0419_background_command_launch_authority.sql",
     );
     const commandRunnerFailureMetadata = completeSourceContract.migrations.some(
       (migration) => migration.path === "0417_command_runner_failure_metadata.sql",
@@ -685,6 +690,7 @@ describe("release schema contract", () => {
       "0416_scheduled_inherited_tool_admission.sql",
       "0417_command_runner_failure_metadata.sql",
       "0418_site_direct_uploads.sql",
+      "0419_background_command_launch_authority.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -740,6 +746,7 @@ describe("release schema contract", () => {
         (newSessionDraftProjectProvenanceBackfill ? 1 : 0) +
         (commandCompletionObservation ? 1 : 0) +
         (siteDirectUploads ? 1 : 0) +
+        (backgroundCommandLaunchAuthority ? 1 : 0) +
         (commandRunnerFailureMetadata ? 1 : 0) +
         (scheduledInheritedToolAdmission ? 1 : 0) +
         (scheduledGeneratedProducerMaterialization ? 1 : 0) +
@@ -983,6 +990,9 @@ describe("release schema contract", () => {
             latestMigration: "0412_new_session_draft_project_provenance_validation.sql",
           }
         : {}),
+      ...(backgroundCommandLaunchAuthority
+        ? { latestMigration: "0419_background_command_launch_authority.sql" }
+        : {}),
       ...(sessionFilterActivity ? { latestMigration: "0413_session_filter_activity.sql" } : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
@@ -1064,6 +1074,9 @@ describe("release schema contract", () => {
     );
     const siteDirectUploads = completeSourceContract.migrations.some(
       (migration) => migration.path === "0418_site_direct_uploads.sql",
+    );
+    const backgroundCommandLaunchAuthority = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0419_background_command_launch_authority.sql",
     );
     const commandRunnerFailureMetadata = completeSourceContract.migrations.some(
       (migration) => migration.path === "0417_command_runner_failure_metadata.sql",
@@ -1378,6 +1391,7 @@ describe("release schema contract", () => {
       "0416_scheduled_inherited_tool_admission.sql",
       "0417_command_runner_failure_metadata.sql",
       "0418_site_direct_uploads.sql",
+      "0419_background_command_launch_authority.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -1667,6 +1681,7 @@ describe("release schema contract", () => {
         (newSessionDraftProjectProvenanceBackfill ? 1 : 0) +
         (commandCompletionObservation ? 1 : 0) +
         (siteDirectUploads ? 1 : 0) +
+        (backgroundCommandLaunchAuthority ? 1 : 0) +
         (commandRunnerFailureMetadata ? 1 : 0) +
         (scheduledGeneratedProducerMaterialization ? 1 : 0) +
         (newSessionDraftProjectProvenanceValidation ? 1 : 0) +
@@ -1912,6 +1927,9 @@ describe("release schema contract", () => {
         ? {
             latestMigration: "0412_new_session_draft_project_provenance_validation.sql",
           }
+        : {}),
+      ...(backgroundCommandLaunchAuthority
+        ? { latestMigration: "0419_background_command_launch_authority.sql" }
         : {}),
       ...(sessionFilterActivity ? { latestMigration: "0413_session_filter_activity.sql" } : {}),
     });


### PR DESCRIPTION
Background command completions and input-wait timeouts lost their original human authority, so a session with an attached personal Variable Set failed before its next attempt. Preserve the exact launch/waiting turn and eligible successor authority, while keeping different causal turns separate and normal once/revocation checks intact.

Migration 0419 adds immutable launch turn/attempt/generation receipts for both command providers. Existing managed receipts support exact legacy replay; unattributed Connected Machine rows stay service-owned. The existing exact-set pre-claim recovery can restore only proven, unconsumed root command/timeout inputs, without replaying an accepted turn.

Tracking: https://linear.app/cloudgeni/issue/OPE-452/preserve-exact-command-launch-human-authority-in-background-result

Validation:
- 46 tests / 517 assertions: PostgreSQL lifecycle, managed/current/legacy and old-writer replay, dedicated schema, two-human isolation, once/revoked denial, recovery/idempotency, command observation and schema contracts.
- Actual managed-auth HTTP session creation and personal Variable Set acceptance passes 21 assertions; the identical test fails with 42501 on untouched 107aa146b.
- Exact-head full repository types, lint/format, all 11 impact guards, fresh package build/publish closure and changeset validation pass.
- Parent and runtime independent reviews approved 7e544c948b42703312d91560a8864ff9fc952a4b before publication.

0419 is additive and rolling. No deployment or live session recovery is included.

## Summary by Sourcery

Preserve exact human authority for background command and input-wait continuations without broadening personal grants or conflating causal turns.

Bug Fixes:
- Preserve the originating human authority across background command results and input-wait timeout continuations, allowing personal Variable Set sessions to continue with the correct authorization.

Enhancements:
- Record immutable command launch receipts and exact timeout causality while keeping different human turns isolated and preserving existing once-use and revocation enforcement.
- Support safe recovery of proven, unconsumed pre-claim command and timeout failures without replaying accepted turns or assigning authority to unattributed legacy Connected Machine commands.

Documentation:
- Document command and timeout causal-authority inheritance, legacy behavior, recovery constraints, and rolling migration requirements.

Tests:
- Add lifecycle coverage for managed and Connected Machine commands, timeout continuations, legacy replay, human isolation, grant limits, revocation, recovery, idempotency, and migration schema validation.