### PR TITLE
fix(web): clear sent composer uploads

### DIFF
--- a/apps/web/src/lib/use-follow-up-repositories.ts
+++ b/apps/web/src/lib/use-follow-up-repositories.ts
@@ -1,4 +1,8 @@
-import { mergeResourceRefs } from "@opengeni/contracts";
+import {
+  mergeResourceRefs,
+  normalizeRepositoryTransportUri,
+  stableJson,
+} from "@opengeni/contracts";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -10,6 +14,23 @@ import {
   type RepoDraft,
 } from "@/lib/session-tools";
 import type { GitHubRepository, ResourceRef, Session } from "@/types";
+
+type RepositoryResource = Extract<ResourceRef, { kind: "repository" }>;
+
+function manualDraftSignature(draft: RepoDraft): string | null {
+  try {
+    const uri = normalizeRepositoryTransportUri(
+      draft.url.includes("://") ? draft.url : `https://${draft.url}`,
+    );
+    return `${uri}\u0000${draft.ref.trim()}\u0000${draft.expectedCommitSha ?? ""}`;
+  } catch {
+    return null;
+  }
+}
+
+function manualResourceSignature(resource: RepositoryResource): string {
+  return `${resource.uri}\u0000${resource.ref}\u0000${resource.expectedCommitSha ?? ""}`;
+}
 
 /**
  * Session-scoped repository additions for the follow-up composer. Session
@@ -135,6 +156,8 @@ export function useFollowUpRepositories(session: Session): {
     pendingRepoIds,
     pendingRepoRefs,
   ]);
+  const pendingResourcesRef = useRef(pendingBuild.resources);
+  pendingResourcesRef.current = pendingBuild.resources;
   const selectionCount =
     selectedRepoIds.size +
     selectedPersonalRepoIds.size +
@@ -508,13 +531,71 @@ export function useFollowUpRepositories(session: Session): {
     );
     if (repositories.length === 0) return;
     setOptimisticMountedRepos((current) => mergeResourceRefs(current, repositories));
-    // The picker is disabled during delivery, so every pending selection belongs
-    // to the immutable wire input accepted by this callback.
-    setPendingRepoIds(new Set());
-    setPendingRepoRefs({});
-    setPendingPersonalRepoIds(new Set());
-    setPendingPersonalRepoRefs({});
-    setPendingManualRepos([]);
+
+    // An optimistic Send can be accepted after the picker becomes editable
+    // again. Remove only pending selections represented by this immutable wire
+    // snapshot; later additions must remain queued for the next message.
+    const acceptedKeys = new Set(repositories.map(stableJson));
+    const pendingResources = pendingResourcesRef.current;
+    const acceptedRepoIds = new Set(
+      pendingResources.flatMap((resource) =>
+        resource.kind === "repository" &&
+        resource.githubRepositoryId !== undefined &&
+        acceptedKeys.has(stableJson(resource))
+          ? [resource.githubRepositoryId]
+          : [],
+      ),
+    );
+    const acceptedPersonalRepoIds = new Set(
+      pendingResources.flatMap((resource) =>
+        resource.kind === "repository" &&
+        resource.connectionType === "github_personal" &&
+        typeof resource.repositoryId === "string" &&
+        acceptedKeys.has(stableJson(resource))
+          ? [resource.repositoryId]
+          : [],
+      ),
+    );
+    const acceptedManualDraftKeys = new Set(
+      pendingResources.flatMap((resource) => {
+        if (
+          resource.kind !== "repository" ||
+          resource.connectionType === "github_personal" ||
+          resource.githubRepositoryId !== undefined ||
+          resource.githubInstallationId !== undefined ||
+          !acceptedKeys.has(stableJson(resource))
+        ) {
+          return [];
+        }
+        return [manualResourceSignature(resource)];
+      }),
+    );
+
+    setPendingRepoIds((current) => {
+      const next = new Set([...current].filter((id) => !acceptedRepoIds.has(id)));
+      return next.size === current.size ? current : next;
+    });
+    setPendingRepoRefs((current) => {
+      const next = { ...current };
+      for (const id of acceptedRepoIds) delete next[id];
+      return Object.keys(next).length === Object.keys(current).length ? current : next;
+    });
+    setPendingPersonalRepoIds((current) => {
+      const next = new Set([...current].filter((id) => !acceptedPersonalRepoIds.has(id)));
+      return next.size === current.size ? current : next;
+    });
+    setPendingPersonalRepoRefs((current) => {
+      const next = { ...current };
+      for (const id of acceptedPersonalRepoIds) delete next[id];
+      return Object.keys(next).length === Object.keys(current).length ? current : next;
+    });
+    setPendingManualRepos((current) => {
+      const next = current.filter((draft) => {
+        const signature = manualDraftSignature(draft);
+        return signature === null || !acceptedManualDraftKeys.has(signature);
+      });
+      return next.length === current.length ? current : next;
+    });
   }, []);
 
   return {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1559,7 +1559,18 @@ function SessionChatPane(props: {
       );
       repositories.commitSent(input.resources ?? []);
     },
-    onSent: (_text, input) => personalAttachment.onAccepted(input),
+    // Steer and recovered sends do not pass through onSubmitted. Keep the
+    // host-owned upload/repository queue in sync once those inputs are
+    // accepted too; the immutable input snapshot preserves later additions.
+    onSent: (_text, input) => {
+      attachments.removeReadyFiles(
+        (input.resources ?? []).flatMap((resource) =>
+          resource.kind === "file" ? [resource.fileId] : [],
+        ),
+      );
+      repositories.commitSent(input.resources ?? []);
+      personalAttachment.onAccepted(input);
+    },
     onDeliveryError: personalAttachment.onDeliveryError,
   });
   useBrowserAccountBridgeBlocker(`session-composer:${props.session.id}`, () => {

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -2677,6 +2677,39 @@ describe("useComposer queue-vs-steer", () => {
     await hook.unmount();
   });
 
+  test("accepted Steer reports host-owned resources through onSent", async () => {
+    let submitted: SendMessageInput | undefined;
+    let accepted: SendMessageInput | undefined;
+    const client = fakeClient({
+      steerMessage: async (_ws, _session, input) => {
+        if (typeof input !== "string") submitted = input;
+        return steerResult();
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: {
+            resources: [{ kind: "file", fileId: "steered-file" }],
+          },
+          onSent: (_text, input) => {
+            accepted = input;
+          },
+        }),
+      undefined,
+    );
+
+    await flushing(async () => {
+      expect(await hook.result.current.steer("do this immediately")).toBe(true);
+    });
+
+    expect(submitted?.resources).toEqual([{ kind: "file", fileId: "steered-file" }]);
+    expect(accepted?.resources).toEqual([{ kind: "file", fileId: "steered-file" }]);
+    await hook.unmount();
+  });
+
   test("projects Steer immediately, keeps it accepted, then settles when execution starts", async () => {
     let resolveSteer!: (value: SteerMessageResult) => void;
     const pendingSteer = new Promise<SteerMessageResult>((resolve) => {


### PR DESCRIPTION
## Root cause
Host-owned file attachments were removed only from the normal `onSubmitted` path. Steer and recovered sends call `onSent` instead, so the accepted file remained rendered in the composer draft.

## Fix
- Remove accepted file IDs from host attachment state in `onSent`.
- Commit accepted repository resources there as well.
- Make repository cleanup snapshot-safe so selections added after an optimistic send remain queued.
- Add regression coverage for accepted Steer resources.

## Verification
- `bun test packages/react/test/hooks.test.tsx packages/react/test/use-file-attachments.test.tsx packages/react/test/chat-composer-uploads.test.tsx`
- `bun run typecheck`
- targeted Oxlint
- `bun run format:check`
- `git diff --check`

## Summary by Sourcery

Keep composer-owned uploads and repository selections synchronized across all accepted message-send paths.

Bug Fixes:
- Clear accepted file attachments and repository selections when messages are sent through Steer or recovered-send paths.
- Preserve repository selections added after an optimistic send for the next message.

Tests:
- Add regression coverage confirming that accepted Steer messages report host-owned resources through the sent callback.