### PR TITLE
fix(runtime): support Site skills in read-only worker installations

### DIFF
--- a/.changeset/quiet-sites-readonly.md
+++ b/.changeset/quiet-sites-readonly.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Compose Site package-version metadata in the skill manifest without writing into the worker application directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1271,11 +1271,10 @@ human-input forms, and timeline history. `ChatComposer` remains the lower-level
 input surface, not an implicit queue or whole conversation. Sites use the same
 component with their standard Site-bound SDK client.
 
-Site authoring installs exact npm package versions from the runtime-generated
-`package-versions.json` beside the skill. The manifest carries this generated
-file without writing into the worker's application directory. Stable defaults come from source
-package manifests; canary deployments set `OPENGENI_SITE_PACKAGE_VERSIONS` to
-their published SDK/React/Codemode version map. Only local development enables
+Site authoring installs exact npm versions from `package-versions.json`, generated
+in the skill manifest without worker-directory writes. Stable defaults use source
+manifests; canaries set `OPENGENI_SITE_PACKAGE_VERSIONS` to their published
+SDK/React/Codemode versions. Only local development enables
 `OPENGENI_LOCAL_SITE_PACKAGES` and packages dirty checkout source into archives
 at `/opt/opengeni/site-packages`; deployed images do not bake those archives.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1272,7 +1272,8 @@ input surface, not an implicit queue or whole conversation. Sites use the same
 component with their standard Site-bound SDK client.
 
 Site authoring installs exact npm package versions from the runtime-generated
-`package-versions.json` beside the skill. Stable defaults come from source
+`package-versions.json` beside the skill. The manifest carries this generated
+file without writing into the worker's application directory. Stable defaults come from source
 package manifests; canary deployments set `OPENGENI_SITE_PACKAGE_VERSIONS` to
 their published SDK/React/Codemode version map. Only local development enables
 `OPENGENI_LOCAL_SITE_PACKAGES` and packages dirty checkout source into archives

--- a/packages/runtime/src/runtime-skills.ts
+++ b/packages/runtime/src/runtime-skills.ts
@@ -3,9 +3,9 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   renameSync,
   rmSync,
-  writeFileSync,
 } from "node:fs";
 import { sitePackageVersions } from "./site-package-versions";
 import { dirname, isAbsolute, join, relative } from "node:path";
@@ -112,7 +112,6 @@ const emptyNativeToolSkillSet: NativeToolSkillSet = Object.freeze({
 });
 
 let stagedBundledArtifactSkillsDir: string | null = null;
-let stagedBundledSiteSkillsDir: string | null = null;
 let stagedBundledVideoSkillsDir: string | null = null;
 
 /**
@@ -141,7 +140,7 @@ export function composeRuntimeSkills(
   const children: Record<string, Entry> = {};
   for (const source of nativeSources) {
     for (const name of source.names) {
-      children[name] = localDir({ src: join(source.directory, name) });
+      children[name] = source.entries?.[name] ?? localDir({ src: join(source.directory, name) });
     }
   }
 
@@ -292,12 +291,14 @@ function selectionForActivation({
 
 function nativeToolSkillSources(nativeTools: NativeToolSkillSet): Array<{
   directory: string;
+  entries?: Record<string, Entry>;
   lazySource: LocalDirLazySkillSource;
   names: string[];
   reason: string;
 }> {
   const sources: Array<{
     directory: string;
+    entries?: Record<string, Entry>;
     lazySource: LocalDirLazySkillSource;
     names: string[];
     reason: string;
@@ -312,9 +313,13 @@ function nativeToolSkillSources(nativeTools: NativeToolSkillSet): Array<{
     });
   }
   if (nativeTools.sites) {
-    const directory = bundledSiteSkillsDir();
+    const directory = packagedSkillDirectory("bundled_site_skills");
+    const site = bundledSkillEntry(join(directory, "opengeni-sites"), {
+      "package-versions.json": file({ content: JSON.stringify(sitePackageVersions(), null, 2) }),
+    });
     sources.push({
       directory,
+      entries: { "opengeni-sites": site },
       lazySource: localDirLazySkillSource({ src: directory }),
       names: skillDirNames(directory),
       reason: "bundled Site authoring skill",
@@ -355,19 +360,16 @@ function bundledArtifactSkillsDir(): string {
   return stagedBundledArtifactSkillsDir;
 }
 
-function bundledSiteSkillsDir(): string {
-  const packaged = packagedSkillDirectory("bundled_site_skills");
-  if (!stagedBundledSiteSkillsDir) {
-    stagedBundledSiteSkillsDir = stageSkillDirectory(
-      packaged,
-      join(process.cwd(), ".opengeni", "bundled_site_skills"),
-    );
-    writeFileSync(
-      join(stagedBundledSiteSkillsDir, "opengeni-sites", "package-versions.json"),
-      JSON.stringify(sitePackageVersions(), null, 2),
-    );
+/** Compose generated metadata in the manifest, never in the installed application. */
+function bundledSkillEntry(directory: string, overrides: Record<string, Entry> = {}): Dir {
+  const children: Record<string, Entry> = {};
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    children[entry.name] = entry.isDirectory()
+      ? bundledSkillEntry(path)
+      : file({ content: readFileSync(path, "utf8") });
   }
-  return stagedBundledSiteSkillsDir;
+  return dir({ children: { ...children, ...overrides } });
 }
 
 function bundledVideoSkillsDir(): string {

--- a/packages/runtime/src/runtime-skills.ts
+++ b/packages/runtime/src/runtime-skills.ts
@@ -320,7 +320,7 @@ function nativeToolSkillSources(nativeTools: NativeToolSkillSet): Array<{
     sources.push({
       directory,
       entries: { "opengeni-sites": site },
-      lazySource: localDirLazySkillSource({ src: directory }),
+      lazySource: localDirLazySkillSource({ src: directory, baseDir: directory }),
       names: skillDirNames(directory),
       reason: "bundled Site authoring skill",
     });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -11116,12 +11116,8 @@ describe("runtime Skill activation", () => {
     });
     const index = enabled.lazySource.getIndex?.(emptyManifest, ".agents") ?? [];
     expect(index.map((entry) => entry.name)).toContain("opengeni-sites");
-    const packagePins = JSON.parse(
-      readFileSync(
-        join(process.cwd(), ".opengeni/bundled_site_skills/opengeni-sites/package-versions.json"),
-        "utf8",
-      ),
-    );
+    const siteSource = (enabled.lazySource.source as any).children["opengeni-sites"];
+    const packagePins = JSON.parse(siteSource.children["package-versions.json"].content);
     expect(Object.keys(packagePins).sort()).toEqual([
       "@opengeni/codemode",
       "@opengeni/react",

--- a/packages/runtime/test/site-skill-readonly.test.ts
+++ b/packages/runtime/test/site-skill-readonly.test.ts
@@ -25,6 +25,8 @@ test("Site skill composition needs no writable application directory", () => {
         sites: true, editableArtifacts: false, videoGeneration: false,
       });
       const site = composition.lazySource.source.children["opengeni-sites"];
+      const index = composition.lazySource.getIndex({ extraPathGrants: [] }, ".agents");
+      if (!index.some(entry => entry.name === "opengeni-sites")) throw new Error("missing skill index");
       if (!site.children["SKILL.md"].content.includes("OpenGeni")) throw new Error("missing skill");
       if (!site.children.agents.children["openai.yaml"].content) throw new Error("missing nested asset");
       console.log(site.children["package-versions.json"].content);

--- a/packages/runtime/test/site-skill-readonly.test.ts
+++ b/packages/runtime/test/site-skill-readonly.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("Site skill composition needs no writable application directory", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "opengeni-readonly-skill-"));
+  try {
+    // Fail any attempt to create the former worker-local staging directory,
+    // including when tests run as root and chmod would not enforce read-only.
+    writeFileSync(join(cwd, ".opengeni"), "not a directory");
+    const modulePath = new URL("../src/runtime-skills.ts", import.meta.url).pathname;
+    const pins = {
+      "@opengeni/sdk": "3.7.1-canary.2",
+      "@opengeni/react": "3.7.1-canary.2",
+      "@opengeni/codemode": "0.4.28-canary.2",
+    };
+    const result = Bun.spawnSync(
+      [
+        process.execPath,
+        "--eval",
+        `
+      const { composeRuntimeSkills } = await import(${JSON.stringify(modulePath)});
+      const composition = composeRuntimeSkills([], {
+        sites: true, editableArtifacts: false, videoGeneration: false,
+      });
+      const site = composition.lazySource.source.children["opengeni-sites"];
+      if (!site.children["SKILL.md"].content.includes("OpenGeni")) throw new Error("missing skill");
+      if (!site.children.agents.children["openai.yaml"].content) throw new Error("missing nested asset");
+      console.log(site.children["package-versions.json"].content);
+    `,
+      ],
+      {
+        cwd,
+        env: { ...process.env, OPENGENI_SITE_PACKAGE_VERSIONS: JSON.stringify(pins) },
+      },
+    );
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.toString())).toEqual(pins);
+    expect(readdirSync(cwd)).toEqual([".opengeni"]);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Compose deployment package pins as a virtual skill manifest file, without writing into the application installation.
- Preserve bundled skill content and nested assets alongside exact deployment versions.
- Add a regression test that makes the former staging path unusable even under root.

## Verification
- Runtime typecheck passed.
- 19 runtime Skill activation tests passed.
- Read-only application regression and package pin validation passed.

No migrations or SDK API changes.

## Summary by Sourcery

Compose Site package-version metadata in the skill manifest so read-only worker installations can activate bundled Site skills safely.

Bug Fixes:
- Support Site skill activation in read-only worker application installations without creating local staging directories.

Enhancements:
- Preserve bundled Site skill files and nested assets while composing deployment package metadata directly in the skill manifest.

Documentation:
- Document that Site package versions are generated in the skill manifest without worker-directory writes.

Tests:
- Add regression coverage ensuring Site skill composition works when the former staging path cannot be created and preserves package pins and nested assets.