### PR TITLE
feat: add workspace pause and resume duration timers

### DIFF
--- a/.changeset/workspace-pause-durations.md
+++ b/.changeset/workspace-pause-durations.md
@@ -1,0 +1,12 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/core": minor
+"@opengeni/sdk": minor
+"@opengeni/api-router": minor
+"@opengeni/worker-bundle": minor
+---
+
+Add durable workspace pause/resume timers with duration controls, countdowns,
+manual cancellation, and idempotent worker execution. Migration 0420 requires a
+maintenance deployment: drain old writers and deploy matching API/workers.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1975,6 +1975,10 @@ const routeLabelPatterns: Array<{
     label: "/v1/workspaces/:workspaceId/inference-control",
   },
   {
+    pattern: /^\/v1\/workspaces\/[^/]+\/pause-timer$/,
+    label: "/v1/workspaces/:workspaceId/pause-timer",
+  },
+  {
     pattern:
       /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/fs\/(list|list-batch|read|write|delete|move|mkdir)$/,
     label: "/v1/workspaces/:workspaceId/sessions/:id/fs/:operation",

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -1,3 +1,5 @@
+import { SessionControlConflictError, WorkspacePauseTimerInputError } from "@opengeni/db";
+import { WorkspacePauseTimerRequest } from "@opengeni/contracts";
 import { createHash } from "node:crypto";
 import {
   AddWorkspaceMemberRequest,
@@ -95,6 +97,7 @@ import {
   assertWorkspaceMemberRemovable,
   assertWorkspaceMemberUpdateAllowed,
   controlHumanWorkspace,
+  controlHumanWorkspaceTimer,
 } from "@opengeni/core";
 import { boundedLimit } from "../http/common";
 import { ApiHttpError } from "../http/api-error";
@@ -822,6 +825,39 @@ export function registerWorkspaceRoutes(app: Hono, deps: ApiRouteDeps): void {
       allowedModels: canonicalWorkspacePolicyModelIds(catalog.settings, payload.allowedModels),
     });
     return c.json(policy);
+  });
+
+  app.post("/v1/workspaces/:workspaceId/pause-timer", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+    if (workspaceControlUtf8Bytes(grant.subjectId) > WORKSPACE_CONTROL_ACTOR_MAX_BYTES) {
+      throw new HTTPException(400, { message: "workspace-control actor is too large" });
+    }
+    const parsed = WorkspacePauseTimerRequest.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) throw new HTTPException(400, { message: "Invalid pause timer" });
+    try {
+      await controlHumanWorkspaceTimer(
+        {
+          db: deps.db,
+          bus: deps.bus,
+          workflowClient: deps.workflowClient,
+          ...(deps.schedulePromptPostCommit
+            ? { schedulePromptPostCommit: deps.schedulePromptPostCommit }
+            : {}),
+        },
+        { accountId: grant.accountId, workspaceId, subjectId: grant.subjectId },
+        parsed.data,
+      );
+    } catch (error) {
+      if (error instanceof SessionControlConflictError)
+        throw new HTTPException(409, {
+          message: "Workspace changed. Reopen the timer and try again.",
+        });
+      if (error instanceof WorkspacePauseTimerInputError)
+        throw new HTTPException(400, { message: error.message });
+      throw error;
+    }
+    return c.json({ ok: true });
   });
 
   app.post("/v1/workspaces/:workspaceId/inference-control", async (c) => {

--- a/apps/api/test/workspace-control-events.test.ts
+++ b/apps/api/test/workspace-control-events.test.ts
@@ -249,3 +249,25 @@ describe("workspace control event API", () => {
     expect(countBoundSecond.headers.get("X-OpenGeni-Next-After")).toBe("2");
   });
 });
+
+test("pause timers require workspace admin even for an authenticated workspace reader", async () => {
+  const token = await signDelegatedAccessToken(SECRET, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    subjectId: grant.subjectId,
+    permissions: ["workspace:read"],
+    principalKind: "human_session",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  const response = await app.request(`http://x/v1/workspaces/${grant.workspaceId}/pause-timer`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      action: "set",
+      pauseInSeconds: 60,
+      clientEventId: crypto.randomUUID(),
+      expectedRevision: 0,
+    }),
+  });
+  expect(response.status).toBe(403);
+});

--- a/apps/web/src/components/workspace-runtime-control.tsx
+++ b/apps/web/src/components/workspace-runtime-control.tsx
@@ -1,0 +1,331 @@
+import { OpenGeniApiError } from "@opengeni/sdk";
+import { useEffect, useId, useState } from "react";
+import { ChevronDownIcon, Clock3Icon, Loader2Icon, PauseIcon, PlayIcon } from "lucide-react";
+import type { Workspace, WorkspacePauseTimerRequest } from "@opengeni/contracts";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+type Control = Workspace["inferenceControl"];
+export function durationLabel(seconds: number): string {
+  const minutes = Math.max(1, Math.ceil(seconds / 60));
+  const hours = Math.floor(minutes / 60);
+  return hours ? `${hours} hr${minutes % 60 ? ` ${minutes % 60} min` : ""}` : `${minutes} min`;
+}
+export function workspaceTimerLabel(control: Control, now: number): string | null {
+  const timer = control.timer;
+  if (!timer) return control.state === "paused" ? "Paused until you resume" : null;
+  const remaining = (Date.parse(timer.dueAt) - now) / 1000;
+  if (remaining <= 0) return timer.action === "pause" ? "Pausing…" : "Resuming…";
+  return timer.action === "resume"
+    ? `Resumes in ${durationLabel(remaining)}`
+    : `Pauses in ${durationLabel(remaining)} · ${timer.pauseForSeconds ? `for ${durationLabel(timer.pauseForSeconds)}` : "until resumed"}`;
+}
+
+function DurationField(props: {
+  label: string;
+  special?: string;
+  value: number | null;
+  onChange: (value: number | null) => void;
+  disabled: boolean;
+}) {
+  const id = useId();
+  const presets = [900, 1800, 3600, 7200];
+  const [custom, setCustom] = useState(props.value !== null && !presets.includes(props.value));
+  const [unit, setUnit] = useState(60);
+  return (
+    <div className="grid gap-2">
+      <label className="text-xs font-medium text-fg-muted" htmlFor={id}>
+        {props.label}
+      </label>
+      <Select
+        id={id}
+        disabled={props.disabled}
+        value={custom ? "custom" : props.value === null ? "special" : String(props.value)}
+        onChange={(event) => {
+          const value = event.target.value;
+          setCustom(value === "custom");
+          props.onChange(value === "special" ? null : value === "custom" ? 1800 : Number(value));
+        }}
+      >
+        {props.special ? <option value="special">{props.special}</option> : null}
+        <option value="900">15 minutes</option>
+        <option value="1800">30 minutes</option>
+        <option value="3600">1 hour</option>
+        <option value="7200">2 hours</option>
+        <option value="custom">Custom…</option>
+      </Select>
+      {custom ? (
+        <div className="flex gap-2">
+          <Input
+            className="min-w-0 flex-1"
+            type="number"
+            aria-label={`${props.label} amount`}
+            min={1}
+            max={2592000 / unit}
+            step={1}
+            disabled={props.disabled}
+            value={props.value === null || !Number.isFinite(props.value) ? "" : props.value / unit}
+            onChange={(event) =>
+              props.onChange(
+                event.target.value === "" ? Number.NaN : Number(event.target.value) * unit,
+              )
+            }
+          />
+          <div className="w-28 shrink-0 [&>span]:w-full">
+            <Select
+              aria-label={`${props.label} unit`}
+              value={unit}
+              disabled={props.disabled}
+              onChange={(event) => {
+                const next = Number(event.target.value);
+                props.onChange(((props.value ?? 1800) / unit) * next);
+                setUnit(next);
+              }}
+            >
+              <option value={60}>Minutes</option>
+              <option value={3600}>Hours</option>
+            </Select>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function WorkspaceRuntimeControl(props: {
+  control: Control;
+  canManage: boolean;
+  onControl: (action: "pause" | "resume") => Promise<void>;
+  onTimer: (
+    request: Omit<WorkspacePauseTimerRequest, "clientEventId" | "expectedRevision">,
+    revision: number,
+  ) => Promise<void>;
+  onRefresh: () => Promise<void>;
+}) {
+  const { control, onRefresh } = props;
+  const paused = control.state === "paused";
+  const [open, setOpen] = useState(false);
+  const [editingPaused, setEditingPaused] = useState(paused);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pauseIn, setPauseIn] = useState<number | null>(null);
+  const [pauseFor, setPauseFor] = useState<number | null>(null);
+  const [editingRevision, setEditingRevision] = useState(control.revision);
+  const [now, setNow] = useState(Date.now());
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {
+    setOffset(control.serverTime ? Date.parse(control.serverTime) - Date.now() : 0);
+  }, [control.serverTime]);
+  useEffect(() => {
+    if (!control.timer) return;
+    const tick = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, [control.timer]);
+  useEffect(() => {
+    // SSE is the fast path. A bounded refresh also repairs a missed event or worker restart.
+    if (!control.timer) return;
+    const tick = setInterval(() => {
+      void onRefresh().catch(() => undefined);
+    }, 10000);
+    return () => clearInterval(tick);
+  }, [control.timer, onRefresh]);
+  const label = workspaceTimerLabel(control, now + offset);
+  const validDuration = (value: number | null) =>
+    value === null || (Number.isInteger(value) && value >= 60 && value <= 2592000);
+  const valid =
+    validDuration(pauseIn) && validDuration(pauseFor) && (!editingPaused || pauseFor !== null);
+  function editTimer() {
+    setEditingRevision(control.revision);
+    setEditingPaused(paused);
+    setPauseIn(
+      control.timer?.action === "pause"
+        ? Math.max(60, Math.ceil((Date.parse(control.timer.dueAt) - now - offset) / 60000) * 60)
+        : null,
+    );
+    setPauseFor(
+      control.timer?.action === "resume"
+        ? Math.max(60, Math.ceil((Date.parse(control.timer.dueAt) - now - offset) / 60000) * 60)
+        : (control.timer?.pauseForSeconds ?? (paused ? 1800 : null)),
+    );
+    setError(null);
+    setOpen(true);
+  }
+  async function run(action: () => Promise<void>) {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+      setOpen(false);
+    } catch (failure) {
+      setError(
+        failure instanceof OpenGeniApiError && failure.status === 409
+          ? "Workspace changed. Close and reopen the timer to use the latest state."
+          : "Couldn't update the workspace. Please try again.",
+      );
+      void props.onRefresh().catch(() => undefined);
+    } finally {
+      setBusy(false);
+    }
+  }
+  const preview = !valid
+    ? "Choose a whole duration between 1 minute and 30 days."
+    : editingPaused
+      ? `Resume after ${durationLabel(pauseFor!)}.`
+      : `${pauseIn ? `Pause in ${durationLabel(pauseIn)}` : "Pause now"}${pauseFor ? `, then resume after ${durationLabel(pauseFor)}.` : ", until you resume."}`;
+  return (
+    <section
+      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border p-4"
+      aria-label="Workspace runtime"
+    >
+      <div>
+        <h2 className="text-sm font-medium">Workspace runtime</h2>
+        <p className="mt-1 text-xs text-fg-muted">
+          {paused
+            ? "New agent work is paused for this workspace."
+            : "Agents can start and continue work in this workspace."}
+        </p>
+        {label ? (
+          <button
+            type="button"
+            disabled={!props.canManage || busy}
+            onClick={editTimer}
+            className="mt-2 flex items-center gap-1.5 text-xs text-fg-muted hover:text-fg disabled:cursor-default"
+            aria-label={`${label}. Edit pause timer`}
+          >
+            <Clock3Icon className="size-3" aria-hidden="true" />
+            {label}
+          </button>
+        ) : null}
+        {error && !open ? (
+          <p role="alert" className="mt-2 text-xs text-status-error">
+            {error}
+          </p>
+        ) : null}
+      </div>
+      {props.canManage ? (
+        <div className="flex items-center">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="rounded-r-none"
+            disabled={busy}
+            onClick={() => void run(() => props.onControl(paused ? "resume" : "pause"))}
+          >
+            {busy ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : paused ? (
+              <PlayIcon className="size-3.5" />
+            ) : (
+              <PauseIcon className="size-3.5" />
+            )}
+            {paused ? "Resume workspace" : "Pause workspace"}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="rounded-l-none border-l border-border px-2"
+            disabled={busy}
+            onClick={editTimer}
+            aria-label="Pause timer"
+            aria-haspopup="dialog"
+          >
+            <ChevronDownIcon className="size-3.5" />
+          </Button>
+        </div>
+      ) : null}
+      <Dialog
+        open={open}
+        onOpenChange={(value) => {
+          if (!busy) setOpen(value);
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{editingPaused ? "Resume timer" : "Pause timer"}</DialogTitle>
+            <DialogDescription>Give your workspace a break.</DialogDescription>
+          </DialogHeader>
+          <form
+            className="grid gap-5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (valid)
+                void run(() =>
+                  props.onTimer(
+                    {
+                      action: "set",
+                      pauseInSeconds: editingPaused ? 0 : (pauseIn ?? 0),
+                      pauseForSeconds: pauseFor,
+                    },
+                    editingRevision,
+                  ),
+                );
+            }}
+          >
+            {!editingPaused ? (
+              <DurationField
+                key={`in-${editingRevision}`}
+                label="Pause in"
+                special="Now"
+                value={pauseIn}
+                onChange={setPauseIn}
+                disabled={busy}
+              />
+            ) : null}
+            <DurationField
+              key={`for-${editingRevision}`}
+              label={editingPaused ? "Resume in" : "Pause for"}
+              special={editingPaused ? undefined : "Until I resume"}
+              value={pauseFor}
+              onChange={setPauseFor}
+              disabled={busy}
+            />
+            <p className="text-xs leading-relaxed text-fg-muted" aria-live="polite">
+              {preview}
+            </p>
+            {error ? (
+              <p role="alert" className="text-xs text-status-error">
+                {error}
+              </p>
+            ) : null}
+            <div className="flex items-center justify-between gap-2">
+              {control.timer ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() =>
+                    void run(() => props.onTimer({ action: "cancel" }, editingRevision))
+                  }
+                >
+                  Cancel timer
+                </Button>
+              ) : (
+                <span />
+              )}
+              <Button type="submit" size="sm" disabled={busy || !valid}>
+                {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+                {!editingPaused && pauseIn === null ? "Pause now" : "Set timer"}
+              </Button>
+            </div>
+            {editingPaused && control.timer ? (
+              <p className="-mt-3 text-xs text-fg-muted">
+                Cancelling the timer leaves the workspace paused.
+              </p>
+            ) : null}
+          </form>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/context-principal-transition.test.ts
+++ b/apps/web/src/context-principal-transition.test.ts
@@ -180,7 +180,7 @@ describe("principal transition contract", () => {
 
   test("mutation callers do not toast, refresh, or announce stale results", () => {
     expect(workspaceSettingsSource).toContain(
-      "const updated = await context.setWorkspaceInferenceControl(workspaceId, action)",
+      "await context.setWorkspaceInferenceControl(workspaceId, action)",
     );
     expect(transcriptionSettingsSource).toContain(
       "const updated = await context.updateWorkspaceSettings(workspaceId",

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -1,3 +1,4 @@
+import { WorkspaceRuntimeControl } from "@/components/workspace-runtime-control";
 // Workspace settings hub: browse links to workspace config surfaces, then
 // name/rename, members, API keys, memory/transcription/Codex policy, Codex
 // subscriptions, and a danger zone with workspace deletion. The org/billing
@@ -10,9 +11,7 @@ import {
   CopyIcon,
   KeyRoundIcon,
   Loader2Icon,
-  PauseIcon,
   PencilIcon,
-  PlayIcon,
   PlusIcon,
   ShrinkIcon,
   Trash2Icon,
@@ -154,7 +153,6 @@ function OperationalWorkspaceSettingsRoute({
   const [createKeyOpen, setCreateKeyOpen] = useState(false);
   const [revokingKey, setRevokingKey] = useState<ApiKey | null>(null);
   const [busy, setBusy] = useState(false);
-  const [controlBusy, setControlBusy] = useState(false);
   const [gatewayRevision, setGatewayRevision] = useState(0);
   const canManageApiKeys = hasWorkspacePermission(
     context.accessContext,
@@ -232,26 +230,6 @@ function OperationalWorkspaceSettingsRoute({
   function cancelRename() {
     setNameDraft(activeWorkspace?.name ?? "");
     setNameEditing(false);
-  }
-
-  async function toggleWorkspaceControl() {
-    if (!activeWorkspace || !canRename || controlBusy) return;
-    const acceptedTransition = context.captureWorkspaceInvocation(workspaceId);
-    if (!acceptedTransition) return;
-    const action = activeWorkspace.inferenceControl.state === "paused" ? "resume" : "pause";
-    setControlBusy(true);
-    try {
-      const updated = await context.setWorkspaceInferenceControl(workspaceId, action);
-      if (updated && context.ownsWorkspaceInvocation(workspaceId, acceptedTransition)) {
-        toast.success(action === "pause" ? "Workspace paused" : "Workspace resumed");
-      }
-    } catch (error) {
-      toast.error(`Couldn't ${action} the workspace`, {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setControlBusy(false);
-    }
   }
 
   async function createKey() {
@@ -441,36 +419,28 @@ function OperationalWorkspaceSettingsRoute({
               ) : null}
             </section>
 
-            <section className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border p-4">
-              <div>
-                <h2 className="text-sm font-medium">Workspace runtime</h2>
-                <p className="mt-1 text-xs text-fg-muted">
-                  {activeWorkspace?.inferenceControl.state === "paused"
-                    ? "New agent work is paused for this workspace."
-                    : "Agents can start and continue work in this workspace."}
-                </p>
-              </div>
-              {canRename ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled={controlBusy}
-                  onClick={() => void toggleWorkspaceControl()}
-                >
-                  {controlBusy ? (
-                    <Loader2Icon className="size-3.5 animate-spin" />
-                  ) : activeWorkspace?.inferenceControl.state === "paused" ? (
-                    <PlayIcon className="size-3.5" />
-                  ) : (
-                    <PauseIcon className="size-3.5" />
-                  )}
-                  {activeWorkspace?.inferenceControl.state === "paused"
-                    ? "Resume workspace"
-                    : "Pause workspace"}
-                </Button>
-              ) : null}
-            </section>
+            {activeWorkspace ? (
+              <WorkspaceRuntimeControl
+                key={workspaceId}
+                control={activeWorkspace.inferenceControl}
+                canManage={canRename}
+                onControl={async (action) => {
+                  await context.setWorkspaceInferenceControl(workspaceId, action);
+                }}
+                onRefresh={() => context.refreshWorkspace(workspaceId)}
+                onTimer={async (request, expectedRevision) => {
+                  const accepted = context.captureWorkspaceInvocation(workspaceId);
+                  if (!accepted) return;
+                  await context.client.setWorkspacePauseTimer(workspaceId, {
+                    ...request,
+                    expectedRevision,
+                    clientEventId: crypto.randomUUID(),
+                  });
+                  if (context.ownsWorkspaceInvocation(workspaceId, accepted))
+                    await context.refreshWorkspace(workspaceId);
+                }}
+              />
+            ) : null}
 
             {personal ? <PersonalWorkspaceNotice organizationLabel={organizationLabel} /> : null}
 

--- a/apps/worker/src/activities/workflow-wake.ts
+++ b/apps/worker/src/activities/workflow-wake.ts
@@ -1,3 +1,11 @@
+import {
+  fireWorkspacePauseTimerInTransaction,
+  listDueWorkspacePauseTimers,
+  withWorkspaceRls,
+  getWorkspaceControlEvent,
+  type Database,
+} from "@opengeni/db";
+import { publishDurableWorkspaceControlEvent } from "@opengeni/events";
 import type { ControlActivityServices } from "./types";
 import {
   reconcileAutomaticSessionTitleFanout,
@@ -24,6 +32,34 @@ export function createWorkflowWakeActivities(services: () => Promise<ControlActi
   return {
     async dispatchSessionWorkflowWakes(): Promise<DispatchSessionWorkflowWakesResult> {
       const service = await services();
+      // Timer commits produce ordinary durable wakes; drain those below in the same sweep.
+      const timers = await listDueWorkspacePauseTimers(service.db, 100);
+      for (const timer of timers) {
+        try {
+          const result = await withWorkspaceRls(service.db, timer.workspace_id, (scoped) =>
+            scoped.transaction((tx) =>
+              fireWorkspacePauseTimerInTransaction(tx as unknown as Database, {
+                workspaceId: timer.workspace_id,
+                timerId: timer.timer_id,
+              }),
+            ),
+          );
+          if (result?.workspaceControlEventId) {
+            const event = await getWorkspaceControlEvent(
+              service.db,
+              timer.workspace_id,
+              result.workspaceControlEventId,
+            );
+            if (event)
+              await publishDurableWorkspaceControlEvent(service.bus, timer.workspace_id, event);
+          }
+        } catch (error) {
+          service.observability.warn("Workspace pause timer will retry", {
+            workspaceId: timer.workspace_id,
+            error: String(error),
+          });
+        }
+      }
       let claimed = 0;
       let delivered = 0;
       let failed = 0;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1638,3 +1638,14 @@ not an append-only ledger of everything the repository has ever learned.
 Agent goal lifecycle exposes `goal_resume` alongside `goal_pause`: any pause reason or actor is resumable; active goals return unchanged. See `docs/goals.md`.
 
 Filtered session page ownership and its maintenance boundary: [session pagination](session-pagination.md).
+
+### Workspace pause durations
+
+Workspace pause timers persist on `workspace_inference_controls` and execute
+under the workspace control fence through the control-worker wake sweep.
+Manual controls cancel pending automation; a timer resumes only its own pause
+revision. The API accepts durations, Postgres owns deadlines, and clients render
+countdowns. Canonical: `packages/db/src/session-control.ts`,
+`apps/worker/src/activities/workflow-wake.ts`, and
+`apps/web/src/components/workspace-runtime-control.tsx`.
+See [workspace pause timers](workspace-pause-timers.md) for behavior and rollout.

--- a/docs/workspace-pause-timers.md
+++ b/docs/workspace-pause-timers.md
@@ -1,0 +1,45 @@
+# Workspace pause timers
+
+Workspace settings → General retains the immediate Pause/Resume button. The
+adjacent chevron opens Pause in (Now or duration) and Pause for (Until I resume
+or duration). Already paused: Resume in. Presets: 15/30 minutes, 1/2 hours.
+Custom: whole minutes/hours, one minute–30 days. Click the countdown to edit.
+
+One timer per workspace. Cancel timer preserves runtime state. Manual
+Pause/Resume cancels automation, even a desired-state no-op. Exact retries do
+not modify newer timers. A combined timer measures Pause for from the actual
+admission pause. After downtime, an overdue pause starts its full duration;
+an overdue resume runs on recovery. Independent session pauses retain their
+existing semantics; cancelled work is never revived.
+
+`POST /v1/workspaces/:workspaceId/pause-timer` requires workspace admin:
+`action: set | cancel`, `clientEventId`, `expectedRevision`, optional
+`pauseInSeconds` and nullable `pauseForSeconds`. Already paused requires zero
+Pause in and a resume duration. Invalid input/state: 400. Stale revision: 409.
+SDK: `setWorkspacePauseTimer`. Workspace projection includes
+`inferenceControl.timer` and `serverTime` for relative countdowns.
+
+Postgres owns deadlines on `workspace_inference_controls`. The existing control
+fence serializes edits, manual actions and execution. Timer/phase receipt keys
+make retries idempotent; automatic resume checks its original pause revision.
+The control-worker wake dispatcher processes up to 100 due timers per sweep,
+normally every ten seconds, then drains normal durable wakes. No browser or
+agent inference is required. Workspace events refresh clients; the settings
+view also refreshes every ten seconds while a timer exists. Execution occurs
+on the next available sweep, not as a precise alarm.
+
+Migration 0420 is **maintenance-only**. Drain old API, control and turn workers
+before migration; deploy the matching version everywhere. Older writers do not
+cancel timers and older clients reject timer event actions. Do not restart old
+writers after activation.
+
+Verification:
+
+- `bun test packages/db/test/workspace-pause-timers.test.ts`
+- `bun test apps/api/test/workspace-control-events.test.ts`
+- `bun scripts/run-browser-e2e.ts ./test/e2e/workspace-pause-timers.browser.e2e.ts`
+
+The browser suite uses the real API, non-superuser PostgreSQL and actual worker
+sweep. It advances test-database deadlines to verify transitions quickly and
+captures runtime, editor, saving, validation, transition, conflict and mobile
+states to `OPENGENI_TIMER_SCREENSHOTS` (default `/tmp/opengeni-pause-timer-screenshots`).

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1560,6 +1560,30 @@ export const ManagedAccount = z.object({
 });
 export type ManagedAccount = z.infer<typeof ManagedAccount>;
 
+export const WorkspacePauseTimer = z.object({
+  id: z.string().uuid(),
+  action: z.enum(["pause", "resume"]),
+  dueAt: z.string().datetime(),
+  pauseForSeconds: z.number().int().min(60).max(2592000).nullable(),
+});
+export type WorkspacePauseTimer = z.infer<typeof WorkspacePauseTimer>;
+export const WorkspacePauseTimerRequest = z
+  .object({
+    action: z.enum(["set", "cancel"]),
+    pauseInSeconds: z
+      .number()
+      .int()
+      .min(0)
+      .max(2592000)
+      .refine((v) => v === 0 || v >= 60)
+      .optional(),
+    pauseForSeconds: z.number().int().min(60).max(2592000).nullable().optional(),
+    clientEventId: z.string().min(1).max(200),
+    expectedRevision: z.number().int().nonnegative(),
+  })
+  .strict();
+export type WorkspacePauseTimerRequest = z.infer<typeof WorkspacePauseTimerRequest>;
+
 export const Workspace = z.object({
   id: z.string().uuid(),
   accountId: z.string().uuid(),
@@ -1579,6 +1603,8 @@ export const Workspace = z.object({
   // PATCH merges so newer settings survive an older server.
   settings: z.record(z.string(), z.unknown()),
   inferenceControl: z.object({
+    timer: WorkspacePauseTimer.nullable().optional(),
+    serverTime: z.string().optional(),
     state: z.enum(["active", "paused"]),
     revision: z.number().int().nonnegative(),
     reason: z.string().nullable(),
@@ -7369,7 +7395,7 @@ export const WorkspaceControlEvent = z.object({
   type: z.literal("workspace.control.changed"),
   scope: z.enum(["workspace", "session"]),
   rootSessionId: z.string().uuid().nullable(),
-  action: z.enum(["pause", "resume"]),
+  action: z.enum(["pause", "resume", "timer_set", "timer_cancelled"]),
   automatic: z.boolean(),
   reason: z.string().nullable(),
   actor: z.string().min(1),

--- a/packages/core/src/application/session-commands.ts
+++ b/packages/core/src/application/session-commands.ts
@@ -28,6 +28,7 @@ import {
   moveQueuedTurnInTransaction,
   mutateSessionControlInTransaction,
   mutateWorkspaceControlInTransaction,
+  setWorkspacePauseTimerInTransaction,
   projectEffectiveControlForRelatedAccess,
   runIdempotentPersistenceTransaction,
   saveComposerDraftInTransaction,
@@ -1064,4 +1065,35 @@ export async function saveHumanComposerDraft(
       ),
   );
   return composerDraft(row)!;
+}
+
+export async function controlHumanWorkspaceTimer(
+  deps: Parameters<typeof controlHumanWorkspace>[0],
+  context: Parameters<typeof controlHumanWorkspace>[1],
+  input: import("@opengeni/contracts").WorkspacePauseTimerRequest,
+): Promise<void> {
+  const result = await withWorkspaceRls(deps.db, context.workspaceId, (scoped) =>
+    scoped.transaction((tx) =>
+      setWorkspacePauseTimerInTransaction(tx as unknown as Database, {
+        ...input,
+        ...context,
+      }),
+    ),
+  );
+  scheduleSessionCommandPostCommit(deps, "human_workspace_timer", [
+    ...(result.workspaceControlEventId
+      ? [
+          {
+            kind: "workspace_control_fanout" as const,
+            run: async () =>
+              await publishWorkspaceControlEvent(
+                deps,
+                context.workspaceId,
+                result.workspaceControlEventId!,
+              ),
+          },
+        ]
+      : []),
+    { kind: "workflow_wake" as const, run: async () => await requestControlWakeDispatch(deps, 1) },
+  ]);
 }

--- a/packages/db/drizzle/0420_workspace_pause_timers.sql
+++ b/packages/db/drizzle/0420_workspace_pause_timers.sql
@@ -1,0 +1,53 @@
+-- deployment-mode: maintenance
+-- Drain old API/control/turn workers before activation. New timer event actions
+-- and manual-control cancellation semantics must be installed together.
+ALTER TABLE workspace_inference_controls
+  ADD COLUMN timer_id uuid,
+  ADD COLUMN timer_action text,
+  ADD COLUMN timer_due_at timestamptz,
+  ADD COLUMN timer_pause_for_seconds integer,
+  ADD COLUMN timer_pause_revision bigint,
+  ADD CONSTRAINT workspace_pause_timer_shape CHECK (
+    (timer_id IS NULL AND timer_action IS NULL AND timer_due_at IS NULL
+      AND timer_pause_for_seconds IS NULL AND timer_pause_revision IS NULL)
+    OR (timer_id IS NOT NULL AND timer_action IS NOT NULL AND timer_due_at IS NOT NULL
+      AND ((timer_action = 'pause' AND timer_pause_revision IS NULL)
+        OR (timer_action = 'resume' AND timer_pause_revision IS NOT NULL AND timer_pause_for_seconds IS NULL))
+      AND (timer_pause_for_seconds IS NULL OR timer_pause_for_seconds BETWEEN 60 AND 2592000))
+  );
+CREATE INDEX workspace_pause_timer_due_idx ON workspace_inference_controls(timer_due_at, workspace_id)
+  WHERE timer_id IS NOT NULL;
+ALTER TABLE workspace_control_events DROP CONSTRAINT workspace_control_events_action_check;
+ALTER TABLE workspace_control_events ADD CONSTRAINT workspace_control_events_action_check
+  CHECK (action IN ('pause', 'resume', 'timer_set', 'timer_cancelled'));
+
+-- Narrow, read-only inventory capability. FORCE RLS stays enabled; only the
+-- table owner inside this SECURITY DEFINER function gets cross-tenant discovery.
+DO $migration$
+DECLARE data_schema text := current_schema(); owner_name text := current_user;
+BEGIN
+  EXECUTE format('CREATE POLICY workspace_pause_timer_discovery ON %I.workspace_inference_controls
+    FOR SELECT TO %I USING (current_setting(''opengeni.pause_timer_discovery'', true) = ''1'')',
+    data_schema, owner_name);
+  EXECUTE format($create$
+    CREATE FUNCTION opengeni_private.list_due_workspace_pause_timers(p_limit integer)
+    RETURNS TABLE(workspace_id uuid, timer_id uuid)
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+    AS $body$
+    DECLARE previous text := current_setting('opengeni.pause_timer_discovery', true);
+    BEGIN
+      PERFORM set_config('opengeni.pause_timer_discovery', '1', true);
+      RETURN QUERY SELECT c.workspace_id, c.timer_id FROM %I.workspace_inference_controls c
+        WHERE c.timer_id IS NOT NULL AND c.timer_due_at <= clock_timestamp()
+        ORDER BY c.timer_due_at, c.workspace_id LIMIT greatest(1, least(coalesce(p_limit, 100), 1000));
+      PERFORM set_config('opengeni.pause_timer_discovery', coalesce(previous, ''), true);
+    END $body$;
+  $create$, data_schema);
+END $migration$;
+REVOKE ALL ON FUNCTION opengeni_private.list_due_workspace_pause_timers(integer) FROM PUBLIC;
+DO $grant$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.list_due_workspace_pause_timers(integer) TO opengeni_app;
+  END IF;
+END $grant$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -75741,6 +75741,15 @@ async function workspaceControlProjection(
       .limit(1);
     if (!control) throw new Error(`Workspace ${workspaceId} has no inference control`);
     return {
+      timer: control.timerId
+        ? {
+            id: control.timerId,
+            action: control.timerAction as "pause" | "resume",
+            dueAt: control.timerDueAt!.toISOString(),
+            pauseForSeconds: control.timerPauseForSeconds,
+          }
+        : null,
+      serverTime: new Date().toISOString(),
       state: control.workspaceState as "active" | "paused",
       revision: Number(control.revision),
       reason: control.reason,
@@ -76470,3 +76479,15 @@ export * from "./session-tenancy";
 export * from "./governed-learning-activation";
 export * from "./automations";
 export * from "./organization-model-providers";
+
+export {
+  setWorkspacePauseTimerInTransaction,
+  fireWorkspacePauseTimerInTransaction,
+} from "./session-control";
+
+export async function listDueWorkspacePauseTimers(db: Database, limit = 100) {
+  return await rawRows<{ workspace_id: string; timer_id: string }>(
+    db,
+    sql`select * from opengeni_private.list_due_workspace_pause_timers(${limit})`,
+  );
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -405,6 +405,11 @@ export const workspaceInferenceControls = pgTable(
     accountId: uuid("account_id").notNull(),
     revision: bigint("revision", { mode: "number" }).notNull().default(0),
     workspaceState: text("workspace_state").notNull().default("active"),
+    timerId: uuid("timer_id"),
+    timerAction: text("timer_action"),
+    timerDueAt: timestamp("timer_due_at", { withTimezone: true }),
+    timerPauseForSeconds: integer("timer_pause_for_seconds"),
+    timerPauseRevision: bigint("timer_pause_revision", { mode: "number" }),
     workspacePauseRevision: bigint("workspace_pause_revision", {
       mode: "number",
     }),
@@ -420,6 +425,20 @@ export const workspaceInferenceControls = pgTable(
       columns: [table.workspaceId, table.accountId],
       foreignColumns: [workspaces.id, workspaces.accountId],
     }).onDelete("cascade"),
+    timerDue: index("workspace_pause_timer_due_idx")
+      .on(table.timerDueAt, table.workspaceId)
+      .where(sql`${table.timerId} is not null`),
+    timerShape: check(
+      "workspace_pause_timer_shape",
+      sql`
+      (${table.timerId} is null and ${table.timerAction} is null and ${table.timerDueAt} is null
+        and ${table.timerPauseForSeconds} is null and ${table.timerPauseRevision} is null)
+      or (${table.timerId} is not null and ${table.timerAction} is not null and ${table.timerDueAt} is not null
+        and ((${table.timerAction} = 'pause' and ${table.timerPauseRevision} is null)
+          or (${table.timerAction} = 'resume' and ${table.timerPauseRevision} is not null and ${table.timerPauseForSeconds} is null))
+        and (${table.timerPauseForSeconds} is null or ${table.timerPauseForSeconds} between 60 and 2592000))
+    `,
+    ),
     workspaceAccountIdentity: uniqueIndex("workspace_inference_controls_workspace_account_uq").on(
       table.workspaceId,
       table.accountId,
@@ -7526,7 +7545,7 @@ export const workspaceControlEvents = pgTable(
     ),
     actionValid: check(
       "workspace_control_events_action_check",
-      sql`${table.action} in ('pause', 'resume')`,
+      sql`${table.action} in ('pause', 'resume', 'timer_set', 'timer_cancelled')`,
     ),
   }),
 );

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -4,6 +4,7 @@ import {
   childPausedClassification,
   McpPersonalConnectionDelegations,
   workspaceControlUtf8Bytes,
+  type WorkspacePauseTimerRequest,
   type SessionMcpApprovalPolicy,
   type TurnInitiatorContext,
 } from "@opengeni/contracts";
@@ -176,6 +177,11 @@ export type WorkspaceControlRow = {
   revision: number | string;
   workspaceState: string;
   workspacePauseRevision: number | string | null;
+  timerId: string | null;
+  timerAction: string | null;
+  timerDueAt: Date | string | null;
+  timerPauseForSeconds: number | null;
+  timerPauseRevision: number | string | null;
   reason: string | null;
   changedBy: string | null;
   changedAt: Date | string | null;
@@ -546,6 +552,9 @@ export async function lockWorkspaceInferenceControl(
         revision,
         workspace_state as "workspaceState",
         workspace_pause_revision as "workspacePauseRevision",
+        timer_id as "timerId", timer_action as "timerAction",
+        timer_due_at as "timerDueAt", timer_pause_for_seconds as "timerPauseForSeconds",
+        timer_pause_revision as "timerPauseRevision",
         reason,
         changed_by as "changedBy",
         changed_at as "changedAt"
@@ -3921,6 +3930,8 @@ export async function mutateWorkspaceControlInTransaction(
     operationKey: string;
     action: "pause" | "resume";
     reason?: string | null;
+    /** Internal timer executor retains/replaces its own timer atomically. */
+    timerExecution?: boolean;
     expectedRevision?: number | null;
     /** Request-scoped callers bound the control prefix wait; lifecycle callers omit it. */
     controlLockTimeoutMs?: number;
@@ -3986,7 +3997,8 @@ export async function mutateWorkspaceControlInTransaction(
     "workspace pause revision",
   );
   const changed =
-    input.action === "pause"
+    (!input.timerExecution && workspace.timerId != null) ||
+    (input.action === "pause"
       ? workspace.workspaceState !== "paused" ||
         workspacePauseRevision === null ||
         (await workspacePauseEffectsNeeded(db, {
@@ -3997,7 +4009,7 @@ export async function mutateWorkspaceControlInTransaction(
         (await continuableWakeRepairNeeded(db, {
           workspaceId: input.workspaceId,
           rootSessionId: null,
-        }));
+        })));
   if (!changed) {
     const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
       result: {
@@ -4035,6 +4047,7 @@ export async function mutateWorkspaceControlInTransaction(
   const [updated] = await db
     .update(schema.workspaceInferenceControls)
     .set({
+      ...(!input.timerExecution ? clearWorkspaceTimerFields : {}),
       revision,
       workspaceState: input.action === "pause" ? "paused" : "active",
       workspacePauseRevision: input.action === "pause" ? revision : null,
@@ -4060,7 +4073,7 @@ export async function mutateWorkspaceControlInTransaction(
     scope: "workspace",
     rootSessionId: null,
     action: input.action,
-    automatic: false,
+    automatic: input.timerExecution === true,
     reason: input.reason ?? null,
     actor,
   });
@@ -4113,7 +4126,7 @@ async function insertWorkspaceControlEventInTransaction(
     revision: number;
     scope: "workspace" | "session";
     rootSessionId: string | null;
-    action: "pause" | "resume";
+    action: "pause" | "resume" | "timer_set" | "timer_cancelled";
     automatic: boolean;
     reason: string | null;
     actor: string;
@@ -4156,4 +4169,164 @@ async function insertWorkspaceControlEventInTransaction(
     throw new SessionControlInvariantError("Workspace control event was not inserted");
   }
   return event.id;
+}
+
+export class WorkspacePauseTimerInputError extends Error {}
+
+const clearWorkspaceTimerFields = {
+  timerId: null,
+  timerAction: null,
+  timerDueAt: null,
+  timerPauseForSeconds: null,
+  timerPauseRevision: null,
+};
+
+/** Called under workspace RLS. The same control fence serializes timers and human actions. */
+export async function setWorkspacePauseTimerInTransaction(
+  db: Database,
+  input: WorkspacePauseTimerRequest & { accountId: string; workspaceId: string; subjectId: string },
+): Promise<{ workspaceControlEventId: string | null }> {
+  let workspace = await lockWorkspaceInferenceControl(db, input.workspaceId, "update", {
+    lockTimeoutMs: workspaceControlRequestLockTimeoutMs(),
+  });
+  const reserved = await reserveSessionCommandReceipt(db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    actor: { type: "human", subjectId: input.subjectId },
+    action: `workspace.timer.${input.action}`,
+    targetSessionId: null,
+    targetTurnId: null,
+    operationKey: input.clientEventId,
+    canonicalRequestHash: canonicalSessionCommandHash({
+      action: input.action,
+      pauseInSeconds: input.pauseInSeconds ?? 0,
+      pauseForSeconds: input.pauseForSeconds ?? null,
+      expectedRevision: input.expectedRevision,
+    }),
+  });
+  if (reserved.replay)
+    return {
+      workspaceControlEventId:
+        (reserved.receipt.result.workspaceControlEventId as string | null) ?? null,
+    };
+  if (Number(workspace.revision) !== input.expectedRevision)
+    throw new SessionControlConflictError();
+  let action: "pause" | "resume" = "pause";
+  let delay = input.pauseInSeconds ?? 0;
+  let pauseRevision: number | null = null;
+  if (input.action === "set") {
+    if (workspace.workspaceState === "paused") {
+      if (delay !== 0 || input.pauseForSeconds == null) {
+        throw new WorkspacePauseTimerInputError("A paused workspace requires a resume duration");
+      }
+      action = "resume";
+      delay = input.pauseForSeconds;
+      pauseRevision = Number(workspace.workspacePauseRevision);
+    } else if (delay === 0) {
+      await mutateWorkspaceControlInTransaction(db, {
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        actor: { type: "human", subjectId: input.subjectId },
+        operationKey: `timer-pause:${reserved.receipt.id}`,
+        action: "pause",
+      });
+      workspace = await lockWorkspaceInferenceControl(db, input.workspaceId, "update");
+      action = "resume";
+      delay = input.pauseForSeconds ?? 0;
+      pauseRevision = Number(workspace.workspacePauseRevision);
+    }
+  }
+  const hasTimer = input.action === "set" && delay > 0;
+  const [clock] = await db.execute<{ now: Date }>(sql`select clock_timestamp() as now`);
+  const revision = nextRevision(workspace);
+  await db
+    .update(schema.workspaceInferenceControls)
+    .set({
+      ...clearWorkspaceTimerFields,
+      ...(hasTimer
+        ? {
+            timerId: reserved.receipt.id,
+            timerAction: action,
+            timerDueAt: new Date(new Date(clock!.now).getTime() + delay * 1000),
+            timerPauseForSeconds: action === "pause" ? (input.pauseForSeconds ?? null) : null,
+            timerPauseRevision: pauseRevision,
+          }
+        : {}),
+      revision,
+      updatedAt: new Date(clock!.now),
+    })
+    .where(eq(schema.workspaceInferenceControls.workspaceId, input.workspaceId));
+  const workspaceControlEventId = await insertWorkspaceControlEventInTransaction(db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    revision,
+    scope: "workspace",
+    rootSessionId: null,
+    action: hasTimer ? "timer_set" : "timer_cancelled",
+    automatic: false,
+    reason: null,
+    actor: input.subjectId,
+  });
+  await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
+    controlRevision: revision,
+    result: { workspaceControlEventId },
+  });
+  return { workspaceControlEventId };
+}
+
+/** Discovery is a hint. Identity, deadline and pause ownership are rechecked under the fence. */
+export async function fireWorkspacePauseTimerInTransaction(
+  db: Database,
+  input: { workspaceId: string; timerId: string },
+): Promise<{ workspaceControlEventId: string | null; wakeCount: number } | null> {
+  const workspace = await lockWorkspaceInferenceControl(db, input.workspaceId, "update", {
+    lockTimeoutMs: 1000,
+  });
+  const [clock] = await db.execute<{ now: Date }>(sql`select clock_timestamp() as now`);
+  if (
+    workspace.timerId !== input.timerId ||
+    !workspace.timerDueAt ||
+    new Date(workspace.timerDueAt).getTime() > new Date(clock!.now).getTime()
+  )
+    return null;
+  const action = workspace.timerAction as "pause" | "resume";
+  // A superseding pause must never be undone by an old timer, even across rolling upgrades.
+  if (
+    action === "resume" &&
+    (workspace.workspaceState !== "paused" ||
+      Number(workspace.workspacePauseRevision) !== Number(workspace.timerPauseRevision))
+  ) {
+    await db
+      .update(schema.workspaceInferenceControls)
+      .set(clearWorkspaceTimerFields)
+      .where(eq(schema.workspaceInferenceControls.workspaceId, input.workspaceId));
+    return null;
+  }
+  const result = await mutateWorkspaceControlInTransaction(db, {
+    accountId: workspace.accountId,
+    workspaceId: input.workspaceId,
+    actor: { type: "service", subjectId: "service:workspace-pause-timer" },
+    operationKey: `timer:${input.timerId}:${action}`,
+    action,
+    timerExecution: true,
+  });
+  // Use application time only for display elsewhere; deadlines are database-clock based.
+  const [applied] = await db.execute<{ now: Date }>(sql`select clock_timestamp() as now`);
+  await db
+    .update(schema.workspaceInferenceControls)
+    .set({
+      ...clearWorkspaceTimerFields,
+      ...(action === "pause" && workspace.timerPauseForSeconds !== null
+        ? {
+            timerId: input.timerId,
+            timerAction: "resume",
+            timerDueAt: new Date(
+              new Date(applied!.now).getTime() + workspace.timerPauseForSeconds * 1000,
+            ),
+            timerPauseRevision: result.revision,
+          }
+        : {}),
+    })
+    .where(eq(schema.workspaceInferenceControls.workspaceId, input.workspaceId));
+  return result;
 }

--- a/packages/db/test/workspace-pause-timers.test.ts
+++ b/packages/db/test/workspace-pause-timers.test.ts
@@ -1,0 +1,253 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import {
+  bootstrapWorkspace,
+  createDb,
+  getWorkspace,
+  withWorkspaceRls,
+  listDueWorkspacePauseTimers,
+  setWorkspacePauseTimerInTransaction,
+  fireWorkspacePauseTimerInTransaction,
+  mutateWorkspaceControlInTransaction,
+  type Database,
+} from "../src/index";
+let shared: SharedTestDatabase;
+let client: ReturnType<typeof createDb>;
+beforeAll(async () => {
+  shared = (await acquireSharedTestDatabase("workspace-pause-timers"))!;
+  if (!shared) throw new Error("Real PostgreSQL required");
+  client = createDb(shared.appUrl);
+}, 180_000);
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+});
+async function fixture() {
+  const id = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: id,
+    accountName: "Timers",
+    workspaceExternalSource: "test",
+    workspaceExternalId: id,
+    workspaceName: "Timers",
+    subjectId: id,
+  });
+  const grant = access.workspaceGrants[0]!;
+  const context = { accountId: grant.accountId, workspaceId: grant.workspaceId!, subjectId: id };
+  const transaction = <T>(fn: (db: Database) => Promise<T>) =>
+    withWorkspaceRls(client.db, context.workspaceId, (scoped) =>
+      scoped.transaction((tx) => fn(tx as unknown as Database)),
+    );
+  const control = async () =>
+    (await getWorkspace(client.db, context.workspaceId))!.inferenceControl;
+  const set = async (pauseInSeconds = 60, pauseForSeconds: number | null = 120) => {
+    const request = {
+      ...context,
+      action: "set" as const,
+      pauseInSeconds,
+      pauseForSeconds,
+      expectedRevision: (await control()).revision,
+      clientEventId: crypto.randomUUID(),
+    };
+    await transaction((db) => setWorkspacePauseTimerInTransaction(db, request));
+    return request;
+  };
+  const due = () =>
+    transaction((db) =>
+      db.execute(
+        sql`update workspace_inference_controls set timer_due_at = clock_timestamp() - interval '1 second' where workspace_id = ${context.workspaceId}`,
+      ),
+    );
+  const fire = (timerId: string) =>
+    transaction((db) =>
+      fireWorkspacePauseTimerInTransaction(db, { workspaceId: context.workspaceId, timerId }),
+    );
+  const manual = (action: "pause" | "resume", operationKey = crypto.randomUUID()) =>
+    transaction((db) =>
+      mutateWorkspaceControlInTransaction(db, {
+        ...context,
+        action,
+        operationKey,
+        actor: { type: "human", subjectId: id },
+      }),
+    );
+  return { ...context, transaction, control, set, due, fire, manual };
+}
+
+test("delayed pause then full duration resume, durable discovery and concurrent retries", async () => {
+  const f = await fixture();
+  await f.set(60, 120);
+  const timer = (await f.control()).timer!;
+  expect((await f.control()).state).toBe("active");
+  expect(await f.fire(timer.id)).toBeNull();
+  await f.due();
+  expect(await listDueWorkspacePauseTimers(client.db)).toContainEqual({
+    workspace_id: f.workspaceId,
+    timer_id: timer.id,
+  });
+  const applied = await Promise.all([f.fire(timer.id), f.fire(timer.id)]);
+  expect(applied.filter(Boolean)).toHaveLength(1);
+  const paused = await f.control();
+  expect(paused.state).toBe("paused");
+  expect(paused.timer?.action).toBe("resume");
+  expect(Date.parse(paused.timer!.dueAt) - Date.now()).toBeGreaterThan(115000);
+  // Recreate the connection to prove no process-local timer owns the obligation.
+  const restarted = createDb(shared.appUrl);
+  expect((await getWorkspace(restarted.db, f.workspaceId))!.inferenceControl.timer?.id).toBe(
+    timer.id,
+  );
+  await restarted.close();
+  await f.due();
+  await f.fire(timer.id);
+  expect((await f.control()).state).toBe("active");
+  expect((await f.control()).timer).toBeNull();
+  expect(await f.fire(timer.id)).toBeNull();
+}, 30000);
+
+test("immediate finite pause, edit resume duration, cancel leaves paused", async () => {
+  const f = await fixture();
+  await f.set(0, 60);
+  expect((await f.control()).state).toBe("paused");
+  await f.set(0, 3600);
+  expect(Date.parse((await f.control()).timer!.dueAt) - Date.now()).toBeGreaterThan(3590000);
+  await f
+    .transaction((db) =>
+      setWorkspacePauseTimerInTransaction(db, {
+        ...f,
+        action: "cancel",
+        expectedRevision: 0,
+        clientEventId: crypto.randomUUID(),
+      }),
+    )
+    .then(
+      () => {
+        throw new Error("stale edit accepted");
+      },
+      (error) => expect(error.constructor.name).toBe("SessionControlConflictError"),
+    );
+  const control = await f.control();
+  await f.transaction((db) =>
+    setWorkspacePauseTimerInTransaction(db, {
+      ...f,
+      action: "cancel",
+      expectedRevision: control.revision,
+      clientEventId: crypto.randomUUID(),
+    }),
+  );
+  expect((await f.control()).state).toBe("paused");
+  expect((await f.control()).timer).toBeNull();
+});
+
+test("manual no-op resume cancels delayed pause; replay cannot cancel its replacement", async () => {
+  const f = await fixture();
+  await f.set();
+  const old = (await f.control()).timer!;
+  const key = crypto.randomUUID();
+  await f.manual("resume", key);
+  expect((await f.control()).timer).toBeNull();
+  await f.set();
+  const newer = (await f.control()).timer!;
+  await f.manual("resume", key);
+  expect((await f.control()).timer?.id).toBe(newer.id);
+  await f.due();
+  expect(await f.fire(old.id)).toBeNull();
+  expect((await f.control()).state).toBe("active");
+});
+
+test("manual pause cancels timed resume; replayed set cannot resurrect it", async () => {
+  const f = await fixture();
+  const request = await f.set(0, 60);
+  const old = (await f.control()).timer!;
+  await f.manual("pause");
+  expect((await f.control()).timer).toBeNull();
+  await f.transaction((db) => setWorkspacePauseTimerInTransaction(db, request));
+  expect((await f.control()).timer).toBeNull();
+  expect(await f.fire(old.id)).toBeNull();
+  expect((await f.control()).state).toBe("paused");
+});
+
+test("indefinite delayed pause and immediate indefinite pause leave no resume", async () => {
+  const f = await fixture();
+  await f.set(60, null);
+  const id = (await f.control()).timer!.id;
+  await f.due();
+  await f.fire(id);
+  expect((await f.control()).state).toBe("paused");
+  expect((await f.control()).timer).toBeNull();
+  await f.manual("resume");
+  await f.set(0, null);
+  expect((await f.control()).state).toBe("paused");
+  expect((await f.control()).timer).toBeNull();
+});
+
+test("RLS denies a cross-workspace mutation", async () => {
+  const a = await fixture();
+  const b = await fixture();
+  await expect(
+    a.transaction((db) =>
+      setWorkspacePauseTimerInTransaction(db, {
+        accountId: b.accountId,
+        workspaceId: b.workspaceId,
+        subjectId: a.subjectId,
+        action: "set",
+        pauseInSeconds: 60,
+        expectedRevision: 0,
+        clientEventId: crypto.randomUUID(),
+      }),
+    ),
+  ).rejects.toThrow();
+  expect((await b.control()).timer).toBeNull();
+});
+
+test("timer resume preserves an independently paused session", async () => {
+  const {
+    createSession,
+    mutateSessionControlInTransaction,
+    evaluateSessionControl,
+    withWorkspaceSessionActivityRls,
+  } = await import("../src/index");
+  const f = await fixture();
+  const session = await createSession(client.db, {
+    accountId: f.accountId,
+    workspaceId: f.workspaceId,
+    initialMessage: "Wait here",
+    resources: [],
+    metadata: {},
+    model: "scripted-model",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  await withWorkspaceSessionActivityRls(client.db, f.workspaceId, (db) =>
+    mutateSessionControlInTransaction(db, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      sessionId: session.id,
+      actor: { type: "human", subjectId: f.subjectId },
+      operationKey: crypto.randomUUID(),
+      action: "pause",
+    }),
+  );
+  await f.set(0, 60);
+  const id = (await f.control()).timer!.id;
+  await f.due();
+  await f.fire(id);
+  expect((await f.control()).state).toBe("active");
+  expect(
+    await f.transaction((db) => evaluateSessionControl(db, f.workspaceId, session.id)),
+  ).toMatchObject({ state: "paused", directState: "paused" });
+});
+
+test("forged discovery flag grants the app no cross-tenant table access", async () => {
+  const f = await fixture();
+  await f.set();
+  const rows = await client.db.transaction(async (tx) => {
+    await tx.execute(sql`select set_config('opengeni.pause_timer_discovery', '1', true)`);
+    return await tx.execute(
+      sql`select workspace_id from workspace_inference_controls where workspace_id = ${f.workspaceId}`,
+    );
+  });
+  expect(rows).toHaveLength(0);
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2474,6 +2474,13 @@ export class OpenGeniClient {
     });
   }
 
+  async setWorkspacePauseTimer(
+    workspaceId: string,
+    request: import("./types").WorkspacePauseTimerRequest,
+  ): Promise<{ ok: boolean }> {
+    return await this.requestJson("POST", `/v1/workspaces/${workspaceId}/pause-timer`, request);
+  }
+
   async setWorkspaceInferenceState(
     workspaceId: string,
     request: {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -911,6 +911,8 @@ export type {
   SessionPromptRouting,
   SteerSessionQueueItemRequest,
   WorkspaceInferenceControlResponse,
+  WorkspacePauseTimer,
+  WorkspacePauseTimerRequest,
   SessionPendingInputPreview,
   SessionSystemUpdate,
   SessionSystemUpdateKind,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -4339,6 +4339,8 @@ export type Workspace = {
   agentInstructions: string | null;
   settings: Record<string, unknown>;
   inferenceControl: {
+    timer?: WorkspacePauseTimer | null | undefined;
+    serverTime?: string | undefined;
     state: "active" | "paused";
     revision: number;
     reason: string | null;
@@ -4963,6 +4965,20 @@ export type SessionControlResponse = {
   cancelledTurnCount: number;
 };
 
+export type WorkspacePauseTimer = {
+  id: string;
+  action: "pause" | "resume";
+  dueAt: string;
+  pauseForSeconds: number | null;
+};
+export type WorkspacePauseTimerRequest = {
+  action: "set" | "cancel";
+  pauseInSeconds?: number | undefined;
+  pauseForSeconds?: number | null | undefined;
+  clientEventId: string;
+  expectedRevision: number;
+};
+
 export type WorkspaceInferenceControlResponse = {
   receipt: SessionCommandReceipt;
   state: "active" | "paused";
@@ -4980,7 +4996,7 @@ export type WorkspaceControlEvent = {
   type: "workspace.control.changed";
   scope: "workspace" | "session";
   rootSessionId: string | null;
-  action: "pause" | "resume";
+  action: "pause" | "resume" | "timer_set" | "timer_cancelled";
   automatic: boolean;
   reason: string | null;
   actor: string;

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -2327,3 +2327,18 @@ test("filters schedules by session on the server", async () => {
   expect(url.searchParams.get("limit")).toBe("10");
   expect(url.searchParams.get("offset")).toBe("20");
 });
+
+test("sets a workspace duration timer through the public endpoint", async () => {
+  const { client, requests } = makeClient(() => jsonResponse({ ok: true }));
+  const request = {
+    action: "set" as const,
+    pauseInSeconds: 1800,
+    pauseForSeconds: 7200,
+    clientEventId: "timer-save",
+    expectedRevision: 7,
+  };
+  expect(await client.setWorkspacePauseTimer(WORKSPACE_ID, request)).toEqual({ ok: true });
+  expect(requests[0]!.url).toEndWith(`/v1/workspaces/${WORKSPACE_ID}/pause-timer`);
+  expect(requests[0]!.method).toBe("POST");
+  expect(JSON.parse(requests[0]!.body!)).toEqual(request);
+});

--- a/packages/sdk/test/contract-parity.test.ts
+++ b/packages/sdk/test/contract-parity.test.ts
@@ -1425,3 +1425,32 @@ describe("SDK / contracts parity", () => {
     ).toBe(true);
   });
 });
+
+test("workspace timer wire types match contracts", async () => {
+  const { WorkspacePauseTimer, WorkspacePauseTimerRequest } = await import("@opengeni/contracts");
+  const request: import("../src/types").WorkspacePauseTimerRequest = {
+    action: "set",
+    pauseInSeconds: 1800,
+    pauseForSeconds: 7200,
+    expectedRevision: 4,
+    clientEventId: "timer-parity",
+  };
+  const contractRequest: import("@opengeni/contracts").WorkspacePauseTimerRequest = request;
+  const sdkRequest: import("../src/types").WorkspacePauseTimerRequest =
+    WorkspacePauseTimerRequest.parse(contractRequest);
+  expect(sdkRequest).toEqual(request);
+  const contractTimer = WorkspacePauseTimer.parse({
+    id: crypto.randomUUID(),
+    action: "pause",
+    dueAt: new Date().toISOString(),
+    pauseForSeconds: 7200,
+  });
+  const sdkTimer: import("../src/types").WorkspacePauseTimer = contractTimer;
+  const timer: import("@opengeni/contracts").WorkspacePauseTimer = sdkTimer;
+  expect(timer).toEqual(contractTimer);
+  for (const seconds of [-1, 1, 59, 2592001, 1.5]) {
+    expect(
+      WorkspacePauseTimerRequest.safeParse({ ...request, pauseInSeconds: seconds }).success,
+    ).toBe(false);
+  }
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,9 +131,7 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe(
-      "0419_background_command_launch_authority.sql",
-    );
+    expect(completeSourceContract.latestMigration).toBe("0420_workspace_pause_timers.sql");
     const sandboxDeadlineIndex = completeSourceContract.migrations.findIndex(
       (migration) => migration.path === "0397_sandbox_deadline_rotation_preemption.sql",
     );
@@ -691,6 +689,7 @@ describe("release schema contract", () => {
       "0417_command_runner_failure_metadata.sql",
       "0418_site_direct_uploads.sql",
       "0419_background_command_launch_authority.sql",
+      "0420_workspace_pause_timers.sql",
     ]);
     const migrationsBeforeAutomaticSessionTitles = completeSourceContract.migrations.filter(
       (migration) => !automaticSessionTitleMigrationPaths.has(migration.path),
@@ -735,11 +734,20 @@ describe("release schema contract", () => {
         ...completeSourceContract,
         latestMigration: "0413_session_filter_activity.sql",
       };
+    const workspacePauseTimers = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0420_workspace_pause_timers.sql",
+    );
+    if (workspacePauseTimers)
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0420_workspace_pause_timers.sql",
+      };
     expect(completeSourceContract).toMatchObject({
       ...(sandboxDeadlineRotationPreemption
         ? { latestMigration: "0397_sandbox_deadline_rotation_preemption.sql" }
         : {}),
       fileCount:
+        (workspacePauseTimers ? 1 : 0) +
         (sessionFilterActivity ? 1 : 0) +
         (newSessionDraftProjectProvenance ? 1 : 0) +
         (newSessionDraftProjectProvenanceIndex ? 1 : 0) +
@@ -812,114 +820,116 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: siteDirectUploads
-        ? "0418_site_direct_uploads.sql"
-        : commandRunnerFailureMetadata
-          ? "0417_command_runner_failure_metadata.sql"
-          : scheduledInheritedToolAdmission
-            ? "0416_scheduled_inherited_tool_admission.sql"
-            : commandCompletionObservation
-              ? "0415_command_completion_observation.sql"
-              : scheduledGeneratedProducerMaterialization
-                ? "0414_scheduled_generated_producer_materialization.sql"
-                : sessionFilterActivity
-                  ? "0413_session_filter_activity.sql"
-                  : newSessionDraftProjectProvenanceValidation
-                    ? "0412_new_session_draft_project_provenance_validation.sql"
-                    : newSessionDraftProjectProvenanceBackfill
-                      ? "0411_new_session_draft_project_provenance_backfill.sql"
-                      : newSessionDraftProjectProvenanceIndex
-                        ? "0410_new_session_draft_project_provenance_index.sql"
-                        : newSessionDraftProjectProvenance
-                          ? "0409_new_session_draft_project_provenance.sql"
-                          : scheduledSessionTargetIndex
-                            ? "0408_scheduled_session_target_index.sql"
-                            : connectedCommandTrackingRetirement
-                              ? "0407_connected_command_tracking_retirement.sql"
-                              : sandboxProviderDeadlineInteractionFollowup
-                                ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-                                : organizationModelProviderConnections
-                                  ? "0390_organization_model_provider_connections.sql"
-                                  : modelCatalogAndGatewayCustomModels
-                                    ? "0389_model_catalog_and_gateway_custom_models.sql"
-                                    : sandboxProviderDeadlineInteractions
-                                      ? "0388_sandbox_provider_deadline_interactions.sql"
-                                      : boundHostExportSessionPayloads
-                                        ? "0387_bound_host_export_session_payloads.sql"
-                                        : localOrganizationAdministration
-                                          ? "0386_local_organization_administration.sql"
-                                          : connectedMachineLegacyTildeWorkdirs
-                                            ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                                            : codexCooldownRevisionGuardPrivileges
-                                              ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                                              : codexCooldownReconciliation
-                                                ? "0383_codex_cooldown_reconciliation.sql"
-                                                : organizationApiKeyProvenance
-                                                  ? "0382_organization_api_key_provenance.sql"
-                                                  : organizationCodexSubscriptionInheritance
-                                                    ? "0381_organization_codex_subscription_inheritance.sql"
-                                                    : autonomousCompanyProfileAgentPolicy
-                                                      ? "0380_autonomous_company_profile_agent_policy.sql"
-                                                      : sessionEventRawLaneActivation
-                                                        ? "0379_session_event_raw_lane_activation.sql"
-                                                        : scopedRigHealthAuditTimestamp
-                                                          ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                                          : scopedRigHealthProjection
-                                                            ? "0377_scoped_rig_health_projection.sql"
-                                                            : organizationWorkspaceInventory
-                                                              ? "0376_organization_workspace_inventory.sql"
-                                                              : sessionRecoveryObservability
-                                                                ? "0375_session_recovery_observability.sql"
-                                                                : sessionEventCursors
-                                                                  ? "0374_session_event_cursors.sql"
-                                                                  : sandboxSharedPreparation
-                                                                    ? "0373_sandbox_shared_preparation.sql"
-                                                                    : orderedVariableSetRuntimeAuthority
-                                                                      ? "0372_ordered_variable_set_runtime_authority.sql"
-                                                                      : workspaceMemberCandidateInventory
-                                                                        ? "0371_workspace_member_candidate_inventory.sql"
-                                                                        : workspaceMemberManagementScope
-                                                                          ? "0370_workspace_member_management_scope.sql"
-                                                                          : localHumanPersonalAuthority
-                                                                            ? "0369_local_human_personal_authority.sql"
-                                                                            : sessionDiscoveryClaimSearchIndex
-                                                                              ? "0368_session_discovery_claim_search_index.sql"
-                                                                              : sessionDiscoveryGoalSearchIndex
-                                                                                ? "0367_session_discovery_goal_search_index.sql"
-                                                                                : sessionDiscoveryTitleSearchIndex
-                                                                                  ? "0366_session_discovery_title_search_index.sql"
-                                                                                  : permissionScopedWorkClaims
-                                                                                    ? "0365_permission_scoped_work_claims.sql"
-                                                                                    : workspaceLearningPolicySnapshotLockOrder
-                                                                                      ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                                                      : organizationRecoveryCustody
-                                                                                        ? "0363_organization_recovery_custody.sql"
-                                                                                        : managedAuthSessionSets
-                                                                                          ? "0362_managed_auth_session_sets.sql"
-                                                                                          : rememberKnowledgeMemoryMaterialization
-                                                                                            ? "0361_remember_knowledge_memory_materialization.sql"
-                                                                                            : organizationIdentityConfirmationPrompt
-                                                                                              ? "0360_organization_identity_confirmation_prompt.sql"
-                                                                                              : insightsForceRlsReadCapability
-                                                                                                ? "0359_insights_force_rls_read_capability.sql"
-                                                                                                : prReviewManagedGithubApp
-                                                                                                  ? "0358_pr_review_managed_github_app.sql"
-                                                                                                  : rigPlatformBaseOnly
-                                                                                                    ? "0357_rig_platform_base_only.sql"
-                                                                                                    : setBasedInsightsSessionVisibility
-                                                                                                      ? "0356_set_based_insights_session_visibility.sql"
-                                                                                                      : automaticSessionTitleQuarantine
-                                                                                                        ? "0355_automatic_session_title_quarantine.sql"
-                                                                                                        : automaticSessionTitleQuarantineIndex
-                                                                                                          ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                                                          : automaticSessionTitlePolicyFence
-                                                                                                            ? "0353_automatic_session_title_policy_fence.sql"
-                                                                                                            : sessionVariableSetAttachments
-                                                                                                              ? "0352_session_variable_set_attachments.sql"
-                                                                                                              : migrationsBeforeAutomaticSessionTitles.at(
-                                                                                                                  -1,
-                                                                                                                )
-                                                                                                                  ?.path,
+      latestMigration: workspacePauseTimers
+        ? "0420_workspace_pause_timers.sql"
+        : siteDirectUploads
+          ? "0418_site_direct_uploads.sql"
+          : commandRunnerFailureMetadata
+            ? "0417_command_runner_failure_metadata.sql"
+            : scheduledInheritedToolAdmission
+              ? "0416_scheduled_inherited_tool_admission.sql"
+              : commandCompletionObservation
+                ? "0415_command_completion_observation.sql"
+                : scheduledGeneratedProducerMaterialization
+                  ? "0414_scheduled_generated_producer_materialization.sql"
+                  : sessionFilterActivity
+                    ? "0413_session_filter_activity.sql"
+                    : newSessionDraftProjectProvenanceValidation
+                      ? "0412_new_session_draft_project_provenance_validation.sql"
+                      : newSessionDraftProjectProvenanceBackfill
+                        ? "0411_new_session_draft_project_provenance_backfill.sql"
+                        : newSessionDraftProjectProvenanceIndex
+                          ? "0410_new_session_draft_project_provenance_index.sql"
+                          : newSessionDraftProjectProvenance
+                            ? "0409_new_session_draft_project_provenance.sql"
+                            : scheduledSessionTargetIndex
+                              ? "0408_scheduled_session_target_index.sql"
+                              : connectedCommandTrackingRetirement
+                                ? "0407_connected_command_tracking_retirement.sql"
+                                : sandboxProviderDeadlineInteractionFollowup
+                                  ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+                                  : organizationModelProviderConnections
+                                    ? "0390_organization_model_provider_connections.sql"
+                                    : modelCatalogAndGatewayCustomModels
+                                      ? "0389_model_catalog_and_gateway_custom_models.sql"
+                                      : sandboxProviderDeadlineInteractions
+                                        ? "0388_sandbox_provider_deadline_interactions.sql"
+                                        : boundHostExportSessionPayloads
+                                          ? "0387_bound_host_export_session_payloads.sql"
+                                          : localOrganizationAdministration
+                                            ? "0386_local_organization_administration.sql"
+                                            : connectedMachineLegacyTildeWorkdirs
+                                              ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                                              : codexCooldownRevisionGuardPrivileges
+                                                ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                                                : codexCooldownReconciliation
+                                                  ? "0383_codex_cooldown_reconciliation.sql"
+                                                  : organizationApiKeyProvenance
+                                                    ? "0382_organization_api_key_provenance.sql"
+                                                    : organizationCodexSubscriptionInheritance
+                                                      ? "0381_organization_codex_subscription_inheritance.sql"
+                                                      : autonomousCompanyProfileAgentPolicy
+                                                        ? "0380_autonomous_company_profile_agent_policy.sql"
+                                                        : sessionEventRawLaneActivation
+                                                          ? "0379_session_event_raw_lane_activation.sql"
+                                                          : scopedRigHealthAuditTimestamp
+                                                            ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                                            : scopedRigHealthProjection
+                                                              ? "0377_scoped_rig_health_projection.sql"
+                                                              : organizationWorkspaceInventory
+                                                                ? "0376_organization_workspace_inventory.sql"
+                                                                : sessionRecoveryObservability
+                                                                  ? "0375_session_recovery_observability.sql"
+                                                                  : sessionEventCursors
+                                                                    ? "0374_session_event_cursors.sql"
+                                                                    : sandboxSharedPreparation
+                                                                      ? "0373_sandbox_shared_preparation.sql"
+                                                                      : orderedVariableSetRuntimeAuthority
+                                                                        ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                                        : workspaceMemberCandidateInventory
+                                                                          ? "0371_workspace_member_candidate_inventory.sql"
+                                                                          : workspaceMemberManagementScope
+                                                                            ? "0370_workspace_member_management_scope.sql"
+                                                                            : localHumanPersonalAuthority
+                                                                              ? "0369_local_human_personal_authority.sql"
+                                                                              : sessionDiscoveryClaimSearchIndex
+                                                                                ? "0368_session_discovery_claim_search_index.sql"
+                                                                                : sessionDiscoveryGoalSearchIndex
+                                                                                  ? "0367_session_discovery_goal_search_index.sql"
+                                                                                  : sessionDiscoveryTitleSearchIndex
+                                                                                    ? "0366_session_discovery_title_search_index.sql"
+                                                                                    : permissionScopedWorkClaims
+                                                                                      ? "0365_permission_scoped_work_claims.sql"
+                                                                                      : workspaceLearningPolicySnapshotLockOrder
+                                                                                        ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                                        : organizationRecoveryCustody
+                                                                                          ? "0363_organization_recovery_custody.sql"
+                                                                                          : managedAuthSessionSets
+                                                                                            ? "0362_managed_auth_session_sets.sql"
+                                                                                            : rememberKnowledgeMemoryMaterialization
+                                                                                              ? "0361_remember_knowledge_memory_materialization.sql"
+                                                                                              : organizationIdentityConfirmationPrompt
+                                                                                                ? "0360_organization_identity_confirmation_prompt.sql"
+                                                                                                : insightsForceRlsReadCapability
+                                                                                                  ? "0359_insights_force_rls_read_capability.sql"
+                                                                                                  : prReviewManagedGithubApp
+                                                                                                    ? "0358_pr_review_managed_github_app.sql"
+                                                                                                    : rigPlatformBaseOnly
+                                                                                                      ? "0357_rig_platform_base_only.sql"
+                                                                                                      : setBasedInsightsSessionVisibility
+                                                                                                        ? "0356_set_based_insights_session_visibility.sql"
+                                                                                                        : automaticSessionTitleQuarantine
+                                                                                                          ? "0355_automatic_session_title_quarantine.sql"
+                                                                                                          : automaticSessionTitleQuarantineIndex
+                                                                                                            ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                                                            : automaticSessionTitlePolicyFence
+                                                                                                              ? "0353_automatic_session_title_policy_fence.sql"
+                                                                                                              : sessionVariableSetAttachments
+                                                                                                                ? "0352_session_variable_set_attachments.sql"
+                                                                                                                : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                                                    -1,
+                                                                                                                  )
+                                                                                                                    ?.path,
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -994,6 +1004,7 @@ describe("release schema contract", () => {
         ? { latestMigration: "0419_background_command_launch_authority.sql" }
         : {}),
       ...(sessionFilterActivity ? { latestMigration: "0413_session_filter_activity.sql" } : {}),
+      ...(workspacePauseTimers ? { latestMigration: "0420_workspace_pause_timers.sql" } : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
       organizationUserSetupTokenTransport
@@ -1268,6 +1279,7 @@ describe("release schema contract", () => {
       expect(taskTreeNotes).toMatchObject({ deploymentMode: "rolling" });
     }
     const appendedMigrationPaths = [
+      "0420_workspace_pause_timers.sql",
       "0398_organization_workspace_management_entry.sql",
       "0394_session_selected_skill_activation.sql",
       "0392_context_compaction_pending_observability.sql",
@@ -1672,8 +1684,17 @@ describe("release schema contract", () => {
         ...completeSourceContract,
         latestMigration: "0413_session_filter_activity.sql",
       };
+    const workspacePauseTimers = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0420_workspace_pause_timers.sql",
+    );
+    if (workspacePauseTimers)
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0420_workspace_pause_timers.sql",
+      };
     expect(completeSourceContract).toMatchObject({
       fileCount:
+        (workspacePauseTimers ? 1 : 0) +
         (scheduledInheritedToolAdmission ? 1 : 0) +
         (sessionFilterActivity ? 1 : 0) +
         (newSessionDraftProjectProvenance ? 1 : 0) +
@@ -1932,6 +1953,7 @@ describe("release schema contract", () => {
         ? { latestMigration: "0419_background_command_launch_authority.sql" }
         : {}),
       ...(sessionFilterActivity ? { latestMigration: "0413_session_filter_activity.sql" } : {}),
+      ...(workspacePauseTimers ? { latestMigration: "0420_workspace_pause_timers.sql" } : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
       organizationUserSetupTokenTransport

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -26,6 +26,7 @@ const testFiles =
         "./test/e2e/restored-attachment-preview.browser.e2e.ts",
         "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
+        "./test/e2e/workspace-pause-timers.browser.e2e.ts",
         "./test/e2e/session-rail-row-metadata.browser.e2e.ts",
         "./test/e2e/setup-account-token.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",

--- a/test/e2e/workspace-pause-timers.browser.e2e.ts
+++ b/test/e2e/workspace-pause-timers.browser.e2e.ts
@@ -1,0 +1,238 @@
+import { createWorkflowWakeActivities } from "../../apps/worker/src/activities/workflow-wake";
+import type { ControlActivityServices } from "../../apps/worker/src/activities/types";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { chromium, type Browser, type Page } from "playwright";
+import AxeBuilder from "@axe-core/playwright";
+import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
+import { createDb, getWorkspace, withWorkspaceRls } from "@opengeni/db";
+import { sql } from "drizzle-orm";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  freePort,
+  startProcess,
+  type SharedTestDatabase,
+  type StartedProcess,
+} from "@opengeni/testing";
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const shots = process.env.OPENGENI_TIMER_SCREENSHOTS ?? "/tmp/opengeni-pause-timer-screenshots";
+const workflowClient: SessionWorkflowClient = {
+  signalUserMessage: async () => {},
+  wakeSessionWorkflow: async () => {},
+  requestSessionWorkflowWakeDispatch: async () => {},
+  signalApprovalDecision: async () => {},
+  signalSessionControl: async () => {},
+  syncScheduledTask: async () => {},
+  deleteScheduledTaskSchedule: async () => {},
+  triggerScheduledTask: async () => {},
+  startRigVerification: async () => {},
+};
+const bus = new MemoryEventBus();
+let shared: SharedTestDatabase;
+let db: ReturnType<typeof createDb>;
+let api: ReturnType<typeof Bun.serve>;
+let web: StartedProcess;
+let browser: Browser;
+let page: Page;
+let apiUrl: string;
+let webUrl: string;
+let workspaceId: string;
+const pageErrors: string[] = [];
+beforeAll(async () => {
+  shared = (await acquireSharedTestDatabase("pause-timers-browser"))!;
+  if (!shared) throw new Error("PostgreSQL required");
+  db = createDb(shared.appUrl);
+  const apiPort = await freePort();
+  const webPort = await freePort();
+  apiUrl = `http://127.0.0.1:${apiPort}`;
+  webUrl = `http://127.0.0.1:${webPort}`;
+  const app = createApp({
+    settings: testSettings({
+      databaseUrl: shared.appUrl,
+      productAccessMode: "configured",
+      delegationSecret: undefined,
+    }),
+    db: db.db,
+    bus,
+    workflowClient,
+  });
+  api = Bun.serve({ hostname: "127.0.0.1", port: apiPort, idleTimeout: 120, fetch: app.fetch });
+  web = await startProcess(
+    ["bun", "run", "vite", "--port", String(webPort), "--strictPort", "--host", "127.0.0.1"],
+    {
+      cwd: `${repoRoot}/apps/web`,
+      env: { VITE_API_BASE_URL: apiUrl },
+      ready: async () => (await fetch(webUrl).catch(() => null))?.ok === true,
+      timeoutMs: 60000,
+    },
+  );
+  browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    extraHTTPHeaders: { "x-opengeni-subject": "timer-owner" },
+  });
+  await context.addInitScript(() => {
+    if (location.origin !== "null")
+      localStorage.setItem("opengeni.accessKey", "configured-test-placeholder");
+  });
+  page = await context.newPage();
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+  await page.goto(webUrl);
+  await page.waitForURL(/\/workspaces\/[^/]+\/sessions/, { timeout: 60000 });
+  workspaceId = page.url().match(/\/workspaces\/([^/]+)/)![1]!;
+  await page.goto(`${webUrl}/workspaces/${workspaceId}/settings`);
+  await page.getByRole("region", { name: "Workspace runtime" }).waitFor();
+  await mkdir(shots, { recursive: true });
+}, 180000);
+afterAll(async () => {
+  await browser?.close();
+  await web?.stop();
+  await api?.stop(false);
+  await db?.close();
+  await shared?.release();
+}, 60000);
+const runtime = () => page.getByRole("region", { name: "Workspace runtime" });
+async function capture(name: string, dialog = false) {
+  await page.screenshot({ path: `${shots}/${name}-full.png`, fullPage: false });
+  await (dialog ? page.getByRole("dialog") : runtime()).screenshot({
+    path: `${shots}/${name}.png`,
+  });
+}
+async function post(path: string, body: unknown, subject = "timer-owner") {
+  return await fetch(`${apiUrl}/v1/workspaces/${workspaceId}/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-opengeni-subject": subject },
+    body: JSON.stringify(body),
+  });
+}
+async function refresh() {
+  await page.reload();
+  await runtime().waitFor();
+}
+async function dueAndFire() {
+  const timer = (await getWorkspace(db.db, workspaceId))!.inferenceControl.timer!;
+  await withWorkspaceRls(db.db, workspaceId, (scoped) =>
+    scoped.execute(
+      sql`update workspace_inference_controls set timer_due_at = clock_timestamp() - interval '1 second' where workspace_id = ${workspaceId}`,
+    ),
+  );
+  await refresh();
+  await page
+    .getByText(timer.action === "pause" ? "Pausing…" : "Resuming…", { exact: true })
+    .waitFor();
+  await capture(timer.action === "pause" ? "12-pausing" : "13-resuming");
+  const service = {
+    db: db.db,
+    bus,
+    wakeSessionWorkflow: null,
+    observability: { info() {}, warn() {}, incrementCounter() {}, observeHistogram() {} },
+  } as unknown as ControlActivityServices;
+  await createWorkflowWakeActivities(async () => service).dispatchSessionWorkflowWakes();
+}
+
+test("all timer states through the real settings UI and API", async () => {
+  await capture("01-active");
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await capture("02-default-editor", true);
+  await page.getByLabel("Pause in", { exact: true }).selectOption("1800");
+  await page.getByLabel("Pause for", { exact: true }).selectOption("7200");
+  await capture("03-combined-editor", true);
+  let releaseSave!: () => void;
+  const saveGate = new Promise<void>((resolve) => {
+    releaseSave = resolve;
+  });
+  await page.route(
+    "**/pause-timer",
+    async (route) => {
+      await saveGate;
+      await route.continue();
+    },
+    { times: 1 },
+  );
+  await page.getByRole("button", { name: "Set timer", exact: true }).click();
+  await capture("14-saving", true);
+  expect(await page.getByRole("button", { name: "Set timer", exact: true }).isDisabled()).toBe(
+    true,
+  );
+  releaseSave();
+  await page.getByRole("dialog").waitFor({ state: "hidden" });
+  await page.getByText(/Pauses in 30 min · for 2 hr/).waitFor();
+  await capture("04-delayed-finite");
+  await dueAndFire();
+  await refresh();
+  await page.getByText(/Resumes in 2 hr/).waitFor();
+  await capture("05-paused-finite");
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await capture("06-resume-editor", true);
+  await page.getByRole("button", { name: "Cancel timer", exact: true }).click();
+  await page.getByText("Paused until you resume", { exact: true }).waitFor();
+  await capture("07-paused-indefinite");
+  await page.getByRole("button", { name: "Resume workspace", exact: true }).click();
+  await page.getByRole("button", { name: "Pause workspace", exact: true }).waitFor();
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await page.getByLabel("Pause in", { exact: true }).selectOption("3600");
+  await page.getByRole("button", { name: "Set timer", exact: true }).click();
+  await page.getByText(/Pauses in 1 hr · until resumed/).waitFor();
+  await capture("08-delayed-indefinite");
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await page.getByLabel("Pause for", { exact: true }).selectOption("custom");
+  await page.getByLabel("Pause for amount", { exact: true }).fill("90");
+  await capture("09-custom-duration", true);
+  await page.getByLabel("Pause for amount", { exact: true }).fill("0");
+  expect(await page.getByRole("button", { name: "Set timer", exact: true }).isDisabled()).toBe(
+    true,
+  );
+  await capture("10-invalid-duration", true);
+  await page.getByLabel("Pause for amount", { exact: true }).fill("90");
+  const accessibility = await new AxeBuilder({ page }).include('[role="dialog"]').analyze();
+  expect(accessibility.violations).toEqual([]);
+  await page.keyboard.press("Escape");
+  await page.getByRole("dialog").waitFor({ state: "hidden" });
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await page.getByRole("button", { name: "Cancel timer", exact: true }).click();
+  await page.getByRole("dialog").waitFor({ state: "hidden" });
+  // Pause now for 15 minutes, then exercise the actual automatic resume transition.
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await page.getByLabel("Pause for", { exact: true }).selectOption("900");
+  await page.getByRole("button", { name: "Pause now", exact: true }).click();
+  await page.getByText(/Resumes in 15 min/).waitFor();
+  await dueAndFire();
+  await refresh();
+  expect((await getWorkspace(db.db, workspaceId))!.inferenceControl.state).toBe("active");
+  await capture("11-resumed");
+  // Another admin changes the workspace while the editor is open.
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await post("inference-control", { action: "pause", clientEventId: crypto.randomUUID() });
+  await page.getByRole("button", { name: "Pause now", exact: true }).click();
+  await page.getByRole("alert").filter({ hasText: "Workspace changed" }).waitFor();
+  await capture("15-stale-edit", true);
+  await page.keyboard.press("Escape");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "Pause timer", exact: true }).click();
+  await capture("16-mobile-editor", true);
+  await page.keyboard.press("Escape");
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  expect(pageErrors).toEqual([]);
+}, 120000);
+
+test("API validates input, conflicts and paused-state errors", async () => {
+  const control = (await getWorkspace(db.db, workspaceId))!.inferenceControl;
+  const request = {
+    action: "set",
+    pauseInSeconds: 60,
+    expectedRevision: control.revision,
+    clientEventId: crypto.randomUUID(),
+  };
+  expect((await post("pause-timer", { ...request, pauseInSeconds: -1 })).status).toBe(400);
+  expect((await post("pause-timer", { ...request, expectedRevision: 0 })).status).toBe(409);
+  expect(
+    (await post("inference-control", { action: "pause", clientEventId: crypto.randomUUID() }))
+      .status,
+  ).toBe(200);
+  const paused = (await getWorkspace(db.db, workspaceId))!.inferenceControl;
+  expect(
+    (await post("pause-timer", { ...request, expectedRevision: paused.revision })).status,
+  ).toBe(400);
+});


### PR DESCRIPTION
## Summary

Adds duration-based workspace pause timers behind a chevron beside Pause/Resume in General settings. Supports pause now for a duration, pause later indefinitely, and pause later then resume; paused workspaces can set a resume duration. The UI shows a countdown, edit/cancel, pending transitions, validation, conflict and saving states.

Postgres stores deadlines. The existing control-worker sweep executes timers under the workspace control fence and reuses interruption/wake handling. Manual controls cancel automation; receipt replay cannot disturb newer timers, and automatic resume verifies ownership of the pause.

## Testing

- [x] Full 32-project typecheck; final SDK/web typechecks
- [x] Lint, format, production web build/bundle budgets
- [x] Timer database tests: concurrency, restart persistence, replay, cancellation, stale edits, independent session pauses, FORCE-RLS
- [x] Existing control-plane/algebra and API tests; SDK client/contract parity
- [x] Real API + PostgreSQL browser flow invoking the actual dispatcher activity; 16 screenshot states, keyboard and dialog accessibility
- [x] Migration ordinal, schema-contract, RLS-backfill and timeout-budget guards

Browser acceptance advances persisted test deadlines; Temporal signal delivery is stubbed. No live production agent run was performed. Screenshots are reproducible via `OPENGENI_TIMER_SCREENSHOTS=/path bun scripts/run-browser-e2e.ts ./test/e2e/workspace-pause-timers.browser.e2e.ts`.

## Delivery integrity

- [x] Branch created from current main; unrelated local changes preserved in the original checkout.
- [x] Independent review completed; conflict-response and rollout findings resolved.
- [x] Candidate remains frozen during CI; any subsequent source revision must address a defect or compatibility issue.

## Notes

**Migration 0420 is maintenance-only. Drain old API/control/turn workers before activation and deploy matching versions together.** Old writers do not clear timers and old clients do not recognize the new timer event actions. Timer execution runs on the next available sweep, normally within ten seconds; it is not a precise alarm.

## Summary by Sourcery

Enable durable workspace pause and resume timers with administrator controls, countdown-based settings UI, and safe worker-driven execution.

New Features:
- Add configurable workspace pause and resume timers with immediate, delayed, finite-duration, and indefinite options.
- Expose timer state and countdowns in workspace settings, including editing and cancellation controls.
- Add an authenticated SDK and API endpoint for workspace pause timer management.

Bug Fixes:
- Ensure timer execution is durable, restart-safe, idempotent, and protected against stale updates or conflicting manual controls.
- Prevent automatic resume from overriding newer workspace or independent session pause state.

Enhancements:
- Integrate timer execution into the control-worker wake sweep and workspace control event stream.
- Extend workspace projections and control events with timer metadata and automatic transition states.

Build:
- Add migration 0420 for persisted timer deadlines, constraints, indexing, and discovery access.

Deployment:
- Require a maintenance deployment that drains older API and worker writers before activating migration 0420 and deploying matching service versions.

Documentation:
- Document workspace pause timer behavior, API usage, execution semantics, and rollout requirements.

Tests:
- Add database, API, SDK, contract, accessibility, and browser end-to-end coverage for timer lifecycle, conflicts, retries, persistence, security, and UI states.