### PR TITLE
fix: repair workspace pause timer CI integration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1639,13 +1639,4 @@ Agent goal lifecycle exposes `goal_resume` alongside `goal_pause`: any pause rea
 
 Filtered session page ownership and its maintenance boundary: [session pagination](session-pagination.md).
 
-### Workspace pause durations
-
-Workspace pause timers persist on `workspace_inference_controls` and execute
-under the workspace control fence through the control-worker wake sweep.
-Manual controls cancel pending automation; a timer resumes only its own pause
-revision. The API accepts durations, Postgres owns deadlines, and clients render
-countdowns. Canonical: `packages/db/src/session-control.ts`,
-`apps/worker/src/activities/workflow-wake.ts`, and
-`apps/web/src/components/workspace-runtime-control.tsx`.
-See [workspace pause timers](workspace-pause-timers.md) for behavior and rollout.
+Workspace timers: [implementation and rollout](workspace-pause-timers.md).

--- a/packages/db/test/migration-0149-workspace-artifacts.test.ts
+++ b/packages/db/test/migration-0149-workspace-artifacts.test.ts
@@ -5,7 +5,6 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { bootstrapWorkspace, createDb } from "../src/index";
 
 const migration = "0149_workspace_artifacts.sql";
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
@@ -57,7 +56,6 @@ describe("workspace artifacts migration", () => {
   test("freezes only historical NULL permissions and preserves empty and narrow selections", async () => {
     if (!available || !blank) return;
     const admin = postgres(blank.databaseUrl, { max: 1 });
-    let db: ReturnType<typeof createDb> | null = null;
     try {
       await admin.unsafe(`create table schema_migrations (
         name text primary key,
@@ -71,17 +69,12 @@ describe("workspace artifacts migration", () => {
           on conflict do nothing`;
       }
 
-      db = createDb(blank.databaseUrl);
-      const access = await bootstrapWorkspace(db.db, {
-        accountExternalSource: "migration-0147",
-        accountExternalId: crypto.randomUUID(),
-        accountName: "Migration 0149 account",
-        workspaceExternalSource: "migration-0147",
-        workspaceExternalId: crypto.randomUUID(),
-        workspaceName: "Migration 0149 workspace",
-        subjectId: "user:migration-0147",
-      });
-      const grant = access.workspaceGrants[0]!;
+      // Seed the historical schema directly: today's bootstrap includes columns
+      // introduced after this migration and cannot run against this prefix.
+      const grant = { accountId: crypto.randomUUID(), workspaceId: crypto.randomUUID() };
+      await admin`insert into managed_accounts (id, name) values (${grant.accountId}, 'Migration 0149 account')`;
+      await admin`insert into workspaces (id, account_id, name) values (${grant.workspaceId}, ${grant.accountId}, 'Migration 0149 workspace')`;
+      await admin`insert into workspace_inference_controls (workspace_id, account_id) values (${grant.workspaceId}, ${grant.accountId})`;
       const historicalTools = FIRST_PARTY_MCP_TOOL_NAMES.filter(
         (name) => !name.startsWith("artifacts_"),
       );
@@ -156,7 +149,6 @@ describe("workspace artifacts migration", () => {
       expect(column?.column_default).toContain("artifacts_publish");
       expect(column?.column_default).toContain("artifacts_rollback");
     } finally {
-      await db?.close();
       await admin.end();
     }
   }, 180_000);

--- a/packages/db/test/migration-0343-personal-document-force-rls-lock-repair.test.ts
+++ b/packages/db/test/migration-0343-personal-document-force-rls-lock-repair.test.ts
@@ -66,6 +66,15 @@ describe("migration 0343 personal Document FORCE-RLS lock repair", () => {
       add column input_wait_until timestamptz,
       add column input_wait_reason text,
       add column input_wait_set_at timestamptz`;
+    // The current claim adapter also reads timer fields under the workspace
+    // fence. These temporary nullable fields are removed before 0420 runs.
+    await admin`
+      alter table workspace_inference_controls
+      add column timer_id uuid,
+      add column timer_action text,
+      add column timer_due_at timestamptz,
+      add column timer_pause_for_seconds integer,
+      add column timer_pause_revision bigint`;
     await provisionRoles(adminUrl, { appPassword, rlsStrategy: "force" });
 
     const [posture] = await admin<Array<{ superuser: boolean; bypassRls: boolean }>>`
@@ -227,6 +236,13 @@ describe("migration 0343 personal Document FORCE-RLS lock repair", () => {
     await app.end({ timeout: 5 });
     expect(await applicationSessionCount()).toBe(0);
     await admin`drop table session_event_cursors`;
+    await admin`
+      alter table workspace_inference_controls
+      drop column timer_id,
+      drop column timer_action,
+      drop column timer_due_at,
+      drop column timer_pause_for_seconds,
+      drop column timer_pause_revision`;
     await admin`
       alter table sessions
       drop column variable_set_ids,

--- a/packages/db/test/migration-0398-organization-workspace-management-entry.test.ts
+++ b/packages/db/test/migration-0398-organization-workspace-management-entry.test.ts
@@ -56,6 +56,16 @@ test("preserves legacy create outcomes and custom runtime-role access across mig
     await migrate(blank.databaseUrl, undefined, {
       applicationDatabaseRoles: [customRole],
     });
+    // Current access bootstrap writes the complete control-row shape. Keep
+    // these nullable adapter fields while this fixture replays only 0398;
+    // 0420 remains held and this disposable database is released below.
+    await admin`
+      alter table workspace_inference_controls
+      add column timer_id uuid,
+      add column timer_action text,
+      add column timer_due_at timestamptz,
+      add column timer_pause_for_seconds integer,
+      add column timer_pause_revision bigint`;
     await provisionRoles(blank.databaseUrl, {
       appRole: customRole,
       appPassword: customPassword,

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -112,6 +112,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
       "test/e2e/slack-settings.browser.e2e.ts",
+      "test/e2e/workspace-pause-timers.browser.e2e.ts",
       WORKSPACE_SWITCHER_TRIGGER_E2E,
     ]);
     expect(sdk.browserAcceptanceLanes).toEqual([
@@ -347,6 +348,7 @@ describe("fail-closed change impact", () => {
       "test/e2e/slack-access-link.browser.e2e.ts",
       "test/e2e/slack-installation-binding.browser.e2e.ts",
       "test/e2e/slack-settings.browser.e2e.ts",
+      "test/e2e/workspace-pause-timers.browser.e2e.ts",
       WORKSPACE_SWITCHER_TRIGGER_E2E,
     ]);
     expect(tests.e2e).not.toContain("test/e2e/codex-overview.e2e.ts");

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -192,6 +192,15 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
   ],
   "test/e2e/code-editor.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
   "test/e2e/composer-responsive.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
+  "test/e2e/workspace-pause-timers.browser.e2e.ts": [
+    "opengeni-web",
+    "@opengeni/api-router",
+    "@opengeni/contracts",
+    "@opengeni/db",
+    "@opengeni/sdk",
+    "@opengeni/worker-bundle",
+    "@opengeni/testing",
+  ],
   "test/e2e/connected-machine-removal.browser.e2e.ts": [
     "opengeni-web",
     "@opengeni/api-router",


### PR DESCRIPTION
## Summary
Repairs CI integration for workspace pause timers: restores the architecture document word budget, keeps historical 0149, 0343, and 0398 fixtures compatible with their frozen schemas, and registers the new timer browser suite in CI dependency selection. Runtime behavior and migrations are unchanged. Temporary 0343 timer fields are removed before the real migration chain runs.

## Validation
- Historical fixtures: 5 tests passed against PostgreSQL.
- CI planning: 70 tests passed.
- Documentation references, formatting, lint, and migration test budgets passed.
- Independent review completed on the exact final commit; no blockers.
