### PR TITLE
feat(web): add Light, Dark, and System appearance choices

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -38,6 +38,23 @@
         }
       })();
     </script>
+    <script id="opengeni-appearance-bootstrap">
+      // Apply before styles paint; keep in sync with src/lib/appearance.tsx.
+      (() => {
+        let preference = "system";
+        try {
+          preference = localStorage.getItem("opengeni.appearance") || "system";
+        } catch {}
+        const theme =
+          preference === "light" || preference === "dark"
+            ? preference
+            : matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.dataset.ogTheme = theme;
+        document.documentElement.classList.toggle("dark", theme === "dark");
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>OpenGeni</title>
   </head>

--- a/apps/web/src/components/appearance-menu.tsx
+++ b/apps/web/src/components/appearance-menu.tsx
@@ -1,0 +1,46 @@
+import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+
+import {
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { parseAppearance, useAppearance } from "@/lib/appearance";
+
+const options = [
+  { value: "light", label: "Light", icon: SunIcon },
+  { value: "dark", label: "Dark", icon: MoonIcon },
+  { value: "system", label: "System", icon: MonitorIcon },
+] as const;
+
+export function AppearanceMenu() {
+  const { appearance, setAppearance } = useAppearance();
+
+  return (
+    <>
+      <DropdownMenuLabel className="text-xs font-normal text-fg-muted">
+        Appearance
+      </DropdownMenuLabel>
+      <DropdownMenuRadioGroup
+        aria-label="Appearance"
+        value={appearance}
+        onValueChange={(value) => setAppearance(parseAppearance(value))}
+        className="grid grid-cols-3 gap-1 px-1 pb-1"
+      >
+        {options.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuRadioItem
+            key={value}
+            value={value}
+            onSelect={(event) => event.preventDefault()}
+            className="min-h-16 cursor-pointer flex-col justify-center gap-1.5 rounded-md border border-transparent px-2 py-2 text-xs text-fg-muted data-[state=checked]:border-border-strong data-[state=checked]:bg-surface-2 data-[state=checked]:text-fg [&>span]:top-1.5 [&>span]:right-1.5 [&>span]:left-auto [&>span]:size-2"
+          >
+            <Icon className="size-4" aria-hidden="true" />
+            {label}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+      <DropdownMenuSeparator />
+    </>
+  );
+}

--- a/apps/web/src/components/browser-account-menu.tsx
+++ b/apps/web/src/components/browser-account-menu.tsx
@@ -1,3 +1,4 @@
+import { AppearanceMenu } from "@/components/appearance-menu";
 import { useBrowserAccounts } from "@opengeni/react/accounts";
 import type { ManagedAuthSessionSetProjection } from "@opengeni/sdk/accounts";
 import {
@@ -302,6 +303,7 @@ export function BrowserAccountMenu() {
             className="min-h-11 forced-colors:text-[CanvasText]!"
             disabled={busy}
           />
+          <AppearanceMenu />
           {showAnalyticsPreferences ? (
             <DropdownMenuItem className="min-h-11" onSelect={() => openAnalyticsPreferences()}>
               <ChartColumnIcon className="size-4" />

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -1,3 +1,4 @@
+import { AppearanceMenu } from "@/components/appearance-menu";
 // Pinned rail footer: the collapse-toggle chevron and the signed-in user menu
 // (account/sign-out, depending on auth mode). Collapsed → just the avatar +
 // a collapse chevron, both with tooltips.
@@ -91,7 +92,7 @@ export function RailFooter() {
               <button
                 type="button"
                 aria-label="Account menu"
-                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none pointer-coarse:py-2"
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-11"
               >
                 <Avatar size="sm">
                   {image ? <AvatarImage src={image} alt="" /> : null}
@@ -114,7 +115,7 @@ export function RailFooter() {
             <DropdownMenuContent
               align="start"
               side={rail.collapsed ? "right" : "top"}
-              className="min-w-56"
+              className="w-[min(18rem,calc(100vw-1rem))]"
             >
               <DropdownMenuLabel className="grid gap-0.5">
                 <span className="truncate text-sm">{displayName}</span>
@@ -126,6 +127,7 @@ export function RailFooter() {
               {managed ? (
                 <OrganizationInvitationsMenuItem controller={organizationInvitations} />
               ) : null}
+              <AppearanceMenu />
               {showAnalyticsPreferences ? (
                 <DropdownMenuItem onSelect={() => openAnalyticsPreferences()}>
                   <ChartColumnIcon className="size-4" />

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+import { useAppearance } from "@/lib/appearance";
 import {
   CircleCheckIcon,
   InfoIcon,
@@ -8,9 +9,10 @@ import {
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
+  const { resolvedTheme } = useAppearance();
   return (
     <Sonner
-      theme="dark"
+      theme={resolvedTheme}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/apps/web/src/lib/appearance.test.ts
+++ b/apps/web/src/lib/appearance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import { APPEARANCE_KEY, parseAppearance } from "./appearance";
+
+const html = readFileSync(new URL("../../index.html", import.meta.url), "utf8");
+const bootstrap = html.match(
+  /<script id="opengeni-appearance-bootstrap">([\s\S]*?)<\/script>/,
+)![1]!;
+
+describe("appearance before first paint", () => {
+  for (const stored of [null, "system", "light", "dark", "invalid"]) {
+    for (const systemDark of [true, false]) {
+      test(`${stored} with system dark=${systemDark}`, () => {
+        const root = {
+          dataset: {} as Record<string, string>,
+          classList: {
+            toggle: (_: string, on: boolean) => {
+              dark = on;
+            },
+          },
+        };
+        let dark = false;
+        runInNewContext(bootstrap, {
+          document: { documentElement: root },
+          localStorage: {
+            getItem: (key: string) => {
+              expect(key).toBe(APPEARANCE_KEY);
+              return stored;
+            },
+          },
+          matchMedia: () => ({ matches: systemDark }),
+        });
+        const preference = parseAppearance(stored);
+        const expected = preference === "system" ? (systemDark ? "dark" : "light") : preference;
+        expect(root.dataset.ogTheme).toBe(expected);
+        expect(dark).toBe(expected === "dark");
+      });
+    }
+  }
+  test("blocked storage falls back to system without breaking startup", () => {
+    const root = { dataset: {} as Record<string, string>, classList: { toggle: () => {} } };
+    runInNewContext(bootstrap, {
+      document: { documentElement: root },
+      localStorage: {
+        getItem: () => {
+          throw new Error("blocked");
+        },
+      },
+      matchMedia: () => ({ matches: false }),
+    });
+    expect(root.dataset.ogTheme).toBe("light");
+  });
+});

--- a/apps/web/src/lib/appearance.tsx
+++ b/apps/web/src/lib/appearance.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  useCallback,
+  useMemo,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Appearance = "light" | "dark" | "system";
+export const APPEARANCE_KEY = "opengeni.appearance";
+export const SYSTEM_DARK_QUERY = "(prefers-color-scheme: dark)";
+
+export function parseAppearance(value: string | null): Appearance {
+  return value === "light" || value === "dark" ? value : "system";
+}
+
+function readAppearance(): Appearance {
+  try {
+    return parseAppearance(window.localStorage.getItem(APPEARANCE_KEY));
+  } catch {
+    return "system";
+  }
+}
+
+const AppearanceContext = createContext<{
+  appearance: Appearance;
+  resolvedTheme: "light" | "dark";
+  setAppearance: (value: Appearance) => void;
+}>({ appearance: "system", resolvedTheme: "dark", setAppearance: () => {} });
+
+export function AppearanceProvider({ children }: { children: ReactNode }) {
+  const [appearance, updateAppearance] = useState(readAppearance);
+  const [systemDark, setSystemDark] = useState(() => window.matchMedia(SYSTEM_DARK_QUERY).matches);
+  const resolvedTheme = appearance === "system" ? (systemDark ? "dark" : "light") : appearance;
+
+  useEffect(() => {
+    const media = window.matchMedia(SYSTEM_DARK_QUERY);
+    const onChange = () => setSystemDark(media.matches);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === APPEARANCE_KEY || event.key === null) updateAppearance(readAppearance());
+    };
+    onChange();
+    media.addEventListener("change", onChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      media.removeEventListener("change", onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.ogTheme = resolvedTheme;
+    document.documentElement.classList.toggle("dark", resolvedTheme === "dark");
+  }, [resolvedTheme]);
+
+  const setAppearance = useCallback((value: Appearance) => {
+    updateAppearance(value);
+    try {
+      window.localStorage.setItem(APPEARANCE_KEY, value);
+    } catch {
+      // A blocked storage area must not prevent changing this tab's appearance.
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ appearance, resolvedTheme, setAppearance }),
+    [appearance, resolvedTheme, setAppearance],
+  );
+
+  return <AppearanceContext.Provider value={value}>{children}</AppearanceContext.Provider>;
+}
+
+export function useAppearance() {
+  return useContext(AppearanceContext);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,5 @@
 import "./lib/crypto-random-uuid";
+import { AppearanceProvider } from "./lib/appearance";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
@@ -22,6 +23,8 @@ if (preloadRecoveryStorage) {
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AppearanceProvider>
+      <App />
+    </AppearanceProvider>
   </React.StrictMode>,
 );

--- a/apps/web/test/appearance-fixture.tsx
+++ b/apps/web/test/appearance-fixture.tsx
@@ -1,0 +1,53 @@
+import { createRoot } from "react-dom/client";
+import { AppearanceProvider } from "../src/lib/appearance";
+import { AppearanceMenu } from "../src/components/appearance-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../src/components/ui/dropdown-menu";
+import { Toaster } from "../src/components/ui/sonner";
+import { toast } from "sonner";
+import "../src/styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <AppearanceProvider>
+    <main className="flex h-screen bg-background text-foreground">
+      <aside className="flex w-64 flex-col border-r bg-surface p-2">
+        <div className="p-3 text-sm font-medium">OpenGeni</div>
+        <div className="mt-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger className="min-h-11 w-full rounded-md p-2 text-left text-sm hover:bg-surface-2">
+              Jorge
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="top"
+              align="start"
+              className="w-[min(18rem,calc(100vw-1rem))]"
+            >
+              <DropdownMenuLabel>
+                Jorge
+                <span className="block text-xs font-normal text-fg-subtle">jorge@example.com</span>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <AppearanceMenu />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </aside>
+      <section className="flex-1 p-8">
+        <h1 className="text-xl font-medium">Your workspace</h1>
+        <p className="mt-2 text-sm text-fg-muted">A comfortable space for your next idea.</p>
+        <button
+          className="mt-6 rounded-md bg-surface-2 px-4 py-2 text-sm"
+          onClick={() => toast.success("Appearance updated")}
+        >
+          Show notification
+        </button>
+      </section>
+    </main>
+    <Toaster />
+  </AppearanceProvider>,
+);

--- a/apps/web/test/appearance.html
+++ b/apps/web/test/appearance.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Appearance</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./appearance-fixture.tsx"></script>
+  </body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -638,6 +638,11 @@ packages; it does not own session or authorization semantics. Advanced hosts
 may embed API/core/worker packages, but the same domain and persistence
 boundaries still apply.
 
+The stock console owns browser-local appearance in `apps/web/src/lib/appearance.tsx`.
+Both account menus expose Light, Dark, and System; the resolved palette is applied
+to the document for shared React surfaces and portals. The early bootstrap in
+`apps/web/index.html` restores that choice before first paint.
+
 ---
 
 ## 5. Runtime spine: session → turn → attempt

--- a/test/e2e/appearance.browser.e2e.ts
+++ b/test/e2e/appearance.browser.e2e.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Page } from "playwright";
+
+describe("Appearance in Chromium", () => {
+  let browser: Browser;
+  let page: Page;
+  let web: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        ".",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${new URL("../..", import.meta.url).pathname}/apps/web`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/test/appearance.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ viewport: { width: 1120, height: 760 } });
+    page = await context.newPage();
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  }, 30_000);
+
+  async function openAppearance() {
+    const trigger = page.getByRole("button", { name: "Jorge", exact: true, includeHidden: true });
+    if ((await trigger.getAttribute("aria-expanded")) !== "true") await trigger.click();
+    await page.getByRole("menuitemradio", { name: "Light", exact: true }).waitFor();
+  }
+
+  async function theme(value: string) {
+    await page.waitForFunction(
+      (expected) => document.documentElement.dataset.ogTheme === expected,
+      value,
+    );
+    expect(await page.locator("html").evaluate((el) => el.classList.contains("dark"))).toBe(
+      value === "dark",
+    );
+  }
+
+  test("saved choices, live system changes, keyboard and cross-tab synchronization", async () => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto(`${baseUrl}/test/appearance.html`);
+    await theme("light");
+    await openAppearance();
+    expect(
+      await page
+        .getByRole("menuitemradio", { name: "System", exact: true })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    await page.getByRole("menuitemradio", { name: "Dark", exact: true }).click();
+    await theme("dark");
+    await page.reload();
+    await theme("dark");
+    await page.emulateMedia({ colorScheme: "light" });
+    await theme("dark");
+    await openAppearance();
+    await page.getByRole("menuitemradio", { name: "Light", exact: true }).focus();
+    await page.keyboard.press("Enter");
+    await theme("light");
+    await openAppearance();
+    await page.getByRole("menuitemradio", { name: "System", exact: true }).click();
+    await page.emulateMedia({ colorScheme: "dark" });
+    await theme("dark");
+    await page.emulateMedia({ colorScheme: "light" });
+    await theme("light");
+    const other = await page.context().newPage();
+    await other.goto(`${baseUrl}/test/appearance.html`);
+    await other.evaluate(() => localStorage.setItem("opengeni.appearance", "dark"));
+    await theme("dark");
+    await other.evaluate(() => localStorage.clear());
+    await theme("light");
+    await other.close();
+    await page.keyboard.press("Escape");
+    await page.getByRole("button", { name: "Show notification" }).click();
+    expect(await page.locator("[data-sonner-toaster]").getAttribute("data-sonner-theme")).toBe(
+      "light",
+    );
+  });
+
+  test("desktop and narrow menus fit the viewport in both palettes", async () => {
+    for (const width of [1120, 390]) {
+      await page.setViewportSize({ width, height: 760 });
+      for (const colorScheme of ["light", "dark"] as const) {
+        await page.emulateMedia({ colorScheme });
+        await page.goto(`${baseUrl}/test/appearance.html`);
+        await openAppearance();
+        const menu = page.getByRole("menuitemradio", { name: "System", exact: true });
+        const box = (await menu.boundingBox())!;
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(width);
+        expect(box.height).toBeGreaterThanOrEqual(44);
+        await page.screenshot({ path: `/tmp/opengeni-appearance-${width}-${colorScheme}.png` });
+      }
+    }
+  });
+});


### PR DESCRIPTION
Adds Light, Dark, and System choices directly to both account menus. System is the default; choices persist locally, synchronize between tabs, and apply before first paint. Notifications now follow the selected palette.

The compact icon choices stay open for immediate preview and fit narrow screens. The legacy account trigger also gets a consistent touch target and focus ring; long account labels stay within the viewport.

Validation: web typecheck, targeted lint, production web build including bundle budget, 14 bootstrap/index tests, and Chromium tests covering keyboard selection, persistence, live OS changes, cross-tab updates, notifications, and desktop/mobile geometry. Inspected light/dark screenshots. Independent review: no blocking findings.

## Summary by Sourcery

Provide consistent, persistent appearance selection across the web console with Light, Dark, and System themes.

New Features:
- Add Light, Dark, and System appearance choices to both account menus.
- Persist appearance preferences locally and synchronize them across tabs and system color-scheme changes.

Bug Fixes:
- Apply the selected appearance before the first paint to prevent theme flashing.
- Make notifications follow the resolved appearance theme.

Enhancements:
- Improve appearance-menu usability with compact preview controls, keyboard support, focus states, touch targets, and narrow-viewport layout handling.

Documentation:
- Document browser-local appearance ownership and early theme initialization in the architecture guide.

Tests:
- Add unit and Chromium coverage for bootstrap behavior, persistence, keyboard selection, system changes, cross-tab synchronization, notifications, and responsive menu geometry.