### PR TITLE
fix(ui): resolve light-mode contrast and theme artifacts

### DIFF
--- a/.changeset/light-theme-message-details.md
+++ b/.changeset/light-theme-message-details.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Use the selected appearance for message-detail backgrounds instead of the operating system theme.

--- a/apps/web/src/components/browser-account-menu.tsx
+++ b/apps/web/src/components/browser-account-menu.tsx
@@ -223,6 +223,7 @@ export function BrowserAccountMenu() {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
+          tabIndex={0}
           align="start"
           side={rail.collapsed ? "right" : "top"}
           className="w-[min(22rem,calc(100vw-1rem))] forced-colors:border-[CanvasText] forced-colors:text-[CanvasText]! motion-reduce:[&_*]:animate-none"

--- a/apps/web/src/components/personal-workspace-badge.tsx
+++ b/apps/web/src/components/personal-workspace-badge.tsx
@@ -11,7 +11,7 @@ export function PersonalWorkspaceBadge({
     <span
       aria-hidden={decorative || undefined}
       className={cn(
-        "shrink-0 rounded-full border border-brand/35 bg-brand/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-brand",
+        "shrink-0 rounded-full border border-brand/35 bg-brand/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-[var(--og-color-accent-strong)]",
         className,
       )}
     >

--- a/apps/web/src/routes/onboarding-preview.tsx
+++ b/apps/web/src/routes/onboarding-preview.tsx
@@ -202,7 +202,7 @@ function AdditionalOrganizationPreview() {
               type="button"
               className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left"
             >
-              <span className="flex size-7 items-center justify-center rounded-md bg-brand-strong/25 text-xs font-semibold text-brand">
+              <span className="flex size-7 items-center justify-center rounded-md bg-brand-strong/25 text-xs font-semibold text-[var(--og-color-accent-strong)]">
                 A
               </span>
               <span className="min-w-0 flex-1 truncate text-sm font-medium">Analytics</span>

--- a/apps/web/test/appearance-fixture.tsx
+++ b/apps/web/test/appearance-fixture.tsx
@@ -21,7 +21,7 @@ createRoot(document.getElementById("root")!).render(
         <div className="mt-auto">
           <DropdownMenu>
             <DropdownMenuTrigger className="min-h-11 w-full rounded-md p-2 text-left text-sm hover:bg-surface-2">
-              Jorge
+              Example user
             </DropdownMenuTrigger>
             <DropdownMenuContent
               side="top"
@@ -29,8 +29,8 @@ createRoot(document.getElementById("root")!).render(
               className="w-[min(18rem,calc(100vw-1rem))]"
             >
               <DropdownMenuLabel>
-                Jorge
-                <span className="block text-xs font-normal text-fg-subtle">jorge@example.com</span>
+                Example user
+                <span className="block text-xs font-normal text-fg-subtle">user@example.test</span>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <AppearanceMenu />

--- a/apps/web/test/appearance-fixture.tsx
+++ b/apps/web/test/appearance-fixture.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import { PersonalWorkspaceBadge } from "../src/components/personal-workspace-badge";
 import { AppearanceProvider } from "../src/lib/appearance";
 import { AppearanceMenu } from "../src/components/appearance-menu";
 import {
@@ -39,6 +40,9 @@ createRoot(document.getElementById("root")!).render(
       </aside>
       <section className="flex-1 p-8">
         <h1 className="text-xl font-medium">Your workspace</h1>
+        <div className="mt-4 rounded-md bg-surface-3 p-3">
+          <PersonalWorkspaceBadge />
+        </div>
         <p className="mt-2 text-sm text-fg-muted">A comfortable space for your next idea.</p>
         <button
           className="mt-6 rounded-md bg-surface-2 px-4 py-2 text-sm"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,7 @@
 
 ## 1. Scope
 
-This map covers product shape, invariants, execution paths, repository ownership,
-and canonical-source routing. Exact inventories belong in code and focused docs.
+Product shape, invariants, execution paths, and source ownership. Exact inventories live in code.
 
 ---
 
@@ -638,10 +637,7 @@ packages; it does not own session or authorization semantics. Advanced hosts
 may embed API/core/worker packages, but the same domain and persistence
 boundaries still apply.
 
-The stock console owns browser-local appearance in `apps/web/src/lib/appearance.tsx`.
-Both account menus expose Light, Dark, and System; the resolved palette is applied
-to the document for shared React surfaces and portals. The early bootstrap in
-`apps/web/index.html` restores that choice before first paint.
+Console appearance: `apps/web/src/lib/appearance.tsx`; pre-paint bootstrap: `apps/web/index.html`.
 
 ---
 

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -3677,7 +3677,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
         {item.details ? (
           <details className="mt-2 text-og-control">
             <summary className="cursor-pointer font-medium">{item.details.label}</summary>
-            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-og-sm bg-black/5 p-2 font-mono dark:bg-white/5">
+            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-og-sm bg-og-fg/5 p-2 font-mono">
               {JSON.stringify(item.details.value, null, 2)}
             </pre>
           </details>

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -2307,12 +2307,6 @@
 :where(.og-root).bg-black,:where(.og-root) .bg-black {
     background-color: var(--color-black);
   }
-:where(.og-root).bg-black\/5,:where(.og-root) .bg-black\/5 {
-    background-color: color-mix(in srgb, #000 5%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-black) 5%, transparent);
-    }
-  }
 :where(.og-root).bg-black\/45,:where(.og-root) .bg-black\/45 {
     background-color: color-mix(in srgb, #000 45%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2429,6 +2423,12 @@
   }
 :where(.og-root).bg-og-fg-subtle,:where(.og-root) .bg-og-fg-subtle {
     background-color: var(--og-color-fg-subtle);
+  }
+:where(.og-root).bg-og-fg\/5,:where(.og-root) .bg-og-fg\/5 {
+    background-color: var(--og-color-fg);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--og-color-fg) 5%, transparent);
+    }
   }
 :where(.og-root).bg-og-status-cancelled,:where(.og-root) .bg-og-status-cancelled {
     background-color: var(--og-color-status-cancelled);
@@ -5094,14 +5094,6 @@
 :where(.og-root).xl\:grid-cols-3,:where(.og-root) .xl\:grid-cols-3 {
     @media (width >= 80rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-  }
-:where(.og-root).dark\:bg-white\/5,:where(.og-root) .dark\:bg-white\/5 {
-    @media (prefers-color-scheme: dark) {
-      background-color: color-mix(in srgb, #fff 5%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
-      }
     }
   }
 :where(.og-root).dark\:data-\[variant\=destructive\]\:focus\:bg-destructive\/20,:where(.og-root) .dark\:data-\[variant\=destructive\]\:focus\:bg-destructive\/20 {

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -96,6 +96,7 @@ describe("fail-closed change impact", () => {
     expect(sdk.unitTests).toContain("packages/sdk/test/client.test.ts");
     expect(sdk.e2eTests).toEqual([
       AI_GATEWAY_CONNECTION_E2E,
+      "test/e2e/appearance.browser.e2e.ts",
       "test/e2e/code-editor.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",
@@ -332,6 +333,7 @@ describe("fail-closed change impact", () => {
     expect(tests.integration.length).toBeGreaterThan(0);
     expect(tests.e2e).toEqual([
       AI_GATEWAY_CONNECTION_E2E,
+      "test/e2e/appearance.browser.e2e.ts",
       "test/e2e/code-editor.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -310,6 +310,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
     "@opengeni/testing",
   ],
   "test/e2e/personal-workspace-accessibility.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
+  "test/e2e/appearance.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/workspace-switcher-trigger.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/session-rail-row-metadata.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/setup-account-token.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],

--- a/test/e2e/appearance.browser.e2e.ts
+++ b/test/e2e/appearance.browser.e2e.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from "@axe-core/playwright";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
 import { chromium, type Browser, type Page } from "playwright";
@@ -106,6 +107,10 @@ describe("Appearance in Chromium", () => {
       for (const colorScheme of ["light", "dark"] as const) {
         await page.emulateMedia({ colorScheme });
         await page.goto(`${baseUrl}/test/appearance.html`);
+        const accessibility = await new AxeBuilder({ page })
+          .withRules(["color-contrast"])
+          .analyze();
+        expect(accessibility.violations).toEqual([]);
         await openAppearance();
         const menu = page.getByRole("menuitemradio", { name: "System", exact: true });
         const box = (await menu.boundingBox())!;

--- a/test/e2e/appearance.browser.e2e.ts
+++ b/test/e2e/appearance.browser.e2e.ts
@@ -46,7 +46,11 @@ describe("Appearance in Chromium", () => {
   }, 30_000);
 
   async function openAppearance() {
-    const trigger = page.getByRole("button", { name: "Jorge", exact: true, includeHidden: true });
+    const trigger = page.getByRole("button", {
+      name: "Example user",
+      exact: true,
+      includeHidden: true,
+    });
     if ((await trigger.getAttribute("aria-expanded")) !== "true") await trigger.click();
     await page.getByRole("menuitemradio", { name: "Light", exact: true }).waitFor();
   }

--- a/test/e2e/organization-onboarding-acceptance.e2e.ts
+++ b/test/e2e/organization-onboarding-acceptance.e2e.ts
@@ -224,6 +224,13 @@ async function expectNoAxeViolations(page: Page, include = "body"): Promise<void
     .include(include)
     .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
     .analyze();
+  if (report.violations.length) {
+    await writeFile(
+      `${EVIDENCE_DIR}/contrast-failure.json`,
+      JSON.stringify(report.violations, null, 2),
+    );
+    await page.screenshot({ path: `${EVIDENCE_DIR}/contrast-failure.png` });
+  }
   expect(
     report.violations.map((violation) => ({
       id: violation.id,


### PR DESCRIPTION
Fixes light-mode issues found during the appearance rollout audit. The Personal badge had 4.0:1 text contrast on its tinted background; it and onboarding preview initials now use the canonical stronger accent. Message detail backgrounds use the foreground token instead of an OS-driven dark variant, so explicit appearance wins.

Adds badge contrast checks in both palettes, retains screenshots and full accessibility findings on onboarding failures, and registers the appearance browser suite in CI. Compacts appearance documentation to restore the architecture word budget.

Validation: real onboarding API/Postgres/browser suite (3 tests, 99 assertions), appearance Chromium suite (2 tests, 27 assertions), 38 CI impact tests, bootstrap tests, web typecheck, lint, formatting, generated CSS check, docs guard, production build/bundle budget. Independent review found no blockers. Visually inspected actual staging composer, model picker, conversation/error banner, file browser, General/Members/Models settings, Insights charts, and mobile composer in the light palette using a temporary document theme override; staging does not yet contain the toggle. Also inspected the corrected local onboarding screenshot.

The taller browser-account menu also becomes explicitly keyboard-focusable when it overflows at 200% zoom, preserving Radix arrow-key/typeahead behavior. Final source repair was driven by the real account accessibility failure, not a base-branch advance. Full account acceptance passes locally: 3 tests / 307 assertions. Responsive composer suite also passes locally: 3 tests / 46 assertions. Independent review found no keyboard regression.

## Summary by Sourcery

Resolve light-theme contrast and appearance-selection issues while strengthening accessibility coverage and account-menu usability.

Bug Fixes:
- Fix light-mode contrast for personal workspace badges and onboarding preview initials.
- Use the selected appearance for message-detail backgrounds instead of the operating-system theme.
- Make overflowing account menus keyboard-focusable at high zoom without disrupting menu keyboard interactions.

Enhancements:
- Add automated color-contrast validation for both appearance palettes and preserve screenshots plus detailed accessibility evidence for onboarding failures.

CI:
- Register the appearance browser suite in change-impact CI coverage.

Documentation:
- Condense the architecture documentation while retaining appearance ownership and bootstrap references.

Tests:
- Extend appearance browser tests with automated contrast checks.

Chores:
- Regenerate compiled styles for the updated foreground-based message-detail background.