### PR TITLE
fix: build portable web images without ARM emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1508,9 +1508,6 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -1,10 +1,6 @@
 ARG BUN_VERSION=1.4.0
-FROM oven/bun:${BUN_VERSION} AS source-base
-
-WORKDIR /app
-
-ARG OPENGENI_SERVER_VERSION
-ENV OPENGENI_SERVER_VERSION=$OPENGENI_SERVER_VERSION
+# Share the frozen-install inputs without tying them to a CPU architecture.
+FROM scratch AS workspace-manifests
 
 COPY package.json bun.lock tsconfig.base.json ./
 COPY apps/api/package.json apps/api/package.json
@@ -43,6 +39,11 @@ COPY packages/tool-gateway/package.json packages/tool-gateway/package.json
 COPY packages/xai-subscription/package.json packages/xai-subscription/package.json
 COPY patches patches
 
+FROM oven/bun:${BUN_VERSION} AS source-base
+WORKDIR /app
+ARG OPENGENI_SERVER_VERSION
+ENV OPENGENI_SERVER_VERSION=$OPENGENI_SERVER_VERSION
+COPY --from=workspace-manifests / /app/
 RUN bun install --frozen-lockfile
 
 COPY --chown=bun:bun . .
@@ -195,11 +196,32 @@ RUN bun scripts/build-runtime-processes.ts artifact-materializer
 EXPOSE 9465
 CMD ["bun", "apps/worker/dist/process/artifact-materializer/artifact-materializer-entry.js"]
 
-FROM base AS web-build
+# Browser assets and the Bun server bundle are architecture-independent. Run
+# Vite/Rolldown only on the builder CPU: ARM emulation can stall demo bundling.
+FROM --platform=$BUILDPLATFORM oven/bun:${BUN_VERSION} AS web-build
+WORKDIR /app
+COPY --from=workspace-manifests / /app/
+RUN bun install --frozen-lockfile
+COPY --chown=bun:bun . .
+RUN install -d -o bun -g bun -m 0755 /workspace /app/web-server
+ARG OPENGENI_SERVER_VERSION
 ARG OPENGENI_DEPLOYMENT_REVISION=dev
-ENV VITE_OPENGENI_DEPLOYMENT_REVISION=$OPENGENI_DEPLOYMENT_REVISION
-RUN bun run --cwd apps/web build
+ENV NODE_ENV=production \
+  OPENGENI_SERVER_VERSION=$OPENGENI_SERVER_VERSION \
+  VITE_OPENGENI_DEPLOYMENT_REVISION=$OPENGENI_DEPLOYMENT_REVISION
+USER bun
+RUN bun run --cwd apps/web build \
+  && bun build apps/web/src/server.ts --target=bun --outfile=/app/web-server/server.ts
 
-FROM web-build AS web
+# No target-architecture RUN steps or copied native build dependencies.
+FROM oven/bun:${BUN_VERSION} AS web
+WORKDIR /app
+ARG OPENGENI_SERVER_VERSION
+ENV NODE_ENV=production OPENGENI_SERVER_VERSION=$OPENGENI_SERVER_VERSION
+COPY --from=web-build --chown=bun:bun /app/apps/web/dist ./apps/web/dist
+COPY --from=web-build --chown=bun:bun /app/apps/web/package.json ./apps/web/package.json
+COPY --from=web-build --chown=bun:bun /app/web-server/server.ts ./apps/web/src/server.ts
+COPY --from=web-build --chown=bun:bun /workspace /workspace
+USER bun
 EXPOSE 3000
 CMD ["bun", "run", "--cwd", "apps/web", "start"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1494,7 +1494,7 @@ services and credentials explicitly.
 Release publication is an evidence-bound process spanning npm packages,
 container images, the Helm chart, the Rust agent, and retained source identity.
 Package manifests, Changesets configuration, CI workflows, and release scripts
-own the exact closure and procedure. Do not copy those inventories here.
+own the exact closure and procedure. Web image assets compile natively for both CPU targets.
 
 Canonical commands and contribution rules are in
 [`../AGENTS.md`](../AGENTS.md) and [`../CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1215,6 +1215,11 @@ content-hashed `/assets/*` responses are served with immutable one-year caching,
 while the HTML shell revalidates. The API compresses JSON responses and leaves
 SSE and other streaming transports uncompressed.
 
+Web assets, the React demo, and the server bundle compile once on BuildKit's
+native build platform. The amd64 and arm64 web images copy those portable
+outputs into their respective Bun runtime images without executing target
+architecture build steps. Web image publication therefore does not need QEMU.
+
 Build local OpenGeni workload images:
 
 ```bash

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "path": ".github/workflows/ci.yml",
-      "sha256": "f8e82313d21eba3e032f52a31ec3d47b970ce678a2ae097278546493522ec0ca"
+      "sha256": "e2a6dff995443c049a33b5c844f1beb0be0e079d15c1c5119a61c00b2d44d39b"
     },
     {
       "path": ".github/workflows/desktop-e2e.yml",

--- a/scripts/workload-image-system-packages-contract.test.ts
+++ b/scripts/workload-image-system-packages-contract.test.ts
@@ -64,6 +64,29 @@ function keepsSpecializedWorkloadPackagesCoalesced(source: string): boolean {
 }
 
 describe("workload image system package contract", () => {
+  test("builds web assets natively and assembles either runtime architecture without execution", async () => {
+    const dockerfile = await readFile(resolve(root, "docker/opengeni.Dockerfile"), "utf8");
+    const builder = stage(dockerfile, "web-build");
+    const runtime = stage(dockerfile, "web");
+    expect(builder).toStartWith("FROM --platform=$BUILDPLATFORM oven/bun:${BUN_VERSION}");
+    expect(builder).toContain("COPY --from=workspace-manifests / /app/");
+    expect(builder).toContain("bun run --cwd apps/web build");
+    expect(builder).toContain("bun build apps/web/src/server.ts --target=bun");
+    expect(runtime).toStartWith("FROM oven/bun:${BUN_VERSION} AS web");
+    expect(runtime).not.toMatch(/^RUN\s/mu);
+    expect(runtime).not.toContain("node_modules");
+    expect(runtime).toContain("/app/apps/web/dist ./apps/web/dist");
+    expect(runtime).toContain("/app/web-server/server.ts ./apps/web/src/server.ts");
+    expect(runtime).toContain("USER bun");
+    const ci = await readFile(resolve(root, ".github/workflows/ci.yml"), "utf8");
+    const webJob = ci.slice(
+      ci.indexOf("  web-image:"),
+      ci.indexOf("  artifact-materializer-image:"),
+    );
+    expect(webJob).toContain("platforms: linux/amd64,linux/arm64");
+    expect(webJob).not.toContain("setup-qemu-action");
+  });
+
   test("coalesces specialized workload packages without weakening their runtime base", async () => {
     const dockerfile = await readFile(resolve(root, "docker/opengeni.Dockerfile"), "utf8");
 


### PR DESCRIPTION
The ARM64 web image could hang until CI timeout while Rollup rendered the React demo under QEMU. Build the portable web assets and bundled Bun server once on the build host, then copy them into architecture-native Bun runtime images. The web image job no longer needs QEMU; both AMD64 and ARM64 remain published.

Validation: actual dual-architecture OCI build passed; both runtime images served the SPA, React demo, gzip/immutable assets, and no-store setup page as uid 1000. Deployment revision is embedded and runtime images contain no node_modules. 86 focused tests passed, plus lint, formatting, docs-reference and Bun-version checks.

## Summary by Sourcery

Build architecture-independent web assets and server bundles on the build host before assembling native multi-architecture Bun runtime images.

Bug Fixes:
- Build portable amd64 and arm64 web images without requiring QEMU or target-architecture build execution.

Enhancements:
- Compile web assets and the bundled Bun server once on the native build platform, then assemble minimal architecture-specific runtime images from those outputs.

CI:
- Remove QEMU setup from the web image CI job while continuing to publish both amd64 and arm64 images.

Documentation:
- Document native web asset compilation and QEMU-free multi-architecture web image publication.

Tests:
- Add contract coverage verifying native web builds, portable runtime assembly, absence of runtime build steps and node_modules, and QEMU-free CI configuration.