### PR TITLE
fix: embedded conversation contrast and session Site previews

### DIFF
--- a/.agents/skills/opengeni-sites/SKILL.md
+++ b/.agents/skills/opengeni-sites/SKILL.md
@@ -143,11 +143,14 @@ import { SessionConversation } from "@opengeni/react/session-ui";
 import "@opengeni/react/compiled.css";
 
 const site = createOpenGeniSiteClient();
+// Match the theme to your chat panel; omit this wrapper for the dark default.
+<div data-og-theme="light" style={{ height: "100%", minHeight: 0 }}>
 <SessionConversation
   client={site.client}
   workspaceId={site.workspaceId}
   sessionId={sessionId}
 />
+</div>
 ```
 
 `sessionId` is the existing session or the id returned by `site.client.createSession`.
@@ -158,6 +161,12 @@ pairing it with a timeline does not create the queue UI.
 Use the lower-level hooks/components only for intentionally custom behavior.
 
 The host owns the chat's available space; `SessionConversation` fills it.
+The SDK defaults to dark colors. On a light panel, set `data-og-theme="light"`
+on its wrapper; changing the Site's body background does not select the SDK
+theme, and the outer OpenGeni app's theme does not cross the iframe. Keep
+foreground and background on the same SDK tokens rather than overriding
+message/button colors individually. Check a real assistant reply, expanded
+steps, composer and menus for readable contrast in the chosen theme.
 For a full-height page, use a `height: 100dvh` flex-column layout with the
 chat panel `flex: 1; min-height: 0` below its header. Keep intervening
 flex/grid children shrinkable (`min-height: 0; min-width: 0`). The SDK owns

--- a/.changeset/site-panel-theme.md
+++ b/.changeset/site-panel-theme.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+"@opengeni/contracts": patch
+---
+
+Keep embedded conversation foreground and background theme-matched. Support filtering published Sites by creating or publishing session for the session Artifacts panel.

--- a/apps/api/src/routes/workspace-artifacts.ts
+++ b/apps/api/src/routes/workspace-artifacts.ts
@@ -181,7 +181,9 @@ export function registerWorkspaceArtifactRoutes(app: Hono, deps: ApiRouteDeps): 
     const workspaceId = context.req.param("workspaceId");
     await requireAccessGrant(context, deps, workspaceId, "artifacts:read");
     if (!deps.objectStorage)
-      throw new HTTPException(503, { message: "Object storage is not configured" });
+      throw new HTTPException(503, {
+        message: "Object storage is not configured",
+      });
     const ref = await getWorkspaceArtifactContentRef(
       deps.db,
       workspaceId,
@@ -193,13 +195,20 @@ export function registerWorkspaceArtifactRoutes(app: Hono, deps: ApiRouteDeps): 
 
   app.get(base, async (context) => {
     const workspaceId = context.req.param("workspaceId");
-    await requireAccessGrant(context, deps, workspaceId, "artifacts:read");
+    const grant = await requireAccessGrant(context, deps, workspaceId, "artifacts:read");
     const query = WorkspaceArtifactListQuery.safeParse({
       limit: context.req.query("limit"),
       cursor: context.req.query("cursor"),
       status: context.req.query("status"),
+      sourceSessionId: context.req.query("sourceSessionId"),
     });
     if (!query.success) throw new HTTPException(422, { message: "Invalid artifact list query" });
+    if (
+      query.data.sourceSessionId &&
+      !(await canReadProvenanceSession(deps, grant, query.data.sourceSessionId))
+    ) {
+      throw new HTTPException(404, { message: "Session not found" });
+    }
     try {
       return context.json(
         WorkspaceArtifactListResponse.parse(
@@ -208,6 +217,9 @@ export function registerWorkspaceArtifactRoutes(app: Hono, deps: ApiRouteDeps): 
               limit: query.data.limit,
               ...(query.data.cursor ? { cursor: query.data.cursor } : {}),
               ...(query.data.status ? { status: query.data.status } : {}),
+              ...(query.data.sourceSessionId
+                ? { sourceSessionId: query.data.sourceSessionId }
+                : {}),
             }),
           ),
         ),
@@ -281,7 +293,9 @@ export function registerWorkspaceArtifactRoutes(app: Hono, deps: ApiRouteDeps): 
     const workspaceId = context.req.param("workspaceId");
     await requireAccessGrant(context, deps, workspaceId, "artifacts:read");
     if (!deps.objectStorage)
-      throw new HTTPException(503, { message: "Object storage is not configured" });
+      throw new HTTPException(503, {
+        message: "Object storage is not configured",
+      });
     const ref = await getWorkspaceArtifactContentRef(
       deps.db,
       workspaceId,

--- a/apps/api/test/workspace-artifacts.test.ts
+++ b/apps/api/test/workspace-artifacts.test.ts
@@ -755,6 +755,36 @@ describe("workspace artifact API and PostgreSQL authority", () => {
       expect(created.version.sourceTurnId).toBe(attempt.turnId);
       expect(created.version.sourceAttemptId).toBe(attempt.attemptId);
       expect(created.version.sourceExecutionGeneration).toBe(attempt.executionGeneration);
+      const sessionList = await request(
+        grant,
+        ["artifacts:read", "sessions:read"],
+        `/v1/workspaces/${grant.workspaceId}/published-artifacts?sourceSessionId=${attempt.sessionId}`,
+      );
+      expect(sessionList.status).toBe(200);
+      const sessionSites = WorkspaceArtifactListResponse.parse(await sessionList.json());
+      expect(sessionSites.artifacts.map((site) => site.id)).toContain(created.artifact.id);
+      const unrelated = await seedAttempt(grant);
+      const unrelatedList = await request(
+        grant,
+        ["artifacts:read", "sessions:read"],
+        `/v1/workspaces/${grant.workspaceId}/published-artifacts?sourceSessionId=${unrelated.sessionId}`,
+      );
+      expect(WorkspaceArtifactListResponse.parse(await unrelatedList.json()).artifacts).toEqual([]);
+      const inaccessible = await seedAttempt(otherGrant);
+      const deniedList = await request(
+        grant,
+        ["artifacts:read"],
+        `/v1/workspaces/${grant.workspaceId}/published-artifacts?sourceSessionId=${inaccessible.sessionId}`,
+      );
+      // Legacy local authorization can admit the metadata query, but tenant
+      // filtering must still return no artifact from the other workspace.
+      expect(WorkspaceArtifactListResponse.parse(await deniedList.json()).artifacts).toEqual([]);
+      const invalidList = await request(
+        grant,
+        ["artifacts:read"],
+        `/v1/workspaces/${grant.workspaceId}/published-artifacts?sourceSessionId=invalid`,
+      );
+      expect(invalidList.status).toBe(422);
 
       const putsAfterCreate = objectPutCount;
       const replayResult = await mcp.callTool({
@@ -848,6 +878,37 @@ describe("workspace artifact API and PostgreSQL authority", () => {
       const restored = WorkspaceArtifactMutationResponse.parse(JSON.parse(restoreText.text));
       expect(restored.artifact.status).toBe("active");
       expect(restored.event.sourceExecutionGeneration).toBe(attempt.executionGeneration);
+      // A later publisher must not erase the original session's association.
+      const later = await seedAttempt(grant);
+      await publishWorkspaceArtifactVersion(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        artifactId: created.artifact.id,
+        expectedCurrentVersionId: created.version.id,
+        contentKey: `workspace-artifacts/${grant.workspaceId}/later.html`,
+        contentSha256: "1".repeat(64),
+        sizeBytes: 100,
+        requestedTools: [],
+        operationKey: crypto.randomUUID(),
+        actorSubjectId: grant.subjectId,
+        sourceSessionId: later.sessionId,
+        sourceTurnId: later.turnId,
+        sourceAttemptId: later.attemptId,
+        sourceExecutionGeneration: later.executionGeneration,
+        sourceToolName: "artifacts_publish",
+        persistContent: async () => undefined,
+        discardContent: async () => undefined,
+      });
+      for (const sessionId of [attempt.sessionId, later.sessionId]) {
+        const listed = await request(
+          grant,
+          ["artifacts:read", "sessions:read"],
+          `/v1/workspaces/${grant.workspaceId}/published-artifacts?sourceSessionId=${sessionId}&limit=1`,
+        );
+        const page = WorkspaceArtifactListResponse.parse(await listed.json());
+        expect(page.artifacts.map((site) => site.id)).toEqual([created.artifact.id]);
+        expect(page.truncated).toBe(false);
+      }
 
       const replacement = await supersedeAttempt(attempt);
       const putsBeforeStaleAttempt = objectPutCount;

--- a/apps/web/src/components/artifacts/artifact-sandbox.tsx
+++ b/apps/web/src/components/artifacts/artifact-sandbox.tsx
@@ -30,6 +30,7 @@ export function ArtifactSandbox(props: {
   toolBridge?: PublishedHtmlArtifactToolBridge;
   connectedToolCount?: number;
   sourceFileCount?: number;
+  fill?: boolean;
 }) {
   const [reloadKey, setReloadKey] = useState(0);
   const [focused, setFocused] = useState(false);
@@ -42,6 +43,7 @@ export function ArtifactSandbox(props: {
         "overflow-hidden rounded-2xl border border-border/80 bg-white shadow-sm",
         focused && "fixed inset-0 z-50 flex flex-col rounded-none border-0 bg-surface shadow-none",
         props.className,
+        props.fill && "flex min-h-0 flex-col",
       )}
     >
       <div className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-border/80 bg-surface/95 px-3 sm:px-4">
@@ -134,6 +136,7 @@ export function ArtifactSandbox(props: {
         toolBridge={props.toolBridge}
         className={cn(
           "h-[clamp(30rem,62vh,48rem)] w-full border-0 bg-white",
+          props.fill && "h-0 min-h-0 flex-1",
           focused && "min-h-0 flex-1",
         )}
       />

--- a/apps/web/src/components/session/editable-artifacts-workspace.test.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.test.tsx
@@ -12,6 +12,11 @@ import { createRoot } from "react-dom/client";
 mock.module("@/routes/editable-artifact", () => ({
   EditableArtifactRoute: () => null,
 }));
+mock.module("@/routes/artifacts", () => ({
+  ArtifactDetailRoute: ({ artifactId, embedded }: { artifactId: string; embedded?: boolean }) => (
+    <div data-site-preview={artifactId}>{embedded ? "Embedded Site" : "Full Site"}</div>
+  ),
+}));
 
 const { SessionEditableArtifactsWorkspace } = await import("./editable-artifacts-workspace");
 
@@ -27,6 +32,42 @@ afterAll(() => {
 });
 
 describe("SessionEditableArtifactsWorkspace empty states", () => {
+  test("opens a session Site in the shared preview with a full-page link", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const id = "22222222-2222-4222-8222-222222222222";
+    const route = createRootRoute({
+      component: () => (
+        <SessionEditableArtifactsWorkspace
+          workspaceId="11111111-1111-4111-8111-111111111111"
+          artifacts={[{ id, title: "Dashboard", modality: "site" }]}
+          status="ready"
+          onRetry={() => undefined}
+        />
+      ),
+    });
+    const router = createRouter({
+      routeTree: route,
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+    try {
+      await act(async () => {
+        await router.load();
+        root.render(<RouterProvider router={router} />);
+      });
+      expect(
+        container.querySelector("[data-site-preview]")?.getAttribute("data-site-preview"),
+      ).toBe(id);
+      expect(container.textContent).toContain("Embedded Site");
+      expect(container.querySelector("a")?.getAttribute("href")).toBe(
+        `/workspaces/11111111-1111-4111-8111-111111111111/artifacts/${id}`,
+      );
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
   test("restores and reports the selected artifact", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -60,7 +101,7 @@ describe("SessionEditableArtifactsWorkspace empty states", () => {
         root.render(<RouterProvider router={router} />);
       });
       const select = container.querySelector<HTMLSelectElement>(
-        'select[aria-label="Choose editable artifact"]',
+        'select[aria-label="Choose artifact"]',
       );
       expect(select?.value).toBe(secondId);
 

--- a/apps/web/src/components/session/editable-artifacts-workspace.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.tsx
@@ -13,11 +13,14 @@ import { useEffect, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { EditableArtifactRoute } from "@/routes/editable-artifact";
+import { ArtifactDetailRoute } from "@/routes/artifacts";
 
 export type SessionEditableArtifactSummary = Readonly<{
   id: string;
-  modality: "document" | "spreadsheet" | "presentation";
+  modality: "document" | "spreadsheet" | "presentation" | "site";
   title: string;
+  versionId?: string;
+  siteStatus?: "active" | "archived";
 }>;
 
 export type SessionEditableArtifactsStatus = "loading" | "ready" | "error";
@@ -79,7 +82,7 @@ export function SessionEditableArtifactsWorkspace({
               ? "Opening the shared workspace."
               : failed
                 ? "The shared workspace could not be loaded."
-                : "Ask the agent to create or import a document, spreadsheet, or presentation."}
+                : "Ask the agent to create or import a Site, document, spreadsheet, or presentation."}
           </p>
           {failed ? (
             <Button type="button" variant="outline" size="sm" className="mt-4" onClick={onRetry}>
@@ -100,7 +103,7 @@ export function SessionEditableArtifactsWorkspace({
         {artifacts.length > 1 ? (
           <div className="min-w-0 flex-1 [&>span]:block [&>span]:w-full">
             <Select
-              aria-label="Choose editable artifact"
+              aria-label="Choose artifact"
               className="h-8 min-w-0 border-0 bg-transparent pl-1 font-medium shadow-none"
               value={artifact.id}
               onChange={(event) => {
@@ -119,7 +122,9 @@ export function SessionEditableArtifactsWorkspace({
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium">{artifact.title}</p>
             <p className="truncate text-xs capitalize text-fg-subtle">
-              {artifact.modality} · shared editor
+              {artifact.modality === "site"
+                ? "Site · published preview"
+                : `${artifact.modality} · shared editor`}
             </p>
           </div>
         )}
@@ -141,25 +146,39 @@ export function SessionEditableArtifactsWorkspace({
           variant="ghost"
           size="icon-sm"
           className="ml-auto shrink-0"
-          title="Open full-page editor"
+          title={artifact.modality === "site" ? "Open Site" : "Open full-page editor"}
         >
           <Link
-            to="/workspaces/$workspaceId/artifacts/editable/$artifactId"
+            to={
+              artifact.modality === "site"
+                ? "/workspaces/$workspaceId/artifacts/$artifactId"
+                : "/workspaces/$workspaceId/artifacts/editable/$artifactId"
+            }
             params={{ workspaceId, artifactId: artifact.id }}
-            aria-label={`Open ${artifact.title} in the full-page editor`}
+            aria-label={`Open ${artifact.title} full-page`}
           >
             <Maximize2Icon className="size-4" />
           </Link>
         </Button>
       </div>
       <div className="min-h-0 flex-1">
-        <EditableArtifactRoute workspaceId={workspaceId} artifactId={artifact.id} />
+        {artifact.modality === "site" ? (
+          <ArtifactDetailRoute
+            key={`${artifact.id}:${artifact.versionId ?? ""}:${artifact.siteStatus ?? ""}`}
+            workspaceId={workspaceId}
+            artifactId={artifact.id}
+            embedded
+          />
+        ) : (
+          <EditableArtifactRoute workspaceId={workspaceId} artifactId={artifact.id} />
+        )}
       </div>
     </div>
   );
 }
 
-function artifactIcon(modality: "document" | "spreadsheet" | "presentation"): ReactNode {
+function artifactIcon(modality: SessionEditableArtifactSummary["modality"]): ReactNode {
+  if (modality === "site") return <PanelsTopLeftIcon className="size-4" />;
   if (modality === "document") return <FilePenLineIcon className="size-4" />;
   if (modality === "spreadsheet") return <Table2Icon className="size-4" />;
   return <GalleryHorizontalEndIcon className="size-4" />;

--- a/apps/web/src/components/session/editable-artifacts-workspace.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.tsx
@@ -8,12 +8,14 @@ import {
   RefreshCwIcon,
   Table2Icon,
 } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import { lazy, useEffect, useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { EditableArtifactRoute } from "@/routes/editable-artifact";
-import { ArtifactDetailRoute } from "@/routes/artifacts";
+const ArtifactDetailRoute = lazy(() =>
+  import("@/routes/artifacts").then((module) => ({ default: module.ArtifactDetailRoute })),
+);
 
 export type SessionEditableArtifactSummary = Readonly<{
   id: string;

--- a/apps/web/src/lib/artifact-refresh.test.ts
+++ b/apps/web/src/lib/artifact-refresh.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { retainArtifactsAfterRefreshFailure } from "./artifact-refresh";
+
+test("denied or missing artifacts are removed rather than retaining a mounted preview", () => {
+  for (const status of [400, 401, 403, 404, 409, 422]) {
+    expect(retainArtifactsAfterRefreshFailure({ status })).toBe(false);
+  }
+  expect(retainArtifactsAfterRefreshFailure(new Error("Invalid response"))).toBe(false);
+});
+
+test("transient refresh failures retain the previous preview", () => {
+  for (const status of [408, 429, 500, 502, 503, 504]) {
+    expect(retainArtifactsAfterRefreshFailure({ status })).toBe(true);
+  }
+  expect(retainArtifactsAfterRefreshFailure(new TypeError("Failed to fetch"))).toBe(true);
+});

--- a/apps/web/src/lib/artifact-refresh.ts
+++ b/apps/web/src/lib/artifact-refresh.ts
@@ -1,0 +1,8 @@
+/** Preserve previews only for transient failures, never an authoritative denial. */
+export function retainArtifactsAfterRefreshFailure(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "status" in error) {
+    const status = error.status;
+    return typeof status === "number" && (status === 408 || status === 429 || status >= 500);
+  }
+  return error instanceof TypeError; // Fetch transport failure.
+}

--- a/apps/web/src/lib/session-artifact-discovery.ts
+++ b/apps/web/src/lib/session-artifact-discovery.ts
@@ -1,0 +1,68 @@
+import type { SessionEditableArtifactSummary } from "@/components/session/editable-artifacts-workspace";
+import { editableArtifactClient } from "./editable-artifact-client";
+import { createConsoleEditableArtifactReplicaId } from "./editable-artifact-browser";
+import { retainArtifactsAfterRefreshFailure } from "./artifact-refresh";
+
+export async function discoverSessionArtifacts(
+  workspaceId: string,
+  sessionId: string,
+  current: () => boolean,
+) {
+  const [documents, sites] = await Promise.allSettled([
+    editableArtifactClient
+      .listSessionEditableArtifacts(workspaceId, sessionId, {
+        replicaId: createConsoleEditableArtifactReplicaId(),
+      })
+      .then((result) => result.artifacts),
+    (async () => {
+      const result: SessionEditableArtifactSummary[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await editableArtifactClient.listWorkspaceArtifacts(workspaceId, {
+          sourceSessionId: sessionId,
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        });
+        if (!current()) return [];
+        result.push(
+          ...page.artifacts.map((site) => ({
+            id: site.id,
+            title: site.title,
+            modality: "site" as const,
+            versionId: site.currentVersion?.id,
+            siteStatus: site.status,
+          })),
+        );
+        cursor = page.nextCursor ?? undefined;
+      } while (cursor);
+      return result;
+    })(),
+  ]);
+  return (previous: readonly SessionEditableArtifactSummary[]) => ({
+    status:
+      documents.status === "fulfilled" && sites.status === "fulfilled"
+        ? ("ready" as const)
+        : ("error" as const),
+    artifacts: [
+      ...settledArtifacts(
+        documents,
+        previous.filter((item) => item.modality !== "site"),
+      ),
+      ...settledArtifacts(
+        sites,
+        previous.filter((item) => item.modality === "site"),
+      ),
+    ],
+  });
+}
+
+function settledArtifacts(
+  result: PromiseSettledResult<readonly SessionEditableArtifactSummary[]>,
+  previous: readonly SessionEditableArtifactSummary[],
+): readonly SessionEditableArtifactSummary[] {
+  return result.status === "fulfilled"
+    ? result.value
+    : retainArtifactsAfterRefreshFailure(result.reason)
+      ? previous
+      : [];
+}

--- a/apps/web/src/routes/artifacts.tsx
+++ b/apps/web/src/routes/artifacts.tsx
@@ -197,9 +197,11 @@ function ArtifactListRoute({ workspaceId }: { workspaceId: string }) {
 export function ArtifactDetailRoute({
   workspaceId,
   artifactId,
+  embedded = false,
 }: {
   workspaceId: string;
   artifactId: string;
+  embedded?: boolean;
 }) {
   const context = useAppContext();
   const navigate = useNavigate();
@@ -338,6 +340,39 @@ export function ArtifactDetailRoute({
     }
   };
   const archived = detail?.artifact.status === "archived";
+  if (embedded) {
+    if (error)
+      return (
+        <LoadErrorState
+          title="Couldn't load Site"
+          error={asError(error)}
+          onRetry={() => void load()}
+        />
+      );
+    if (!detail || !content)
+      return (
+        <div role="status" className="p-4 text-sm text-fg-muted">
+          Loading Site…
+        </div>
+      );
+    if (archived)
+      return (
+        <div className="p-4 text-sm text-fg-muted">
+          This Site is archived. Open it full-page to restore it.
+        </div>
+      );
+    return (
+      <ArtifactSandbox
+        html={content.html}
+        title={detail.artifact.title}
+        versionLabel={`v${detail.artifact.currentVersion?.revision}`}
+        toolBridge={siteToolBridge}
+        connectedToolCount={content.requestedTools.length}
+        fill
+        className="h-full rounded-none border-0"
+      />
+    );
+  }
   return (
     <ContentPage width="wide">
       <div className="mb-5 border-b border-border pb-5">

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -50,6 +50,7 @@ import {
 import { toast } from "sonner";
 
 import { isApiErrorStatus } from "@/api";
+import { retainArtifactsAfterRefreshFailure } from "@/lib/artifact-refresh";
 import { ConsoleComposer } from "@/components/Composer";
 import { ComposerMobilePlus } from "@/components/composer-mobile-plus";
 import { LoadingPanel } from "@/components/common";
@@ -77,7 +78,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Notice } from "@/components/ui/notice";
-import type { EditableArtifactResource } from "@opengeni/sdk/artifacts";
 import { useAppContext } from "@/context";
 import { useBrowserAccountBridgeBlocker } from "@/lib/browser-account-bridge";
 import type {
@@ -353,7 +353,10 @@ export function SessionRoute({
     windowFocused: document.hasFocus(),
   }));
   const [attentionRetryRevision, setAttentionRetryRevision] = useState(0);
-  const reconciledSessionRead = useRef<{ sessionId: string; revision: number } | null>(null);
+  const reconciledSessionRead = useRef<{
+    sessionId: string;
+    revision: number;
+  } | null>(null);
   useEffect(() => {
     if (!fetchedSession || sessionReadRevision === 0) return;
     if (
@@ -362,7 +365,10 @@ export function SessionRoute({
     ) {
       return;
     }
-    reconciledSessionRead.current = { sessionId, revision: sessionReadRevision };
+    reconciledSessionRead.current = {
+      sessionId,
+      revision: sessionReadRevision,
+    };
     const accepted = context.sessionChannelProjectionAuthority.recordRead(
       fetchedSession,
       sessionReadGeneration,
@@ -1072,7 +1078,7 @@ function useSessionEditableArtifactSummaries(input: {
   const [loaded, setLoaded] = useState<{
     key: string;
     status: SessionEditableArtifactsStatus;
-    artifacts: readonly EditableArtifactResource[];
+    artifacts: readonly SessionEditableArtifactSummary[];
   } | null>(null);
 
   useEffect(() => {
@@ -1091,19 +1097,56 @@ function useSessionEditableArtifactSummaries(input: {
       import("@/lib/editable-artifact-browser"),
     ])
       .then(async ([{ editableArtifactClient }, { createConsoleEditableArtifactReplicaId }]) => {
-        const result = await editableArtifactClient.listSessionEditableArtifacts(
-          input.workspaceId,
-          input.sessionId,
-          {
+        const [result, sites] = await Promise.allSettled([
+          editableArtifactClient.listSessionEditableArtifacts(input.workspaceId, input.sessionId, {
             replicaId: createConsoleEditableArtifactReplicaId(),
-          },
-        );
+          }),
+          (async () => {
+            const sitePages = await editableArtifactClient.listWorkspaceArtifacts(
+              input.workspaceId,
+              {
+                sourceSessionId: input.sessionId,
+                limit: 100,
+              },
+            );
+            while (sitePages.nextCursor) {
+              const page = await editableArtifactClient.listWorkspaceArtifacts(input.workspaceId, {
+                sourceSessionId: input.sessionId,
+                limit: 100,
+                cursor: sitePages.nextCursor,
+              });
+              if (!current) return [];
+              sitePages.artifacts.push(...page.artifacts);
+              sitePages.nextCursor = page.nextCursor;
+            }
+            return sitePages.artifacts;
+          })(),
+        ]);
         if (current) {
-          setLoaded({
+          setLoaded((previous) => ({
             key: authorityKey,
-            status: "ready",
-            artifacts: result.artifacts,
-          });
+            status:
+              result.status === "fulfilled" && sites.status === "fulfilled" ? "ready" : "error",
+            artifacts: [
+              ...(result.status === "fulfilled"
+                ? result.value.artifacts
+                : previous?.key === authorityKey &&
+                    retainArtifactsAfterRefreshFailure(result.reason)
+                  ? previous.artifacts.filter((item) => item.modality !== "site")
+                  : []),
+              ...(sites.status === "fulfilled"
+                ? sites.value.map((site) => ({
+                    id: site.id,
+                    title: site.title,
+                    modality: "site" as const,
+                    versionId: site.currentVersion?.id,
+                    siteStatus: site.status,
+                  }))
+                : previous?.key === authorityKey && retainArtifactsAfterRefreshFailure(sites.reason)
+                  ? previous.artifacts.filter((item) => item.modality === "site")
+                  : []),
+            ],
+          }));
         }
       })
       .catch(() => {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -50,7 +50,6 @@ import {
 import { toast } from "sonner";
 
 import { isApiErrorStatus } from "@/api";
-import { retainArtifactsAfterRefreshFailure } from "@/lib/artifact-refresh";
 import { ConsoleComposer } from "@/components/Composer";
 import { ComposerMobilePlus } from "@/components/composer-mobile-plus";
 import { LoadingPanel } from "@/components/common";
@@ -1092,60 +1091,17 @@ function useSessionEditableArtifactSummaries(input: {
             artifacts: previous?.key === authorityKey ? previous.artifacts : [],
           },
     );
-    void Promise.all([
-      import("@/lib/editable-artifact-client"),
-      import("@/lib/editable-artifact-browser"),
-    ])
-      .then(async ([{ editableArtifactClient }, { createConsoleEditableArtifactReplicaId }]) => {
-        const [result, sites] = await Promise.allSettled([
-          editableArtifactClient.listSessionEditableArtifacts(input.workspaceId, input.sessionId, {
-            replicaId: createConsoleEditableArtifactReplicaId(),
-          }),
-          (async () => {
-            const sitePages = await editableArtifactClient.listWorkspaceArtifacts(
-              input.workspaceId,
-              {
-                sourceSessionId: input.sessionId,
-                limit: 100,
-              },
-            );
-            while (sitePages.nextCursor) {
-              const page = await editableArtifactClient.listWorkspaceArtifacts(input.workspaceId, {
-                sourceSessionId: input.sessionId,
-                limit: 100,
-                cursor: sitePages.nextCursor,
-              });
-              if (!current) return [];
-              sitePages.artifacts.push(...page.artifacts);
-              sitePages.nextCursor = page.nextCursor;
-            }
-            return sitePages.artifacts;
-          })(),
-        ]);
+    void import("@/lib/session-artifact-discovery")
+      .then(async ({ discoverSessionArtifacts }) => {
+        const reconcile = await discoverSessionArtifacts(
+          input.workspaceId,
+          input.sessionId,
+          () => current,
+        );
         if (current) {
           setLoaded((previous) => ({
             key: authorityKey,
-            status:
-              result.status === "fulfilled" && sites.status === "fulfilled" ? "ready" : "error",
-            artifacts: [
-              ...(result.status === "fulfilled"
-                ? result.value.artifacts
-                : previous?.key === authorityKey &&
-                    retainArtifactsAfterRefreshFailure(result.reason)
-                  ? previous.artifacts.filter((item) => item.modality !== "site")
-                  : []),
-              ...(sites.status === "fulfilled"
-                ? sites.value.map((site) => ({
-                    id: site.id,
-                    title: site.title,
-                    modality: "site" as const,
-                    versionId: site.currentVersion?.id,
-                    siteStatus: site.status,
-                  }))
-                : previous?.key === authorityKey && retainArtifactsAfterRefreshFailure(sites.reason)
-                  ? previous.artifacts.filter((item) => item.modality === "site")
-                  : []),
-            ],
+            ...reconcile(previous?.key === authorityKey ? previous.artifacts : []),
           }));
         }
       })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1257,13 +1257,11 @@ Historical `ComputerUse`, `on-turn`, and `computer_screenshot` contract shapes
 remain parseable for old events, SDK clients, and retained evidence, but they do
 not register a runnable legacy computer tool.
 
-Sites retain immutable HTML, optional source, tool allowlists and rollback;
-they remain separate from Documents and editable artifacts. Agents upload through
-signed URLs and publish upload IDs, without hashes or byte counts. Source JSON
-is capped at 64 MiB; HTML is streamed within storage limits. Retrieval returns
-download URLs; viewing loads HTML into the existing opaque-origin srcDoc frame.
-The Artifacts dock includes session-created/published Sites via version provenance
-(`sourceSessionId`, filtered before pagination), reusing the Site viewer/bridge.
+Sites retain immutable HTML, optional source, tool allowlists and rollback,
+separately from Documents/editable artifacts. Agents publish signed-upload IDs,
+without hashes/sizes. Source JSON allows 64 MiB; HTML follows storage limits.
+Retrieval yields download URLs; the opaque-origin srcDoc viewer/bridge also
+serves session docks, filtered before pagination by version `sourceSessionId`.
 
 Canonical: [`artifact-engine.md`](artifact-engine.md),
 [`artifact-collaboration.md`](artifact-collaboration.md), and
@@ -1274,11 +1272,10 @@ Canonical: [`artifact-engine.md`](artifact-engine.md),
 `@opengeni/sdk` owns client contracts; `@opengeni/react` owns hooks/UI.
 `apps/web` consumes them, never owns hidden domain semantics.
 
-`SessionConversation` is the complete embed: event feed, queue/actions, durable
-composer, model policy, human-input forms, and history. `ChatComposer` is input
-only. Sites use the same component with their Site-bound client.
-Conversation foreground/background share theme tokens; light embeds use
-`data-og-theme="light"` inside their iframe.
+`SessionConversation` includes feed, queue/actions, durable composer, model policy,
+human-input forms and history. `ChatComposer` is input-only. Sites supply their
+Site-bound client. Foreground/background share tokens; light embeds set
+`data-og-theme="light"` inside the iframe.
 
 Sites install exact SDK/React/Codemode/CLI versions from virtual skill file
 `package-versions.json`: source-manifest defaults or canary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1262,6 +1262,8 @@ they remain separate from Documents and editable artifacts. Agents upload throug
 signed URLs and publish upload IDs, without hashes or byte counts. Source JSON
 is capped at 64 MiB; HTML is streamed within storage limits. Retrieval returns
 download URLs; viewing loads HTML into the existing opaque-origin srcDoc frame.
+The Artifacts dock includes session-created/published Sites via version provenance
+(`sourceSessionId`, filtered before pagination), reusing the Site viewer/bridge.
 
 Canonical: [`artifact-engine.md`](artifact-engine.md),
 [`artifact-collaboration.md`](artifact-collaboration.md), and
@@ -1275,6 +1277,8 @@ Canonical: [`artifact-engine.md`](artifact-engine.md),
 `SessionConversation` is the complete embed: event feed, queue/actions, durable
 composer, model policy, human-input forms, and history. `ChatComposer` is input
 only. Sites use the same component with their Site-bound client.
+Conversation foreground/background share theme tokens; light embeds use
+`data-og-theme="light"` inside their iframe.
 
 Sites install exact SDK/React/Codemode/CLI versions from virtual skill file
 `package-versions.json`: source-manifest defaults or canary

--- a/packages/contracts/src/artifacts.ts
+++ b/packages/contracts/src/artifacts.ts
@@ -179,6 +179,8 @@ export const WorkspaceArtifactListQuery = z.object({
     .default(WORKSPACE_ARTIFACT_LIST_DEFAULT),
   cursor: z.string().min(1).max(WORKSPACE_ARTIFACT_CURSOR_MAX_CHARS).optional(),
   status: WorkspaceArtifactStatus.optional(),
+  /** Sites created or published by this session, including older versions. */
+  sourceSessionId: z.string().uuid().optional(),
 });
 export type WorkspaceArtifactListQuery = z.infer<typeof WorkspaceArtifactListQuery>;
 

--- a/packages/db/src/workspace-artifacts.ts
+++ b/packages/db/src/workspace-artifacts.ts
@@ -215,6 +215,7 @@ export async function listWorkspaceArtifacts(
     limit?: number;
     cursor?: string;
     status?: "active" | "archived";
+    sourceSessionId?: string;
   } = {},
 ): Promise<{
   artifacts: WorkspaceArtifact[];
@@ -226,6 +227,14 @@ export async function listWorkspaceArtifacts(
     const cursor = options.cursor ? decodeListCursor(options.cursor) : null;
     const visibility = and(
       eq(schema.workspaceArtifacts.workspaceId, workspaceId),
+      ...(options.sourceSessionId
+        ? [
+            sql`exists (select 1 from ${schema.workspaceArtifactVersions} as published_version
+              where published_version.artifact_id = ${schema.workspaceArtifacts.id}
+                and published_version.workspace_id = ${schema.workspaceArtifacts.workspaceId}
+                and published_version.source_session_id = ${options.sourceSessionId}::uuid)`,
+          ]
+        : []),
       ...(options.status ? [eq(schema.workspaceArtifacts.status, options.status)] : []),
       ...(cursor
         ? [

--- a/packages/react/demo/conversation-layout.tsx
+++ b/packages/react/demo/conversation-layout.tsx
@@ -26,6 +26,13 @@ const events: SessionEvent[] = Array.from({ length: 8 }, (_, i) => ({
   payload: { text: `Message ${i}\n` + "Expandable message content. ".repeat(120) },
   occurredAt: new Date().toISOString(),
 }));
+events.push({
+  ...events[0]!,
+  id: "assistant-reply",
+  sequence: 9,
+  type: "agent.message.completed",
+  payload: { text: "Readable assistant reply in the selected theme." },
+});
 let release: (() => void) | undefined;
 const pending: SessionEvent[] = [];
 const client = fakeClient({
@@ -68,7 +75,12 @@ function append() {
 function App() {
   const [height, setHeight] = useState(500);
   return (
-    <main style={{ width: "min(760px,100%)" }}>
+    <main
+      data-og-theme={
+        new URLSearchParams(location.search).get("theme") === "light" ? "light" : undefined
+      }
+      style={{ width: "min(760px,100%)", background: "#fffdf9", padding: 16 }}
+    >
       <button onClick={append}>Append live message</button>
       <button onClick={() => setHeight(height === 500 ? 350 : 500)}>Resize host</button>
       <section style={{ height, display: "flex", flexDirection: "column" }}>

--- a/packages/react/src/components/session-conversation.tsx
+++ b/packages/react/src/components/session-conversation.tsx
@@ -59,7 +59,10 @@ function Conversation({
   const error = detail.error ?? feed.error ?? human.error;
   return (
     <div
-      className={cn("og-root flex min-h-0 min-w-0 flex-col gap-2 overflow-hidden", className)}
+      className={cn(
+        "og-root flex min-h-0 min-w-0 flex-col gap-2 overflow-hidden bg-og-bg text-og-fg",
+        className,
+      )}
       ref={region}
       style={{ height }}
       data-og-conversation=""

--- a/packages/react/test/session-conversation.test.tsx
+++ b/packages/react/test/session-conversation.test.tsx
@@ -107,6 +107,9 @@ test("complete conversation loads queue and provides queue actions beside compos
     await flush(100);
     expect(streams).toBe(1);
     expect(view.container.querySelector("textarea")).not.toBeNull();
+    const surface = view.container.querySelector("[data-og-conversation]");
+    expect(surface?.classList.contains("bg-og-bg")).toBe(true);
+    expect(surface?.classList.contains("text-og-fg")).toBe(true);
     expect(view.container.textContent).toContain("2 queued");
     const button = [...view.container.querySelectorAll("button")].find((node) =>
       node.textContent?.includes("2 queued"),

--- a/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
+++ b/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
@@ -143,11 +143,14 @@ import { SessionConversation } from "@opengeni/react/session-ui";
 import "@opengeni/react/compiled.css";
 
 const site = createOpenGeniSiteClient();
+// Match the theme to your chat panel; omit this wrapper for the dark default.
+<div data-og-theme="light" style={{ height: "100%", minHeight: 0 }}>
 <SessionConversation
   client={site.client}
   workspaceId={site.workspaceId}
   sessionId={sessionId}
 />
+</div>
 ```
 
 `sessionId` is the existing session or the id returned by `site.client.createSession`.
@@ -158,6 +161,12 @@ pairing it with a timeline does not create the queue UI.
 Use the lower-level hooks/components only for intentionally custom behavior.
 
 The host owns the chat's available space; `SessionConversation` fills it.
+The SDK defaults to dark colors. On a light panel, set `data-og-theme="light"`
+on its wrapper; changing the Site's body background does not select the SDK
+theme, and the outer OpenGeni app's theme does not cross the iframe. Keep
+foreground and background on the same SDK tokens rather than overriding
+message/button colors individually. Check a real assistant reply, expanded
+steps, composer and menus for readable contrast in the chosen theme.
 For a full-height page, use a `height: 100dvh` flex-column layout with the
 chat panel `flex: 1; min-height: 0` below its header. Keep intervening
 flex/grid children shrinkable (`min-height: 0; min-width: 0`). The SDK owns

--- a/packages/sdk/src/artifact-client.ts
+++ b/packages/sdk/src/artifact-client.ts
@@ -151,6 +151,7 @@ export class OpenGeniClient extends OpenGeniDocumentAuthorityClient {
     if (options.limit !== undefined) query.set("limit", String(options.limit));
     if (options.cursor) query.set("cursor", options.cursor);
     if (options.status) query.set("status", options.status);
+    if (options.sourceSessionId) query.set("sourceSessionId", options.sourceSessionId);
     const suffix = query.size > 0 ? `?${query.toString()}` : "";
     return await this.requestJson<WorkspaceArtifactListResponse>(
       "GET",

--- a/packages/sdk/src/workspace-artifacts.ts
+++ b/packages/sdk/src/workspace-artifacts.ts
@@ -62,6 +62,7 @@ export type WorkspaceArtifactEvent = {
 };
 
 export type WorkspaceArtifactListOptions = {
+  sourceSessionId?: string;
   limit?: number;
   cursor?: string;
   status?: WorkspaceArtifact["status"];

--- a/packages/sdk/test/workspace-artifacts.test.ts
+++ b/packages/sdk/test/workspace-artifacts.test.ts
@@ -23,12 +23,13 @@ describe("workspace artifacts SDK", () => {
         limit: 25,
         cursor: "opaque-cursor",
         status: "active",
+        sourceSessionId: WORKSPACE_ID,
       }),
     ).toEqual({ artifacts: [], nextCursor: null, truncated: false });
     expect(requests.map((request) => [request.method, request.url])).toEqual([
       [
         "GET",
-        `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/published-artifacts?limit=25&cursor=opaque-cursor&status=active`,
+        `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/published-artifacts?limit=25&cursor=opaque-cursor&status=active&sourceSessionId=${WORKSPACE_ID}`,
       ],
     ]);
   });

--- a/test/e2e/composer-responsive.browser.e2e.ts
+++ b/test/e2e/composer-responsive.browser.e2e.ts
@@ -50,6 +50,39 @@ describe("container-responsive public composer demo", () => {
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 30_000);
 
+  test("conversation paints a matched surface on light hosts in both themes", async () => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      const colors: string[] = [];
+      for (const theme of ["light", "dark"]) {
+        await page.goto(`${baseUrl}/conversation-layout.html?theme=${theme}`);
+        const reply = page.getByText("Readable assistant reply in the selected theme.", {
+          exact: true,
+        });
+        await reply.waitFor();
+        const styles = await reply.evaluate((element) => {
+          const conversation = element.closest("[data-og-conversation]")!;
+          return {
+            foreground: getComputedStyle(element).color,
+            background: getComputedStyle(conversation).backgroundColor,
+          };
+        });
+        expect(styles.background).not.toBe("rgba(0, 0, 0, 0)");
+        expect(styles.foreground).not.toBe(styles.background);
+        colors.push(styles.foreground);
+        const accessibility = await new AxeBuilder({ page })
+          .include(".og-markdown-body")
+          .withRules(["color-contrast"])
+          .analyze();
+        expect(accessibility.violations).toEqual([]);
+      }
+      expect(colors[0]).not.toBe(colors[1]);
+    } finally {
+      await context.close();
+    }
+  });
+
   test("desktop measurement does not widen the document after a mobile resize", async () => {
     const context = await browser.newContext({
       viewport: { width: 1440, height: 1000 },


### PR DESCRIPTION
## Summary
- Paint embedded conversations with matching foreground/background theme tokens; document light-theme opt-in in bundled Site guidance.
- Show Sites created or published by a session in its Artifacts dock, using immutable version provenance and the existing viewer bridge.
- Drop cached previews on authoritative refresh failures; preserve transient-failure recovery.

## Verification
- Independent fresh-eyes review completed; denied-refresh finding corrected and re-reviewed.
- SDK, React, dock and refresh regression tests: 11 passed.
- PostgreSQL artifact API tests: 6 passed.
- Browser light/dark contrast regression passed; both themes visually inspected locally.
- Web/API/React typechecks, lint, CSS and docs guards passed.

Includes package changesets. No migrations.

## Summary by Sourcery

Improve embedded conversation contrast and surface session-created or published Sites in the Artifacts dock with reliable preview refresh behavior.

New Features:
- Show Sites created or published by the current session in the session Artifacts panel, with embedded previews and links to full-page views.
- Allow workspace artifact listings to filter Sites by session provenance across all published versions.

Bug Fixes:
- Match embedded conversation foreground and background colors to the selected SDK theme for readable light and dark displays.
- Remove cached artifact previews after authoritative refresh failures while retaining them for transient network or server failures.

Enhancements:
- Reuse the existing Site viewer and tool bridge for session-dock previews, including appropriate handling for archived Sites.

Documentation:
- Document opting embedded conversations into the light theme and using matched SDK theme tokens.

Tests:
- Add coverage for session Site discovery, provenance filtering, refresh-failure behavior, embedded Site previews, SDK query support, and light/dark contrast.