### PR TITLE
fix(network): avoid probing protected API routes for OAuth metadata

### DIFF
--- a/.changeset/correct-prm-discovery-paths.md
+++ b/.changeset/correct-prm-discovery-paths.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/network": patch
+---
+
+Use protected-resource metadata prefix locations instead of guessing a metadata URL beneath the protected API route. Preserve explicitly advertised URLs and fail-closed metadata handling.

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -1847,7 +1847,7 @@ describe("connections routes", () => {
     }
   });
 
-  test("oauth start/callback supports same-origin 2025-03-26 metadata without RFC 8707 resource parameters", async () => {
+  test("oauth start/callback supports legacy metadata behind a protected API catch-all", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const upstreamMcp = startTestMcpServer();
@@ -1876,6 +1876,9 @@ describe("connections routes", () => {
               ? {}
               : { body: await request.arrayBuffer() }),
           });
+        }
+        if (url.pathname.startsWith("/mcp/")) {
+          return new Response("protected API route", { status: 401 });
         }
         if (url.pathname.includes("oauth-protected-resource")) {
           metadataRequests.push(url.pathname);
@@ -1950,7 +1953,6 @@ describe("connections routes", () => {
       expect(tokenRequests[0]!.get("resource")).toBeNull();
       expect(metadataRequests).toEqual([
         "/.well-known/oauth-protected-resource/mcp",
-        "/mcp/.well-known/oauth-protected-resource",
         "/.well-known/oauth-protected-resource",
         "/.well-known/oauth-authorization-server",
       ]);

--- a/docs/integrations-design.md
+++ b/docs/integrations-design.md
@@ -296,6 +296,11 @@ Served publicly at `GET /v1/integrations/oauth/client-metadata.json`:
 
 - PKCE S256 always; refuse ASes not advertising it.
 - `state` signed, single-use, TTL-bound, workspace+subject-bound; callback validates all of it.
+- RFC 9728 discovery probes the well-known prefix before the resource path,
+  then the origin-root location, after any explicitly advertised metadata URL.
+  It does not guess metadata beneath the resource API path: a protected API
+  catch-all there may return 401 even when metadata is absent. Explicitly
+  advertised URLs remain authoritative regardless of their path shape.
 - RFC 9728 PRM is authoritative whenever present. Malformed, contradictory,
   unreachable, redirected-to-unsafe, or otherwise invalid PRM is a hard failure;
   it never causes a legacy downgrade.

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -290,9 +290,15 @@ export function protectedResourceMetadataCandidates(
   resourceUrl: string,
   advertisedUrl?: string,
 ): string[] {
+  const url = new URL(resourceUrl);
+  const path = url.pathname.replace(/^\/+|\/+$/g, "");
   return uniqueStrings([
     ...(advertisedUrl !== undefined ? [advertisedUrl] : []),
-    ...oauthWellKnownCandidates(resourceUrl, "oauth-protected-resource"),
+    // RFC 9728 inserts the well-known prefix before the resource path.
+    // Appending it instead can hit a protected API catch-all and fail with
+    // 401 before genuine metadata absence permits legacy discovery.
+    `${url.origin}/.well-known/oauth-protected-resource${path ? `/${path}` : ""}`,
+    `${url.origin}/.well-known/oauth-protected-resource`,
   ]);
 }
 

--- a/packages/network/src/mcp-oauth-discovery.ts
+++ b/packages/network/src/mcp-oauth-discovery.ts
@@ -291,13 +291,13 @@ export function protectedResourceMetadataCandidates(
   advertisedUrl?: string,
 ): string[] {
   const url = new URL(resourceUrl);
-  const path = url.pathname.replace(/^\/+|\/+$/g, "");
+  const path = url.pathname === "/" ? "" : url.pathname;
   return uniqueStrings([
     ...(advertisedUrl !== undefined ? [advertisedUrl] : []),
     // RFC 9728 inserts the well-known prefix before the resource path.
     // Appending it instead can hit a protected API catch-all and fail with
     // 401 before genuine metadata absence permits legacy discovery.
-    `${url.origin}/.well-known/oauth-protected-resource${path ? `/${path}` : ""}`,
+    `${url.origin}/.well-known/oauth-protected-resource${path}${url.search}`,
     `${url.origin}/.well-known/oauth-protected-resource`,
   ]);
 }

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   McpOAuthDiscoveryError,
   parseMcpOAuthChallenge,
+  protectedResourceMetadataCandidates,
   resolveMcpOAuthDiscovery,
   type McpOAuthMetadataFetchResult,
 } from "../src/mcp-oauth-discovery";
@@ -43,6 +44,68 @@ const modernAs = {
 };
 
 describe("MCP OAuth discovery", () => {
+  test("does not downgrade an authorization failure at advertised or standard metadata", async () => {
+    for (const advertised of [undefined, `${resourceUrl}/.well-known/oauth-protected-resource`]) {
+      const requested: string[] = [];
+      await expect(
+        resolveMcpOAuthDiscovery({
+          resourceUrl,
+          challenge: {
+            scheme: "bearer",
+            scope: [],
+            ...(advertised ? { resourceMetadata: advertised } : {}),
+          },
+          fetchMetadata: async ({ url }) => {
+            requested.push(url);
+            throw new Error("HTTP 401 metadata denied");
+          },
+          validateEndpoint,
+          canonicalizeResource,
+        }),
+      ).rejects.toThrow("HTTP 401 metadata denied");
+      expect(requested).toEqual([advertised ?? modernPrmUrl]);
+    }
+  });
+  test("uses prefix and root PRM locations, preserving explicit advertised URLs", () => {
+    expect(protectedResourceMetadataCandidates(resourceUrl)).toEqual([
+      modernPrmUrl,
+      "https://mcp.example.test/.well-known/oauth-protected-resource",
+    ]);
+    expect(protectedResourceMetadataCandidates("https://mcp.example.test/")).toEqual([
+      "https://mcp.example.test/.well-known/oauth-protected-resource",
+    ]);
+    const advertised = `${resourceUrl}/.well-known/oauth-protected-resource`;
+    expect(protectedResourceMetadataCandidates(resourceUrl, advertised)[0]).toBe(advertised);
+  });
+
+  test("legacy discovery does not probe a protected resource catch-all as metadata", async () => {
+    const requested: string[] = [];
+    const legacyMetadataUrl = "https://mcp.example.test/.well-known/oauth-authorization-server";
+    const fetchMetadata = metadataFetcher({
+      [legacyMetadataUrl]: {
+        ...modernAs,
+        issuer: "https://mcp.example.test",
+      },
+    });
+    const result = await resolveMcpOAuthDiscovery({
+      resourceUrl,
+      challenge: parseMcpOAuthChallenge('Bearer error="invalid_token"'),
+      fetchMetadata: async ({ url }) => {
+        requested.push(url);
+        if (url.startsWith(`${resourceUrl}/`)) throw new Error("HTTP 401 protected API route");
+        return fetchMetadata({ url });
+      },
+      validateEndpoint,
+      canonicalizeResource,
+    });
+    expect(result.mode).toBe("legacy_2025_03_26_metadata");
+    expect(requested).toEqual([
+      modernPrmUrl,
+      "https://mcp.example.test/.well-known/oauth-protected-resource",
+      legacyMetadataUrl,
+    ]);
+  });
+
   test("parses parameterless challenges and stops before the next auth scheme", () => {
     expect(parseMcpOAuthChallenge('Bearer, Basic scope="must-not-leak"')).toEqual({
       scheme: "bearer",

--- a/packages/network/test/mcp-oauth-discovery.test.ts
+++ b/packages/network/test/mcp-oauth-discovery.test.ts
@@ -74,8 +74,37 @@ describe("MCP OAuth discovery", () => {
     expect(protectedResourceMetadataCandidates("https://mcp.example.test/")).toEqual([
       "https://mcp.example.test/.well-known/oauth-protected-resource",
     ]);
+    expect(
+      protectedResourceMetadataCandidates("https://mcp.example.test/v1/mcp/?tenant=a%2Fb"),
+    ).toEqual([
+      "https://mcp.example.test/.well-known/oauth-protected-resource/v1/mcp/?tenant=a%2Fb",
+      "https://mcp.example.test/.well-known/oauth-protected-resource",
+    ]);
+    expect(protectedResourceMetadataCandidates("https://mcp.example.test//v1/mcp/")[0]).toBe(
+      "https://mcp.example.test/.well-known/oauth-protected-resource//v1/mcp/",
+    );
     const advertised = `${resourceUrl}/.well-known/oauth-protected-resource`;
     expect(protectedResourceMetadataCandidates(resourceUrl, advertised)[0]).toBe(advertised);
+  });
+
+  test("uses slash-preserving modern metadata without falling back to legacy", async () => {
+    const slashResource = `${resourceUrl}/`;
+    const slashMetadata = `${modernPrmUrl}/`;
+    const result = await resolveMcpOAuthDiscovery({
+      resourceUrl: slashResource,
+      challenge: { scheme: "bearer", scope: [] },
+      fetchMetadata: metadataFetcher({
+        [slashMetadata]: {
+          resource: slashResource,
+          authorization_servers: [modernAs.issuer],
+        },
+        [modernAsMetadataUrl]: modernAs,
+      }),
+      validateEndpoint,
+      canonicalizeResource,
+    });
+    expect(result.mode).toBe("rfc9728_protected_resource");
+    expect(result.provenance.protectedResourceMetadataUrl).toBe(slashMetadata);
   });
 
   test("legacy discovery does not probe a protected resource catch-all as metadata", async () => {


### PR DESCRIPTION
## Summary

- Discover protected-resource metadata at RFC 9728 prefix and origin-root locations; stop guessing a suffix beneath the resource API path.
- Keep explicitly advertised URLs authoritative and preserve hard failures on metadata authorization errors.
- Use the shared runtime/catalog resolver, with a synthetic protected API catch-all regression and OAuth start/callback coverage.

## Cause

A server can legitimately protect every path beneath its MCP route while publishing no protected-resource metadata. A guessed suffix URL then returns 401, preventing legacy same-origin authorization-server discovery even though the standard metadata locations return 404. This corrects the guessed locations rather than treating 401 as absence.

## Validation

- Regression verified failing on unchanged source and passing with the fix.
- Network and PostgreSQL-backed connection routes: 105 passing tests, including synthetic OAuth start/callback.
- Catalog refresh: 13 passing tests.
- Network and API typechecks and whitespace checks pass.
- Review follow-up preserves resource path/query identity, with trailing-slash modern-discovery coverage. The test-path comparison finding was disproved with the original-source failing regression.

Responsible session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/1c7d1a07-58e9-4d94-b8ac-eecf09a1d133