### PR TITLE
fix(sandbox): align build-only multiarch Linux headers

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -35,8 +35,8 @@ RUN set -eux; \
     dpkg --add-architecture "$(xx-info debian-arch)"; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-      linux-libc-dev/bookworm "linux-libc-dev:$(xx-info debian-arch)/bookworm"; \
-    xx-apt-get install -y --no-install-recommends xx-c-essentials
+      linux-libc-dev/bookworm "linux-libc-dev:$(xx-info debian-arch)/bookworm"
+RUN xx-apt-get install -y --no-install-recommends xx-c-essentials
 COPY agent .
 # Cache mounts keep the crates.io registry and the per-target build directory
 # between builds so an edit under agent/ recompiles only the changed crates.

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update \
 
 WORKDIR /src/agent
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y --no-install-recommends xx-c-essentials
+# Multi-Arch:same headers must have identical versions. Security mirrors can
+# publish architectures at different times; use bookworm's matching header pair
+# in this build-only stage, without changing the runtime image's packages.
+RUN set -eux; \
+    dpkg --add-architecture "$(xx-info debian-arch)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      linux-libc-dev/bookworm "linux-libc-dev:$(xx-info debian-arch)/bookworm"; \
+    xx-apt-get install -y --no-install-recommends xx-c-essentials
 COPY agent .
 # Cache mounts keep the crates.io registry and the per-target build directory
 # between builds so an edit under agent/ recompiles only the changed crates.


### PR DESCRIPTION
## Summary
Select native and target linux-libc-dev from the same Debian bookworm release before installing cross-compilation essentials. Multi-Arch:same headers cannot coexist at different versions when security mirrors publish architecture updates at different times.

This affects only the Rust cross-build stage. Runtime packages, integrity checks and dependency lockfiles remain unchanged.

## Verification
Reproduced the original failure with the same Rust base and pinned xx image. Actual Docker installation of the matching headers followed by xx-c-essentials passed for ARM64. Independent review in progress; normal multiarch image CI remains the final build check.

## Summary by Sourcery

Align native and target Linux development headers in the sandbox cross-build stage before installing cross-compilation essentials.

Bug Fixes:
- Fix Rust cross-build failures caused by mismatched native and target Multi-Arch Linux headers from Debian security mirrors.

Build:
- Install matching bookworm native and target linux-libc-dev packages in the build-only sandbox stage before cross-compilation setup.