### PR TITLE
fix(release): keep fixed canary package groups in sync

### DIFF
--- a/scripts/publish-canary.test.ts
+++ b/scripts/publish-canary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { nextCanaryVersion } from "./publish-canary";
+import { nextCanaryVersion, planCanaryVersions } from "./publish-canary";
 
 describe("nextCanaryVersion", () => {
   test("starts at canary.0 from a stable version", () => {
@@ -12,5 +12,56 @@ describe("nextCanaryVersion", () => {
 
   test("restarts at 0 when the committed base moved", () => {
     expect(nextCanaryVersion("2.1.0", "2.0.0-canary.9")).toBe("2.1.0-canary.0");
+  });
+});
+
+describe("planCanaryVersions", () => {
+  const packages = ["tool", "document", "presentation", "spreadsheet", "unrelated"].map((name) => ({
+    name,
+    version: "1.0.0",
+  }));
+  const fixed = [["tool", "document", "presentation", "spreadsheet"]];
+
+  test("recovers a partial publish without splitting fixed package versions", () => {
+    const versions = planCanaryVersions(
+      packages,
+      new Map([
+        ["tool", "1.0.0-canary.6"],
+        ["document", "1.0.0-canary.5"],
+        ["presentation", "1.0.0-canary.5"],
+        ["spreadsheet", "1.0.0-canary.5"],
+        ["unrelated", "1.0.0-canary.2"],
+      ]),
+      fixed,
+    );
+    for (const name of fixed[0]!) expect(versions.get(name)).toBe("1.0.0-canary.7");
+    expect(versions.get("unrelated")).toBe("1.0.0-canary.3");
+  });
+
+  test("uses the furthest published member, even when the tool is behind", () => {
+    const versions = planCanaryVersions(
+      packages,
+      new Map([["spreadsheet", "1.0.0-canary.12"]]),
+      fixed,
+    );
+    for (const name of fixed[0]!) expect(versions.get(name)).toBe("1.0.0-canary.13");
+  });
+
+  test("starts a new shared base at zero", () => {
+    const versions = planCanaryVersions(packages, new Map([["tool", "0.9.0-canary.99"]]), fixed);
+    for (const name of fixed[0]!) expect(versions.get(name)).toBe("1.0.0-canary.0");
+  });
+
+  test("refuses inconsistent or incomplete fixed groups before writing versions", () => {
+    expect(() =>
+      planCanaryVersions(
+        [{ name: "tool", version: "2.0.0" }, ...packages.slice(1)],
+        new Map(),
+        fixed,
+      ),
+    ).toThrow("committed base version");
+    expect(() => planCanaryVersions(packages.slice(1), new Map(), fixed)).toThrow(
+      "not publishable",
+    );
   });
 });

--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env bun
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   publishableWorkspacePackages,
+  repoRoot,
   topologicallySortedPackages,
   type WorkspacePackage,
 } from "./publishable-workspaces";
@@ -16,6 +18,35 @@ export function nextCanaryVersion(baseVersion: string, lastCanary: string | null
     if (Number.isInteger(n) && n >= 0) return `${prefix}${n + 1}`;
   }
   return `${prefix}0`;
+}
+
+export function planCanaryVersions(
+  packages: readonly { name: string; version: string }[],
+  tags: ReadonlyMap<string, string | null>,
+  fixedGroups: readonly (readonly string[])[],
+): Map<string, string> {
+  const versions = new Map(
+    packages.map((pkg) => [pkg.name, nextCanaryVersion(pkg.version, tags.get(pkg.name) ?? null)]),
+  );
+  for (const group of fixedGroups) {
+    if (group.length === 0) continue;
+    const planned = group.map((name) => {
+      const version = versions.get(name);
+      if (!version) throw new Error(`Fixed canary package is not publishable: ${name}`);
+      return version;
+    });
+    const base = planned[0]!.replace(/-canary\.\d+$/, "");
+    if (planned.some((version) => !version.startsWith(`${base}-canary.`))) {
+      throw new Error(
+        `Fixed canary packages must share a committed base version: ${group.join(", ")}`,
+      );
+    }
+    const next = Math.max(
+      ...planned.map((version) => Number(version.slice(`${base}-canary.`.length))),
+    );
+    for (const name of group) versions.set(name, `${base}-canary.${next}`);
+  }
+  return versions;
 }
 
 function npmCanaryTag(name: string): string | null {
@@ -45,8 +76,16 @@ export function main(): void {
     throw new Error("NODE_AUTH_TOKEN is required to publish canary packages");
   }
   const packages = topologicallySortedPackages(publishableWorkspacePackages());
+  const config = JSON.parse(readFileSync(join(repoRoot, ".changeset/config.json"), "utf8")) as {
+    fixed?: string[][];
+  };
+  const versions = planCanaryVersions(
+    packages,
+    new Map(packages.map((pkg) => [pkg.name, npmCanaryTag(pkg.name)])),
+    config.fixed ?? [],
+  );
   for (const pkg of packages) {
-    const next = nextCanaryVersion(pkg.version, npmCanaryTag(pkg.name));
+    const next = versions.get(pkg.name)!;
     writeVersion(pkg, next);
     process.stdout.write(`${pkg.name}@${next}\n`);
   }


### PR DESCRIPTION
## Summary
- Respect existing Changesets fixed groups when allocating canary versions.
- After a partial publish, advance every fixed-group member together beyond the furthest published member.
- Reject inconsistent fixed-group input before rewriting manifests.

## Verification
- bun test scripts/publish-canary.test.ts: 7 passed, 18 assertions.
- Regression coverage for partial publication, a non-leading member ahead, new base versions, and invalid groups.

Build/publishing tooling only; no runtime changes.

## Summary by Sourcery

Keep canary versions synchronized across Changesets fixed package groups during publishing.

Bug Fixes:
- Keep packages in Changesets fixed groups on synchronized canary versions after partial or out-of-order publication.
- Reject fixed groups with inconsistent base versions or missing publishable members before manifests are rewritten.

Enhancements:
- Use a coordinated canary version plan for fixed groups while preserving independent versioning for unrelated packages.

Build:
- Update canary publishing tooling to read fixed package groups from Changesets configuration.

Tests:
- Add regression coverage for partial publication, out-of-order fixed-group members, new base versions, and invalid fixed-group inputs.