### PR TITLE
fix: preserve latest started model across session continuations and UI

### DIFF
--- a/.changeset/latest-started-session-policy.md
+++ b/.changeset/latest-started-session-policy.md
@@ -1,5 +1,6 @@
 ---
 "@opengeni/db": patch
+"@opengeni/core": patch
 "@opengeni/contracts": patch
 ---
 

--- a/.changeset/latest-started-session-policy.md
+++ b/.changeset/latest-started-session-policy.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/contracts": patch
+---
+
+Inherit model, effort and speed from the latest started turn for follow-ups and voice handoffs. Project the same policy in session reads, fresh drafts and Insights without changing accepted turns or stored creation settings.

--- a/apps/api/test/model-catalog-session-prompt-replay.test.ts
+++ b/apps/api/test/model-catalog-session-prompt-replay.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
-import { bootstrapWorkspace, createDb, type DbClient } from "@opengeni/db";
+import {
+  appendSessionEvents,
+  bootstrapWorkspace,
+  createDb,
+  createSession,
+  enqueueSessionTurn,
+  type DbClient,
+} from "@opengeni/db";
 import { signDelegatedAccessToken, type AccessGrant } from "@opengeni/contracts";
 import {
   acquireSharedTestDatabase,
@@ -177,6 +184,74 @@ afterAll(async () => {
   await client?.close();
   await shared?.release();
 }, 60_000);
+
+describe("follow-up policy inheritance", () => {
+  test("fresh draft and omitted follow-up policy use latest started model even if original was removed", async () => {
+    if (!available) throw new Error("PostgreSQL required");
+    const id = crypto.randomUUID();
+    const owner = await provisionActor({
+      accountExternalId: id,
+      workspaceExternalId: id,
+      subjectId: `user:${id}`,
+    });
+    const workspaceId = owner.workspaceId!;
+    const headers = { authorization: await bearer(owner), "content-type": "application/json" };
+    const app = buildApp(new FakeWorkflowClient());
+    await installCatalog(
+      { schemaVersion: 1, defaultModel: "scripted-model", builtInModels: ["scripted-model"] },
+      1,
+    );
+    const session = await createSession(client.db, {
+      accountId: owner.accountId,
+      workspaceId,
+      initialMessage: "original",
+      model: "removed-original-model",
+      resources: [],
+      metadata: {},
+      reasoningEffort: "low",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    const turn = await enqueueSessionTurn(client.db, {
+      accountId: owner.accountId,
+      workspaceId,
+      metadata: {},
+      initiator: { kind: "subject", subjectId: owner.subjectId },
+      sessionId: session.id,
+      triggerEventId: crypto.randomUUID(),
+      temporalWorkflowId: `session-${session.id}`,
+      source: "user",
+      prompt: "new model",
+      model: "scripted-model",
+      reasoningEffort: "high",
+      latencyMode: "standard",
+      resources: [],
+      tools: [],
+      sandboxBackend: "none",
+    });
+    await appendSessionEvents(client.db, workspaceId, session.id, [
+      { type: "turn.started", turnId: turn.id, payload: {} },
+    ]);
+    const draft = await app.request(
+      `http://x/v1/workspaces/${workspaceId}/sessions/${session.id}/composer-draft`,
+      { headers },
+    );
+    expect(draft.status).toBe(200);
+    expect(await draft.json()).toMatchObject({ model: "scripted-model", reasoningEffort: "high" });
+    const response = await app.request(
+      `http://x/v1/workspaces/${workspaceId}/sessions/${session.id}/steer`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ text: "continue", clientEventId: crypto.randomUUID() }),
+      },
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      turn: { model: "scripted-model", reasoningEffort: "high" },
+    });
+  });
+});
 
 describe("model catalog prompt receipt replay (real PostgreSQL)", () => {
   test("replays committed Send and Steer before a removed deployment model is resolved", async () => {

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -104,7 +104,6 @@ export function createGoalActivities(services: () => Promise<ControlActivityServ
       settings,
       workspaceModelPolicy,
       inheritedModel: inheritedContinuationModel,
-      sessionModel: session.model,
     });
     continuationModel = modelDecision.model;
     let modelPolicyBlocked = modelDecision.blocked;
@@ -207,7 +206,6 @@ export function goalContinuationModelDecision(input: {
   settings: Settings;
   workspaceModelPolicy: Awaited<ReturnType<typeof getWorkspaceModelPolicy>>;
   inheritedModel: string;
-  sessionModel: string;
 }): { model: string; blocked: string | null } {
   const catalogSettings = input.settings.supergrokSubscriptionEnabled
     ? withXaiSubscriptionCatalogProvider(
@@ -224,11 +222,11 @@ export function goalContinuationModelDecision(input: {
       providerId: policyProviderIdForModel(catalogSettings, modelId),
       modelId,
     }).allowed;
-  const candidates = [...new Set([input.inheritedModel, input.sessionModel])];
-  for (const model of candidates) {
-    if (resolveModelProvider(catalogSettings, model) && !policyBlocks(model)) {
-      return { model, blocked: null };
-    }
+  if (
+    resolveModelProvider(catalogSettings, input.inheritedModel) &&
+    !policyBlocks(input.inheritedModel)
+  ) {
+    return { model: input.inheritedModel, blocked: null };
   }
   if (!resolveModelProvider(catalogSettings, input.inheritedModel)) {
     return {

--- a/apps/worker/test/goals.test.ts
+++ b/apps/worker/test/goals.test.ts
@@ -98,15 +98,17 @@ describe("goalContinuationPrompt", () => {
 });
 
 describe("goalContinuationModelDecision", () => {
-  test("falls back to the session model when the inherited model left the catalog", () => {
+  test("does not revert to the original model when the inherited model left the catalog", () => {
     expect(
       goalContinuationModelDecision({
         settings: testSettings(),
         workspaceModelPolicy: null,
         inheritedModel: "removed/provider-model",
-        sessionModel: "scripted-model",
       }),
-    ).toEqual({ model: "scripted-model", blocked: null });
+    ).toMatchObject({
+      model: "removed/provider-model",
+      blocked: expect.stringContaining("no longer in the deployment or workspace catalog"),
+    });
   });
 
   test("pauses instead of materializing when neither inherited nor session model exists", () => {
@@ -115,7 +117,6 @@ describe("goalContinuationModelDecision", () => {
         settings: testSettings(),
         workspaceModelPolicy: null,
         inheritedModel: "removed/provider-model",
-        sessionModel: "removed/session-model",
       }),
     ).toMatchObject({
       model: "removed/provider-model",
@@ -133,7 +134,6 @@ describe("goalContinuationModelDecision", () => {
           settings,
           workspaceModelPolicy: null,
           inheritedModel: model,
-          sessionModel: "scripted-model",
         }),
       ).toEqual({ model, blocked: null });
     }

--- a/docs-site/concepts/sessions.mdx
+++ b/docs-site/concepts/sessions.mdx
@@ -45,3 +45,11 @@ An agent can spawn child sessions for parallel or delegated work. Children run a
 ## Visibility
 
 Workspaces are shared by their members, and sessions in a shared workspace are visible to members by default. An organization owner can allow members to create "Only me" sessions that only their owner can see. Personal workspaces belong to one person.
+
+## Model inheritance
+
+Follow-ups without an explicit selection, voice requests and voice-end handoffs
+use the model, reasoning effort and speed from the latest turn that started.
+Session labels and fresh message drafts use those settings too. Before any turn
+starts, the initial session settings apply. Existing drafts, queued messages and
+historical turns retain their own settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -674,6 +674,8 @@ lifecycle and still loses to a human rename. Custom runtimes without the
 optional auxiliary seam retain the serialized `set_session_title` compatibility
 path.
 
+`packages/db/src/session-execution-policy.ts` derives execution/display policy from the latest started turn, otherwise creation defaults.
+
 ### 5.2 Lifecycle overview
 
 ```mermaid

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -117,6 +117,17 @@ nonempty composer is replaced only after explicit confirmation. An independent
 session fork copies the source session's exact typed reasoning and latency; it
 does not invent defaults or consult either composer.
 
+Session detail/list and Insights model labels project the newest turn with a
+durable `turn.started` event. Fresh actor drafts, omitted follow-up fields, voice
+delegations and voice-end handoffs inherit that same model, reasoning and latency
+policy through `packages/db/src/session-execution-policy.ts`. Creation settings
+are used only before any turn starts. Existing drafts and accepted queued turns
+keep their explicit settings; a rejected admission never changes inheritance.
+The stored session creation fields are not rewritten. API admission freezes its
+resolved policy so billing validation and the accepted turn cannot disagree if
+another turn starts before the prompt transaction commits. A removed or blocked
+inherited model requires a new selection, never a silent switch to the original.
+
 On the server, prompt acceptance remains one canonical Postgres transaction:
 the user event, physically queued turn, immutable admission routing,
 session/queue state, optional realtime mirror, audit receipt,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12071,6 +12071,8 @@ export const Session = z.object({
   /** Frozen creator fact used only for creation attribution/idempotent repair. */
   createdBy: TurnInitiator,
   createdByContext: TurnInitiatorContext,
+  // Read projection: latest turn.started policy, or creation policy before any turn starts.
+  // Accepted/queued turns and actor composer drafts retain their own explicit policy.
   model: z.string(),
   reasoningEffort: ReasoningEffort,
   latencyMode: LatencyMode,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1582,7 +1582,10 @@ export async function postUserMessageTurn(
   // model inherits the session's model downstream (always a configured id).
   assertConfiguredModel(settings, requestedModel);
   const sessionForModelGate = await requireSession(db, workspaceId, sessionId);
-  const effectiveModelForGate = requestedModel ?? sessionForModelGate.model;
+  // Acceptance already froze this policy before resource/credential validation.
+  // A different turn starting meanwhile must not change the model we gate here.
+  const effectiveModelForGate =
+    input.turnExecutionPolicy?.productModelId ?? requestedModel ?? sessionForModelGate.model;
   const freshWorkspaceCustomModel =
     requestedModel !== null &&
     isWorkspaceCustomModelId(settings, requestedModel) &&

--- a/packages/core/test/session-inherited-policy.test.ts
+++ b/packages/core/test/session-inherited-policy.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { resolveTurnExecutionPolicyV1 } from "@opengeni/config";
+import {
+  appendSessionEvents,
+  bootstrapWorkspace,
+  createDb,
+  createSession,
+  enqueueSessionTurn,
+} from "@opengeni/db";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { postUserMessageTurn } from "../src/domain/sessions";
+
+let shared: SharedTestDatabase;
+let client: ReturnType<typeof createDb>;
+beforeAll(async () => {
+  const acquired = await acquireSharedTestDatabase("session-inherited-policy");
+  if (!acquired) throw new Error("PostgreSQL required");
+  shared = acquired;
+  client = createDb(shared.appUrl);
+}, 180_000);
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+test("follow-up gate and accepted turn retain one frozen policy when a different turn starts after preflight", async () => {
+  const id = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: id,
+    accountName: "Policy inheritance",
+    workspaceExternalSource: "test",
+    workspaceExternalId: id,
+    workspaceName: "Policy inheritance",
+    subjectId: id,
+  });
+  const owner = access.workspaceGrants[0]!;
+  const workspaceId = owner.workspaceId!;
+  const settings = testSettings({ databaseUrl: shared.appUrl, sandboxBackend: "none" });
+  const session = await createSession(client.db, {
+    accountId: owner.accountId,
+    workspaceId,
+    initialMessage: "original",
+    model: "scripted-model",
+    resources: [],
+    metadata: {},
+    reasoningEffort: "high",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  // The API has already resolved and validated A before its remaining admission work.
+  const acceptedPolicy = resolveTurnExecutionPolicyV1(settings, {
+    modelId: "scripted-model",
+    requestedModelId: null,
+    modelSource: "session",
+    reasoningEffort: "high",
+    reasoningSource: "session",
+    latencyMode: "standard",
+    latencyModeSource: "session",
+  });
+  // Another previously queued turn starts on B before the final prompt gate.
+  // B is deliberately unavailable here: validating B would reject accepted A.
+  const other = await enqueueSessionTurn(client.db, {
+    accountId: owner.accountId,
+    workspaceId,
+    sessionId: session.id,
+    triggerEventId: crypto.randomUUID(),
+    temporalWorkflowId: `session-${session.id}`,
+    source: "user",
+    prompt: "different turn",
+    model: "unavailable-other-model",
+    reasoningEffort: "low",
+    resources: [],
+    tools: [],
+    metadata: {},
+    sandboxBackend: "none",
+    initiator: { kind: "subject", subjectId: owner.subjectId },
+  });
+  await appendSessionEvents(client.db, workspaceId, session.id, [
+    { type: "turn.started", turnId: other.id, payload: {} },
+  ]);
+  const result = await postUserMessageTurn({
+    db: client.db,
+    bus: new MemoryEventBus(),
+    workflowClient: { wakeSessionWorkflow: async () => undefined },
+    settings,
+    accountId: owner.accountId,
+    workspaceId,
+    sessionId: session.id,
+    text: "continue with accepted policy",
+    resources: [],
+    actor: owner.subjectId,
+    turnExecutionPolicy: acceptedPolicy,
+  });
+  expect(result.turn).toMatchObject({
+    model: "scripted-model",
+    reasoningEffort: "high",
+    latencyMode: "standard",
+  });
+}, 30_000);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -75365,8 +75365,14 @@ async function latestStartedSessionTurnRow(
   workspaceId: string,
   sessionId: string,
 ): Promise<typeof schema.sessionTurns.$inferSelect | null> {
-  const [row] = await latestStartedSessionTurnQuery(db, workspaceId, sessionId);
-  return row ?? null;
+  const latest = latestStartedSessionTurnQuery(db, workspaceId, sessionId).as(
+    "latest_started_turn",
+  );
+  const [row] = await db
+    .select({ turn: schema.sessionTurns })
+    .from(latest)
+    .innerJoin(schema.sessionTurns, eq(schema.sessionTurns.id, latest.id));
+  return row?.turn ?? null;
 }
 
 function mapFile(row: typeof schema.files.$inferSelect): FileAsset {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,7 @@
+import {
+  latestStartedSessionTurnQuery,
+  withLatestStartedSessionPolicy,
+} from "./session-execution-policy";
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import {
@@ -32726,20 +32730,24 @@ async function canonicalSessionRowsFromEventCursors(
       ),
     );
   const cursorBySessionId = new Map(cursors.map((cursor) => [cursor.sessionId, cursor]));
-  return rows.map((row) => {
-    const cursor = cursorBySessionId.get(row.id);
-    if (
-      !cursor ||
-      cursor.accountId !== row.accountId ||
-      cursor.workspaceId !== row.workspaceId ||
-      cursor.lastSequence < row.lastSequence
-    ) {
-      throw new Error(`Session event cursor invariant failed for session ${row.id}`);
-    }
-    return cursor.lastSequence === row.lastSequence
-      ? row
-      : { ...row, lastSequence: cursor.lastSequence };
-  });
+  return withLatestStartedSessionPolicy(
+    db,
+    workspaceId,
+    rows.map((row) => {
+      const cursor = cursorBySessionId.get(row.id);
+      if (
+        !cursor ||
+        cursor.accountId !== row.accountId ||
+        cursor.workspaceId !== row.workspaceId ||
+        cursor.lastSequence < row.lastSequence
+      ) {
+        throw new Error(`Session event cursor invariant failed for session ${row.id}`);
+      }
+      return cursor.lastSequence === row.lastSequence
+        ? row
+        : { ...row, lastSequence: cursor.lastSequence };
+    }),
+  );
 }
 
 function mapSessionAttention(
@@ -63689,29 +63697,11 @@ export async function claimSessionWorkForAttempt(
                   eq(schema.sessionTurns.sessionId, sessionId),
                 ),
               );
-            const [latestStarted] = await tx
-              .select({
-                model: schema.sessionTurns.model,
-                reasoningEffort: schema.sessionTurns.reasoningEffort,
-                latencyMode: schema.sessionTurns.latencyMode,
-                sandboxBackend: schema.sessionTurns.sandboxBackend,
-                sandboxOs: schema.sessionTurns.sandboxOs,
-                initiatingHumanSubjectId: schema.sessionTurns.initiatingHumanSubjectId,
-                initiatorKind: schema.sessionTurns.initiatorKind,
-                initiatorSubjectId: schema.sessionTurns.initiatorSubjectId,
-                xaiProviderAccountAuthoritySnapshot:
-                  schema.sessionTurns.xaiProviderAccountAuthoritySnapshot,
-              })
-              .from(schema.sessionTurns)
-              .where(
-                and(
-                  eq(schema.sessionTurns.workspaceId, workspaceId),
-                  eq(schema.sessionTurns.sessionId, sessionId),
-                  sql`${schema.sessionTurns.startedAt} is not null`,
-                ),
-              )
-              .orderBy(desc(schema.sessionTurns.startedAt), desc(schema.sessionTurns.createdAt))
-              .limit(1);
+            const latestStarted = await latestStartedSessionTurnRow(
+              tx as unknown as Database,
+              workspaceId,
+              sessionId,
+            );
             await tx.execute(sql`set local opengeni.session_inference_claim = '1'`);
             const [compactionTurn] = await tx
               .insert(schema.sessionTurns)
@@ -64015,28 +64005,11 @@ export async function claimSessionWorkForAttempt(
           let frozenTurnExecutionPolicy = goalPolicy?.turnExecutionPolicy
             ? TurnExecutionPolicyV1.parse(goalPolicy.turnExecutionPolicy)
             : null;
-          const [latestStarted] = await tx
-            .select({
-              model: schema.sessionTurns.model,
-              reasoningEffort: schema.sessionTurns.reasoningEffort,
-              latencyMode: schema.sessionTurns.latencyMode,
-              tools: schema.sessionTurns.tools,
-              sandboxBackend: schema.sessionTurns.sandboxBackend,
-              sandboxOs: schema.sessionTurns.sandboxOs,
-              initiatingHumanSubjectId: schema.sessionTurns.initiatingHumanSubjectId,
-              initiatorKind: schema.sessionTurns.initiatorKind,
-              initiatorSubjectId: schema.sessionTurns.initiatorSubjectId,
-            })
-            .from(schema.sessionTurns)
-            .where(
-              and(
-                eq(schema.sessionTurns.workspaceId, workspaceId),
-                eq(schema.sessionTurns.sessionId, sessionId),
-                sql`${schema.sessionTurns.startedAt} is not null`,
-              ),
-            )
-            .orderBy(desc(schema.sessionTurns.startedAt), desc(schema.sessionTurns.createdAt))
-            .limit(1);
+          const latestStarted = await latestStartedSessionTurnRow(
+            tx as unknown as Database,
+            workspaceId,
+            sessionId,
+          );
           let model =
             typeof goalPolicy?.model === "string"
               ? goalPolicy.model
@@ -75152,7 +75125,8 @@ async function mapSessionWithControl(
   const controls = await sessionControlProjections(db, row.workspaceId, [row.id], workspaceControl);
   const control = controls.get(row.id);
   if (!control) throw new Error(`Effective control missing for session ${row.id}`);
-  return mapSession(row, control, mcpServers, pin, attention, archive, tenancyViewer);
+  const [effective] = await withLatestStartedSessionPolicy(db, row.workspaceId, [row]);
+  return mapSession(effective!, control, mcpServers, pin, attention, archive, tenancyViewer);
 }
 
 function mapSessionTenancy(
@@ -75391,30 +75365,8 @@ async function latestStartedSessionTurnRow(
   workspaceId: string,
   sessionId: string,
 ): Promise<typeof schema.sessionTurns.$inferSelect | null> {
-  const [row] = await db
-    .select({ turn: schema.sessionTurns })
-    .from(schema.sessionEvents)
-    .innerJoin(
-      schema.sessionTurns,
-      and(
-        eq(schema.sessionEvents.workspaceId, schema.sessionTurns.workspaceId),
-        eq(schema.sessionEvents.sessionId, schema.sessionTurns.sessionId),
-        eq(schema.sessionEvents.turnId, schema.sessionTurns.id),
-      ),
-    )
-    .where(
-      and(
-        eq(schema.sessionEvents.workspaceId, workspaceId),
-        eq(schema.sessionEvents.sessionId, sessionId),
-        eq(schema.sessionEvents.type, "turn.started"),
-      ),
-    )
-    // session_events_workspace_session_sequence_idx supports this backward
-    // scan; the PK join then fetches exactly one turn row even for very long
-    // sessions with thousands of timeline deltas per turn.
-    .orderBy(desc(schema.sessionEvents.sequence))
-    .limit(1);
-  return row?.turn ?? null;
+  const [row] = await latestStartedSessionTurnQuery(db, workspaceId, sessionId);
+  return row ?? null;
 }
 
 function mapFile(row: typeof schema.files.$inferSelect): FileAsset {

--- a/packages/db/src/insights.ts
+++ b/packages/db/src/insights.ts
@@ -1,3 +1,4 @@
+import { withLatestStartedSessionPolicy } from "./session-execution-policy";
 import { and, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Database } from "./database";
@@ -1056,6 +1057,8 @@ export async function listFloorSessions(
         directControlState: schema.sessions.directControlState,
         nestedAgentDepth: schema.sessions.nestedAgentDepth,
         model: schema.sessions.model,
+        reasoningEffort: schema.sessions.reasoningEffort,
+        latencyMode: schema.sessions.latencyMode,
         sandboxBackend: schema.sessions.sandboxBackend,
         updatedAt: schema.sessions.updatedAt,
         createdAt: schema.sessions.createdAt,
@@ -1064,7 +1067,7 @@ export async function listFloorSessions(
       .where(eq(schema.sessions.workspaceId, workspaceId))
       .orderBy(desc(schema.sessions.updatedAt))
       .limit(limit);
-    return rows;
+    return await withLatestStartedSessionPolicy(scopedDb, workspaceId, rows);
   });
 }
 

--- a/packages/db/src/session-execution-policy.ts
+++ b/packages/db/src/session-execution-policy.ts
@@ -1,0 +1,78 @@
+import { and, desc, eq, getTableColumns, inArray, sql, type SQL } from "drizzle-orm";
+import type { Database } from "./database";
+import * as schema from "./schema";
+
+/** Only a durable turn.started event establishes inherited execution policy. */
+export function latestStartedSessionTurnQuery(
+  db: Database,
+  workspaceId: string,
+  sessionId: string | SQL,
+) {
+  return db
+    .select(getTableColumns(schema.sessionTurns))
+    .from(schema.sessionEvents)
+    .innerJoin(
+      schema.sessionTurns,
+      and(
+        eq(schema.sessionEvents.workspaceId, schema.sessionTurns.workspaceId),
+        eq(schema.sessionEvents.sessionId, schema.sessionTurns.sessionId),
+        eq(schema.sessionEvents.turnId, schema.sessionTurns.id),
+      ),
+    )
+    .where(
+      and(
+        eq(schema.sessionEvents.workspaceId, workspaceId),
+        eq(schema.sessionEvents.sessionId, sessionId),
+        eq(schema.sessionEvents.type, "turn.started"),
+      ),
+    )
+    .orderBy(desc(schema.sessionEvents.sequence))
+    .limit(1);
+}
+
+type PolicyRow = Pick<
+  typeof schema.sessions.$inferSelect,
+  "id" | "model" | "reasoningEffort" | "latencyMode"
+>;
+
+/** Read projection only: never overwrite creation settings or accepted turns.
+ * Call inside the caller's existing workspace/subject RLS boundary.
+ * One bounded lateral lookup per listed session, not one network call per row.
+ */
+export async function withLatestStartedSessionPolicy<T extends PolicyRow>(
+  db: Database,
+  workspaceId: string,
+  rows: readonly T[],
+): Promise<T[]> {
+  if (rows.length === 0) return [];
+  const latest = latestStartedSessionTurnQuery(db, workspaceId, sql`${schema.sessions.id}`).as(
+    "latest_started_policy",
+  );
+  const policies = await db
+    .select({
+      id: schema.sessions.id,
+      model: latest.model,
+      reasoningEffort: latest.reasoningEffort,
+      latencyMode: latest.latencyMode,
+    })
+    .from(schema.sessions)
+    .leftJoinLateral(latest, sql`true`)
+    .where(
+      and(
+        eq(schema.sessions.workspaceId, workspaceId),
+        inArray(schema.sessions.id, [...new Set(rows.map((row) => row.id))]),
+      ),
+    );
+  const byId = new Map(policies.map((policy) => [policy.id, policy]));
+  return rows.map((row) => {
+    const policy = byId.get(row.id);
+    return policy?.model
+      ? {
+          ...row,
+          model: policy.model,
+          reasoningEffort: policy.reasoningEffort ?? row.reasoningEffort,
+          latencyMode: policy.latencyMode ?? row.latencyMode,
+        }
+      : row;
+  });
+}

--- a/packages/db/src/session-execution-policy.ts
+++ b/packages/db/src/session-execution-policy.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, getTableColumns, inArray, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, sql, type SQL } from "drizzle-orm";
 import type { Database } from "./database";
 import * as schema from "./schema";
 
@@ -9,7 +9,12 @@ export function latestStartedSessionTurnQuery(
   sessionId: string | SQL,
 ) {
   return db
-    .select(getTableColumns(schema.sessionTurns))
+    .select({
+      id: schema.sessionTurns.id,
+      model: schema.sessionTurns.model,
+      reasoningEffort: schema.sessionTurns.reasoningEffort,
+      latencyMode: schema.sessionTurns.latencyMode,
+    })
     .from(schema.sessionEvents)
     .innerJoin(
       schema.sessionTurns,

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -1,3 +1,4 @@
+import { withLatestStartedSessionPolicy } from "./session-execution-policy";
 import {
   WORKSPACE_XAI_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1,
   XaiProviderAccountAuthoritySnapshotV1,
@@ -1875,7 +1876,9 @@ export async function submitHumanPromptInTransaction(
     throw new SessionControlConflictError();
   }
 
-  const session = await lockSession(db, input.workspaceId, input.sessionId);
+  const storedSession = await lockSession(db, input.workspaceId, input.sessionId);
+  const [session] = await withLatestStartedSessionPolicy(db, input.workspaceId, [storedSession]);
+  if (!session) throw new Error("Session disappeared during prompt admission");
   if (session.status === "cancelled") {
     throw new QueueCommandConflictError(
       "QUEUE_PROMPT_STARTED",
@@ -1956,9 +1959,15 @@ export async function submitHumanPromptInTransaction(
           resources: withCanonicalResourceMountPaths(
             input.composerDraftResources ?? input.resources,
           ),
-          model: input.model ?? session.model,
-          reasoningEffort: input.reasoningEffort ?? input.reasoningEffortFallback,
-          latencyMode: input.turnExecutionPolicy?.latencyMode ?? input.latencyMode ?? "standard",
+          model: input.turnExecutionPolicy?.productModelId ?? input.model ?? session.model,
+          reasoningEffort:
+            input.turnExecutionPolicy?.reasoningEffort ??
+            input.reasoningEffort ??
+            (session.reasoningEffort as ReasoningEffort),
+          latencyMode:
+            input.turnExecutionPolicy?.latencyMode ??
+            input.latencyMode ??
+            (session.latencyMode as LatencyMode),
         })
     ) {
       throw new QueueCommandConflictError(
@@ -2156,9 +2165,15 @@ export async function submitHumanPromptInTransaction(
           resources: input.resources,
           tools: [],
           toolsProvided: false,
-          model: input.model ?? session.model,
-          reasoningEffort: input.reasoningEffort ?? input.reasoningEffortFallback,
-          latencyMode: input.turnExecutionPolicy?.latencyMode ?? input.latencyMode ?? "standard",
+          model: input.turnExecutionPolicy?.productModelId ?? input.model ?? session.model,
+          reasoningEffort:
+            input.turnExecutionPolicy?.reasoningEffort ??
+            input.reasoningEffort ??
+            (session.reasoningEffort as ReasoningEffort),
+          latencyMode:
+            input.turnExecutionPolicy?.latencyMode ??
+            input.latencyMode ??
+            (session.latencyMode as LatencyMode),
           sandboxBackend: session.sandboxBackend,
           metadata: input.turnExecutionPolicy
             ? metadataWithTurnExecutionPolicyV1(input.turnMetadata ?? {}, input.turnExecutionPolicy)

--- a/packages/db/src/session-realtime-ledger.ts
+++ b/packages/db/src/session-realtime-ledger.ts
@@ -1,6 +1,7 @@
+import { withLatestStartedSessionPolicy } from "./session-execution-policy";
 import { createHash } from "node:crypto";
 
-import { ReasoningEffort, type SessionRealtimeMode } from "@opengeni/contracts";
+import { LatencyMode, ReasoningEffort, type SessionRealtimeMode } from "@opengeni/contracts";
 import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 import type { Database, SessionActivityDatabase } from "./database";
@@ -1147,6 +1148,8 @@ async function admitRealtimeDelegationInTransaction(
   if (!session || session.accountId !== accountId || session.status === "cancelled") {
     throw new SessionRealtimeConflictError("REALTIME_NOT_FOUND", "Session not found");
   }
+  const [policy] = await withLatestStartedSessionPolicy(db, input.workspaceId, [session]);
+  if (!policy) throw new Error("Realtime delegation session disappeared");
   const provenance = {
     source: "realtime_provider_delegation",
     realtimeId: input.realtimeId,
@@ -1179,6 +1182,9 @@ async function admitRealtimeDelegationInTransaction(
     },
     mirrorToRealtime: false,
     resources: [],
+    model: policy.model,
+    reasoningEffort: ReasoningEffort.parse(policy.reasoningEffort),
+    latencyMode: LatencyMode.parse(policy.latencyMode),
     reasoningEffortFallback: ReasoningEffort.parse(session.reasoningEffort),
     turnMetadata: {
       realtimeDelegation: { ...provenance, inputTranscript },

--- a/packages/db/src/session-realtime-ledger.ts
+++ b/packages/db/src/session-realtime-ledger.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
-import { LatencyMode, ReasoningEffort, type SessionRealtimeMode } from "@opengeni/contracts";
-import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { ReasoningEffort, type SessionRealtimeMode } from "@opengeni/contracts";
+import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 import type { Database, SessionActivityDatabase } from "./database";
 import {
@@ -1147,26 +1147,6 @@ async function admitRealtimeDelegationInTransaction(
   if (!session || session.accountId !== accountId || session.status === "cancelled") {
     throw new SessionRealtimeConflictError("REALTIME_NOT_FOUND", "Session not found");
   }
-  const sessionReasoning = ReasoningEffort.parse(session.reasoningEffort);
-  const sessionLatency = LatencyMode.parse(session.latencyMode);
-  const [latestStarted] = await db
-    .select({
-      model: schema.sessionTurns.model,
-      reasoningEffort: schema.sessionTurns.reasoningEffort,
-      latencyMode: schema.sessionTurns.latencyMode,
-    })
-    .from(schema.sessionTurns)
-    .where(
-      and(
-        eq(schema.sessionTurns.workspaceId, input.workspaceId),
-        eq(schema.sessionTurns.sessionId, input.sessionId),
-        sql`${schema.sessionTurns.startedAt} is not null`,
-      ),
-    )
-    .orderBy(desc(schema.sessionTurns.startedAt), desc(schema.sessionTurns.createdAt))
-    .limit(1);
-  const latestReasoning = ReasoningEffort.safeParse(latestStarted?.reasoningEffort);
-  const latestLatency = LatencyMode.safeParse(latestStarted?.latencyMode);
   const provenance = {
     source: "realtime_provider_delegation",
     realtimeId: input.realtimeId,
@@ -1199,10 +1179,7 @@ async function admitRealtimeDelegationInTransaction(
     },
     mirrorToRealtime: false,
     resources: [],
-    model: latestStarted?.model ?? session.model,
-    reasoningEffort: latestReasoning.success ? latestReasoning.data : sessionReasoning,
-    latencyMode: latestLatency.success ? latestLatency.data : sessionLatency,
-    reasoningEffortFallback: sessionReasoning,
+    reasoningEffortFallback: ReasoningEffort.parse(session.reasoningEffort),
     turnMetadata: {
       realtimeDelegation: { ...provenance, inputTranscript },
     },

--- a/packages/db/test/queue-mutations.test.ts
+++ b/packages/db/test/queue-mutations.test.ts
@@ -16,6 +16,9 @@ import {
   evaluateSessionControl,
   getScheduledTargetSessionExecution,
   getSessionTurn,
+  getSession,
+  listSessions,
+  listFloorSessions,
   getSessionQueueSnapshot,
   listSessionTurns,
   markSessionAttemptQuiesced,
@@ -137,6 +140,74 @@ async function storedEvents(workspaceId: string, eventIds: string[]) {
       .where(inArray(schema.sessionEvents.id, eventIds)),
   );
 }
+
+describe("latest started session policy", () => {
+  test("projects and inherits started policy, preserving explicit and queued policies", async () => {
+    const value = await fixture(3);
+    const workspaceId = value.grant.workspaceId!;
+    const initial = { model: "scripted-model", reasoningEffort: "medium", latencyMode: "standard" };
+    expect(await getSession(client.db, workspaceId, value.session.id)).toMatchObject(initial);
+    const started = value.turns[0]!;
+    await withWorkspaceRls(client.db, workspaceId, async (db) => {
+      await db
+        .update(schema.sessionTurns)
+        .set({ reasoningEffort: "high", latencyMode: "priority" })
+        .where(eq(schema.sessionTurns.id, started.id));
+      // Admission failure / startedAt alone cannot replace turn.started truth.
+      await db
+        .update(schema.sessionTurns)
+        .set({ startedAt: new Date(), status: "failed" })
+        .where(eq(schema.sessionTurns.id, value.turns[2]!.id));
+    });
+    await appendSessionEvents(client.db, workspaceId, value.session.id, [
+      {
+        type: "turn.started",
+        turnId: started.id,
+        payload: {},
+      },
+    ]);
+    const effective = { model: started.model, reasoningEffort: "high", latencyMode: "priority" };
+    expect(await getSession(client.db, workspaceId, value.session.id)).toMatchObject(effective);
+    expect(
+      (await listSessions(client.db, workspaceId)).find((row) => row.id === value.session.id),
+    ).toMatchObject(effective);
+    expect(
+      (await listFloorSessions(client.db, workspaceId)).find((row) => row.id === value.session.id),
+    ).toMatchObject({ model: started.model });
+    const submit = (override = {}) =>
+      withWorkspaceSubjectRls(client.db, workspaceId, value.grant.subjectId, (db) =>
+        db.transaction((tx) =>
+          submitHumanPromptInTransaction(tx as unknown as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId,
+            sessionId: value.session.id,
+            subjectId: value.grant.subjectId,
+            actor: value.actor,
+            operationKey: crypto.randomUUID(),
+            delivery: "send",
+            text: "follow up",
+            resources: [],
+            reasoningEffortFallback: "medium",
+            source: "user",
+            ...override,
+          }),
+        ),
+      );
+    const inherited = await submit();
+    expect(await getSessionTurn(client.db, workspaceId, inherited.turnId)).toMatchObject(effective);
+    const explicit = { model: "explicit-model", reasoningEffort: "low", latencyMode: "standard" };
+    const overridden = await submit(explicit);
+    expect(await getSessionTurn(client.db, workspaceId, overridden.turnId)).toMatchObject(explicit);
+    expect(await getSessionTurn(client.db, workspaceId, value.turns[1]!.id)).toMatchObject({
+      model: value.turns[1]!.model,
+    });
+    expect(await getSession(client.db, workspaceId, value.session.id)).toMatchObject(effective);
+    const stored = await withWorkspaceRls(client.db, workspaceId, (db) =>
+      db.select().from(schema.sessions).where(eq(schema.sessions.id, value.session.id)),
+    );
+    expect(stored[0]).toMatchObject(initial);
+  });
+});
 
 describe("canonical queue commands", () => {
   test("projects only prompts admitted to wait behind work into the visible queue", async () => {

--- a/packages/db/test/session-realtime-context.test.ts
+++ b/packages/db/test/session-realtime-context.test.ts
@@ -7,6 +7,7 @@ import {
   activateSessionRealtimeConnectionInTransaction,
   beginSessionRealtimeInTransaction,
   bootstrapWorkspace,
+  appendSessionEvents,
   claimSessionRealtimeConnectionInTransaction,
   claimSessionWorkForAttempt,
   completeSessionRealtimeConnectionInTransaction,
@@ -271,6 +272,54 @@ function sourceEntry(role: "user" | "assistant", text: string): SessionRealtimeC
     payload: { turnId: crypto.randomUUID() },
   };
 }
+
+describe("voice handoff execution policy", () => {
+  test("inherits latest started model, effort and speed when voice ends", async () => {
+    const value = await fixture();
+    const [previous] = await transaction(value.workspaceId, (tx) =>
+      tx
+        .insert(schema.sessionTurns)
+        .values({
+          accountId: value.accountId,
+          workspaceId: value.workspaceId,
+          sessionId: value.session.id,
+          triggerEventId: crypto.randomUUID(),
+          temporalWorkflowId: `session-${value.session.id}`,
+          status: "completed",
+          source: "user",
+          prompt: "changed model",
+          position: 0,
+          resources: [],
+          tools: [],
+          model: "codex/new-model",
+          reasoningEffort: "high",
+          latencyMode: "priority",
+          sandboxBackend: "none",
+        })
+        .returning(),
+    );
+    await appendSessionEvents(client.db, value.workspaceId, value.session.id, [
+      {
+        type: "turn.started",
+        turnId: previous!.id,
+        payload: {},
+      },
+    ]);
+    await runMode(value, [transcript("user", "Finish the remaining work")]);
+    const turns = await transaction(value.workspaceId, (tx) =>
+      tx
+        .select()
+        .from(schema.sessionTurns)
+        .where(eq(schema.sessionTurns.sessionId, value.session.id)),
+    );
+    const handoff = turns.find((turn) => turn.id !== previous!.id);
+    expect(handoff).toMatchObject({
+      model: "codex/new-model",
+      reasoningEffort: "high",
+      latencyMode: "priority",
+    });
+  });
+});
 
 describe("session realtime transcript tail and continuity", () => {
   test("renders escaped, bounded Codex-style tail context", () => {

--- a/packages/db/test/session-realtime-ledger.test.ts
+++ b/packages/db/test/session-realtime-ledger.test.ts
@@ -7,6 +7,7 @@ import {
   acceptSessionHumanInputResponse,
   addSessionSystemUpdate,
   activateSessionRealtimeConnectionInTransaction,
+  appendSessionEvents,
   appendSessionEventsForTurnAttempt,
   appendSessionRealtimeOutboundInTransaction,
   applySessionTurnSettlement,
@@ -1249,8 +1250,10 @@ describe("session realtime ledger", () => {
 
   test("atomically admits one idempotent ordinary turn on the same session without changing hierarchy", async () => {
     const value = await fixture();
+    const priorTurnId = crypto.randomUUID();
     await transaction(value.owner.workspaceId, async (tx) => {
       await tx.insert(schema.sessionTurns).values({
+        id: priorTurnId,
         accountId: value.grant.accountId,
         workspaceId: value.owner.workspaceId,
         sessionId: value.session.id,
@@ -1271,6 +1274,13 @@ describe("session realtime ledger", () => {
         finishedAt: new Date(),
       });
     });
+    await appendSessionEvents(client.db, value.owner.workspaceId, value.session.id, [
+      {
+        type: "turn.started",
+        turnId: priorTurnId,
+        payload: {},
+      },
+    ]);
     const first = await claimInitial(value);
     await complete(value, first.claimed.connection);
     await proveProviderStarted(value, first.claimed.connection);


### PR DESCRIPTION
Voice-end handoffs and follow-ups without an explicit model could revert to a session's creation model after the user switched models. Session lists, Insights and fresh drafts could show or select that same stale model.

Resolve model, reasoning effort and speed from the latest durable `turn.started` event through one shared database helper. Use creation settings only before the first turn starts. Session read projections use the same policy; explicit drafts, accepted queued turns, historical turns and frozen admission snapshots retain their settings. Goal continuations pause if the inherited model is unavailable instead of silently switching back.

Validation: 79 focused PostgreSQL/API/voice/goal regression tests passed; all 32 project typechecks passed; focused lint and documentation checks passed. Both affected old-schema migration suites also pass. Independent review found no blockers. A live desktop check confirms the newer model/effort in the header and composer. Header browser layout failures reproduce on unchanged main. The full local check encounters unavailable opengeni-sandbox:local and shared-process sandbox mock failures; all final-head CI checks passed on 527271296b6df69c2457afe16eca670d454f84a6. An additional 112 isolated goal/control-plane and migration tests passed after the main-branch conflict resolution.
