### PR TITLE
fix: capture exact model context and simplify the debug reader

### DIFF
--- a/.changeset/exact-context-inspector.md
+++ b/.changeset/exact-context-inspector.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/contracts": patch
+"@opengeni/sdk": patch
+---
+
+Capture final provider HTTP request bodies for the context inspector, including conversation input and provider-normalized tools/settings. Keep unsupported or oversized captures explicitly unavailable, label section/item token estimates, and preserve transport cancellation and streaming behavior.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@pierre/diffs": "1.2.11",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-router": "^1.170.15",
+    "@tanstack/react-virtual": "^3.14.11",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/addon-web-links": "0.12.0",
     "@xterm/addon-webgl": "0.19.0",

--- a/apps/web/src/components/session/context-text-reader.tsx
+++ b/apps/web/src/components/session/context-text-reader.tsx
@@ -1,0 +1,249 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ArrowDownIcon, ArrowUpIcon, CopyIcon, SearchIcon, XIcon } from "lucide-react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// Internal layout blocks only. Readers see a single continuous document.
+export function textBlocks(text: string) {
+  const blocks: { start: number; text: string }[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(start + 2000, text.length);
+    if (end < text.length) {
+      const newline = text.lastIndexOf("\n", end);
+      if (newline > start + 1000) end = newline + 1;
+      else {
+        const space = text.lastIndexOf(" ", end);
+        if (space > start + 1000) end = space + 1;
+        else if (/[\uD800-\uDBFF]/.test(text[end - 1]!)) end--;
+      }
+    }
+    blocks.push({ start, text: text.slice(start, end) });
+    start = end;
+  }
+  return blocks;
+}
+export function ContextTextReader({
+  text,
+  initialQuery = "",
+  code = false,
+}: {
+  text: string;
+  initialQuery?: string;
+  code?: boolean;
+}) {
+  const root = useRef<HTMLDivElement>(null);
+  const body = useRef<HTMLDivElement>(null);
+  const search = useRef<HTMLInputElement>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+  const [margin, setMargin] = useState(0);
+  const [finding, setFinding] = useState(Boolean(initialQuery));
+  const [query, setQuery] = useState(initialQuery);
+  const [occurrence, setOccurrence] = useState(0);
+  const [jumpRevision, setJumpRevision] = useState(0);
+  const pendingJump = useRef(true);
+  const blocks = useMemo(() => textBlocks(text), [text]);
+  const matches = useMemo(() => {
+    if (!query) return [];
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const expression = new RegExp(escaped, "gi");
+    const result: number[] = [];
+    for (const match of text.matchAll(expression)) result.push(match.index);
+    return result;
+  }, [text, query]);
+  const active = matches[Math.min(occurrence, matches.length - 1)] ?? -1;
+  const large = text.length > 50000;
+  useLayoutEffect(() => {
+    const viewport =
+      root.current?.closest<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null;
+    setScrollElement(viewport);
+    const update = () => {
+      if (viewport && body.current)
+        setMargin(
+          body.current.getBoundingClientRect().top -
+            viewport.getBoundingClientRect().top +
+            viewport.scrollTop,
+        );
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    if (root.current) observer.observe(root.current);
+    if (viewport) observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [finding]);
+  const virtualizer = useVirtualizer({
+    count: blocks.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: (index) => Math.max(24, Math.ceil((blocks[index]?.text.length ?? 0) / 65) * 24),
+    scrollMargin: margin,
+    overscan: 3,
+    enabled: large,
+    initialRect: { width: 500, height: 600 },
+  });
+  useEffect(() => {
+    if (!pendingJump.current || active < 0 || !large || !scrollElement) return;
+    const index = blocks.findIndex(
+      (block) => active >= block.start && active < block.start + block.text.length,
+    );
+    if (index >= 0) virtualizer.scrollToIndex(index, { align: "center" });
+  }, [active, blocks, large, scrollElement, virtualizer, jumpRevision]);
+  const virtualItems = virtualizer.getVirtualItems();
+  useLayoutEffect(() => {
+    if (!pendingJump.current || active < 0) return;
+    const mark = body.current?.querySelector("mark");
+    if (mark) {
+      mark.scrollIntoView?.({ block: "center" });
+      pendingJump.current = false;
+    }
+  });
+  const move = (delta: number) => {
+    pendingJump.current = true;
+    setJumpRevision((n) => n + 1);
+    setOccurrence((n) => (n + delta + matches.length) % Math.max(1, matches.length));
+  };
+  const renderText = (value: string, start: number) => {
+    const offset = Math.max(0, active - start);
+    const matchEnd = Math.min(value.length, active + query.length - start);
+    return finding && active >= 0 && matchEnd > 0 && active < start + value.length ? (
+      <>
+        {value.slice(0, offset)}
+        <mark className="rounded-sm bg-amber-300/25 text-inherit">
+          {value.slice(offset, matchEnd)}
+        </mark>
+        {value.slice(matchEnd)}
+      </>
+    ) : (
+      value
+    );
+  };
+  return (
+    <div
+      ref={root}
+      tabIndex={0}
+      aria-label="Context text"
+      onPointerDown={(event) => {
+        if (!(event.target as HTMLElement).closest("button,input,a"))
+          root.current?.focus({ preventScroll: true });
+      }}
+      className="min-w-0"
+      onKeyDown={(event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "f") {
+          event.preventDefault();
+          setFinding(true);
+          requestAnimationFrame(() => search.current?.focus());
+        }
+        if (event.key === "Escape") {
+          setFinding(false);
+          setQuery("");
+        }
+      }}
+    >
+      <div className="sticky top-0 z-10 mb-3 flex min-w-0 items-center justify-between gap-2 border-b border-border bg-bg py-2">
+        {finding ? (
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <Input
+              ref={search}
+              autoFocus
+              aria-label="Find in content"
+              placeholder="Find in text…"
+              className="h-7 min-w-0 flex-1"
+              value={query}
+              onChange={(event) => {
+                pendingJump.current = true;
+                setQuery(event.target.value);
+                setOccurrence(0);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  move(event.shiftKey ? -1 : 1);
+                }
+              }}
+            />
+            <span className="shrink-0 text-2xs text-fg-subtle" aria-live="polite">
+              {query ? (matches.length ? `${occurrence + 1}/${matches.length}` : "No results") : ""}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Previous match"
+              disabled={!matches.length}
+              onClick={() => move(-1)}
+            >
+              <ArrowUpIcon className="size-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Next match"
+              disabled={!matches.length}
+              onClick={() => move(1)}
+            >
+              <ArrowDownIcon className="size-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Close find"
+              onClick={() => {
+                setFinding(false);
+                setQuery("");
+              }}
+            >
+              <XIcon className="size-3" />
+            </Button>
+          </div>
+        ) : (
+          <Button size="xs" variant="ghost" onClick={() => setFinding(true)}>
+            <SearchIcon className="size-3" />
+            Find
+          </Button>
+        )}
+        {!finding ? (
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(text);
+                toast.success("Copied");
+              } catch {
+                toast.error("Could not copy");
+              }
+            }}
+          >
+            <CopyIcon className="size-3" />
+            Copy
+          </Button>
+        ) : null}
+      </div>
+      <div
+        ref={body}
+        className={
+          code
+            ? "font-mono text-xs leading-6 text-fg-muted"
+            : "mx-auto max-w-[72ch] font-sans text-[13px] leading-[21px] text-fg"
+        }
+        style={large ? { height: virtualizer.getTotalSize(), position: "relative" } : undefined}
+      >
+        {large ? (
+          virtualItems.map((item) => (
+            <div
+              key={item.key}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
+              className="absolute left-0 top-0 w-full whitespace-pre-wrap [overflow-wrap:anywhere]"
+              style={{ transform: `translateY(${item.start - margin}px)` }}
+            >
+              {renderText(blocks[item.index]!.text, blocks[item.index]!.start)}
+            </div>
+          ))
+        ) : (
+          <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">{renderText(text, 0)}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -199,20 +199,20 @@ export function SessionInspector(props: {
 
       <Tabs defaultValue="overview" className="min-h-0 min-w-0 flex-1 gap-0 overflow-hidden">
         <div className="min-w-0 border-b border-border px-2 py-2">
-          <TabsList className="grid h-8 w-full min-w-0 grid-cols-5 rounded-md bg-bg p-1">
-            <TabsTrigger value="overview" className="h-6 min-w-0 rounded px-1 text-2xs">
+          <TabsList className="flex !h-auto w-full min-w-0 flex-wrap justify-start gap-1 rounded-md bg-bg p-1">
+            <TabsTrigger value="overview" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Overview
             </TabsTrigger>
-            <TabsTrigger value="context" className="h-6 min-w-0 rounded px-1 text-2xs">
+            <TabsTrigger value="context" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Context
             </TabsTrigger>
-            <TabsTrigger value="events" className="h-6 min-w-0 rounded px-1 text-2xs">
+            <TabsTrigger value="events" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Events
             </TabsTrigger>
-            <TabsTrigger value="timeline" className="h-6 min-w-0 rounded px-1 text-2xs">
+            <TabsTrigger value="timeline" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Timeline
             </TabsTrigger>
-            <TabsTrigger value="raw" className="h-6 min-w-0 rounded px-1 text-2xs">
+            <TabsTrigger value="raw" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Raw
             </TabsTrigger>
           </TabsList>
@@ -458,6 +458,7 @@ export function SessionInspector(props: {
             workspaceId={props.session.workspaceId}
             sessionId={props.session.id}
             events={displayEvents}
+            isRunning={props.session.status === "running"}
           />
         </TabsContent>
 

--- a/apps/web/src/components/session/model-context-inspector.test.tsx
+++ b/apps/web/src/components/session/model-context-inspector.test.tsx
@@ -1,31 +1,229 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import type { SessionModelContextResponse } from "@opengeni/sdk";
 
-mock.module("@/context", () => ({
-  useAppContext: () => ({ client: { getSessionModelContext: mock(async () => null) } }),
-}));
-
-mock.module("sonner", () => ({
-  toast: { error: mock(() => undefined), success: mock(() => undefined) },
-}));
+GlobalRegistrator.register();
+const { createRoot } = await import("react-dom/client");
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+const getSessionModelContext = mock(async (): Promise<SessionModelContextResponse> => response);
+const client = { getSessionModelContext };
+mock.module("@/context", () => ({ useAppContext: () => ({ client }) }));
+mock.module("sonner", () => ({ toast: { error: mock(), success: mock() } }));
+const { ModelContextInspectorPane } = await import("./model-context-inspector");
+const { ContextTextReader, textBlocks } = await import("./context-text-reader");
+const response: SessionModelContextResponse = {
+  sessionId: "s",
+  turnId: "t",
+  attemptId: "a",
+  snapshot: {
+    version: 1,
+    source: "model_request",
+    capturedAt: "2026-09-08T12:00:00.000Z",
+    requestIndex: 2,
+    instructions: "",
+    layers: [],
+    tools: [],
+    skills: [],
+    tokens: { instructions: 1, tools: 1, prefix: 2 },
+    providerRequest: {
+      provider: "test",
+      body: '{"instructions":"EXACT SENT TEXT","input":[{"role":"user","content":"Hello"}]}',
+      parts: [
+        { key: "instructions", estimatedTokens: 4, utf8Bytes: 17 },
+        { key: "input", estimatedTokens: 8, utf8Bytes: 30 },
+      ],
+    },
+  },
+};
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
 
 describe("model context inspector", () => {
-  test("reads the latest provider usage event", async () => {
-    const { providerUsageFromEvents } = await import("./model-context-inspector");
+  test("discloses captured content, labels estimates and never substitutes unrelated usage", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          <ModelContextInspectorPane
+            workspaceId="w"
+            sessionId="s"
+            events={[
+              { type: "agent.model.usage", sequence: 9, payload: { inputTokens: 99999 } } as never,
+            ]}
+          />,
+        ),
+      );
+      expect(container.textContent).toContain("Captured request · tokens estimated");
+      expect(container.textContent).toContain("~4");
+      expect(container.textContent).not.toContain("99,999");
+      expect(container.textContent).toContain("Hello");
+      expect(container.textContent).not.toContain("derived");
+      expect(container.textContent).not.toContain("bytes");
+      expect(container.textContent).not.toContain("EXACT SENT TEXT");
+      const button = [...container.querySelectorAll("button")].find((item) =>
+        item.textContent?.startsWith("Instructions"),
+      )!;
+      await act(async () => button.click());
+      expect(container.textContent).toContain("EXACT SENT TEXT");
+      expect(button.getAttribute("aria-pressed")).toBe("true");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("legacy prefixes are explicitly incomplete", async () => {
+    getSessionModelContext.mockResolvedValueOnce({
+      ...response,
+      snapshot: {
+        ...response.snapshot!,
+        providerRequest: undefined,
+        instructions: "legacy prefix",
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(<ModelContextInspectorPane workspaceId="w" sessionId="old" events={[]} />),
+      );
+      expect(container.textContent).toContain("This older capture contains only instructions.");
+      expect(container.textContent).toContain("The full request was not recorded");
+      expect(
+        [...container.querySelectorAll("button")].some((button) =>
+          button.textContent?.includes("Copy request"),
+        ),
+      ).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+  test("large captures keep list and single-item DOM bounded", async () => {
+    const input = Array.from({ length: 6000 }, (_, index) => ({
+      role: "user",
+      content: `message ${index}`,
+    }));
+    input[5999] = { role: "user", content: "HUGE-START " + "x".repeat(1_000_000) + " HUGE-END" };
+    getSessionModelContext.mockResolvedValueOnce({
+      ...response,
+      snapshot: {
+        ...response.snapshot!,
+        providerRequest: {
+          provider: "test",
+          body: JSON.stringify({ input }),
+          parts: [
+            {
+              key: "input",
+              utf8Bytes: 0,
+              estimatedTokens: 300000,
+              itemEstimatedTokens: input.map((_, i) => (i === 5999 ? 250000 : 4)),
+            },
+          ],
+        },
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const button = (text: string) =>
+      [...container.querySelectorAll("button")].find((item) => item.textContent === text)!;
+    try {
+      await act(async () =>
+        root.render(<ModelContextInspectorPane workspaceId="w" sessionId="large" events={[]} />),
+      );
+      expect(container.querySelectorAll("[data-context-row]").length).toBe(30);
+      expect(container.textContent!.length).toBeLessThan(15000);
+      expect(container.textContent).toContain("6,000 items");
+      expect(container.textContent).toContain("HUGE-START");
+      await act(async () =>
+        (container.querySelector("[data-context-row]") as HTMLButtonElement).click(),
+      );
+      expect(container.textContent!.length).toBeLessThan(30000);
+      expect(container.textContent).not.toContain("Previous text");
+      expect(container.querySelector('input[type="number"]')).toBeNull();
+      await act(async () => button("Back to results").click());
+      await act(async () => button("Next").click());
+      expect(container.querySelectorAll("[data-context-row]").length).toBe(30);
+      expect(container.textContent).toContain("31–60 of 6,000");
+      expect(container.textContent).not.toContain("HUGE-START");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+  test("reader preserves full source and reveals search only on request", async () => {
+    const text =
+      "İ Opening paragraph.\n\n" +
+      "Readable paragraph.\n\n".repeat(1000) +
+      "End marker. End marker. [literal]";
     expect(
-      providerUsageFromEvents([
-        {
-          id: "a",
-          type: "agent.model.usage",
-          sequence: 1,
-          payload: { inputTokens: 10, cachedTokens: 2, outputTokens: 4 },
-        } as never,
-        {
-          id: "b",
-          type: "agent.model.usage",
-          sequence: 4,
-          payload: { inputTokens: 99, cachedTokens: 50, outputTokens: 7 },
-        } as never,
-      ]),
-    ).toEqual({ inputTokens: 99, cachedTokens: 50, outputTokens: 7 });
+      textBlocks(text)
+        .map((block) => block.text)
+        .join(""),
+    ).toBe(text);
+    const unbroken = "😀".repeat(100000);
+    expect(
+      textBlocks(unbroken)
+        .map((block) => block.text)
+        .join(""),
+    ).toBe(unbroken);
+    expect(textBlocks(unbroken).every((block) => block.text.length <= 2000)).toBe(true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => root.render(<ContextTextReader text={text} />));
+      expect(container.textContent).toContain(text);
+      expect(container.querySelector("input")).toBeNull();
+      expect(container.textContent).not.toContain("Part 1");
+      const find = [...container.querySelectorAll("button")].find(
+        (button) => button.textContent === "Find",
+      )!;
+      await act(async () => find.click());
+      const input = container.querySelector("input")!;
+      await act(async () => {
+        Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!.call(
+          input,
+          "End marker",
+        );
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      expect(container.querySelector("mark")?.textContent).toBe("End marker");
+      expect(container.textContent).toContain("1/2");
+      await act(async () =>
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })),
+      );
+      expect(container.textContent).toContain("2/2");
+      await act(async () => {
+        Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!.call(
+          input,
+          "[literal]",
+        );
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      expect(container.querySelector("mark")?.textContent).toBe("[literal]");
+      const jump = mock();
+      container.querySelector("mark")!.scrollIntoView = jump;
+      await act(async () =>
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })),
+      );
+      expect(jump).toHaveBeenCalled();
+
+      await act(async () =>
+        (container.querySelector('[aria-label="Close find"]') as HTMLButtonElement).click(),
+      );
+      expect(container.querySelector("input")).toBeNull();
+      expect(container.textContent).toContain(text);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
   });
 });

--- a/apps/web/src/components/session/model-context-inspector.tsx
+++ b/apps/web/src/components/session/model-context-inspector.tsx
@@ -1,252 +1,439 @@
+import { ContextTextReader } from "./context-text-reader";
 import type { SessionModelContextResponse } from "@opengeni/sdk";
-import { CopyIcon, Loader2Icon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
-
-import { CopyableMono, InfoRow, InspectorSection } from "@/components/common";
+import { ArrowLeftIcon, ChevronRightIcon, RefreshCwIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAppContext } from "@/context";
 import type { SessionEvent } from "@/types";
 
-function formatTokens(value: number): string {
-  return `${value.toLocaleString()} tok`;
+const PAGE_SIZE = 30;
+const json = (value: unknown): string => JSON.stringify(value, null, 2) ?? "";
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
-
-export function providerUsageFromEvents(events: SessionEvent[]): {
-  inputTokens: number | null;
-  cachedTokens: number | null;
-  outputTokens: number | null;
-} | null {
-  const usage = [...events]
-    .filter((event) => event.type === "agent.model.usage")
-    .sort((a, b) => b.sequence - a.sequence)[0];
-  if (!usage || !usage.payload || typeof usage.payload !== "object") return null;
-  const payload = usage.payload as Record<string, unknown>;
-  const numberOrNull = (value: unknown): number | null =>
-    typeof value === "number" && Number.isFinite(value) ? value : null;
-  return {
-    inputTokens: numberOrNull(payload.inputTokens),
-    cachedTokens: numberOrNull(payload.cachedTokens),
-    outputTokens: numberOrNull(payload.outputTokens),
-  };
+function readable(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(readable).join("\n\n");
+  const data = record(value);
+  if (typeof data.text === "string") return data.text;
+  if (["input_image", "image_url"].includes(String(data.type))) return "Image attachment";
+  if (data.encrypted_content)
+    return (
+      "Encrypted content. Token count unavailable." +
+      (data.summary ? "\n" + readable(data.summary) : "")
+    );
+  return readableField(data) ?? json(value);
 }
-
+function readableField(data: Record<string, unknown>): string | undefined {
+  const value = data.content ?? data.output ?? data.arguments;
+  return value == null ? undefined : readable(value);
+}
+function labelFor(value: unknown): string {
+  const data = record(value);
+  if (data.role)
+    return (
+      (
+        {
+          user: "You",
+          assistant: "Assistant",
+          developer: "Developer",
+          system: "System",
+          tool: "Tool result",
+        } as Record<string, string>
+      )[String(data.role)] ?? String(data.role)
+    );
+  if (data.type === "function_call") return "Tool call · " + String(data.name ?? "");
+  if (data.type === "function_call_output") return "Tool result";
+  if (data.type === "reasoning") return "Reasoning";
+  if (data.type === "compaction") return "Compacted history";
+  return typeof value === "string" ? "Input" : String(data.type ?? "Message");
+}
+function tokenLabel(value: number | null | undefined) {
+  return value == null ? "Unknown tokens" : "~" + value.toLocaleString() + " tokens";
+}
 export function ModelContextInspectorPane(props: {
   workspaceId: string;
   sessionId: string;
   events: SessionEvent[];
+  isRunning?: boolean;
 }) {
-  const context = useAppContext();
+  const { client } = useAppContext();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [response, setResponse] = useState<SessionModelContextResponse | null>(null);
-
+  const [refresh, setRefresh] = useState(0);
+  const [pending, setPending] = useState<SessionModelContextResponse | null>(null);
+  const currentCapture = useRef<string | null>(null);
+  const loadNext = useRef(false);
+  useEffect(() => {
+    setResponse(null);
+    setPending(null);
+    currentCapture.current = null;
+  }, [client, props.workspaceId, props.sessionId]);
+  // Fetch while mounted, including when a capture commits after a stream event.
+  // One request at a time; obsolete responses cannot leak across sessions.
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
     setLoading(true);
     setError(null);
-    void context.client
-      .getSessionModelContext(props.workspaceId, props.sessionId)
-      .then((next) => {
-        if (!cancelled) setResponse(next);
-      })
-      .catch((caught) => {
+    let followUp = false;
+    const fetchSnapshot = async () => {
+      try {
+        const next = await client.getSessionModelContext(props.workspaceId, props.sessionId);
         if (!cancelled) {
-          setError(caught instanceof Error ? caught.message : String(caught));
+          const key = next.snapshot
+            ? `${next.attemptId}:${next.snapshot.requestIndex}:${next.snapshot.capturedAt}`
+            : null;
+          if (currentCapture.current === null || loadNext.current) {
+            currentCapture.current = key;
+            loadNext.current = false;
+            setResponse(next);
+            setPending(null);
+          } else if (key !== currentCapture.current) {
+            setPending(next);
+          }
+          setError(null);
         }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      } catch (caught) {
+        if (!cancelled) setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          if (props.isRunning || !followUp) {
+            followUp = true;
+            timer = setTimeout(fetchSnapshot, 5000);
+          }
+        }
+      }
+    };
+    void fetchSnapshot();
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
-  }, [context.client, props.sessionId, props.workspaceId]);
+  }, [client, props.workspaceId, props.sessionId, props.isRunning, refresh]);
 
-  const providerUsage = useMemo(() => providerUsageFromEvents(props.events), [props.events]);
-  const snapshot = response?.snapshot ?? null;
-
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center gap-2 text-xs text-fg-subtle">
-        <Loader2Icon className="size-4 animate-spin" />
-        Loading model context…
-      </div>
+  const snapshot = response?.snapshot;
+  const wire = snapshot?.providerRequest;
+  const payload = useMemo(() => (wire?.body ? record(JSON.parse(wire.body)) : null), [wire?.body]);
+  const [section, setSection] = useState("conversation");
+  const [query, setQuery] = useState("");
+  const [largest, setLargest] = useState(false);
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [rawItem, setRawItem] = useState(false);
+  useEffect(() => {
+    setSection("conversation");
+    setQuery("");
+    setPage(0);
+    setSelected(null);
+  }, [props.workspaceId, props.sessionId]);
+  const conversationKey = payload && "messages" in payload ? "messages" : "input";
+  const partFor = (key: string) => wire?.parts.find((part) => part.key === key);
+  const rows = useMemo(() => {
+    const field = payload?.[section === "tools" ? "tools" : conversationKey];
+    const values = Array.isArray(field) ? field : field == null ? [] : [field];
+    const counts = wire?.parts.find(
+      (part) => part.key === (section === "tools" ? "tools" : conversationKey),
+    )?.itemEstimatedTokens;
+    return values.map((value, index) => {
+      const data = record(value);
+      const definition = data.function ? record(data.function) : data;
+      const label =
+        section === "tools" ? String(definition.name ?? data.type ?? "Tool") : labelFor(value);
+      const text = section === "tools" ? json(value) : readable(value);
+      const preview =
+        section === "tools"
+          ? String(definition.description ?? data.type ?? "Tool definition")
+          : text;
+      return {
+        index,
+        value,
+        label,
+        text,
+        preview: preview.slice(0, 180).replace(/\s+/g, " "),
+        search: (label + " " + text).toLowerCase(),
+        tokens: counts?.[index],
+      };
+    });
+  }, [payload, section, conversationKey, wire?.parts]);
+  const filtered = useMemo(() => {
+    const result = rows.filter((row) => row.search.includes(query.toLowerCase()));
+    return result.sort((a, b) =>
+      largest
+        ? (b.tokens ?? -1) - (a.tokens ?? -1) || a.index - b.index
+        : section === "tools"
+          ? a.index - b.index
+          : b.index - a.index,
     );
-  }
-  if (error) {
-    return <p className="p-3 text-xs text-status-waiting">{error}</p>;
-  }
-  if (!snapshot) {
-    return (
-      <p className="p-3 text-xs text-fg-subtle">
-        No captured model request yet. The exact prefix appears here after the agent’s first
-        provider call.
-      </p>
-    );
-  }
-
+  }, [rows, query, largest, section]);
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page, pages - 1);
+  const selectedRow = selected == null ? null : rows[selected];
+  const listSection = section === "conversation" || section === "tools";
+  const navigate = (next: string) => {
+    setSection(next);
+    setSelected(null);
+    setQuery("");
+    setPage(0);
+    setRawItem(false);
+  };
   return (
-    <ScrollArea className="h-full min-w-0">
-      <div className="min-w-0 space-y-4 p-3">
-        <InspectorSection title="Token counts">
-          <InfoRow label="Instructions" value={formatTokens(snapshot.tokens.instructions)} />
-          <InfoRow label="Tools" value={formatTokens(snapshot.tokens.tools)} />
-          <InfoRow label="Prefix total" value={formatTokens(snapshot.tokens.prefix)} />
-          <InfoRow
-            label="Provider input"
-            value={
-              providerUsage?.inputTokens != null
-                ? `${formatTokens(providerUsage.inputTokens)} (reported)`
-                : "unavailable"
-            }
-          />
-          {providerUsage?.cachedTokens != null ? (
-            <InfoRow label="Provider cached" value={formatTokens(providerUsage.cachedTokens)} />
-          ) : null}
-          <p className="text-2xs text-fg-subtle">
-            Prefix counts cover only what was on the wire: the sent system instructions plus eager
-            tool schemas. Searchable tools are listed below but not counted. Estimates are
-            conservative (ASCII/4, non-ASCII counted fully). Provider input is the last reported
-            complete request, including conversation history.
-          </p>
-          <InfoRow label="Request" value={`#${snapshot.requestIndex}`} />
-          {response?.attemptId ? (
-            <InfoRow label="Attempt" value={<CopyableMono value={response.attemptId} />} />
-          ) : null}
-        </InspectorSection>
-
-        <InspectorSection title="System instructions">
-          <p className="text-2xs text-fg-subtle">
-            Raw <code>systemInstructions</code> from the provider ModelRequest at{" "}
-            <code>getResponse</code>/<code>getStreamedResponse</code>, after sandbox wrapping, input
-            filters, and lazy-tool hiding. The OpenAI Responses client sends this same string as{" "}
-            <code>instructions</code>.
-          </p>
-          <pre className="max-h-96 max-w-full overflow-auto rounded-md border border-border bg-bg/35 p-2 text-2xs leading-5 whitespace-pre-wrap text-fg-muted">
-            {snapshot.instructions}
-          </pre>
+    <div
+      className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden"
+      data-testid="model-context-inspector"
+    >
+      <header className="shrink-0 space-y-3 border-b border-border p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium">Captured model request</h3>
+            <p className="mt-1 text-2xs text-fg-subtle break-words">
+              {typeof payload?.model === "string" ? payload.model + " · " : ""}
+              {snapshot ? new Date(snapshot.capturedAt).toLocaleTimeString() : "No capture yet"}
+            </p>
+          </div>
           <Button
-            type="button"
             variant="ghost"
-            size="xs"
+            size="icon-xs"
+            aria-label="Refresh model context"
+            disabled={loading}
             onClick={() => {
-              void navigator.clipboard.writeText(snapshot.instructions).then(
-                () => toast.success("Copied the sent system instructions"),
-                (caught) =>
-                  toast.error("Could not copy", {
-                    description: caught instanceof Error ? caught.message : String(caught),
-                  }),
-              );
+              loadNext.current = true;
+              setSelected(null);
+              setRefresh((n) => n + 1);
             }}
           >
-            <CopyIcon className="size-3" />
-            Copy sent instructions
+            <RefreshCwIcon className="size-3.5" />
           </Button>
-          <div className="text-xs font-medium">Split for reading</div>
-          <p className="text-2xs text-fg-subtle">
-            Derived from the sent string above. The raw block is the source of truth.
-          </p>
-          {snapshot.layers.map((layer) => (
-            <Collapsible
-              key={`${layer.id}:${layer.title}:${layer.utf8Bytes}`}
-              className="min-w-0 overflow-hidden rounded-md border border-border bg-bg/35"
-            >
-              <CollapsibleTrigger asChild>
-                <button
-                  type="button"
-                  className="flex w-full min-w-0 items-center justify-between gap-2 p-2 text-left"
+        </div>
+        {pending ? (
+          <Button
+            size="xs"
+            variant="secondary"
+            className="h-auto whitespace-normal"
+            onClick={() => {
+              currentCapture.current = pending.snapshot
+                ? `${pending.attemptId}:${pending.snapshot.requestIndex}:${pending.snapshot.capturedAt}`
+                : null;
+              setResponse(pending);
+              setPending(null);
+              setSelected(null);
+              setPage(0);
+            }}
+          >
+            New request available · Load latest
+          </Button>
+        ) : null}
+        {payload ? (
+          <>
+            <div className="flex flex-wrap gap-1" aria-label="Context sections">
+              {(
+                [
+                  ["conversation", "Conversation", conversationKey],
+                  ["instructions", "Instructions", "instructions"],
+                  ["tools", "Tools", "tools"],
+                ] as const
+              ).map(([id, label, key]) => (
+                <Button
+                  key={id}
+                  size="xs"
+                  variant={section === id ? "secondary" : "ghost"}
+                  aria-pressed={section === id}
+                  onClick={() => navigate(id)}
                 >
-                  <span className="truncate text-xs font-medium">{layer.title}</span>
-                  <span className="shrink-0 font-mono text-2xs text-fg-subtle">
-                    {formatTokens(layer.estimatedTokens)}
+                  {label}
+                  <span className="text-fg-subtle">
+                    {partFor(key)?.estimatedTokens == null
+                      ? ""
+                      : "~" + partFor(key)!.estimatedTokens!.toLocaleString() + " tokens"}
                   </span>
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <pre className="max-h-80 max-w-full overflow-auto border-t border-border p-2 text-2xs leading-5 whitespace-pre-wrap text-fg-muted">
-                  {layer.content}
-                </pre>
-              </CollapsibleContent>
-            </Collapsible>
-          ))}
-        </InspectorSection>
-
-        <InspectorSection title="Tools as the model sees them">
-          <p className="text-2xs text-fg-subtle">
-            Eager tools are the raw <code>tools</code> array on that same ModelRequest. Searchable
-            tools stay behind tool_search until disclosed and were not sent.
-          </p>
-          {snapshot.tools.map((tool) => (
-            <Collapsible
-              key={`${tool.visibility}:${tool.name}`}
-              className="min-w-0 overflow-hidden rounded-md border border-border bg-bg/35"
-            >
-              <CollapsibleTrigger asChild>
-                <button
-                  type="button"
-                  className="flex w-full min-w-0 items-center justify-between gap-2 p-2 text-left"
-                >
-                  <span className="min-w-0 truncate text-xs font-medium">
-                    {tool.name}{" "}
-                    <span className="font-normal text-fg-subtle">
-                      {tool.visibility}
-                      {tool.namespace ? ` · ${tool.namespace}` : ""}
-                    </span>
+                </Button>
+              ))}
+            </div>
+            {listSection && !selectedRow ? (
+              <>
+                <Input
+                  aria-label="Search captured context"
+                  placeholder={
+                    section === "tools"
+                      ? "Search tool definitions…"
+                      : "Search all captured messages…"
+                  }
+                  value={query}
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setPage(0);
+                  }}
+                />
+                <div className="flex flex-wrap items-center justify-between gap-2 text-2xs text-fg-subtle">
+                  <span>
+                    {filtered.length.toLocaleString()} {section === "tools" ? "tools" : "items"}
+                    {query ? " matching" : " in this request"}
                   </span>
-                  <span className="shrink-0 font-mono text-2xs text-fg-subtle">
-                    {formatTokens(tool.estimatedTokens)}
-                  </span>
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <pre className="max-h-80 max-w-full overflow-auto border-t border-border p-2 text-2xs leading-5 text-fg-muted">
-                  {JSON.stringify(
-                    {
-                      type: tool.type,
-                      name: tool.name,
-                      visibility: tool.visibility,
-                      description: tool.description,
-                      namespace: tool.namespace,
-                      schema: tool.schema,
-                    },
-                    null,
-                    2,
-                  )}
-                </pre>
-              </CollapsibleContent>
-            </Collapsible>
-          ))}
-        </InspectorSection>
-
-        <InspectorSection title="Skills">
-          <p className="text-2xs text-fg-subtle">
-            Parsed from the sent instructions and skill activations. Skills are not a separate
-            provider field.
-          </p>
-          {snapshot.skills.length === 0 ? (
-            <p className="text-xs text-fg-subtle">
-              No skill descriptors were parsed from the sent instructions.
-            </p>
-          ) : (
-            snapshot.skills.map((skill) => (
-              <div
-                key={`${skill.kind}:${skill.name}`}
-                className="rounded-md border border-border bg-bg/35 p-2"
-              >
-                <div className="text-xs font-medium">{skill.name}</div>
-                <div className="mt-1 text-2xs text-fg-subtle">
-                  {skill.kind}
-                  {skill.source ? ` · ${skill.source}` : ""}
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => {
+                      setLargest(!largest);
+                      setPage(0);
+                    }}
+                  >
+                    {largest
+                      ? "Sort: Largest"
+                      : section === "tools"
+                        ? "Sort: Request order"
+                        : "Sort: Newest"}
+                  </Button>
                 </div>
-                <div className="mt-1 text-2xs text-fg-muted">{skill.description}</div>
+              </>
+            ) : null}
+          </>
+        ) : null}
+      </header>
+      <ScrollArea
+        key={section + ":" + selected + ":" + currentPage}
+        className="min-h-0 min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block"
+      >
+        <div className="min-w-0 p-3">
+          {error ? (
+            <p role="alert" className="text-xs text-status-waiting">
+              Could not refresh context. {error}
+            </p>
+          ) : null}
+          {loading && !snapshot ? <p className="text-xs text-fg-subtle">Loading context…</p> : null}
+          {!loading && !snapshot ? (
+            <p className="text-xs text-fg-subtle">No model request captured yet.</p>
+          ) : null}
+          {snapshot && !payload ? (
+            <>
+              <p className="text-xs text-fg-subtle">
+                {wire?.unavailableReason ??
+                  "This older capture contains only instructions. The full request was not recorded."}
+              </p>
+              <ContextTextReader text={snapshot.instructions} />
+            </>
+          ) : null}
+          {payload && listSection ? (
+            selectedRow ? (
+              <div className="space-y-4">
+                <Button size="xs" variant="ghost" onClick={() => setSelected(null)}>
+                  <ArrowLeftIcon className="size-3" />
+                  Back to results
+                </Button>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h4 className="text-sm font-medium break-words">
+                    #{selectedRow.index + 1} · {selectedRow.label}
+                  </h4>
+                  <span className="text-xs text-fg-subtle">{tokenLabel(selectedRow.tokens)}</span>
+                </div>
+                <Button size="xs" variant="secondary" onClick={() => setRawItem(!rawItem)}>
+                  {rawItem ? "Read content" : "View item JSON"}
+                </Button>
+                <ContextTextReader
+                  key={String(selected) + rawItem}
+                  code={rawItem || section === "tools"}
+                  initialQuery={
+                    selectedRow.text.toLowerCase().includes(query.toLowerCase()) ? query : ""
+                  }
+                  text={rawItem ? json(selectedRow.value) : selectedRow.text}
+                />
               </div>
-            ))
-          )}
-        </InspectorSection>
-      </div>
-    </ScrollArea>
+            ) : (
+              <div>
+                {filtered.length === 0 ? (
+                  <p className="py-4 text-xs text-fg-subtle">
+                    {query
+                      ? "No matching items. Try a different search."
+                      : "No items in this request."}
+                  </p>
+                ) : null}
+                {filtered
+                  .slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE)
+                  .map((row) => (
+                    <button
+                      key={row.index}
+                      type="button"
+                      data-context-row
+                      className="group flex w-full min-w-0 items-center gap-3 border-b border-border py-3 text-left hover:bg-bg-muted focus-visible:outline focus-visible:outline-2"
+                      onClick={() => {
+                        setSelected(row.index);
+                        setRawItem(false);
+                      }}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-1">
+                          <span className="min-w-0 truncate text-xs font-medium">
+                            #{row.index + 1} · {row.label}
+                          </span>
+                          <span className="shrink-0 text-2xs text-fg-subtle">
+                            {tokenLabel(row.tokens)}
+                          </span>
+                        </div>
+                        <p className="mt-1 truncate text-xs text-fg-muted">
+                          {row.preview || "Empty content"}
+                        </p>
+                      </div>
+                      <ChevronRightIcon className="size-3 shrink-0 text-fg-subtle" />
+                    </button>
+                  ))}
+              </div>
+            )
+          ) : null}
+          {payload && section === "instructions" ? (
+            <ContextTextReader
+              key={"instructions:" + snapshot?.capturedAt}
+              text={
+                payload.instructions == null
+                  ? "No separate instructions field. System and developer messages appear in Conversation."
+                  : readable(payload.instructions)
+              }
+            />
+          ) : null}
+          {payload && section === "raw" ? (
+            <ContextTextReader code key={"request:" + snapshot?.capturedAt} text={wire!.body!} />
+          ) : null}
+        </div>
+      </ScrollArea>
+      {payload ? (
+        <footer className="shrink-0 space-y-2 border-t border-border p-2">
+          {listSection && !selectedRow && pages > 1 ? (
+            <div className="flex flex-wrap items-center justify-between gap-1">
+              <Button
+                size="xs"
+                variant="ghost"
+                disabled={currentPage === 0}
+                onClick={() => setPage(currentPage - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-2xs text-fg-subtle">
+                {currentPage * PAGE_SIZE + 1}–
+                {Math.min((currentPage + 1) * PAGE_SIZE, filtered.length)} of{" "}
+                {filtered.length.toLocaleString()}
+              </span>
+              <Button
+                size="xs"
+                variant="ghost"
+                disabled={currentPage === pages - 1}
+                onClick={() => setPage(currentPage + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          ) : null}
+          <div className="flex flex-wrap items-center justify-between gap-1">
+            <span className="text-2xs text-fg-subtle">Captured request · tokens estimated</span>
+            <Button variant="ghost" size="xs" onClick={() => navigate("raw")}>
+              Request JSON
+            </Button>
+          </div>
+        </footer>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -34,6 +34,21 @@ export default defineConfig({
         codeSplitting: {
           groups: [
             {
+              // Inspector changes must not pull account-management forms into
+              // the direct-session graph through entry-aware chunk merging.
+              name: "model-connection-settings",
+              test: /(?:components[\\/](?:codex-source-settings|connection-access-settings|model-connection-section|subscription-account-row|subscription-connect-action)\.tsx$|lucide-react[\\/]dist[\\/]esm[\\/]icons[\\/](?:external-link|route|ticket-check)\.mjs$)/,
+              includeDependenciesRecursively: false,
+              priority: 20,
+            },
+            {
+              // Keep context and its virtual reader in the lazy debug inspector.
+              name: "context-inspector",
+              test: /(?:components[\\/]session[\\/](?:model-context-inspector|context-text-reader)\.tsx$|@tanstack[\\+\/]virtual-core|@tanstack[\\+\/]react-virtual)/,
+              includeDependenciesRecursively: false,
+              priority: 20,
+            },
+            {
               // Workspace forms, provider marks, and administration links are
               // shared route primitives. They must not pull the settings
               // implementation into the workspace shell or direct sessions.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
             {
               // Keep context and its virtual reader in the lazy debug inspector.
               name: "context-inspector",
-              test: /(?:components[\\/]session[\\/](?:model-context-inspector|context-text-reader)\.tsx$|@tanstack[\\+\/]virtual-core|@tanstack[\\+\/]react-virtual)/,
+              test: /(?:components[\\/]session[\\/](?:model-context-inspector|context-text-reader)\.tsx$|@tanstack[\\+/]virtual-core|@tanstack[\\+/]react-virtual)/,
               includeDependenciesRecursively: false,
               priority: 20,
             },

--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,7 @@
         "@pierre/diffs": "1.2.11",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-router": "^1.170.15",
+        "@tanstack/react-virtual": "^3.14.11",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/addon-web-links": "0.12.0",
         "@xterm/addon-webgl": "0.19.0",
@@ -1893,6 +1894,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.11", "", { "dependencies": { "@tanstack/virtual-core": "3.17.9" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-SStWf8bYdTgAquYqG4Pi2+d1XimQKoCIJ94H3jsm0D6UA0yqffvWuvUzrrQ4idewFWq8BSPpahnmLVosJIAs6g=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.171.21", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-t6xUHBO94nQDrPHPh6ag5UuKHWIkVjq9s63q2ctbxgzq3vtSoGKmAIdLD5o+NU6JUS1ppXRHgL0YGzEHvH32Ng=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.1", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.171.16", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-qr4voa4cpSMwQvS3867xkU3AB3MtJbTuovKIy+btjJ/Faju6er9w0nDylmD+005Mk/3YKw9/iueZJl2JAB7JOA=="],
@@ -1904,6 +1907,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.9", "", {}, "sha512-M8Bzy7CCMvUjRiuoHVH9mRjyUVczRs8v8RcUEphLFGc445ZP4KQ15Y1sLqhQqJi/HgGJrxfCHnEnIX0x9mVrBg=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1544,7 +1544,7 @@ This index intentionally routes at subsystem granularity. Use
 | --- | --- | --- |
 | Session workflow, wake delivery, or `continueAsNew` | `apps/worker/src/workflows/session.ts` | [`run-lifecycle.md`](run-lifecycle.md) |
 | Turn claim, execution, settlement, or recovery | `apps/worker/src/activities/agent-turn/` | [`run-lifecycle.md`](run-lifecycle.md) |
-| Session Debug model-visible context | `packages/runtime/src/model-context-inspector.ts`, `apps/web/src/components/session/inspector.tsx` | this map §4 and [`run-lifecycle.md`](run-lifecycle.md) |
+| Session Debug model-visible context | `packages/runtime/src/model-request-capture.ts`, `packages/runtime/src/model-provider-client.ts`, `packages/runtime/src/model-context-inspector.ts`, `apps/web/src/components/session/model-context-inspector.tsx`, `apps/web/src/components/session/context-text-reader.tsx` | [`run-lifecycle.md`](run-lifecycle.md#debug-context-capture) |
 | Goals and continuations | `apps/worker/src/activities/goals.ts`, `packages/db/src/` | [`goals.md`](goals.md) |
 | Approval or structured human input | `apps/worker/src/activities/agent-turn/stream-attempt.ts`, `apps/api/src/routes/sessions.ts` | [`human-input.md`](human-input.md) |
 | Schedules | `packages/core/src/domain/scheduled-tasks.ts`, `apps/worker/src/activities/scheduled-tasks.ts` | [`reliability-fixes.md`](reliability-fixes.md) |

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -2158,3 +2158,30 @@ An already-paused session can receive Pause with a new idempotency key to re-arm
 its own settled interruption's missing quiescence wake. This preserves control
 revision and paused admission; the existing worker still proves exact activity
 settlement and writer quiescence. Replaying the same key adds no wake revision.
+
+## Debug context capture
+
+The session Context inspector reads the latest attempt-fenced capture. The runtime
+observes the final HTTP body inside `instrumentedModelFetch`, after Responses/chat
+conversion and Codex, SuperGrok or gateway normalization. It stores the original
+JSON string, including instructions, tools, input and settings; it never rebuilds
+conversation content from events or current configuration. Dispatch proves an
+outbound body, not provider acceptance or expansion of server-side state.
+
+Streaming bodies are teed only when capture is enabled, capped at 4 MiB, and
+cancelled with a failed/aborted transport. Inspection and persistence do not block
+inference. Oversized/unsupported bodies produce an explicit unavailable receipt;
+historical SDK-prefix captures and non-HTTP transports are labeled incomplete.
+Capture ordinals are reserved before reading, so a slower older upload cannot
+replace a newer request. The existing 16 MiB snapshot storage limit still applies.
+
+Section and item token counts are character-based estimates, not provider usage.
+Instructions display as the captured string without reconstructed sub-sections. Media, encrypted state and provider overhead have no exact local count.
+The UI never substitutes the latest session usage event for usage of this exact
+capture. Headers (including provider credentials) are outside the body capture.
+
+The context browser shows 30 item previews per page and searches the full readable
+captured content. Detail views read continuously, virtualize large text internally, support full-text
+Find, and preserve full content for copying. New captures wait for an
+explicit Load latest action while a user inspects an existing request. This is the
+last captured model request, not an archive of the entire session.

--- a/packages/contracts/src/model-context-inspector.ts
+++ b/packages/contracts/src/model-context-inspector.ts
@@ -85,6 +85,25 @@ export const ModelContextSnapshot = z
     source: z.literal("model_request"),
     requestIndex: z.number().int().nonnegative(),
     instructions: z.string(),
+    // Absent on historical SDK-prefix captures. Never infer a wire payload.
+    providerRequest: z
+      .object({
+        provider: z.string(),
+        body: z.string().nullable(),
+        unavailableReason: z.string().optional(),
+        parts: z.array(
+          z
+            .object({
+              key: z.string(),
+              estimatedTokens: z.number().int().nonnegative().nullable(),
+              utf8Bytes: z.number().int().nonnegative(),
+              itemEstimatedTokens: z.array(z.number().int().nonnegative().nullable()).optional(),
+            })
+            .strict(),
+        ),
+      })
+      .strict()
+      .optional(),
     layers: z.array(ModelContextInstructionLayer).max(MODEL_CONTEXT_LAYER_MAX_COUNT),
     tools: z.array(ModelContextTool).max(MODEL_CONTEXT_TOOL_MAX_COUNT),
     skills: z.array(ModelContextSkill).max(MODEL_CONTEXT_SKILL_MAX_COUNT),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -295,6 +295,7 @@ export {
 import {
   joinPersistentAgentInstructionLayers,
   buildModelContextSnapshotFromRequest,
+  buildProviderRequestSnapshot,
   type PersistentAgentInstructionInspection,
   type PersistentAgentInstructionLayerDraft,
 } from "./model-context-inspector";
@@ -302,6 +303,8 @@ import {
   ModelRequestCaptureModel,
   ModelRequestCaptureProvider,
   withModelRequestCapture,
+  type ModelRequestCapture,
+  nextModelContextCaptureIndex,
 } from "./model-request-capture";
 import { decodeValidatedViewImageDataUrl } from "./view-image-validation";
 import {
@@ -7075,11 +7078,10 @@ function measuredModelInputFilter(
 function bindModelVisibleContextCapture(
   agent: Agent<any, any>,
   onCapture: RunAgentStreamOptions["onModelVisibleContext"],
-): ((request: import("@openai/agents").ModelRequest) => Promise<void>) | undefined {
+): ModelRequestCapture | undefined {
   if (!onCapture) return undefined;
-  let requestIndex = 0;
-  return async (request) => {
-    requestIndex += 1;
+  const capture: ModelRequestCapture = async (request) => {
+    const requestIndex = nextModelContextCaptureIndex(agent);
     await onCapture(
       buildModelContextSnapshotFromRequest({
         request,
@@ -7091,6 +7093,18 @@ function bindModelVisibleContextCapture(
       }),
     );
   };
+  capture.nextProviderRequestIndex = () => nextModelContextCaptureIndex(agent);
+  capture.onProviderRequest = async (provider, body, unavailableReason, index) => {
+    await onCapture(
+      buildProviderRequestSnapshot({
+        provider,
+        body,
+        ...(unavailableReason ? { unavailableReason } : {}),
+        requestIndex: index ?? nextModelContextCaptureIndex(agent),
+      }),
+    );
+  };
+  return capture;
 }
 
 function installNonLazyModelRequestCapture(agent: Agent<any, any>): void {

--- a/packages/runtime/src/model-context-inspector.ts
+++ b/packages/runtime/src/model-context-inspector.ts
@@ -17,6 +17,75 @@ export type PersistentAgentInstructionLayerDraft = {
   content: string;
 };
 
+function contextTextEstimate(value: unknown): number | null {
+  const containsNonText = (part: unknown): boolean => {
+    if (Array.isArray(part)) return part.some(containsNonText);
+    if (!part || typeof part !== "object") return false;
+    const record = part as Record<string, unknown>;
+    if (typeof record.encrypted_content === "string") return true;
+    if (
+      ["input_image", "image_url", "input_audio", "input_file", "compaction"].includes(
+        String(record.type),
+      )
+    )
+      return true;
+    return Object.values(record).some(containsNonText);
+  };
+  return containsNonText(value) ? null : estimateSerializedValueTokens(value);
+}
+
+export function buildProviderRequestSnapshot(input: {
+  provider: string;
+  body: string | null;
+  unavailableReason?: string;
+  requestIndex: number;
+}): ModelContextSnapshot {
+  let body = input.body;
+  let unavailableReason = input.unavailableReason;
+  let payload: Record<string, unknown> = {};
+  try {
+    if (body !== null) {
+      const parsed: unknown = JSON.parse(body);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+      payload = parsed as Record<string, unknown>;
+    }
+  } catch {
+    body = null;
+    unavailableReason = "The provider body is not a JSON object.";
+  }
+  const parts = Object.entries(payload).map(([key, value]) => ({
+    key,
+    estimatedTokens: contextTextEstimate(value),
+    utf8Bytes: Buffer.byteLength(JSON.stringify(value), "utf8"),
+    ...(Array.isArray(value) ? { itemEstimatedTokens: value.map(contextTextEstimate) } : {}),
+  }));
+  const instructionsTokens =
+    parts.find((part) => part.key === "instructions")?.estimatedTokens ?? 0;
+  const toolsTokens = parts.find((part) => part.key === "tools")?.estimatedTokens ?? 0;
+  return {
+    version: MODEL_CONTEXT_SNAPSHOT_VERSION,
+    source: "model_request",
+    capturedAt: new Date().toISOString(),
+    requestIndex: input.requestIndex,
+    // Wire body owns the contents. Legacy prefix fields are not reconstructed.
+    instructions: "",
+    layers: [],
+    tools: [],
+    skills: [],
+    tokens: {
+      instructions: instructionsTokens,
+      tools: toolsTokens,
+      prefix: instructionsTokens + toolsTokens,
+    },
+    providerRequest: {
+      provider: input.provider,
+      body,
+      ...(unavailableReason ? { unavailableReason } : {}),
+      parts,
+    },
+  };
+}
+
 export type PersistentAgentInstructionInspection = {
   layers: readonly PersistentAgentInstructionLayerDraft[];
   composed: string;

--- a/packages/runtime/src/model-provider-client.ts
+++ b/packages/runtime/src/model-provider-client.ts
@@ -27,6 +27,7 @@ import {
 import { isModelCallFetch, vercelGatewayRoutingFetch } from "./model-provider-transport";
 import { ReplayableJsonOpenAI } from "./replayable-json-body";
 import { recordModelTransportStarted } from "./model-preparation-diagnostics";
+import { captureProviderRequestBody } from "./model-request-capture";
 
 let runtimeMetricsHooks: RuntimeMetricsHooks | null = null;
 
@@ -376,12 +377,14 @@ export function instrumentedModelFetch(provider: string, inner: typeof fetch): t
     // The attempt-local observer durably checkpoints provider dispatch before
     // this process can place request bytes on the network.
     await recordModelTransportStarted();
+    const capture = captureProviderRequestBody(provider, input, init);
     const started = performance.now();
     try {
-      const response = await inner(input, init);
+      const response = await inner(input, capture.init);
       recordModelCallMetric(provider, response.ok ? "completed" : "failed", started);
       return response;
     } catch (error) {
+      capture.cancel();
       recordModelCallMetric(provider, "failed", started);
       throw error;
     }

--- a/packages/runtime/src/model-request-capture.ts
+++ b/packages/runtime/src/model-request-capture.ts
@@ -90,6 +90,11 @@ export function captureProviderRequestBody(
         if (cancelled) return;
         chunks.push(decoder.decode());
         text = chunks.join("");
+      } catch {
+        void reader.cancel().catch(() => undefined);
+        if (!cancelled)
+          await observer(provider, null, "The provider body could not be read as UTF-8.");
+        return;
       } finally {
         signal?.removeEventListener("abort", cancel);
         reader.releaseLock();

--- a/packages/runtime/src/model-request-capture.ts
+++ b/packages/runtime/src/model-request-capture.ts
@@ -1,22 +1,114 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { Model, ModelProvider, ModelRequest, StreamEvent } from "@openai/agents";
 
-const modelRequestCapture = new AsyncLocalStorage<
-  (request: ModelRequest) => void | Promise<void>
->();
+export type ModelRequestCapture = ((request: ModelRequest) => void | Promise<void>) & {
+  nextProviderRequestIndex?: () => number;
+  onProviderRequest?: (
+    provider: string,
+    body: string | null,
+    reason?: string,
+    index?: number,
+  ) => void | Promise<void>;
+};
+const modelRequestCapture = new AsyncLocalStorage<ModelRequestCapture>();
+const captureIndices = new WeakMap<object, number>();
+
+/** The same agent can re-enter runAgentStream after in-activity compaction. */
+export function nextModelContextCaptureIndex(agent: object): number {
+  const index = (captureIndices.get(agent) ?? 0) + 1;
+  captureIndices.set(agent, index);
+  return index;
+}
 
 export function withModelRequestCapture<T>(
-  capture: ((request: ModelRequest) => void | Promise<void>) | undefined,
+  capture: ModelRequestCapture | undefined,
   fn: () => T,
 ): T {
   return capture ? modelRequestCapture.run(capture, fn) : fn();
+}
+
+/** Observe the final transport bytes, never reconstruct provider serialization.
+ * Tee only while an inspector observer exists. Bound diagnostic memory; retain
+ * an explicit unavailable receipt instead of a partial or older payload.
+ */
+export function captureProviderRequestBody(
+  provider: string,
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+): { init: RequestInit | undefined; captured: Promise<void>; cancel: () => void } {
+  const context = modelRequestCapture.getStore();
+  const callback = context?.onProviderRequest;
+  if (!callback) return { init, captured: Promise.resolve(), cancel: () => {} };
+  // Reserve identity at dispatch, not when asynchronous reading finishes.
+  const index = context.nextProviderRequestIndex?.();
+  const observer = (providerId: string, body: string | null, reason?: string) =>
+    callback(providerId, body, reason, index);
+  let cancel = () => {};
+  let body = init?.body;
+  let nextInit = init;
+  if (body instanceof ReadableStream) {
+    const [sent, inspected] = body.tee();
+    nextInit = { ...init, body: sent };
+    body = inspected;
+  } else if (body == null && input instanceof Request) {
+    body = input.clone().body;
+  }
+  const captured = (async () => {
+    const limit = 4 * 1024 * 1024;
+    let text: string;
+    if (typeof body === "string") {
+      if (Buffer.byteLength(body, "utf8") > limit) {
+        await observer(provider, null, "Request exceeds the 4 MiB capture limit.");
+        return;
+      }
+      text = body;
+    } else if (body instanceof ReadableStream) {
+      const reader = body.getReader();
+      let cancelled = false;
+      cancel = () => {
+        cancelled = true;
+        void reader.cancel().catch(() => undefined);
+      };
+      const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+      signal?.addEventListener("abort", cancel, { once: true });
+      if (signal?.aborted) cancel();
+      const decoder = new TextDecoder("utf-8", { fatal: true });
+      const chunks: string[] = [];
+      let bytes = 0;
+      try {
+        while (true) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          bytes += chunk.value.byteLength;
+          if (bytes > limit) {
+            void reader.cancel().catch(() => undefined);
+            await observer(provider, null, "Request exceeds the 4 MiB capture limit.");
+            return;
+          }
+          chunks.push(decoder.decode(chunk.value, { stream: true }));
+        }
+        if (cancelled) return;
+        chunks.push(decoder.decode());
+        text = chunks.join("");
+      } finally {
+        signal?.removeEventListener("abort", cancel);
+        reader.releaseLock();
+        cancel = () => {};
+      }
+    } else {
+      await observer(provider, null, "This transport body cannot be inspected.");
+      return;
+    }
+    await observer(provider, text);
+  })().catch(() => undefined); // Inspection cannot change inference.
+  return { init: nextInit, captured, cancel: () => cancel() };
 }
 
 export async function notifyModelRequestCapture(request: ModelRequest): Promise<void> {
   const capture = modelRequestCapture.getStore();
   if (!capture) return;
   try {
-    // Copy the on-the-wire prefix immediately. The SDK may reuse the request
+    // Copy the SDK request immediately. This is not the provider wire body.
     // object after we yield to persistence.
     await capture(snapshotModelRequestPrefix(request));
   } catch {
@@ -27,7 +119,7 @@ export async function notifyModelRequestCapture(request: ModelRequest): Promise<
 function snapshotModelRequestPrefix(request: ModelRequest): ModelRequest {
   return {
     ...request,
-    tools: Array.isArray(request.tools) ? [...request.tools] : request.tools,
+    tools: structuredClone(request.tools),
   };
 }
 

--- a/packages/runtime/test/model-request-capture.test.ts
+++ b/packages/runtime/test/model-request-capture.test.ts
@@ -107,3 +107,131 @@ describe("model request capture", () => {
     expect(sent.tools).toEqual([]);
   });
 });
+
+describe("final HTTP body capture", () => {
+  test("observes exact provider-transformed bytes without consuming the upload", async () => {
+    const { captureProviderRequestBody } = await import("../src/model-request-capture");
+    const { buildProviderRequestSnapshot } = await import("../src/model-context-inspector");
+    const { ModelContextSnapshot } = await import("@opengeni/contracts");
+    const body =
+      '{ "model":"provider-model", "instructions":"exact\\n  whitespace", "tools":[{"type":"function","strict":true,"name":"tool"}], "input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}] }';
+    let observed: string | null = null;
+    const capture = Object.assign(() => {}, {
+      onProviderRequest: (provider: string, text: string | null) => {
+        observed = text;
+        const snapshot = ModelContextSnapshot.parse(
+          buildProviderRequestSnapshot({ provider, body: text, requestIndex: 1 }),
+        );
+        expect(snapshot.providerRequest?.body).toBe(body);
+        expect(snapshot.providerRequest?.parts.map((part) => part.key)).toEqual([
+          "model",
+          "instructions",
+          "tools",
+          "input",
+        ]);
+      },
+    });
+    await withModelRequestCapture(capture, async () => {
+      const stream = new Blob([body]).stream();
+      const result = captureProviderRequestBody("test", "https://example.test/responses", {
+        body: stream,
+      });
+      expect(await new Response(result.init?.body).text()).toBe(body);
+      await result.captured;
+    });
+    expect(observed).toBe(body);
+  });
+
+  test("oversized bodies produce an unavailable receipt, never a truncated payload", async () => {
+    const { captureProviderRequestBody } = await import("../src/model-request-capture");
+    const body = "x".repeat(4 * 1024 * 1024 + 1);
+    let reason: string | undefined;
+    let observed: unknown = "not called";
+    const capture = Object.assign(() => {}, {
+      onProviderRequest: (_provider: string, text: string | null, why?: string) => {
+        observed = text;
+        reason = why;
+      },
+    });
+    await withModelRequestCapture(capture, async () => {
+      const result = captureProviderRequestBody("test", "https://example.test/responses", {
+        body: new Blob([body]).stream(),
+      });
+      expect((await new Response(result.init?.body).text()).length).toBe(body.length);
+      await result.captured;
+    });
+    expect(observed).toBeNull();
+    expect(reason).toContain("4 MiB");
+  });
+
+  test("capture failure cannot change transport bytes", async () => {
+    const { captureProviderRequestBody } = await import("../src/model-request-capture");
+    const capture = Object.assign(() => {}, {
+      onProviderRequest: () => {
+        throw new Error("database unavailable");
+      },
+    });
+    await withModelRequestCapture(capture, async () => {
+      const init = { body: '{"input":"unchanged"}' };
+      const result = captureProviderRequestBody("test", "https://example.test/responses", init);
+      expect(result.init).toBe(init);
+      await result.captured;
+    });
+  });
+});
+
+test("failed uploads cancel a stalled diagnostic read without waiting for persistence", async () => {
+  const { captureProviderRequestBody } = await import("../src/model-request-capture");
+  let captured = false;
+  await withModelRequestCapture(
+    Object.assign(() => {}, {
+      onProviderRequest: () => {
+        captured = true;
+      },
+    }),
+    async () => {
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"input":'));
+        },
+      });
+      const result = captureProviderRequestBody("test", "https://example.test/responses", { body });
+      result.cancel();
+      await result.captured;
+      expect(captured).toBe(false);
+      void (result.init!.body as ReadableStream).cancel();
+    },
+  );
+});
+
+test("capture ordinals survive stream re-entry and remain isolated between agents", async () => {
+  const { nextModelContextCaptureIndex } = await import("../src/model-request-capture");
+  const agent = {};
+  const otherAgent = {};
+  expect(nextModelContextCaptureIndex(agent)).toBe(1);
+  expect(nextModelContextCaptureIndex(agent)).toBe(2);
+  expect(nextModelContextCaptureIndex(otherAgent)).toBe(1);
+  expect(nextModelContextCaptureIndex(agent)).toBe(3);
+});
+
+test("media and encrypted state are unknown token costs, not base64 text estimates", async () => {
+  const { buildProviderRequestSnapshot } = await import("../src/model-context-inspector");
+  const snapshot = buildProviderRequestSnapshot({
+    provider: "test",
+    requestIndex: 1,
+    body: JSON.stringify({
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_image", image_url: "data:image/png;base64,AAAA" }],
+        },
+        { type: "reasoning", encrypted_content: "opaque" },
+        { role: "user", content: "Plain text" },
+      ],
+    }),
+  });
+  const input = snapshot.providerRequest!.parts[0]!;
+  expect(input.estimatedTokens).toBeNull();
+  expect(input.itemEstimatedTokens?.slice(0, 2)).toEqual([null, null]);
+  expect(input.itemEstimatedTokens?.[2]).toBeGreaterThan(0);
+});

--- a/packages/runtime/test/model-request-capture.test.ts
+++ b/packages/runtime/test/model-request-capture.test.ts
@@ -109,6 +109,26 @@ describe("model request capture", () => {
 });
 
 describe("final HTTP body capture", () => {
+  test("invalid UTF-8 records unavailability and preserves upload bytes", async () => {
+    const { captureProviderRequestBody } = await import("../src/model-request-capture");
+    const receipts: unknown[] = [];
+    const observer = Object.assign(() => {}, {
+      onProviderRequest: (_provider: string, body: string | null, reason?: string) => {
+        receipts.push({ body, reason });
+      },
+    });
+    await withModelRequestCapture(observer, async () => {
+      const bytes = new Uint8Array([0xc3, 0x28]);
+      const capture = captureProviderRequestBody("test", "https://example.com", {
+        body: new Blob([bytes]).stream(),
+      });
+      expect(new Uint8Array(await new Response(capture.init?.body).arrayBuffer())).toEqual(bytes);
+      await capture.captured;
+    });
+    expect(receipts).toEqual([
+      { body: null, reason: "The provider body could not be read as UTF-8." },
+    ]);
+  });
   test("observes exact provider-transformed bytes without consuming the upload", async () => {
     const { captureProviderRequestBody } = await import("../src/model-request-capture");
     const { buildProviderRequestSnapshot } = await import("../src/model-context-inspector");

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -12179,7 +12179,8 @@ describe("provider item id stripping", () => {
     }
 
     expect(model.calls).toBe(2);
-    expect(requestIndexes).toEqual([1, 1]);
+    // Re-entry retains monotonic capture identity without adding wrappers.
+    expect(requestIndexes).toEqual([1, 2]);
   });
 
   test("external history ownership borrows frozen input without mutating it", async () => {

--- a/packages/sdk/src/model-context.ts
+++ b/packages/sdk/src/model-context.ts
@@ -50,6 +50,19 @@ export type ModelContextTokenCounts = {
 };
 
 export type ModelContextSnapshot = {
+  providerRequest?:
+    | {
+        provider: string;
+        body: string | null;
+        unavailableReason?: string | undefined;
+        parts: {
+          key: string;
+          estimatedTokens: number | null;
+          utf8Bytes: number;
+          itemEstimatedTokens?: (number | null)[] | undefined;
+        }[];
+      }
+    | undefined;
   version: 1;
   capturedAt: string;
   source: "model_request";


### PR DESCRIPTION
The Context inspector now displays the captured outbound provider request instead of reconstructing context from current instructions and events. Captures include conversation input, tool definitions, and provider-normalized settings; unsupported or oversized requests remain explicitly unavailable.

The panel uses searchable bounded item lists and a continuous text reader with on-demand Find/Copy, readable typography, and invisible virtualization for large content. New captures wait for an explicit refresh, and token estimates remain distinct from provider usage.

Validation: independent code and UX reviews; live Azure Luna request inspected; 280px reader and 10,000-paragraph search-to-end verified. Targeted capture/reader/parity tests, full lint/format, all-project typecheck, production web build/bundle budgets, and the integration suite passed. GitHub CI gates the final revision. The broad local unit/browser runs encountered failures outside the changed context components; their isolated CI jobs remain authoritative.

Capture limit remains 4 MiB; provider headers are excluded. Malformed UTF-8 produces an explicit unavailable receipt without changing upload bytes.
