### PR TITLE
docs-site: landing page headline for link previews

### DIFF
--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Introduction"
-description: "OpenGeni is an open, self-hostable runtime for long-running AI agents."
+title: "Long-running AI agents you can trust with real work"
+sidebarTitle: "Introduction"
+description: "OpenGeni is the open, self-hostable runtime for agents that finish the job: durable sessions, human approvals, governed memory, and your choice of compute."
 icon: "house"
 ---
 


### PR DESCRIPTION
## Summary

- The docs landing page was titled "Introduction", so link previews for docs.opengeni.ai rendered "Introduction - OpenGeni" (compare docs.cloudgeni.ai, which leads with a product headline).
- Page title is now a headline, `sidebarTitle` keeps "Introduction" in the navigation, and the description that feeds `og:description` is sharper.

## Testing

- [x] `bunx mint validate` passes
- [x] `bun run format:check` passes
- [ ] `bun run typecheck` / `bun test`: no code changed; CI covers them

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advanced, I kept the candidate head frozen and verified mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change. Freeze-head source admission is required only for `hotfix/*` into `production`.

## Notes

- Mintlify deploys from `main`, so the preview updates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the docs landing page metadata so link previews lead with a clear OpenGeni product headline.

Enhancements:
- Improve the docs landing page metadata with a product-focused headline, clearer navigation labeling, and a sharper description for link previews.

Documentation:
- Update the docs landing page title and description used in user-facing pages and social previews.