### PR TITLE
fix: group deployment models under OpenGeni with Free-only badges

### DIFF
--- a/.changeset/deployment-model-picker-grouping.md
+++ b/.changeset/deployment-model-picker-grouping.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/react": patch
+---
+
+Group deployment-provided models under OpenGeni regardless of upstream provider. Badge only explicitly free models, keep paid rows compact, and preserve separate workspace, organization, and subscription connections with accurate payment descriptions.

--- a/apps/web/src/lib/model-access-onboarding.test.ts
+++ b/apps/web/src/lib/model-access-onboarding.test.ts
@@ -61,6 +61,18 @@ function catalogModel(
 }
 
 describe("preferredConnectedModelId", () => {
+  test("still offers explicitly free deployment models without credit onboarding", () => {
+    expect(
+      preferredConnectedModelId([
+        catalogModel({ id: "paid" }),
+        catalogModel({
+          id: "free",
+          cost: "free",
+          billing: { upstreamPayer: "deployment", metering: "external" },
+        }),
+      ]),
+    ).toBe("free");
+  });
   test("prefers a selectable connected subscription over OpenGeni credits", () => {
     expect(
       preferredConnectedModelId([

--- a/apps/web/src/lib/model-access-onboarding.ts
+++ b/apps/web/src/lib/model-access-onboarding.ts
@@ -15,7 +15,9 @@ export function preferredConnectedModelId(
   models: readonly WorkspaceModelCatalogModel[],
 ): string | null {
   const connected = sortPickerRows(projectPickerRows([...models])).filter(
-    (row) => row.selectable && CONNECTED_BILLING_CLASSES.has(row.billingClass),
+    (row) =>
+      row.selectable &&
+      (row.catalog.cost === "free" || CONNECTED_BILLING_CLASSES.has(row.billingClass)),
   );
   return connected[0]?.id ?? null;
 }

--- a/apps/web/src/lib/model-policy.ts
+++ b/apps/web/src/lib/model-policy.ts
@@ -7,6 +7,7 @@ export {
   groupPickerRowsByBillingClass,
   labelLatencyMode,
   payerSummaryForModel,
+  modelUsesCredits,
   projectPickerRows,
   runnableLatencyModesForModel,
   sortPickerRows,

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -115,6 +115,7 @@ import {
 import {
   effortOptionsForModel,
   findPickerRow,
+  modelUsesCredits,
   runnableLatencyModesForModel,
   type PickerModelRow,
 } from "@/lib/model-policy";
@@ -1286,7 +1287,7 @@ function SessionsIndexRouteContent({
           </div>
         ) : null}
 
-        {selectedPolicyRow?.billingClass === "opengeni_credits" &&
+        {modelUsesCredits(selectedPolicyRow?.catalog) &&
         hasAccountPermission(context.accessContext, workspace?.accountId ?? "", "billing:read") ? (
           <div className="mt-6">
             <Suspense fallback={null}>

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -352,8 +352,11 @@ The table describes credential and upstream-settlement identity, not the
 workspace-facing price. Deployment models—including anonymous and managed
 OpenRouter routes—default to `credits` unless
 `OPENGENI_MODEL_COST_POLICY_JSON` marks the exact product ID `free`. The picker
-may still group such a route under External while the payment sentence and
-`list_models` output show its deployment-defined cost.
+groups all deployment-provided models under OpenGeni, regardless of upstream
+provider or settlement. Only explicitly free models receive a Free badge; paid
+rows omit repetitive credit labels. Payment descriptions remain available to
+assistive technology and on hover, and `list_models` retains the explicit cost.
+Workspace/organization connections and connected subscriptions stay separate.
 
 ### OpenCode Zen temporary free contributor model
 
@@ -419,7 +422,7 @@ promise:
 ```
 
 Requests go from OpenGeni to OpenCode's `opencode.ai` service; this is not local
-inference. Anonymous routes are shown on the External rail. To make this
+inference. Anonymous deployment routes are shown under OpenGeni. To make this
 temporary preview free to the workspace, set
 `OPENGENI_MODEL_COST_POLICY_JSON='{"opencode/muse-spark-1.3-contributor-free":"free"}'`;
 external settlement alone does not bypass credits. A free route still emits
@@ -570,8 +573,8 @@ non-runnable until a reviewed effort vocabulary is mapped.
 OpenRouter membership is curated and production never mirrors `GET /models`.
 The v1 database schema accepts reviewed `:free` slugs only; a key does not make
 every upstream model visible, and workspace policy may hide the starter. The
-provider settles through the deployment's OpenRouter account and appears on the
-External picker rail, while `OPENGENI_MODEL_COST_POLICY_JSON` independently
+provider settles through the deployment's OpenRouter account and appears in the
+OpenGeni picker group, while `OPENGENI_MODEL_COST_POLICY_JSON` independently
 decides whether the workspace sees `free` or `credits`. The shipped default is
 `free`. If an operator changes it to `credits`, managed billing also requires a
 separate `OPENGENI_MODEL_PRICING_JSON` entry.

--- a/packages/contracts/src/model-picker-order.ts
+++ b/packages/contracts/src/model-picker-order.ts
@@ -1,4 +1,6 @@
 export type ModelPickerBillingClass =
+  // Legacy public identifier for the OpenGeni presentation group, including
+  // free deployment models. Never use this UI grouping to decide settlement.
   | "opengeni_credits"
   | "external"
   | "codex_subscription"
@@ -37,15 +39,12 @@ export type ModelPickerBillingCandidate = {
 export function modelPickerBillingClassFor(
   model: ModelPickerBillingCandidate,
 ): ModelPickerBillingClass {
-  if (model.cost === "credits") return "opengeni_credits";
+  if (model.cost === "credits" || model.cost === "free") return "opengeni_credits";
   if (model.cost === "workspace") return "byok";
   if (model.cost === "organization") return "organization_byok";
   const source = model.source;
   const credential = model.credentialSource;
   const payer = model.billing?.upstreamPayer;
-  if (model.billing?.metering === "external" && payer === "deployment") {
-    return "external";
-  }
   if (
     source === "supergrok" ||
     (credential?.kind === "connected_subscription" && credential.provider === "xai")

--- a/packages/contracts/test/model-picker-order.test.ts
+++ b/packages/contracts/test/model-picker-order.test.ts
@@ -6,6 +6,28 @@ import {
 import { compareModelPickerOrder, modelPickerBillingClassFor } from "../src/model-picker-order";
 
 describe("model picker shared ordering", () => {
+  test("groups deployment models together independently of upstream settlement", () => {
+    for (const cost of ["free", "credits", undefined] as const) {
+      for (const metering of ["external", "opengeni_credits"] as const) {
+        expect(
+          modelPickerBillingClassFor({
+            cost,
+            billing: { upstreamPayer: "deployment", metering },
+            credentialSource: { kind: "deployment" },
+          }),
+        ).toBe("opengeni_credits");
+      }
+    }
+    expect(modelPickerBillingClassFor({ cost: "free" })).toBe("opengeni_credits");
+    expect(modelPickerBillingClassFor({ cost: "workspace" })).toBe("byok");
+    expect(modelPickerBillingClassFor({ cost: "organization" })).toBe("organization_byok");
+    expect(modelPickerBillingClassFor({ cost: "subscription", source: "codex" })).toBe(
+      "codex_subscription",
+    );
+    expect(modelPickerBillingClassFor({ cost: "subscription", source: "supergrok" })).toBe(
+      "supergrok_subscription",
+    );
+  });
   test("orders by billing rail, selectability, and label", () => {
     const rows = [
       { billingClass: "byok" as const, selectable: true, label: "Zulu" },
@@ -44,7 +66,7 @@ describe("model picker shared ordering", () => {
       modelPickerBillingClassFor({
         billing: { upstreamPayer: "deployment", metering: "external" },
       }),
-    ).toBe("external");
+    ).toBe("opengeni_credits");
     expect(
       modelPickerBillingClassFor({
         cost: "credits",

--- a/packages/react/src/components/model-policy-picker-menu.tsx
+++ b/packages/react/src/components/model-policy-picker-menu.tsx
@@ -58,14 +58,35 @@ export function ModelPolicyPickerMenu(props: ModelPolicyPickerProps) {
     <PickerNavRow
       key={row.id}
       label={row.label}
-      hint={`${props.messages?.billingHints?.[row.billingClass] ?? payerSummaryForModel(row.catalog)}${row.unavailableReason ? ` · ${row.unavailableReason}` : ""}`}
+      hint={
+        row.billingClass === "opengeni_credits"
+          ? (row.unavailableReason ?? undefined)
+          : [
+              props.messages?.billingHints?.[row.billingClass] ?? payerSummaryForModel(row.catalog),
+              row.unavailableReason,
+            ]
+              .filter(Boolean)
+              .join(" · ")
+      }
       disabled={props.disabled || !row.selectable}
-      title={row.unavailableReason ?? undefined}
+      title={[row.label, payerSummaryForModel(row.catalog), row.unavailableReason]
+        .filter(Boolean)
+        .join(" · ")}
+      description={payerSummaryForModel(row.catalog)}
       active={row.id === props.model}
       showChevron={false}
       trailing={
-        row.id === props.model ? (
-          <CheckIcon className="size-3.5" aria-label={messages.selected} />
+        row.catalog.cost === "free" || row.id === props.model ? (
+          <span className="flex items-center gap-2">
+            {row.catalog.cost === "free" ? (
+              <span className="rounded-og-sm bg-og-surface-2 px-1.5 py-0.5 text-og-control text-og-fg-muted">
+                {messages.free}
+              </span>
+            ) : null}
+            {row.id === props.model ? (
+              <CheckIcon className="size-3.5" aria-label={messages.selected} />
+            ) : null}
+          </span>
         ) : null
       }
       testId={`model-picker-choice-${row.id}`}
@@ -179,7 +200,7 @@ function ModelThinkingControls(props: ModelPolicyPickerProps) {
   const supportsFast = runnableLatencyModesForModel(selected.catalog).includes("fast");
   return (
     <div
-      className="flex items-center gap-2 text-og-control text-og-fg-muted"
+      className="flex flex-wrap items-center gap-2 text-og-control text-og-fg-muted"
       data-testid="model-picker-reasoning"
     >
       <label className="flex min-h-9 items-center gap-2">
@@ -208,7 +229,7 @@ function ModelThinkingControls(props: ModelPolicyPickerProps) {
           onClick={() =>
             props.onLatencyModeChange(props.latencyMode === "fast" ? "standard" : "fast")
           }
-          className="ml-auto flex min-h-9 items-center gap-1.5 rounded-og-sm px-2 hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:opacity-50"
+          className="ml-auto flex min-h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-og-sm px-2 hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:opacity-50"
         >
           <ZapIcon className={cn("size-3.5", props.latencyMode === "fast" && "fill-current")} />
           {messages.fast} <span className="text-og-fg-subtle">{messages.fastRateHint}</span>

--- a/packages/react/src/components/model-policy-picker.tsx
+++ b/packages/react/src/components/model-policy-picker.tsx
@@ -51,6 +51,7 @@ export type ModelPolicyPickerMessages = {
   unsupportedAttachments?: string;
   thinkingEffort?: string;
   selected?: string;
+  free?: string;
 
   billingHints: Record<PickerBillingClass, string>;
 };
@@ -71,9 +72,10 @@ export const defaultModelPolicyPickerMessages: ModelPolicyPickerMessages = {
     "Unsupported attachments stay in the session but are hidden from this model.",
   thinkingEffort: "Thinking effort",
   selected: "Selected",
+  free: "Free",
 
   billingHints: {
-    opengeni_credits: "Will use credits",
+    opengeni_credits: "Provided by OpenGeni",
     external: "Provider terms and limits apply",
     codex_subscription: "ChatGPT / Codex plan",
     supergrok_subscription: "SuperGrok / xAI plan",
@@ -249,6 +251,7 @@ export function PickerNavRow(props: {
   showChevron?: boolean | undefined;
   disabled?: boolean | undefined;
   title?: string | undefined;
+  description?: string | undefined;
   active?: boolean | undefined;
   testId?: string | undefined;
   onClick: () => void;
@@ -258,6 +261,7 @@ export function PickerNavRow(props: {
       type="button"
       disabled={props.disabled}
       title={props.title}
+      aria-description={props.description}
       onClick={props.onClick}
       data-testid={props.testId}
       className={cn(

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -500,6 +500,7 @@ export {
   labelLatencyMode,
   labelReasoningEffort,
   payerSummaryForModel,
+  modelUsesCredits,
   projectClientModelRows,
   projectPickerRows,
   runnableLatencyModesForModel,

--- a/packages/react/src/model-policy.ts
+++ b/packages/react/src/model-policy.ts
@@ -131,6 +131,9 @@ export function payerSummaryForModel(model: ClientModel): string {
   if (model.cost === "workspace") {
     return workspaceProviderPayerSummary(model);
   }
+  if (model.cost === "organization") {
+    return organizationProviderPayerSummary(model);
+  }
 
   // Older client-config payloads do not carry `cost`; preserve their existing
   // settlement-derived label until every deployment has rolled forward.
@@ -149,14 +152,19 @@ export function payerSummaryForModel(model: ClientModel): string {
   if (billing.upstreamPayer === "workspace") {
     return workspaceProviderPayerSummary(model);
   }
-  return "External provider · no OpenGeni credits";
+  if (billing.upstreamPayer === "organization") {
+    return organizationProviderPayerSummary(model);
+  }
+  return billing.upstreamPayer === "deployment"
+    ? "OpenGeni · no model credits"
+    : "External provider · no OpenGeni credits";
 }
 
 export function advancedSourceSummary(model: ClientModel): string | null {
   const source = model.credentialSource;
   if (!source) {
     return model.billing?.metering === "external" && model.billing.upstreamPayer === "deployment"
-      ? "Deployment route · no authentication"
+      ? "Deployment-provided connection"
       : null;
   }
   if (source.kind === "connected_subscription") {
@@ -189,6 +197,16 @@ function workspaceProviderPayerSummary(model: ClientModel): string {
     return "Billed to the workspace Vercel account";
   }
   return "Billed to the workspace provider account";
+}
+
+function organizationProviderPayerSummary(model: ClientModel): string {
+  if (model.provider === "organization-openrouter") {
+    return "Billed to the organization OpenRouter account";
+  }
+  if (model.provider === "organization-gateway") {
+    return "Billed to the organization Vercel account";
+  }
+  return "Billed to the organization provider account";
 }
 
 export function projectPickerRows(models: WorkspaceModelCatalogModel[]): PickerModelRow[] {

--- a/packages/react/src/model-policy.ts
+++ b/packages/react/src/model-policy.ts
@@ -116,6 +116,12 @@ export function labelReasoningEffort(effort: ReasoningEffort): string {
   return effort.slice(0, 1).toUpperCase() + effort.slice(1);
 }
 
+/** Payment prompts must use cost policy, never the presentation group. */
+export function modelUsesCredits(model: ClientModel | undefined): boolean {
+  if (model?.cost !== undefined) return model.cost === "credits";
+  return model?.billing?.metering === "opengeni_credits";
+}
+
 export function payerSummaryForModel(model: ClientModel): string {
   if (model.cost === "free") {
     return "Free in this deployment";

--- a/packages/react/test/model-policy-picker.test.tsx
+++ b/packages/react/test/model-policy-picker.test.tsx
@@ -118,6 +118,76 @@ async function mount(node: React.ReactElement): Promise<HTMLElement> {
 }
 
 describe("ModelPolicyPicker", () => {
+  test("combines deployment providers, preserves connection groups, and badges only explicit free cost", async () => {
+    const deployment = (id: string, cost?: "free" | "credits"): ClientModel => ({
+      id,
+      label: id,
+      provider: id.split("/")[0]!,
+      providerLabel: id.split("/")[0]!,
+      api: "chat",
+      cost,
+      billing: { upstreamPayer: "deployment", metering: "external" },
+    });
+    const models: ClientModel[] = [
+      deployment("azure/model", "credits"),
+      deployment("gateway/model", "credits"),
+      deployment("openrouter/starter:free", "free"),
+      deployment("openrouter/charged:free", "credits"),
+      deployment("anonymous/legacy:free"),
+      { ...deployment("workspace-openrouter/model"), cost: "workspace" },
+      { ...deployment("organization-gateway/model"), cost: "organization" },
+      ...MODELS,
+    ];
+    const before = JSON.stringify(models);
+    const calls: string[] = [];
+    const container = await mount(
+      <ModelPolicyPickerMenu
+        models={models}
+        model="unselected"
+        effort="low"
+        latencyMode="standard"
+        messages={{ free: "Gratis" }}
+        onModelChange={(id) => calls.push(id)}
+        onEffortChange={() => {}}
+        onLatencyModeChange={() => {}}
+      />,
+    );
+    const group = container.querySelector('section[aria-label="OpenGeni"]')!;
+    expect(group.querySelectorAll("button").length).toBe(5);
+    expect(container.querySelector('section[aria-label="External"]')).toBeNull();
+    for (const label of ["Workspace providers", "Organization providers", "Codex"]) {
+      expect(container.querySelector(`section[aria-label="${label}"]`)).toBeTruthy();
+    }
+    expect(group.textContent?.match(/Gratis/g)?.length).toBe(1);
+    expect(group.textContent).not.toContain("credits");
+    const paid = group.querySelector<HTMLButtonElement>(
+      '[data-testid="model-picker-choice-openrouter/charged:free"]',
+    )!;
+    expect(paid.getAttribute("aria-description")).toBe("OpenGeni credits");
+    expect(paid.title).toBe("openrouter/charged:free · OpenGeni credits");
+    await act(async () => paid.click());
+    expect(calls).toEqual(["openrouter/charged:free"]);
+    expect(JSON.stringify(models)).toBe(before);
+  });
+
+  test("keeps the Free badge beside the current-model checkmark", async () => {
+    const model: ClientModel = { ...MODELS[0]!, id: "starter", source: "openrouter", cost: "free" };
+    const container = await mount(
+      <ModelPolicyPickerMenu
+        models={[model]}
+        model={model.id}
+        effort="low"
+        latencyMode="standard"
+        onModelChange={() => {}}
+        onEffortChange={() => {}}
+        onLatencyModeChange={() => {}}
+      />,
+    );
+    const row = container.querySelector('[data-testid="model-picker-choice-starter"]')!;
+    expect(row.textContent).toContain("Free");
+    expect(row.querySelector('[aria-label="Selected"]')).toBeTruthy();
+    expect(row.getAttribute("aria-description")).toBe("Free in this deployment");
+  });
   test("renders the polished model, effort, and Fast trigger from ClientModel data", async () => {
     const container = await mount(
       <ModelPolicyPicker
@@ -548,7 +618,7 @@ describe("ModelPolicyPicker", () => {
     expect(container.querySelector('[data-testid="billing-class-icon-external"]')).toBeNull();
   });
 
-  test("renders the External rail mark for an anonymous provider", async () => {
+  test("renders the OpenGeni mark for an anonymous deployment provider", async () => {
     const external: ClientModel = {
       id: "opencode/x-preview-f-free",
       label: "OpenCode Ox Alpha",
@@ -569,10 +639,12 @@ describe("ModelPolicyPicker", () => {
       />,
     );
 
-    expect(container.querySelector('[data-testid="billing-class-icon-external"]')).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid="billing-class-icon-opengeni_credits"]'),
+    ).toBeTruthy();
   });
 
-  test("shows each deployment model's configured workspace-facing payment", async () => {
+  test("badges only explicitly free deployment models", async () => {
     const freeModel: ClientModel = {
       ...MODELS[0]!,
       id: "deployment/free-model",
@@ -606,10 +678,10 @@ describe("ModelPolicyPicker", () => {
     expect(
       container.querySelector('[data-testid="model-picker-choice-deployment/free-model"]')
         ?.textContent,
-    ).toContain("Free in this deployment");
+    ).toContain("Free");
     expect(
       container.querySelector('[data-testid="model-picker-choice-deployment/credits-model"]')
         ?.textContent,
-    ).toContain("OpenGeni credits");
+    ).not.toContain("OpenGeni credits");
   });
 });

--- a/packages/react/test/model-policy.test.ts
+++ b/packages/react/test/model-policy.test.ts
@@ -8,6 +8,7 @@ import {
   effortOptionsForModel,
   groupPickerRowsByBillingClass,
   payerSummaryForModel,
+  modelUsesCredits,
   projectPickerRows,
 } from "../src/model-policy";
 
@@ -36,6 +37,36 @@ function catalogModel(
 }
 
 describe("model-policy", () => {
+  test("credit notices follow cost policy rather than the OpenGeni group", () => {
+    for (const cost of ["free", "credits", "workspace", "organization", "subscription"] as const) {
+      const model = catalogModel({
+        id: "model",
+        label: "Model",
+        cost,
+        billing: { upstreamPayer: "deployment", metering: "opengeni_credits" },
+      });
+      expect(modelUsesCredits(model)).toBe(cost === "credits");
+    }
+    expect(modelUsesCredits(undefined)).toBe(false);
+    expect(
+      modelUsesCredits(
+        catalogModel({
+          id: "legacy",
+          label: "Legacy",
+          billing: { upstreamPayer: "deployment", metering: "external" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      modelUsesCredits(
+        catalogModel({
+          id: "legacy",
+          label: "Legacy",
+          billing: { upstreamPayer: "deployment", metering: "opengeni_credits" },
+        }),
+      ),
+    ).toBe(true);
+  });
   test("keeps missing-credential deployment models visible but unavailable", () => {
     const model = catalogModel({
       id: "openrouter/starter:free",

--- a/packages/react/test/model-policy.test.ts
+++ b/packages/react/test/model-policy.test.ts
@@ -36,6 +36,33 @@ function catalogModel(
 }
 
 describe("model-policy", () => {
+  test("keeps missing-credential deployment models visible but unavailable", () => {
+    const model = catalogModel({
+      id: "openrouter/starter:free",
+      label: "Starter",
+      cost: "free",
+      billing: { upstreamPayer: "deployment", metering: "external" },
+      credentialReadiness: {
+        status: "not_ready",
+        reason: "missing_credential",
+        basis: "configuration",
+        checkedAt: null,
+      },
+      availability: {
+        status: "unavailable",
+        selectable: false,
+        reason: "missing_credential",
+        checkedAt: null,
+      },
+    });
+    const rows = projectPickerRows([model]);
+    expect(rows[0]).toMatchObject({
+      billingClassLabel: "OpenGeni",
+      selectable: false,
+      unavailableReason: "Credentials required",
+    });
+    expect(rows[0]?.catalog).toBe(model);
+  });
   test("labels organization provider billing separately from workspace BYOK", () => {
     const model = catalogModel({
       id: "organization-openrouter/openai/gpt-org",
@@ -48,6 +75,13 @@ describe("model-policy", () => {
     });
     expect(billingClassForModel(model)).toBe("organization_byok");
     expect(projectPickerRows([model])[0]?.billingClassLabel).toBe("Organization providers");
+    expect(payerSummaryForModel(model)).toBe("Billed to the organization OpenRouter account");
+    expect(payerSummaryForModel({ ...model, cost: undefined })).toBe(
+      "Billed to the organization OpenRouter account",
+    );
+    expect(payerSummaryForModel({ ...model, provider: "organization-gateway" })).toBe(
+      "Billed to the organization Vercel account",
+    );
   });
   test("omits disconnected subscription and workspace Gateway rails", () => {
     const rows = projectPickerRows([
@@ -118,23 +152,23 @@ describe("model-policy", () => {
     expect(billingClassForModel(workspaceModel)).toBe("byok");
     expect(payerSummaryForModel(workspaceModel)).toBe("Billed to the workspace OpenRouter account");
     expect(advancedSourceSummary(workspaceModel)).toBe("Workspace OpenRouter connection");
-    expect(billingClassForModel(deploymentModel)).toBe("external");
+    expect(billingClassForModel(deploymentModel)).toBe("opengeni_credits");
     expect(payerSummaryForModel(deploymentModel)).toBe("Free in this deployment");
   });
 
-  test("labels an anonymous deployment route as External", () => {
+  test("groups an anonymous deployment route under OpenGeni without assuming free access", () => {
     const model = catalogModel({
       id: "opencode/x-preview-f-free",
       label: "OpenCode Ox Alpha",
       billing: { upstreamPayer: "deployment", metering: "external" },
     });
-    expect(billingClassForModel(model)).toBe("external");
+    expect(billingClassForModel(model)).toBe("opengeni_credits");
     expect(projectPickerRows([model])[0]).toMatchObject({
-      billingClass: "external",
-      billingClassLabel: "External",
+      billingClass: "opengeni_credits",
+      billingClassLabel: "OpenGeni",
     });
-    expect(advancedSourceSummary(model)).toBe("Deployment route · no authentication");
-    expect(payerSummaryForModel(model)).toBe("External provider · no OpenGeni credits");
+    expect(advancedSourceSummary(model)).toBe("Deployment-provided connection");
+    expect(payerSummaryForModel(model)).toBe("OpenGeni · no model credits");
   });
 
   test("uses deployment cost before upstream settlement in the payer summary", () => {


### PR DESCRIPTION
## Summary

Deployment-provided free models appeared under External while Azure and gateway models appeared under OpenGeni. Group all deployment models under OpenGeni, with a small Free badge only for explicitly free models. Paid rows stay compact; workspace, organization, and subscription connections remain separate. Full names and payment descriptions remain available through hover and accessibility descriptions.

Credit onboarding now follows model cost instead of the presentation group, so selecting a free model cannot show an empty-credit warning. Preserve free-model onboarding selection and fix organization payment descriptions.

## Testing

- 56 focused tests passed: grouping, cost overrides, Free badges, unavailable models, connection groups, onboarding, and picker interactions.
- Contracts, React, and web typechecks passed.
- Live local new-session route inspected at desktop width. Verified search, keyboard selection, OpenGeni trigger icon, current-model Free badge/checkmark, and absence of the credit warning for a free model.
- Independent review approved after corrections.

## Delivery integrity

- Candidate changes are substantive source fixes; no base-only refreshes.
- No provider routing, credentials, or billing settlement changes.

## Summary by Sourcery

Group deployment models under OpenGeni and make picker presentation and onboarding behavior follow each model’s configured cost.

New Features:
- Group all deployment-provided models under the OpenGeni picker group and mark explicitly free models with a Free badge.
- Expose model payment descriptions through hover and accessibility metadata while preserving separate workspace, organization, and subscription groups.

Bug Fixes:
- Base credit onboarding and credit warnings on the model cost so free models do not trigger empty-credit prompts.
- Correct organization provider payment descriptions and preserve unavailable deployment models in the picker.

Enhancements:
- Keep paid OpenGeni rows compact while retaining full payment and model information for users who need it.

Documentation:
- Update model-provider documentation to describe deployment grouping, cost-based free badges, payment descriptions, and connection separation.

Tests:
- Add coverage for deployment grouping, cost-based credit behavior, Free badges, unavailable models, organization payment descriptions, and picker interactions.