### PR TITLE
fix(db): preserve session recency during Codex bookkeeping

### DIFF
--- a/.changeset/codex-session-recency.md
+++ b/.changeset/codex-session-recency.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Keep workspace Codex source changes, automatic account assignments, and last-used account bookkeeping from changing conversation recency or session ordering. Explicit account switches and semantic session activity retain their existing behavior.

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "postgres": "^3.4.9",
         "typescript": "7.0.2",
         "yaml": "2.9.0",
+        "zod": "^4.2.1",
       },
     },
     "apps/api": {

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -591,3 +591,42 @@ the presence of shadow records alone is not evidence of adaptive benefit.
 - Production release proof must additionally show concurrent live turns selecting
   distinct eligible credential ids and one controlled exhausted credential
   recovering on another id without a duplicate turn/message.
+
+### Conversation recency and historical repair
+
+Workspace pool changes, automatic policy assignments, and last-used credential
+bookkeeping preserve session recency. Manual in-session account switches remain
+explicit session activity. Migration 0426 fixes the bulk reset for old and new
+API binaries; deploy the matching worker binary to fix automatic assignment and
+last-used writes too.
+
+Historical timestamps cannot be reconstructed exactly from events alone: explicit
+session edits may have no event, retention may have removed evidence, and the
+workspace preference timestamp is not a reliable record of previous bulk resets.
+Never blanket-backfill cleared-affinity sessions. An operator must first confirm
+an affected set and independently review the proposed timestamp for each session.
+Use the ordinary configured database identity and tenant scope; the tool grants
+no additional access and does not bypass private-session RLS.
+
+For at most 50 explicit idle sessions, generate a private manifest (no writes):
+
+```bash
+bun scripts/session-recency-repair.ts --workspace-id <uuid> \
+  --session-ids <uuid>,<uuid> --evidence "confirmed incident evidence" > /private/path/recency-plan.json
+```
+
+The proposal is the latest retained semantic event, turn start/finish, or creation
+time. It includes title events and excludes the same raw delta types as ordinary
+activity tracking. Review the manifest against incident evidence before applying:
+
+```bash
+bun scripts/session-recency-repair.ts --apply /private/path/recency-plan.json
+```
+
+Apply rechecks the exact microsecond timestamp, activity revision, durable event
+cursor, idle state, and retained reconstruction under canonical session/cursor
+locks. Changed candidates are skipped. Each successful repair advances the normal
+activity revision (so incremental discovery sees it once), preserves event truth,
+and restores only the timestamp. Save the result beside the manifest. Replaying
+a successfully applied plan is a no-op. No deployment or historical write is
+performed merely by installing the migration.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1990,6 +1990,15 @@ updated-order discovery useful even while a productive session emits a large
 raw token or terminal stream; `session_events` remains the exact sequenced
 audit path for those retained previews.
 
+Provider bookkeeping is not an explicit session mutation for this purpose:
+workspace Codex source changes, automatic policy pins, and recording the last
+used Codex credential preserve both activity fields. A human's explicit
+in-session account switch still counts, as do the ordinary turn/message events.
+Migration 0426 corrects the workspace affinity-reset trigger without rewriting
+historical activity. Retained events cannot reconstruct every legitimate
+non-event session edit, so historical recency repair requires explicit reviewed
+candidates rather than an automatic global backfill.
+
 Operation-keyed session commands retry only their rolled-back database
 transaction on PostgreSQL deadlock or serialization SQLSTATEs, with a bounded
 attempt count. Durable operation receipts make those retries idempotent;

--- a/package.json
+++ b/package.json
@@ -193,7 +193,8 @@
     "playwright": "^1.61.1",
     "postgres": "^3.4.9",
     "typescript": "7.0.2",
-    "yaml": "2.9.0"
+    "yaml": "2.9.0",
+    "zod": "^4.2.1"
   },
   "overrides": {
     "@codemirror/state": "6.7.1",

--- a/packages/db/drizzle/0426_codex_bookkeeping_preserves_session_recency.sql
+++ b/packages/db/drizzle/0426_codex_bookkeeping_preserves_session_recency.sql
@@ -1,0 +1,24 @@
+-- deployment-mode: rolling
+-- Provider affinity is bookkeeping, not semantic conversation activity. Preserve
+-- both updated_at and the activity revision when switching a workspace pool.
+-- Existing API/worker binaries use this same trigger, so the bulk fix is rolling.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '1min';
+
+CREATE OR REPLACE FUNCTION opengeni_private.clear_workspace_codex_session_affinity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+BEGIN
+  UPDATE sessions
+  SET codex_pinned_credential_id = NULL,
+      codex_pin_source = NULL,
+      codex_last_credential_id = NULL
+  WHERE account_id = NEW.account_id AND workspace_id = NEW.workspace_id
+    AND (codex_pinned_credential_id IS NOT NULL OR codex_last_credential_id IS NOT NULL);
+  RETURN NEW;
+END
+$body$;
+-- CREATE OR REPLACE retains the existing owner and PUBLIC-revoked ACL.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -28901,7 +28901,8 @@ export async function setSessionCodexPinInTransaction(
       codexPinnedCredentialId: pinnedCredentialId,
       // Source travels with the pin: a cleared pin (null) clears the source too.
       codexPinSource: pinnedCredentialId === null ? null : source,
-      updatedAt: new Date(),
+      // Only an explicit session account switch is conversation activity.
+      ...(source === "manual" ? { updatedAt: new Date() } : {}),
     })
     .where(and(...conditions))
     .returning({ id: schema.sessions.id });
@@ -28938,7 +28939,7 @@ export async function recordSessionActiveCodexCredential(
   await withWorkspaceSessionActivityRls(db, workspaceId, async (scopedDb) => {
     await scopedDb
       .update(schema.sessions)
-      .set({ codexLastCredentialId: credentialId, updatedAt: new Date() })
+      .set({ codexLastCredentialId: credentialId })
       .where(
         and(
           eq(schema.sessions.workspaceId, workspaceId),

--- a/packages/db/test/codex-pin-source.test.ts
+++ b/packages/db/test/codex-pin-source.test.ts
@@ -1,12 +1,20 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
+import { sql } from "drizzle-orm";
 import {
+  previewSessionRecencyRepair,
+  applySessionRecencyRepair,
+} from "../../../scripts/session-recency-repair";
+import {
+  appendSessionEvents,
+  withWorkspaceSessionActivityRls,
   createDb,
   createSession,
   getSessionCodexState,
   recordSessionActiveCodexCredential,
   setSessionCodexPin,
+  setWorkspaceCodexSubscriptionMode,
   type Database,
   type DbClient,
 } from "../src/index";
@@ -241,5 +249,203 @@ describe("codex_pin_source (AM-2)", () => {
       threw = true;
     }
     expect(threw).toBe(true);
+  });
+});
+
+// Recency is conversation activity, not provider account bookkeeping.
+async function recencySnapshot(workspaceId: string) {
+  return await admin`
+    select s.id, s.updated_at::text as updated_at, s.activity_revision::text as revision,
+      r.revision::text as workspace_revision
+    from sessions s join workspace_session_activity_revisions r using (workspace_id)
+    where s.workspace_id = ${workspaceId}
+    order by s.updated_at desc, s.id desc
+  `;
+}
+
+describe("Codex bookkeeping preserves conversation recency", () => {
+  test("source preference changes clear affinities without reordering sessions", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required for the recency regression");
+    const ws = await freshWorkspace();
+    const other = await freshWorkspace();
+    const credential = await seedCodexAccount(ws);
+    const otherCredential = await seedCodexAccount(other);
+    const first = await seedSession(ws);
+    const second = await seedSession(ws);
+    await seedSession(ws);
+    const outsider = await seedSession(other);
+    await setSessionCodexPin(db, other.workspaceId, outsider, otherCredential);
+    const otherBefore = await recencySnapshot(other.workspaceId);
+    for (const mode of ["workspace", "automatic"] as const) {
+      await setSessionCodexPin(db, ws.workspaceId, first, credential);
+      await setSessionCodexPin(db, ws.workspaceId, second, credential, "policy");
+      await recordSessionActiveCodexCredential(db, ws.workspaceId, first, credential);
+      const before = await recencySnapshot(ws.workspaceId);
+      await setWorkspaceCodexSubscriptionMode(db, { ...ws, subjectId: null, mode });
+      expect(await recencySnapshot(ws.workspaceId)).toEqual(before);
+      for (const id of [first, second]) {
+        expect(await getSessionCodexState(db, ws.workspaceId, id)).toEqual({
+          pinnedCredentialId: null,
+          lastCredentialId: null,
+          pinSource: null,
+        });
+      }
+      expect(await recencySnapshot(other.workspaceId)).toEqual(otherBefore);
+      expect(
+        (await getSessionCodexState(db, other.workspaceId, outsider))?.pinnedCredentialId,
+      ).toBe(otherCredential);
+    }
+  });
+
+  test("policy reassignment and active-account recording do not count as work", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required for the recency regression");
+    const ws = await freshWorkspace();
+    const first = await seedCodexAccount(ws);
+    const second = await seedCodexAccount(ws);
+    const id = await seedSession(ws);
+    const before = await recencySnapshot(ws.workspaceId);
+    await setSessionCodexPin(db, ws.workspaceId, id, first, "policy");
+    await recordSessionActiveCodexCredential(db, ws.workspaceId, id, first);
+    await setSessionCodexPin(db, ws.workspaceId, id, second, "policy");
+    await recordSessionActiveCodexCredential(db, ws.workspaceId, id, second);
+    await setSessionCodexPin(db, ws.workspaceId, id, null, "policy");
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(before);
+    expect((await getSessionCodexState(db, ws.workspaceId, id))?.lastCredentialId).toBe(second);
+  });
+
+  test("an explicit manual account switch still counts as a session change", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required for the recency regression");
+    const ws = await freshWorkspace();
+    const credential = await seedCodexAccount(ws);
+    const id = await seedSession(ws);
+    const before = await recencySnapshot(ws.workspaceId);
+    await setSessionCodexPin(db, ws.workspaceId, id, credential);
+    const after = await recencySnapshot(ws.workspaceId);
+    expect(BigInt(after[0]!.revision)).toBeGreaterThan(BigInt(before[0]!.revision));
+    expect(after[0]!.updated_at).not.toBe(before[0]!.updated_at);
+  });
+});
+
+describe("reviewed historical recency repair", () => {
+  test("preview and apply time out behind an exclusive tenancy fence", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required");
+    const ws = await freshWorkspace();
+    const id = await seedSession(ws);
+    await withWorkspaceSessionActivityRls(db, ws.workspaceId, async (tx) => {
+      await tx.execute(
+        sql`update sessions set status = 'idle', updated_at = updated_at + interval '1 day' where id = ${id}::uuid`,
+      );
+    });
+    const plan = await previewSessionRecencyRepair(
+      db,
+      ws.workspaceId,
+      [id],
+      "Confirmed test incident",
+    );
+    const before = await recencySnapshot(ws.workspaceId);
+    const locked = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const holder = admin.begin(async (tx) => {
+      await tx`select pg_advisory_xact_lock(hashtextextended(${"session-tenancy:" + ws.workspaceId}, 0))`;
+      locked.resolve();
+      await release.promise;
+    });
+    try {
+      await locked.promise;
+      const results = await Promise.allSettled([
+        previewSessionRecencyRepair(db, ws.workspaceId, [id], "Confirmed test incident"),
+        applySessionRecencyRepair(db, plan),
+      ]);
+      for (const result of results) {
+        expect(result.status).toBe("rejected");
+        if (result.status === "rejected")
+          expect(result.reason.code ?? result.reason.cause?.code).toBe("55P03");
+      }
+    } finally {
+      release.resolve();
+      await holder;
+    }
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(before);
+  }, 20_000);
+
+  test("dry-run preserves state, apply retains microseconds and advances only revision, repeat is idempotent", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required");
+    const ws = await freshWorkspace();
+    const id = await seedSession(ws);
+    await withWorkspaceSessionActivityRls(db, ws.workspaceId, async (tx) => {
+      await tx.execute(sql`update sessions set status = 'idle', updated_at = updated_at + interval '1 day'
+        where id = ${id}::uuid`);
+    });
+    const before = await recencySnapshot(ws.workspaceId);
+    const plan = await previewSessionRecencyRepair(
+      db,
+      ws.workspaceId,
+      [id],
+      "Test reproduces confirmed provider-only write",
+    );
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(before);
+    expect(plan.candidates[0]!.proposedUpdatedAt).toMatch(/\.\d{6}Z$/);
+    expect(await applySessionRecencyRepair(db, plan)).toEqual([
+      { sessionId: id, outcome: "applied" },
+    ]);
+    const after = await recencySnapshot(ws.workspaceId);
+    expect(BigInt(after[0]!.revision)).toBeGreaterThan(BigInt(before[0]!.revision));
+    const [exact] =
+      await admin`select to_char(updated_at at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') as at from sessions where id = ${id}`;
+    expect(exact!.at).toBe(plan.candidates[0]!.proposedUpdatedAt);
+    expect(await applySessionRecencyRepair(db, plan)).toEqual([
+      { sessionId: id, outcome: "already_applied" },
+    ]);
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(after);
+  });
+
+  test("a new semantic event invalidates a reviewed repair and still advances recency", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required");
+    const ws = await freshWorkspace();
+    const id = await seedSession(ws);
+    await withWorkspaceSessionActivityRls(db, ws.workspaceId, async (tx) => {
+      await tx.execute(sql`update sessions set status = 'idle', updated_at = updated_at + interval '1 day'
+        where id = ${id}::uuid`);
+    });
+    const plan = await previewSessionRecencyRepair(
+      db,
+      ws.workspaceId,
+      [id],
+      "Confirmed test incident",
+    );
+    const revision = BigInt((await recencySnapshot(ws.workspaceId))[0]!.revision);
+    await appendSessionEvents(db, ws.workspaceId, id, [
+      { type: "user.message", payload: { text: "new work" } },
+    ]);
+    const fresh = await recencySnapshot(ws.workspaceId);
+    expect(BigInt(fresh[0]!.revision)).toBeGreaterThan(revision);
+    expect(await applySessionRecencyRepair(db, plan)).toEqual([
+      { sessionId: id, outcome: "stale" },
+    ]);
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(fresh);
+  });
+
+  test("raw deltas preserve recency but invalidate the reviewed sequence", async () => {
+    if (!available) throw new Error("Real PostgreSQL is required");
+    const ws = await freshWorkspace();
+    const id = await seedSession(ws);
+    await withWorkspaceSessionActivityRls(db, ws.workspaceId, async (tx) => {
+      await tx.execute(sql`update sessions set status = 'idle', updated_at = updated_at + interval '1 day'
+        where id = ${id}::uuid`);
+    });
+    const plan = await previewSessionRecencyRepair(
+      db,
+      ws.workspaceId,
+      [id],
+      "Confirmed test incident",
+    );
+    const before = await recencySnapshot(ws.workspaceId);
+    await appendSessionEvents(db, ws.workspaceId, id, [
+      { type: "agent.message.delta", payload: { text: "raw" } },
+    ]);
+    expect(await recencySnapshot(ws.workspaceId)).toEqual(before);
+    expect(await applySessionRecencyRepair(db, plan)).toEqual([
+      { sessionId: id, outcome: "stale" },
+    ]);
   });
 });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,7 +131,9 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe("0425_feedback_submissions.sql");
+    expect(completeSourceContract.latestMigration).toBe(
+      "0426_codex_bookkeeping_preserves_session_recency.sql",
+    );
     expect(
       completeSourceContract.migrations.find(
         (migration) =>
@@ -257,6 +259,9 @@ describe("release schema contract", () => {
     );
     const modelConnectionAccess = completeSourceContract.migrations.some(
       (migration) => migration.path === "0424_model_connection_access.sql",
+    );
+    const codexBookkeepingPreservesSessionRecency = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0426_codex_bookkeeping_preserves_session_recency.sql",
     );
     const feedbackSubmissions = completeSourceContract.migrations.some(
       (migration) => migration.path === "0425_feedback_submissions.sql",
@@ -650,6 +655,7 @@ describe("release schema contract", () => {
       };
     }
     const automaticSessionTitleMigrationPaths = new Set([
+      "0426_codex_bookkeeping_preserves_session_recency.sql",
       "0398_organization_workspace_management_entry.sql",
       "0395_scheduled_task_unclaimed_occurrence_invalidation.sql",
       "0394_session_selected_skill_activation.sql",
@@ -794,6 +800,11 @@ describe("release schema contract", () => {
         ...completeSourceContract,
         latestMigration: "0425_feedback_submissions.sql",
       };
+    if (codexBookkeepingPreservesSessionRecency)
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0426_codex_bookkeeping_preserves_session_recency.sql",
+      };
     expect(completeSourceContract).toMatchObject({
       ...(sandboxDeadlineRotationPreemption
         ? { latestMigration: "0397_sandbox_deadline_rotation_preemption.sql" }
@@ -801,6 +812,7 @@ describe("release schema contract", () => {
       fileCount:
         (modelConnectionAccess ? 1 : 0) +
         (organizationSupergrokSubscriptions ? 1 : 0) +
+        (codexBookkeepingPreservesSessionRecency ? 1 : 0) +
         (feedbackSubmissions ? 1 : 0) +
         (workspacePauseTimers ? 1 : 0) +
         (sessionFilterActivity ? 1 : 0) +
@@ -877,122 +889,124 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: feedbackSubmissions
-        ? "0425_feedback_submissions.sql"
-        : organizationSupergrokSubscriptions
-          ? "0423_organization_supergrok_subscriptions.sql"
-          : personalWorkspaceOrganizationCodexInheritance
-            ? "0422_personal_workspace_organization_codex_inheritance.sql"
-            : workspacePauseTimers
-              ? "0420_workspace_pause_timers.sql"
-              : siteDirectUploads
-                ? "0418_site_direct_uploads.sql"
-                : commandRunnerFailureMetadata
-                  ? "0417_command_runner_failure_metadata.sql"
-                  : scheduledInheritedToolAdmission
-                    ? "0416_scheduled_inherited_tool_admission.sql"
-                    : commandCompletionObservation
-                      ? "0415_command_completion_observation.sql"
-                      : scheduledGeneratedProducerMaterialization
-                        ? "0414_scheduled_generated_producer_materialization.sql"
-                        : sessionFilterActivity
-                          ? "0413_session_filter_activity.sql"
-                          : newSessionDraftProjectProvenanceValidation
-                            ? "0412_new_session_draft_project_provenance_validation.sql"
-                            : newSessionDraftProjectProvenanceBackfill
-                              ? "0411_new_session_draft_project_provenance_backfill.sql"
-                              : newSessionDraftProjectProvenanceIndex
-                                ? "0410_new_session_draft_project_provenance_index.sql"
-                                : newSessionDraftProjectProvenance
-                                  ? "0409_new_session_draft_project_provenance.sql"
-                                  : scheduledSessionTargetIndex
-                                    ? "0408_scheduled_session_target_index.sql"
-                                    : connectedCommandTrackingRetirement
-                                      ? "0407_connected_command_tracking_retirement.sql"
-                                      : sandboxProviderDeadlineInteractionFollowup
-                                        ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-                                        : organizationModelProviderConnections
-                                          ? "0390_organization_model_provider_connections.sql"
-                                          : modelCatalogAndGatewayCustomModels
-                                            ? "0389_model_catalog_and_gateway_custom_models.sql"
-                                            : sandboxProviderDeadlineInteractions
-                                              ? "0388_sandbox_provider_deadline_interactions.sql"
-                                              : boundHostExportSessionPayloads
-                                                ? "0387_bound_host_export_session_payloads.sql"
-                                                : localOrganizationAdministration
-                                                  ? "0386_local_organization_administration.sql"
-                                                  : connectedMachineLegacyTildeWorkdirs
-                                                    ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                                                    : codexCooldownRevisionGuardPrivileges
-                                                      ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                                                      : codexCooldownReconciliation
-                                                        ? "0383_codex_cooldown_reconciliation.sql"
-                                                        : organizationApiKeyProvenance
-                                                          ? "0382_organization_api_key_provenance.sql"
-                                                          : organizationCodexSubscriptionInheritance
-                                                            ? "0381_organization_codex_subscription_inheritance.sql"
-                                                            : autonomousCompanyProfileAgentPolicy
-                                                              ? "0380_autonomous_company_profile_agent_policy.sql"
-                                                              : sessionEventRawLaneActivation
-                                                                ? "0379_session_event_raw_lane_activation.sql"
-                                                                : scopedRigHealthAuditTimestamp
-                                                                  ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                                                  : scopedRigHealthProjection
-                                                                    ? "0377_scoped_rig_health_projection.sql"
-                                                                    : organizationWorkspaceInventory
-                                                                      ? "0376_organization_workspace_inventory.sql"
-                                                                      : sessionRecoveryObservability
-                                                                        ? "0375_session_recovery_observability.sql"
-                                                                        : sessionEventCursors
-                                                                          ? "0374_session_event_cursors.sql"
-                                                                          : sandboxSharedPreparation
-                                                                            ? "0373_sandbox_shared_preparation.sql"
-                                                                            : orderedVariableSetRuntimeAuthority
-                                                                              ? "0372_ordered_variable_set_runtime_authority.sql"
-                                                                              : workspaceMemberCandidateInventory
-                                                                                ? "0371_workspace_member_candidate_inventory.sql"
-                                                                                : workspaceMemberManagementScope
-                                                                                  ? "0370_workspace_member_management_scope.sql"
-                                                                                  : localHumanPersonalAuthority
-                                                                                    ? "0369_local_human_personal_authority.sql"
-                                                                                    : sessionDiscoveryClaimSearchIndex
-                                                                                      ? "0368_session_discovery_claim_search_index.sql"
-                                                                                      : sessionDiscoveryGoalSearchIndex
-                                                                                        ? "0367_session_discovery_goal_search_index.sql"
-                                                                                        : sessionDiscoveryTitleSearchIndex
-                                                                                          ? "0366_session_discovery_title_search_index.sql"
-                                                                                          : permissionScopedWorkClaims
-                                                                                            ? "0365_permission_scoped_work_claims.sql"
-                                                                                            : workspaceLearningPolicySnapshotLockOrder
-                                                                                              ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                                                              : organizationRecoveryCustody
-                                                                                                ? "0363_organization_recovery_custody.sql"
-                                                                                                : managedAuthSessionSets
-                                                                                                  ? "0362_managed_auth_session_sets.sql"
-                                                                                                  : rememberKnowledgeMemoryMaterialization
-                                                                                                    ? "0361_remember_knowledge_memory_materialization.sql"
-                                                                                                    : organizationIdentityConfirmationPrompt
-                                                                                                      ? "0360_organization_identity_confirmation_prompt.sql"
-                                                                                                      : insightsForceRlsReadCapability
-                                                                                                        ? "0359_insights_force_rls_read_capability.sql"
-                                                                                                        : prReviewManagedGithubApp
-                                                                                                          ? "0358_pr_review_managed_github_app.sql"
-                                                                                                          : rigPlatformBaseOnly
-                                                                                                            ? "0357_rig_platform_base_only.sql"
-                                                                                                            : setBasedInsightsSessionVisibility
-                                                                                                              ? "0356_set_based_insights_session_visibility.sql"
-                                                                                                              : automaticSessionTitleQuarantine
-                                                                                                                ? "0355_automatic_session_title_quarantine.sql"
-                                                                                                                : automaticSessionTitleQuarantineIndex
-                                                                                                                  ? "0354_automatic_session_title_quarantine_index.sql"
-                                                                                                                  : automaticSessionTitlePolicyFence
-                                                                                                                    ? "0353_automatic_session_title_policy_fence.sql"
-                                                                                                                    : sessionVariableSetAttachments
-                                                                                                                      ? "0352_session_variable_set_attachments.sql"
-                                                                                                                      : migrationsBeforeAutomaticSessionTitles.at(
-                                                                                                                          -1,
-                                                                                                                        )
-                                                                                                                          ?.path,
+      latestMigration: codexBookkeepingPreservesSessionRecency
+        ? "0426_codex_bookkeeping_preserves_session_recency.sql"
+        : feedbackSubmissions
+          ? "0425_feedback_submissions.sql"
+          : organizationSupergrokSubscriptions
+            ? "0423_organization_supergrok_subscriptions.sql"
+            : personalWorkspaceOrganizationCodexInheritance
+              ? "0422_personal_workspace_organization_codex_inheritance.sql"
+              : workspacePauseTimers
+                ? "0420_workspace_pause_timers.sql"
+                : siteDirectUploads
+                  ? "0418_site_direct_uploads.sql"
+                  : commandRunnerFailureMetadata
+                    ? "0417_command_runner_failure_metadata.sql"
+                    : scheduledInheritedToolAdmission
+                      ? "0416_scheduled_inherited_tool_admission.sql"
+                      : commandCompletionObservation
+                        ? "0415_command_completion_observation.sql"
+                        : scheduledGeneratedProducerMaterialization
+                          ? "0414_scheduled_generated_producer_materialization.sql"
+                          : sessionFilterActivity
+                            ? "0413_session_filter_activity.sql"
+                            : newSessionDraftProjectProvenanceValidation
+                              ? "0412_new_session_draft_project_provenance_validation.sql"
+                              : newSessionDraftProjectProvenanceBackfill
+                                ? "0411_new_session_draft_project_provenance_backfill.sql"
+                                : newSessionDraftProjectProvenanceIndex
+                                  ? "0410_new_session_draft_project_provenance_index.sql"
+                                  : newSessionDraftProjectProvenance
+                                    ? "0409_new_session_draft_project_provenance.sql"
+                                    : scheduledSessionTargetIndex
+                                      ? "0408_scheduled_session_target_index.sql"
+                                      : connectedCommandTrackingRetirement
+                                        ? "0407_connected_command_tracking_retirement.sql"
+                                        : sandboxProviderDeadlineInteractionFollowup
+                                          ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+                                          : organizationModelProviderConnections
+                                            ? "0390_organization_model_provider_connections.sql"
+                                            : modelCatalogAndGatewayCustomModels
+                                              ? "0389_model_catalog_and_gateway_custom_models.sql"
+                                              : sandboxProviderDeadlineInteractions
+                                                ? "0388_sandbox_provider_deadline_interactions.sql"
+                                                : boundHostExportSessionPayloads
+                                                  ? "0387_bound_host_export_session_payloads.sql"
+                                                  : localOrganizationAdministration
+                                                    ? "0386_local_organization_administration.sql"
+                                                    : connectedMachineLegacyTildeWorkdirs
+                                                      ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                                                      : codexCooldownRevisionGuardPrivileges
+                                                        ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                                                        : codexCooldownReconciliation
+                                                          ? "0383_codex_cooldown_reconciliation.sql"
+                                                          : organizationApiKeyProvenance
+                                                            ? "0382_organization_api_key_provenance.sql"
+                                                            : organizationCodexSubscriptionInheritance
+                                                              ? "0381_organization_codex_subscription_inheritance.sql"
+                                                              : autonomousCompanyProfileAgentPolicy
+                                                                ? "0380_autonomous_company_profile_agent_policy.sql"
+                                                                : sessionEventRawLaneActivation
+                                                                  ? "0379_session_event_raw_lane_activation.sql"
+                                                                  : scopedRigHealthAuditTimestamp
+                                                                    ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                                                    : scopedRigHealthProjection
+                                                                      ? "0377_scoped_rig_health_projection.sql"
+                                                                      : organizationWorkspaceInventory
+                                                                        ? "0376_organization_workspace_inventory.sql"
+                                                                        : sessionRecoveryObservability
+                                                                          ? "0375_session_recovery_observability.sql"
+                                                                          : sessionEventCursors
+                                                                            ? "0374_session_event_cursors.sql"
+                                                                            : sandboxSharedPreparation
+                                                                              ? "0373_sandbox_shared_preparation.sql"
+                                                                              : orderedVariableSetRuntimeAuthority
+                                                                                ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                                                : workspaceMemberCandidateInventory
+                                                                                  ? "0371_workspace_member_candidate_inventory.sql"
+                                                                                  : workspaceMemberManagementScope
+                                                                                    ? "0370_workspace_member_management_scope.sql"
+                                                                                    : localHumanPersonalAuthority
+                                                                                      ? "0369_local_human_personal_authority.sql"
+                                                                                      : sessionDiscoveryClaimSearchIndex
+                                                                                        ? "0368_session_discovery_claim_search_index.sql"
+                                                                                        : sessionDiscoveryGoalSearchIndex
+                                                                                          ? "0367_session_discovery_goal_search_index.sql"
+                                                                                          : sessionDiscoveryTitleSearchIndex
+                                                                                            ? "0366_session_discovery_title_search_index.sql"
+                                                                                            : permissionScopedWorkClaims
+                                                                                              ? "0365_permission_scoped_work_claims.sql"
+                                                                                              : workspaceLearningPolicySnapshotLockOrder
+                                                                                                ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                                                : organizationRecoveryCustody
+                                                                                                  ? "0363_organization_recovery_custody.sql"
+                                                                                                  : managedAuthSessionSets
+                                                                                                    ? "0362_managed_auth_session_sets.sql"
+                                                                                                    : rememberKnowledgeMemoryMaterialization
+                                                                                                      ? "0361_remember_knowledge_memory_materialization.sql"
+                                                                                                      : organizationIdentityConfirmationPrompt
+                                                                                                        ? "0360_organization_identity_confirmation_prompt.sql"
+                                                                                                        : insightsForceRlsReadCapability
+                                                                                                          ? "0359_insights_force_rls_read_capability.sql"
+                                                                                                          : prReviewManagedGithubApp
+                                                                                                            ? "0358_pr_review_managed_github_app.sql"
+                                                                                                            : rigPlatformBaseOnly
+                                                                                                              ? "0357_rig_platform_base_only.sql"
+                                                                                                              : setBasedInsightsSessionVisibility
+                                                                                                                ? "0356_set_based_insights_session_visibility.sql"
+                                                                                                                : automaticSessionTitleQuarantine
+                                                                                                                  ? "0355_automatic_session_title_quarantine.sql"
+                                                                                                                  : automaticSessionTitleQuarantineIndex
+                                                                                                                    ? "0354_automatic_session_title_quarantine_index.sql"
+                                                                                                                    : automaticSessionTitlePolicyFence
+                                                                                                                      ? "0353_automatic_session_title_policy_fence.sql"
+                                                                                                                      : sessionVariableSetAttachments
+                                                                                                                        ? "0352_session_variable_set_attachments.sql"
+                                                                                                                        : migrationsBeforeAutomaticSessionTitles.at(
+                                                                                                                            -1,
+                                                                                                                          )
+                                                                                                                            ?.path,
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -1081,6 +1095,9 @@ describe("release schema contract", () => {
         : {}),
       ...(modelConnectionAccess ? { latestMigration: "0424_model_connection_access.sql" } : {}),
       ...(feedbackSubmissions ? { latestMigration: "0425_feedback_submissions.sql" } : {}),
+      ...(codexBookkeepingPreservesSessionRecency
+        ? { latestMigration: "0426_codex_bookkeeping_preserves_session_recency.sql" }
+        : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
       organizationUserSetupTokenTransport
@@ -1164,6 +1181,9 @@ describe("release schema contract", () => {
     );
     const modelConnectionAccess = completeSourceContract.migrations.some(
       (migration) => migration.path === "0424_model_connection_access.sql",
+    );
+    const codexBookkeepingPreservesSessionRecency = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0426_codex_bookkeeping_preserves_session_recency.sql",
     );
     const feedbackSubmissions = completeSourceContract.migrations.some(
       (migration) => migration.path === "0425_feedback_submissions.sql",
@@ -1371,6 +1391,7 @@ describe("release schema contract", () => {
       expect(taskTreeNotes).toMatchObject({ deploymentMode: "rolling" });
     }
     const appendedMigrationPaths = [
+      "0426_codex_bookkeeping_preserves_session_recency.sql",
       "0424_model_connection_access.sql",
       "0423_organization_supergrok_subscriptions.sql",
       "0420_workspace_pause_timers.sql",
@@ -1814,8 +1835,14 @@ describe("release schema contract", () => {
         ...completeSourceContract,
         latestMigration: "0425_feedback_submissions.sql",
       };
+    if (codexBookkeepingPreservesSessionRecency)
+      completeSourceContract = {
+        ...completeSourceContract,
+        latestMigration: "0426_codex_bookkeeping_preserves_session_recency.sql",
+      };
     expect(completeSourceContract).toMatchObject({
       fileCount:
+        (codexBookkeepingPreservesSessionRecency ? 1 : 0) +
         (feedbackSubmissions ? 1 : 0) +
         (modelConnectionAccess ? 1 : 0) +
         (organizationSupergrokSubscriptions ? 1 : 0) +
@@ -1899,129 +1926,131 @@ describe("release schema contract", () => {
         (workspaceHtmlSiteSources ? 1 : 0) +
         (mcpOauthAuthorizationServer ? 1 : 0) +
         (toolGatewayApprovalCapabilities ? 1 : 0),
-      latestMigration: feedbackSubmissions
-        ? "0425_feedback_submissions.sql"
-        : organizationSupergrokSubscriptions
-          ? "0423_organization_supergrok_subscriptions.sql"
-          : personalWorkspaceOrganizationCodexInheritance
-            ? "0422_personal_workspace_organization_codex_inheritance.sql"
-            : siteDirectUploads
-              ? "0418_site_direct_uploads.sql"
-              : commandRunnerFailureMetadata
-                ? "0417_command_runner_failure_metadata.sql"
-                : scheduledInheritedToolAdmission
-                  ? "0416_scheduled_inherited_tool_admission.sql"
-                  : commandCompletionObservation
-                    ? "0415_command_completion_observation.sql"
-                    : scheduledGeneratedProducerMaterialization
-                      ? "0414_scheduled_generated_producer_materialization.sql"
-                      : sessionFilterActivity
-                        ? "0413_session_filter_activity.sql"
-                        : newSessionDraftProjectProvenanceValidation
-                          ? "0412_new_session_draft_project_provenance_validation.sql"
-                          : newSessionDraftProjectProvenanceBackfill
-                            ? "0411_new_session_draft_project_provenance_backfill.sql"
-                            : newSessionDraftProjectProvenanceIndex
-                              ? "0410_new_session_draft_project_provenance_index.sql"
-                              : newSessionDraftProjectProvenance
-                                ? "0409_new_session_draft_project_provenance.sql"
-                                : scheduledSessionTargetIndex
-                                  ? "0408_scheduled_session_target_index.sql"
-                                  : connectedCommandTrackingRetirement
-                                    ? "0407_connected_command_tracking_retirement.sql"
-                                    : sandboxProviderDeadlineInteractionFollowup
-                                      ? "0391_sandbox_provider_deadline_interaction_followup.sql"
-                                      : organizationModelProviderConnections
-                                        ? "0390_organization_model_provider_connections.sql"
-                                        : modelCatalogAndGatewayCustomModels
-                                          ? "0389_model_catalog_and_gateway_custom_models.sql"
-                                          : sandboxProviderDeadlineInteractions
-                                            ? "0388_sandbox_provider_deadline_interactions.sql"
-                                            : boundHostExportSessionPayloads
-                                              ? "0387_bound_host_export_session_payloads.sql"
-                                              : localOrganizationAdministration
-                                                ? "0386_local_organization_administration.sql"
-                                                : connectedMachineLegacyTildeWorkdirs
-                                                  ? "0385_connected_machine_legacy_tilde_workdirs.sql"
-                                                  : codexCooldownRevisionGuardPrivileges
-                                                    ? "0384_codex_cooldown_revision_guard_privileges.sql"
-                                                    : codexCooldownReconciliation
-                                                      ? "0383_codex_cooldown_reconciliation.sql"
-                                                      : organizationApiKeyProvenance
-                                                        ? "0382_organization_api_key_provenance.sql"
-                                                        : organizationCodexSubscriptionInheritance
-                                                          ? "0381_organization_codex_subscription_inheritance.sql"
-                                                          : autonomousCompanyProfileAgentPolicy
-                                                            ? "0380_autonomous_company_profile_agent_policy.sql"
-                                                            : sessionEventRawLaneActivation
-                                                              ? "0379_session_event_raw_lane_activation.sql"
-                                                              : scopedRigHealthAuditTimestamp
-                                                                ? "0378_scoped_rig_health_audit_timestamp.sql"
-                                                                : scopedRigHealthProjection
-                                                                  ? "0377_scoped_rig_health_projection.sql"
-                                                                  : organizationWorkspaceInventory
-                                                                    ? "0376_organization_workspace_inventory.sql"
-                                                                    : sessionRecoveryObservability
-                                                                      ? "0375_session_recovery_observability.sql"
-                                                                      : sessionEventCursors
-                                                                        ? "0374_session_event_cursors.sql"
-                                                                        : sandboxSharedPreparation
-                                                                          ? "0373_sandbox_shared_preparation.sql"
-                                                                          : orderedVariableSetRuntimeAuthority
-                                                                            ? "0372_ordered_variable_set_runtime_authority.sql"
-                                                                            : workspaceMemberCandidateInventory
-                                                                              ? "0371_workspace_member_candidate_inventory.sql"
-                                                                              : workspaceMemberManagementScope
-                                                                                ? "0370_workspace_member_management_scope.sql"
-                                                                                : localHumanPersonalAuthority
-                                                                                  ? "0369_local_human_personal_authority.sql"
-                                                                                  : sessionDiscoveryClaimSearchIndex
-                                                                                    ? "0368_session_discovery_claim_search_index.sql"
-                                                                                    : sessionDiscoveryGoalSearchIndex
-                                                                                      ? "0367_session_discovery_goal_search_index.sql"
-                                                                                      : sessionDiscoveryTitleSearchIndex
-                                                                                        ? "0366_session_discovery_title_search_index.sql"
-                                                                                        : permissionScopedWorkClaims
-                                                                                          ? "0365_permission_scoped_work_claims.sql"
-                                                                                          : workspaceLearningPolicySnapshotLockOrder
-                                                                                            ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
-                                                                                            : organizationRecoveryCustody
-                                                                                              ? "0363_organization_recovery_custody.sql"
-                                                                                              : managedAuthSessionSets
-                                                                                                ? "0362_managed_auth_session_sets.sql"
-                                                                                                : sessionVariableSetAttachments
-                                                                                                  ? "0352_session_variable_set_attachments.sql"
-                                                                                                  : organizationUserSetupDelivery
-                                                                                                    ? "0351_organization_user_setup_delivery.sql"
-                                                                                                    : organizationSharedWorkspaceAdministration
-                                                                                                      ? "0350_organization_shared_workspace_administration.sql"
-                                                                                                      : greenfieldSessionTenancyActivation
-                                                                                                        ? "0349_greenfield_session_tenancy_activation.sql"
-                                                                                                        : namedSignupAndUserSetup
-                                                                                                          ? "0348_named_signup_and_user_setup.sql"
-                                                                                                          : connectionAuthorityConvergenceEvidence
-                                                                                                            ? "0347_connection_authority_convergence_evidence.sql"
-                                                                                                            : documentMigrationAuditSurface
-                                                                                                              ? "0346_document_migration_audit_surface.sql"
-                                                                                                              : tenantScopedSessionTenancyFence
-                                                                                                                ? "0345_tenant_scoped_session_tenancy_fence.sql"
-                                                                                                                : privateSessionVisibilityTransitionGate
-                                                                                                                  ? "0344_private_session_visibility_transition_gate.sql"
-                                                                                                                  : personalDocumentForceRlsRepair
-                                                                                                                    ? "0343_personal_document_force_rls_lock_repair.sql"
-                                                                                                                    : slackRoutePromptSinglePending
-                                                                                                                      ? "0342_slack_route_prompt_single_pending.sql"
-                                                                                                                      : slackRoutingProbeFence
-                                                                                                                        ? "0341_slack_routing_probe_organization_fence.sql"
-                                                                                                                        : tenancyBackfillActivationEvidence
-                                                                                                                          ? "0340_tenancy_backfill_activation_evidence.sql"
-                                                                                                                          : documentAuthorityReclassification
-                                                                                                                            ? "0339_document_authority_reclassification.sql"
-                                                                                                                            : atomicConnectedMachineAttachments
-                                                                                                                              ? "0338_atomic_connected_machine_attachments.sql"
-                                                                                                                              : routedSlackHandles
-                                                                                                                                ? "0337_slack_routed_action_handles.sql"
-                                                                                                                                : "0336_atomic_session_fork_visibility.sql",
+      latestMigration: codexBookkeepingPreservesSessionRecency
+        ? "0426_codex_bookkeeping_preserves_session_recency.sql"
+        : feedbackSubmissions
+          ? "0425_feedback_submissions.sql"
+          : organizationSupergrokSubscriptions
+            ? "0423_organization_supergrok_subscriptions.sql"
+            : personalWorkspaceOrganizationCodexInheritance
+              ? "0422_personal_workspace_organization_codex_inheritance.sql"
+              : siteDirectUploads
+                ? "0418_site_direct_uploads.sql"
+                : commandRunnerFailureMetadata
+                  ? "0417_command_runner_failure_metadata.sql"
+                  : scheduledInheritedToolAdmission
+                    ? "0416_scheduled_inherited_tool_admission.sql"
+                    : commandCompletionObservation
+                      ? "0415_command_completion_observation.sql"
+                      : scheduledGeneratedProducerMaterialization
+                        ? "0414_scheduled_generated_producer_materialization.sql"
+                        : sessionFilterActivity
+                          ? "0413_session_filter_activity.sql"
+                          : newSessionDraftProjectProvenanceValidation
+                            ? "0412_new_session_draft_project_provenance_validation.sql"
+                            : newSessionDraftProjectProvenanceBackfill
+                              ? "0411_new_session_draft_project_provenance_backfill.sql"
+                              : newSessionDraftProjectProvenanceIndex
+                                ? "0410_new_session_draft_project_provenance_index.sql"
+                                : newSessionDraftProjectProvenance
+                                  ? "0409_new_session_draft_project_provenance.sql"
+                                  : scheduledSessionTargetIndex
+                                    ? "0408_scheduled_session_target_index.sql"
+                                    : connectedCommandTrackingRetirement
+                                      ? "0407_connected_command_tracking_retirement.sql"
+                                      : sandboxProviderDeadlineInteractionFollowup
+                                        ? "0391_sandbox_provider_deadline_interaction_followup.sql"
+                                        : organizationModelProviderConnections
+                                          ? "0390_organization_model_provider_connections.sql"
+                                          : modelCatalogAndGatewayCustomModels
+                                            ? "0389_model_catalog_and_gateway_custom_models.sql"
+                                            : sandboxProviderDeadlineInteractions
+                                              ? "0388_sandbox_provider_deadline_interactions.sql"
+                                              : boundHostExportSessionPayloads
+                                                ? "0387_bound_host_export_session_payloads.sql"
+                                                : localOrganizationAdministration
+                                                  ? "0386_local_organization_administration.sql"
+                                                  : connectedMachineLegacyTildeWorkdirs
+                                                    ? "0385_connected_machine_legacy_tilde_workdirs.sql"
+                                                    : codexCooldownRevisionGuardPrivileges
+                                                      ? "0384_codex_cooldown_revision_guard_privileges.sql"
+                                                      : codexCooldownReconciliation
+                                                        ? "0383_codex_cooldown_reconciliation.sql"
+                                                        : organizationApiKeyProvenance
+                                                          ? "0382_organization_api_key_provenance.sql"
+                                                          : organizationCodexSubscriptionInheritance
+                                                            ? "0381_organization_codex_subscription_inheritance.sql"
+                                                            : autonomousCompanyProfileAgentPolicy
+                                                              ? "0380_autonomous_company_profile_agent_policy.sql"
+                                                              : sessionEventRawLaneActivation
+                                                                ? "0379_session_event_raw_lane_activation.sql"
+                                                                : scopedRigHealthAuditTimestamp
+                                                                  ? "0378_scoped_rig_health_audit_timestamp.sql"
+                                                                  : scopedRigHealthProjection
+                                                                    ? "0377_scoped_rig_health_projection.sql"
+                                                                    : organizationWorkspaceInventory
+                                                                      ? "0376_organization_workspace_inventory.sql"
+                                                                      : sessionRecoveryObservability
+                                                                        ? "0375_session_recovery_observability.sql"
+                                                                        : sessionEventCursors
+                                                                          ? "0374_session_event_cursors.sql"
+                                                                          : sandboxSharedPreparation
+                                                                            ? "0373_sandbox_shared_preparation.sql"
+                                                                            : orderedVariableSetRuntimeAuthority
+                                                                              ? "0372_ordered_variable_set_runtime_authority.sql"
+                                                                              : workspaceMemberCandidateInventory
+                                                                                ? "0371_workspace_member_candidate_inventory.sql"
+                                                                                : workspaceMemberManagementScope
+                                                                                  ? "0370_workspace_member_management_scope.sql"
+                                                                                  : localHumanPersonalAuthority
+                                                                                    ? "0369_local_human_personal_authority.sql"
+                                                                                    : sessionDiscoveryClaimSearchIndex
+                                                                                      ? "0368_session_discovery_claim_search_index.sql"
+                                                                                      : sessionDiscoveryGoalSearchIndex
+                                                                                        ? "0367_session_discovery_goal_search_index.sql"
+                                                                                        : sessionDiscoveryTitleSearchIndex
+                                                                                          ? "0366_session_discovery_title_search_index.sql"
+                                                                                          : permissionScopedWorkClaims
+                                                                                            ? "0365_permission_scoped_work_claims.sql"
+                                                                                            : workspaceLearningPolicySnapshotLockOrder
+                                                                                              ? "0364_workspace_learning_policy_snapshot_lock_order.sql"
+                                                                                              : organizationRecoveryCustody
+                                                                                                ? "0363_organization_recovery_custody.sql"
+                                                                                                : managedAuthSessionSets
+                                                                                                  ? "0362_managed_auth_session_sets.sql"
+                                                                                                  : sessionVariableSetAttachments
+                                                                                                    ? "0352_session_variable_set_attachments.sql"
+                                                                                                    : organizationUserSetupDelivery
+                                                                                                      ? "0351_organization_user_setup_delivery.sql"
+                                                                                                      : organizationSharedWorkspaceAdministration
+                                                                                                        ? "0350_organization_shared_workspace_administration.sql"
+                                                                                                        : greenfieldSessionTenancyActivation
+                                                                                                          ? "0349_greenfield_session_tenancy_activation.sql"
+                                                                                                          : namedSignupAndUserSetup
+                                                                                                            ? "0348_named_signup_and_user_setup.sql"
+                                                                                                            : connectionAuthorityConvergenceEvidence
+                                                                                                              ? "0347_connection_authority_convergence_evidence.sql"
+                                                                                                              : documentMigrationAuditSurface
+                                                                                                                ? "0346_document_migration_audit_surface.sql"
+                                                                                                                : tenantScopedSessionTenancyFence
+                                                                                                                  ? "0345_tenant_scoped_session_tenancy_fence.sql"
+                                                                                                                  : privateSessionVisibilityTransitionGate
+                                                                                                                    ? "0344_private_session_visibility_transition_gate.sql"
+                                                                                                                    : personalDocumentForceRlsRepair
+                                                                                                                      ? "0343_personal_document_force_rls_lock_repair.sql"
+                                                                                                                      : slackRoutePromptSinglePending
+                                                                                                                        ? "0342_slack_route_prompt_single_pending.sql"
+                                                                                                                        : slackRoutingProbeFence
+                                                                                                                          ? "0341_slack_routing_probe_organization_fence.sql"
+                                                                                                                          : tenancyBackfillActivationEvidence
+                                                                                                                            ? "0340_tenancy_backfill_activation_evidence.sql"
+                                                                                                                            : documentAuthorityReclassification
+                                                                                                                              ? "0339_document_authority_reclassification.sql"
+                                                                                                                              : atomicConnectedMachineAttachments
+                                                                                                                                ? "0338_atomic_connected_machine_attachments.sql"
+                                                                                                                                : routedSlackHandles
+                                                                                                                                  ? "0337_slack_routed_action_handles.sql"
+                                                                                                                                  : "0336_atomic_session_fork_visibility.sql",
       ...(workspaceMemoryAndLearningDefaults
         ? { latestMigration: "0393_workspace_memory_and_learning_defaults.sql" }
         : {}),
@@ -2100,6 +2129,9 @@ describe("release schema contract", () => {
         : {}),
       ...(modelConnectionAccess ? { latestMigration: "0424_model_connection_access.sql" } : {}),
       ...(feedbackSubmissions ? { latestMigration: "0425_feedback_submissions.sql" } : {}),
+      ...(codexBookkeepingPreservesSessionRecency
+        ? { latestMigration: "0426_codex_bookkeeping_preserves_session_recency.sql" }
+        : {}),
     });
     expect(completeSourceContractWithOrganizationWorkspaceManagementEntry.latestMigration).toBe(
       organizationUserSetupTokenTransport

--- a/scripts/session-recency-repair.ts
+++ b/scripts/session-recency-repair.ts
@@ -1,0 +1,179 @@
+/** Operator-only, explicit-ID repair. Never infers that missing events prove inactivity. */
+import { readFile } from "node:fs/promises";
+import { dbSearchPath, getSettings } from "@opengeni/config";
+import { SESSION_EVENT_RAW_DELTA_TYPES } from "@opengeni/contracts";
+import {
+  createDb,
+  lockSessionEventWriteRows,
+  withWorkspaceRls,
+  rlsContextForWorkspace,
+  type Database,
+} from "@opengeni/db";
+import { withRestoredSessionActivityRlsContext } from "../packages/db/src/database";
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+
+const timestamp = z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/);
+const Candidate = z
+  .object({
+    sessionId: z.string().uuid(),
+    expectedUpdatedAt: timestamp,
+    expectedRevision: z.string().regex(/^\d+$/),
+    expectedSequence: z.number().int().nonnegative(),
+    proposedUpdatedAt: timestamp,
+  })
+  .strict();
+export const RecencyRepairManifest = z
+  .object({
+    version: z.literal(1),
+    workspaceId: z.string().uuid(),
+    // The operator must independently establish the bookkeeping incident. This is
+    // an attestation, not a conclusion inferred from retained event coverage.
+    evidence: z.string().min(1).max(2000),
+    candidates: z.array(Candidate).min(1).max(50),
+  })
+  .strict()
+  .refine(
+    (m) => new Set(m.candidates.map((c) => c.sessionId)).size === m.candidates.length,
+    "duplicate session IDs",
+  );
+export type RecencyRepairPlan = z.infer<typeof RecencyRepairManifest>;
+
+type EvidenceRow = z.infer<typeof Candidate> & { status: string; activeTurnId: string | null };
+async function evidence(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<EvidenceRow | null> {
+  const rows = await db.execute(sql`
+    select s.id as "sessionId", s.status, s.active_turn_id as "activeTurnId",
+      to_char(s.updated_at at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') as "expectedUpdatedAt",
+      s.activity_revision::text as "expectedRevision",
+      coalesce(c.last_sequence, s.last_sequence) as "expectedSequence",
+      to_char(greatest(s.created_at,
+        (select max(e.occurred_at) from session_events e
+          where e.workspace_id = s.workspace_id and e.session_id = s.id
+            and e.type not in (${sql.join(
+              SESSION_EVENT_RAW_DELTA_TYPES.map((t) => sql`${t}`),
+              sql`, `,
+            )})),
+        (select max(greatest(t.started_at, t.finished_at)) from session_turns t
+          where t.workspace_id = s.workspace_id and t.session_id = s.id)
+      ) at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') as "proposedUpdatedAt"
+    from sessions s left join session_event_cursors c
+      on c.workspace_id = s.workspace_id and c.session_id = s.id
+    where s.workspace_id = ${workspaceId}::uuid and s.id = ${sessionId}::uuid
+  `);
+  return (rows as unknown as EvidenceRow[])[0] ?? null;
+}
+
+export async function previewSessionRecencyRepair(
+  db: Database,
+  workspaceId: string,
+  sessionIds: string[],
+  incidentEvidence: string,
+): Promise<RecencyRepairPlan> {
+  z.string().uuid().parse(workspaceId);
+  z.array(z.string().uuid()).min(1).max(50).parse(sessionIds);
+  const candidates = [];
+  for (const sessionId of sessionIds) {
+    const row = await db.transaction(
+      async (transaction) => {
+        const tx = transaction as unknown as Database;
+        await tx.execute(sql`set local lock_timeout = '5s'`);
+        await tx.execute(sql`set local statement_timeout = '10s'`);
+        return await withWorkspaceRls(tx, workspaceId, async (scoped) =>
+          evidence(scoped, workspaceId, sessionId),
+        );
+      },
+      { isolationLevel: "repeatable read", accessMode: "read only" },
+    );
+    if (!row || row.status !== "idle" || row.activeTurnId !== null) {
+      throw new Error(`Session ${sessionId} is unavailable or not idle`);
+    }
+    const { status: _status, activeTurnId: _activeTurnId, ...candidate } = row;
+    if (candidate.proposedUpdatedAt >= candidate.expectedUpdatedAt) {
+      throw new Error(`Session ${sessionId} has no older reconstruction candidate`);
+    }
+    candidates.push(candidate);
+  }
+  return RecencyRepairManifest.parse({
+    version: 1,
+    workspaceId,
+    evidence: incidentEvidence,
+    candidates,
+  });
+}
+
+export async function applySessionRecencyRepair(db: Database, input: RecencyRepairPlan) {
+  const plan = RecencyRepairManifest.parse(input);
+  const results = [];
+  for (const candidate of plan.candidates) {
+    const outcome = await db.transaction(async (transaction) => {
+      const outer = transaction as unknown as Database;
+      // Bound the workspace lookup and tenancy fence as well as the row locks.
+      await outer.execute(sql`set local lock_timeout = '5s'`);
+      await outer.execute(sql`set local statement_timeout = '10s'`);
+      const context = {
+        ...(await rlsContextForWorkspace(outer, plan.workspaceId)),
+        workspaceId: plan.workspaceId,
+      };
+      return await withRestoredSessionActivityRlsContext(outer, context, async (tx) => {
+        await tx.execute(sql`set local lock_timeout = '5s'`);
+        await tx.execute(sql`set local statement_timeout = '10s'`);
+        // Canonical session + cursor locks serialize semantic and raw event writers.
+        await lockSessionEventWriteRows(tx, {
+          workspaceId: plan.workspaceId,
+          sessionIds: [candidate.sessionId],
+          controlLock: "share",
+        });
+        const current = await evidence(tx, plan.workspaceId, candidate.sessionId);
+        if (!current || current.status !== "idle" || current.activeTurnId !== null) return "stale";
+        if (current.expectedUpdatedAt === candidate.proposedUpdatedAt) return "already_applied";
+        if (
+          candidate.proposedUpdatedAt >= candidate.expectedUpdatedAt ||
+          current.expectedUpdatedAt !== candidate.expectedUpdatedAt ||
+          current.expectedRevision !== candidate.expectedRevision ||
+          current.expectedSequence !== candidate.expectedSequence ||
+          current.proposedUpdatedAt !== candidate.proposedUpdatedAt
+        )
+          return "stale";
+        await tx.execute(sql`update sessions set updated_at = ${candidate.proposedUpdatedAt}::timestamptz
+        where workspace_id = ${plan.workspaceId}::uuid and id = ${candidate.sessionId}::uuid`);
+        // The normal outer activity gate advances the revision; never rewind it.
+        return "applied";
+      });
+    });
+    results.push({ sessionId: candidate.sessionId, outcome });
+  }
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const value = (name: string) => {
+    const index = args.indexOf(name);
+    return index < 0 ? undefined : args[index + 1];
+  };
+  const applyPath = value("--apply");
+  const settings = getSettings();
+  const searchPath = dbSearchPath(settings);
+  const client = createDb(settings.databaseUrl, searchPath ? { searchPath } : {});
+  try {
+    if (applyPath) {
+      const plan = RecencyRepairManifest.parse(JSON.parse(await readFile(applyPath, "utf8")));
+      console.log(JSON.stringify(await applySessionRecencyRepair(client.db, plan), null, 2));
+    } else {
+      const plan = await previewSessionRecencyRepair(
+        client.db,
+        value("--workspace-id") ?? "",
+        (value("--session-ids") ?? "").split(","),
+        value("--evidence") ?? "",
+      );
+      console.log(JSON.stringify(plan, null, 2));
+    }
+  } finally {
+    await client.close();
+  }
+}
+if (import.meta.main) await main();


### PR DESCRIPTION
Changing the workspace Codex source reset affinities and stamped every affected session with the same current time, making old conversations appear recently active. Automatic policy assignment and last-used credential recording could also advance recency. Preserve the existing semantic `updated_at` and activity-revision contract for these bookkeeping writes; explicit manual account switches still count as activity.

The rolling migration replaces the reset trigger without changing historical migrations or blanket-rewriting timestamps. A documented operator tool can preview and apply at most 50 explicitly reviewed idle-session repairs, using microsecond timestamp/revision/event-sequence checks and canonical locks. It refuses stale evidence, preserves RLS and event history, and advances the normal discovery revision. Historical repairs are not run by deployment.

Validation:
- Reproduced the original bug with failing real-Postgres regression tests before fixing it.
- 16 Codex/repair tests pass, including source changes in both directions, cross-workspace isolation, policy and manual paths, stale/idempotent repairs, raw deltas, and blocked tenancy-fence timeouts.
- 41 broader activity-gate, event-monitoring, Codex inheritance and resolver tests pass; 8 release-schema contract tests pass.
- Full 32-project typecheck passes; migration ordinal, schema registration, RLS backfill, test-budget and docs guards pass.
- Independent design and implementation reviews completed; implementation approved after addressing the timeout finding.

Fixes OPE-463

## Summary by Sourcery

Preserve conversation recency during Codex bookkeeping while providing a guarded workflow for explicitly reviewed historical repairs.

New Features:
- Add an operator-reviewed tool for safely previewing and applying up to 50 explicit historical session-recency repairs.

Bug Fixes:
- Prevent Codex workspace source resets, automatic policy assignments, and last-used credential bookkeeping from altering conversation recency or session ordering.
- Preserve manual account switches and normal semantic activity as recency updates.

Enhancements:
- Add a rolling migration that corrects workspace Codex affinity resets without rewriting historical timestamps or event history.
- Make historical repairs validate precise timestamps, activity revisions, event sequences, idle state, tenancy scope, and concurrent changes before applying idempotently.

Build:
- Add Zod as a runtime dependency for repair-manifest validation.

Deployment:
- Register rolling migration 0426 for the Codex bookkeeping recency fix without performing historical repairs during deployment.

Documentation:
- Document the recency semantics, deployment expectations, and reviewed historical repair workflow for operators.

Tests:
- Add real-PostgreSQL regression coverage for Codex bookkeeping, manual activity behavior, cross-workspace isolation, stale and idempotent repairs, raw event handling, and tenancy-lock timeouts.
- Update release-schema contract coverage for the new migration.