### PR TITLE
docs: publish the chat integration guide and access reference

### DIFF
--- a/docs-site/concepts/memory-and-knowledge.mdx
+++ b/docs-site/concepts/memory-and-knowledge.mdx
@@ -14,6 +14,8 @@ Memory is retrieval context, never conversation history: the model sees relevant
 
 Integrations can choose a per-session `memoryScope`: `workspace`, `user`, `session`, or `off`. User and session scopes can read shared workspace facts, but their saves, corrections, and deletions stay within their own memory layer. Reading a shared fact does not allow a private chat to change it for everyone.
 
+The [chat integration](/guides/integrate-your-product#choose-agent-access-and-memory) exposes this as `memory: "workspace" | "user" | "session" | false`. If omitted, memory follows the chat's `agentAccess` scope, which defaults to `"session"`. User memory follows the product's opaque user label within the tenant and requires that label. `false` disables Memory tools, not the conversation's durable history, and it does not change which other sessions the agent may reach. Memory retrieval and saving also require Memory to be enabled for the workspace.
+
 ## Documents and Knowledge
 
 Upload documents or sync them from connected sources such as Google Drive. OpenGeni indexes them for hybrid vector and keyword search, and agents retrieve permission-filtered passages with citations. A separate curated Knowledge lane holds human-reviewed claims for facts that should not change without review.

--- a/docs-site/concepts/sessions.mdx
+++ b/docs-site/concepts/sessions.mdx
@@ -4,7 +4,7 @@ description: "The durable unit of agent work, and how input, streaming, and cont
 icon: "comments"
 ---
 
-A **session** is one durable conversation and workstream: its history, policy, visibility, and compute context. Sessions belong to a workspace, and every API route for them is workspace-scoped.
+A **session** is one durable conversation and workstream: its history, policy, visibility, and compute context. Sessions belong to a workspace. Operational session routes use that workspace; an organization-wide inventory can list readable sessions across shared workspaces.
 
 ## Three identities
 
@@ -45,6 +45,20 @@ An agent can spawn child sessions for parallel or delegated work. Children run a
 ## Visibility
 
 Workspaces are shared by their members, and sessions in a shared workspace are visible to members by default. An organization owner can allow members to create "Only me" sessions that only their owner can see. Personal workspaces belong to one person.
+
+## Agent access in product integrations
+
+`agentAccess` controls how an agent reaches other session trees within its workspace:
+
+| Scope       | Agent reach                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| `session`   | Its own conversation tree, including children                                                  |
+| `user`      | Other trees with the same non-null product/user label, when the target also permits access     |
+| `workspace` | Other trees in the workspace, subject to the target's scope and existing private-session rules |
+
+The more restrictive side wins across trees. Children inherit the parent's scope and can only narrow it. These rules do not make product-created chats invisible to authorized human workspace members or organization API keys. The product backend must still authorize each user's requests.
+
+The chat API defaults to `agentAccess: "session"`, while raw session creation defaults to `"workspace"`. An integration can separately choose where the agent saves [Memory](/concepts/memory-and-knowledge). Access scope and memory are frozen when a conversation is created; reopening the same conversation does not reconfigure them. See [Integrate your product](/guides/integrate-your-product#choose-agent-access-and-memory).
 
 ## Browsing and archiving
 

--- a/docs-site/guides/integrate-your-product.mdx
+++ b/docs-site/guides/integrate-your-product.mdx
@@ -1,96 +1,151 @@
 ---
 title: "Integrate your product"
-description: "Put durable agent sessions behind your own backend with the SDK and React components."
+description: "Add durable agent chat with one server handler, your own authentication, and per-conversation access and memory."
 icon: "plug"
 ---
 
-The canonical integration keeps OpenGeni as a service behind your product backend. Your product owns its users, tenants, business data, and navigation. OpenGeni owns durable sessions, turns, events, approvals, files, tools, and execution.
+Put OpenGeni behind your product's existing chat endpoint with `@opengeni/sdk/chat`. Your backend authenticates users and chooses their tenant. OpenGeni maps each tenant to an organization workspace and each conversation to a durable session, then handles execution, history, streaming, approvals, and questions.
 
-```text
-product browser or mobile client
-            |  your own authenticated routes
-            v
-your product backend
-  - authenticates product users
-  - maps product tenant -> OpenGeni workspace id
-  - holds the organization API key
-  - stores its own Skills
-            |  @opengeni/sdk
-            v
-OpenGeni API
-  - organization workspaces
-  - sessions, turns, events, files, tools, execution
-```
+The browser talks to your backend. The organization API key stays on that backend.
 
-## 1. Create an organization API key
+<Note>
+  Use the repository's workspace packages for this integration. Stable `3.3.2` packages do not
+  export `/chat`, and `@opengeni/react@3.8.0-canary.0` has a broken published `/chat` export. The
+  source workspace includes the component. Use a deployment containing the [chat
+  integration](https://github.com/Cloudgeni-ai/opengeni/pull/2310), and set its API URL explicitly.
+  Merging the feature into `main` does not update the hosted API by itself.
+</Note>
 
-An organization API key is held only by your backend. Create it in organization settings or through the organization API-key routes. The token is shown once; store it in your secret manager and rotate by creating a replacement before revoking the old key.
+## Connect your backend
 
-Never ship it to browser bundles, mobile apps, prompts, tool output, or logs.
+Create a **full-access organization API key** in organization settings or through the organization API-key routes. Store its one-time token in your secret manager. A read-only key can inspect sessions but cannot create chats or send messages. See [Authentication](/reference/authentication#organization-key-access).
 
-## 2. Map each tenant to a workspace
-
-For each product boundary that may share agent authority and resources (a tenant, a project, a user), idempotently resolve an organization workspace keyed by a stable external id:
+Clone the [repository](https://github.com/Cloudgeni-ai/opengeni), run `bun install` at its root, and start with the [chat quickstart](https://github.com/Cloudgeni-ai/opengeni/tree/main/examples/chat-quickstart). It resolves the SDK and React workspace packages from source. Adapt its server and component using the examples below; replace its demo authentication with your product's real verifier.
 
 ```ts
-import { OpenGeniClient } from "@opengeni/sdk";
+import { OpenGeni, createChatHandler } from "@opengeni/sdk/chat";
+import { authenticate } from "./auth"; // Your product's server-side authentication.
 
-const client = new OpenGeniClient({
+const og = new OpenGeni({
   baseUrl: process.env.OPENGENI_API_BASE_URL!,
-  apiKey: process.env.OPENGENI_ORGANIZATION_API_KEY!,
+  apiKey: process.env.OPENGENI_API_KEY!,
+  organizationId: process.env.OPENGENI_ORGANIZATION_ID!,
+  source: "acme-product",
 });
 
-const { workspace, created } = await client.ensureWorkspace({
-  accountId: process.env.OPENGENI_ORGANIZATION_ID!,
-  externalSource: "acme-product",
-  externalId: tenant.id,
-  name: tenant.displayName,
-});
-```
+export const handleChat = createChatHandler(og, {
+  resolve: async (request) => {
+    const me = await authenticate(request);
+    if (!me) return new Response("Unauthorized", { status: 401 });
 
-Persist the returned workspace id next to your tenant record. Retries return the same workspace with `created: false`.
-
-## 3. Create sessions in that workspace
-
-```ts
-const session = await client.createSession(workspace.id, {
-  initialMessage: userMessage,
-  idempotencyKey: request.id,
-  skills: selectedSkills, // your own Skill content
-  tools: selectedIntegrationServers, // MCP servers the agent may use
+    return {
+      tenant: me.tenantId,
+      user: me.userId,
+      agentAccess: "session",
+      memory: "user",
+    };
+  },
 });
 ```
 
-Use an idempotency key whenever a product request may be retried. Skills are your product's data: store and version them with your integration code and pass them per session.
+`authenticate` is your existing cookie or bearer verifier, not an OpenGeni function. It must return the user's authorized tenant and user ID; never take either directly from the request body or an unverified identity header. Keep `source` stable: it identifies your product when mapping tenants and users.
 
-## 4. Stream events to your users
+Set `OPENGENI_API_BASE_URL` to the compatible deployment from the note above. If omitted, `OpenGeni` defaults to `https://app.opengeni.ai`, so do not rely on that default before the hosted API supports this feature. Each tenant's workspace is resolved idempotently on first use; the conversation's session is created on its first message. These are organization workspaces, not Personal workspaces.
 
-Proxy the session's SSE stream through your own route so the organization key stays server-side. The re-emitted wire format is identical, so the browser consumes it with the same SDK or a plain `EventSource`, including resume after a reconnect:
+## Mount the handler
 
-```ts
-import { proxySessionEventStream } from "@opengeni/sdk";
+Register the same `handleChat(request)` function for all three routes in your server framework:
 
-export function GET(request: Request): Response {
-  // authenticate your user and resolve their session, then:
-  return proxySessionEventStream(client, workspaceId, sessionId, {
-    after: request,
-    signal: request.signal,
-  });
+| Route                    | Purpose                                                              |
+| ------------------------ | -------------------------------------------------------------------- |
+| `GET /api/chat`          | Restore messages, unresolved approvals/questions, and session status |
+| `POST /api/chat`         | Send a message and stream the reply                                  |
+| `POST /api/chat/respond` | Answer a pending approval or question and stream the continuation    |
+
+Protect all three routes through the handler's `resolve` hook. A framework's `POST` export for `/api/chat` does not automatically register `/api/chat/respond`.
+
+Keep one stable conversation ID per chat thread. The React component sends it in `x-opengeni-conversation`; the handler scopes it to the authenticated user. Two users supplying the same conversation ID reach different sessions. If your host omits `user`, it must return an authorized `conversation` from `resolve` itself. Host-supplied conversation IDs take precedence over client IDs.
+
+## Render the chat
+
+Use your product's authenticated user and tenant state to render the component:
+
+```tsx
+import { OpenGeniChat } from "@opengeni/react/chat";
+import "@opengeni/react/compiled.css";
+
+export function ProductChat({
+  tenantId,
+  userId,
+  conversationId,
+}: {
+  tenantId: string;
+  userId: string;
+  conversationId: string;
+}) {
+  return (
+    <OpenGeniChat
+      handlerUrl="/api/chat"
+      conversation={conversationId}
+      authKey={JSON.stringify([tenantId, userId])}
+    />
+  );
 }
 ```
 
-## 5. Render the timeline
+The component restores history and unresolved decisions on reload, streams replies, and renders approval and structured-question forms. It needs no SDK client or OpenGeni credential in the browser.
 
-`@opengeni/react` provides the session timeline, composer, status badges, and an optional sandbox workbench, all themed through CSS variables. Point it at your proxy routes and it renders streaming messages, tool calls, approvals, and structured questions with the same behavior as the OpenGeni console.
+For cookie authentication, change `authKey` when the signed-in user or tenant changes, and unmount the chat on sign-out. This clears messages, pending cards, drafts, and in-flight requests before loading the new identity's history, even if the conversation ID stays the same. `authKey` is a local reset key, not an authentication credential, and is never sent to the server.
 
-## 6. Give the agent your tools
+If your product uses an auth header, pass it through `headers`. Changed header values also reset the chat. Header callbacks are evaluated on each host render, so re-render the host when their credentials change. Your backend's `resolve` hook still owns authorization.
 
-Expose your product's data and actions as an authenticated MCP server and pass it in the session's tools. The agent reads and mutates the same records your human workflow uses, and mutations can be gated by approval.
+## Choose agent access and memory
 
-## Worked example
+Use one workspace per customer when their documents, instructions, Connections, and integrations are shared. Choose which other conversations an agent can reach and which memories it can save within that workspace:
 
-The [Northstar support example](https://github.com/Cloudgeni-ai/opengeni/tree/main/examples/northstar-support) is a small support SaaS showing the whole loop: backend-created sessions, a proxied stream, an embedded timeline, and an authenticated MCP server whose tools operate on the product's tickets.
+| Product behavior                                 | `agentAccess` | `memory`      |
+| ------------------------------------------------ | ------------- | ------------- |
+| Each conversation works independently            | `"session"`   | `"session"`   |
+| Independent conversations remember the same user | `"session"`   | `"user"`      |
+| One user's conversations can collaborate         | `"user"`      | `"user"`      |
+| The tenant's conversations can collaborate       | `"workspace"` | `"workspace"` |
 
-## Authority in depth
+The chat API defaults to `agentAccess: "session"`; omitted `memory` follows `agentAccess`. Supply a `user` label for user-scoped access and memory. Use `memory: false` to disable Memory tools for that conversation; its durable conversation history remains available. Memory also needs to be enabled for the workspace.
 
-The repository's [product integration guide](https://github.com/Cloudgeni-ai/opengeni/blob/main/docs/product-integration.md) is the canonical contract for key scopes, workspace kinds, Personal-workspace exclusion, and delegated tokens for hosts acting on behalf of their own users. See also [Authentication](/reference/authentication).
+A session can reach its own child tree. Across trees, both sessions must permit access, and the more restrictive setting wins. User-scoped access requires the same product/user label. An optional embedding-host restriction can narrow access further.
+
+User and session memory can read shared workspace facts, but their saves, corrections, and deletions stay in their own memory layer. Memory does not grant access to another session's transcript. See [Memory and knowledge](/concepts/memory-and-knowledge).
+
+These choices are set when the session is created. Reopening an existing conversation with different options does not change its stored policy. The raw session API uses `agentAccess`, `endUser: { source, id }`, and `memoryScope` (including `"off"`); its default agent access remains `"workspace"`.
+
+<Note>
+  Agent access is separate from human visibility. These product-created sessions remain shared for
+  authorized workspace members and organization API keys, including read-only organization keys.
+  Your backend must enforce product-user access on every request. An end-user label is not an
+  OpenGeni login, and `agentAccess` does not restrict the organization key.
+</Note>
+
+Use separate workspaces when groups need different workspace resources or integrations. See [Sessions and turns](/concepts/sessions#agent-access-in-product-integrations) for the distinction between agent reach and visibility.
+
+## Keep an existing chat client
+
+Set the handler's `format` when your product already has a text-chat client:
+
+| `format`             | Client protocol                                           |
+| -------------------- | --------------------------------------------------------- |
+| `"native"` (default) | `OpenGeniChat` or a client consuming OpenGeni chat chunks |
+| `"vercel"`           | Vercel AI SDK UI message stream                           |
+| `"openai-chat"`      | OpenAI Chat Completions-shaped requests and responses     |
+| `"openai-responses"` | OpenAI Responses-shaped requests and responses            |
+
+The Vercel and OpenAI adapters send the latest user message and import earlier text messages from that request as context only when creating the conversation. After that, OpenGeni owns the history. These are text-chat adapters, not replacements for every feature of those APIs; execution and approval handling remain OpenGeni's. The history and `/respond` routes keep their native JSON and SSE contracts regardless of `format`.
+
+See the [SDK reference](/reference/sdk#chat-api) and the [runnable chat quickstart](https://github.com/Cloudgeni-ai/opengeni/tree/main/examples/chat-quickstart) for the complete setup. Replace the example's demo authentication before using it with real users.
+
+## Use the full session API when needed
+
+`og.client` exposes the ordinary `OpenGeniClient`. The chat's `workspaceId` and `sessionId` address the same durable session, so you can add files, tools, voice, and an embedded session timeline as your product grows.
+
+For direct session integration, explicitly resolve tenant workspaces with `ensureWorkspace`, create sessions with `createSession`, and proxy the session event stream through your authenticated backend. That path gives your product control over session orchestration and rendering. See the [canonical product integration guide](https://github.com/Cloudgeni-ai/opengeni/blob/main/docs/product-integration.md) and the [Northstar support example](https://github.com/Cloudgeni-ai/opengeni/tree/main/examples/northstar-support).
+
+Keep product Skills in your product's versioned configuration and pass the selected definitions with session creation. Expose product data and actions through authenticated MCP tools, with approval where needed.

--- a/docs-site/reference/authentication.mdx
+++ b/docs-site/reference/authentication.mdx
@@ -4,7 +4,7 @@ description: "How callers identify themselves to the OpenGeni API."
 icon: "key"
 ---
 
-The API is workspace-scoped: protected routes carry the workspace id in the URL, and every request resolves to an access grant before route code touches workspace data. Which credential you use depends on who is calling.
+Session operations are workspace-scoped; organization routes manage shared workspaces, keys, and session inventory across them. Every request resolves to an access grant before route code touches protected data. Which credential you use depends on who is calling.
 
 ## Choosing a credential
 
@@ -18,13 +18,36 @@ The API is workspace-scoped: protected routes carry the workspace id in the URL,
 
 ## Credentials
 
-| Credential             | Transport                       | Lifetime                 | Notes                                                                                                                                                                                                                                                  |
-| ---------------------- | ------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Organization API key   | `Authorization: Bearer ogk_...` | Until revoked or expired | Created through organization settings or the organization API-key routes. Shown once, stored hashed. Fixed scope: read the organization, create and administer workspaces, manage keys. Usable only with organization workspaces, never from a browser |
-| Workspace API key      | `Authorization: Bearer ogk_...` | Until revoked or expired | Issued by an authorized caller for one workspace; cannot exceed that workspace's grant                                                                                                                                                                 |
-| Delegated access token | `Authorization: Bearer ogd_...` | Short, embedded expiry   | HMAC-signed by your host with `OPENGENI_DELEGATION_SECRET`; embeds workspace, account, and permissions                                                                                                                                                 |
-| Deployment access key  | `x-opengeni-access-key` header  | Static                   | Optional coarse perimeter enabled by `OPENGENI_AUTH_REQUIRED=true`. Not an identity                                                                                                                                                                    |
-| Managed web session    | Cookie                          | Session                  | Email and password sign-in in `managed` mode                                                                                                                                                                                                           |
+| Credential             | Transport                       | Lifetime                 | Notes                                                                                                                                                                                                        |
+| ---------------------- | ------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Organization API key   | `Authorization: Bearer ogk_...` | Until revoked or expired | Created through organization settings or the organization API-key routes. Shown once, stored hashed. Full or read-only access to organization workspaces; Personal workspaces are excluded. Server-side only |
+| Workspace API key      | `Authorization: Bearer ogk_...` | Until revoked or expired | Issued by an authorized caller for one workspace; cannot exceed that workspace's grant                                                                                                                       |
+| Delegated access token | `Authorization: Bearer ogd_...` | Short, embedded expiry   | HMAC-signed by your host with `OPENGENI_DELEGATION_SECRET`; embeds workspace, account, and permissions                                                                                                       |
+| Deployment access key  | `x-opengeni-access-key` header  | Static                   | Optional coarse perimeter enabled by `OPENGENI_AUTH_REQUIRED=true`. Not an identity                                                                                                                          |
+| Managed web session    | Cookie                          | Session                  | Email and password sign-in in `managed` mode                                                                                                                                                                 |
+
+## Organization key access
+
+Read-only organization keys and organization-wide session inventory require a deployment containing the [chat integration changes](https://github.com/Cloudgeni-ai/opengeni/pull/2310). See the [package and deployment setup](/guides/integrate-your-product#connect-your-backend) for availability.
+
+Choose an access tier when creating an organization key:
+
+| `access`           | Use                                                                                           |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| `"full"` (default) | Provision workspaces, create and control sessions, and administer keys                        |
+| `"read"`           | Inventory shared workspaces and read their sessions, events, and files for reporting or audit |
+
+Create a read-only key with `createOrganizationApiKey(organizationId, { name, access: "read" })` from an authorized administrative backend. It cannot create sessions, send or control turns, change configuration, or mint other keys. Use a full-access key for the chat handler, which creates tenant workspaces and sends messages.
+
+Both tiers can use `listOrganizationSessions` or `iterateOrganizationSessions` to discover readable sessions across the organization's shared workspaces. Personal workspaces and Only me sessions are excluded. Agent access scopes and end-user filters do not restrict the organization key's authority.
+
+## Authenticate users of your chat
+
+`createChatHandler` uses your product's `resolve(request)` hook on sends, history reads, and approval/question responses. Verify the product's session cookie or bearer, then return the user's allowed tenant and user ID. The organization key authenticates your backend to OpenGeni; it does not authenticate a product user to your backend.
+
+The handler namespaces client conversation IDs to the resolved user. An opaque end-user label is not an OpenGeni account and does not grant authority. If you omit the user label, the host must resolve an authorized conversation itself.
+
+For the React component, bind `authKey` to your signed-in user and tenant when using cookie authentication, change it on identity switches, and unmount on sign-out. This clears the old transcript and pending requests in the browser. The key stays local and does not replace server-side authentication. See [Integrate your product](/guides/integrate-your-product).
 
 ## Rules that hold everywhere
 

--- a/docs-site/reference/sdk.mdx
+++ b/docs-site/reference/sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SDK"
-description: "The TypeScript SDK and React components for the OpenGeni API."
+description: "Choose the chat handler and component or the full TypeScript session client."
 icon: "code"
 ---
 
@@ -9,7 +9,55 @@ icon: "code"
   repository are the authority for exact method signatures and the current version.
 </Note>
 
-## @opengeni/sdk
+## Choose an entry point
+
+| Import                 | Use it for                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `@opengeni/sdk/chat`   | Server-side chat, tenant mapping, conversation identity, and a host HTTP handler        |
+| `@opengeni/react/chat` | A chat component that talks to your handler and restores messages and pending decisions |
+| `@opengeni/sdk`        | The full session, workspace, file, tool, and event API                                  |
+
+For a product adding chat, start with [Integrate your product](/guides/integrate-your-product). Keep the organization API key on your backend.
+
+## Chat API
+
+Use the repository workspace packages and a compatible server deployment for these examples. Stable `3.3.2` lacks `/chat`, and the React `3.8.0-canary.0` package cannot resolve its published `/chat` entry point. Follow the [source quickstart and deployment setup](/guides/integrate-your-product#connect-your-backend) before using them.
+
+```ts
+import { OpenGeni } from "@opengeni/sdk/chat";
+
+const og = new OpenGeni({
+  baseUrl: process.env.OPENGENI_API_BASE_URL!,
+  apiKey: process.env.OPENGENI_API_KEY!,
+  organizationId: process.env.OPENGENI_ORGANIZATION_ID!,
+  source: "acme-product",
+});
+
+const chat = await og.chat({
+  tenant: "acme",
+  user: "u_42",
+  conversation: "c_9",
+  agentAccess: "session",
+  memory: "user",
+});
+const reply = await chat.send("What did we decide last time?");
+console.log(reply.text);
+```
+
+In an authenticated product, resolve `tenant` and `user` on your server. The session is created on first send, and the same product, tenant, user, and conversation IDs reopen it. `agentAccess` defaults to `"session"`; `memory` defaults to the same scope and accepts `false` to disable Memory tools. Both settings apply at creation, not when reopening an existing session.
+
+| API                                          | Purpose                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `chat.send(message)`                         | Aggregate a reply with `text`, `status`, and any pending decision          |
+| `chat.stream(message)`                       | Iterate text, tool activity, pending decisions, and the final reply        |
+| `chat.snapshot()`                            | Restore messages, unresolved decisions, and session status                 |
+| `chat.respond(input)`                        | Continue after a human approves/rejects a tool or answers/skips a question |
+| `createChatHandler(og, { resolve, format })` | Serve your authenticated chat, history, and decision routes                |
+| `og.client`                                  | Use the full SDK on the same session                                       |
+
+A reply can be `completed`, `pending`, or `cancelled`. Present pending requests to the user before calling `respond`; a text reply alone does not imply that the turn completed. The handler supports native, Vercel UI message stream, OpenAI Chat Completions, and OpenAI Responses text-chat formats. Its history and decision endpoints remain native. See the [handler setup and protocol choices](/guides/integrate-your-product#mount-the-handler) for route registration and history ownership.
+
+## Full TypeScript client
 
 A framework-agnostic TypeScript client with zero runtime dependencies. It needs only WHATWG `fetch` and streams, so it runs in Node 18+, Bun, Deno, browsers, and edge runtimes.
 
@@ -25,6 +73,7 @@ const client = new OpenGeniClient({
   apiKey: process.env.OPENGENI_API_KEY!,
 });
 
+const workspaceId = process.env.OPENGENI_WORKSPACE_ID!;
 const session = await client.createSession(workspaceId, {
   initialMessage: "Investigate the failing deploy on staging",
   resources: [{ kind: "repository", uri: "https://github.com/acme/app.git", ref: "main" }],
@@ -41,7 +90,8 @@ What it covers:
 
 | Area                         | Highlights                                                                                                                        |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Organizations and workspaces | Organization API keys, idempotent `ensureWorkspace`, workspace settings                                                           |
+| Organizations and workspaces | Full/read-only organization API keys, idempotent `ensureWorkspace`, workspace settings                                            |
+| Organization sessions        | Paginated `listOrganizationSessions` and `iterateOrganizationSessions` across shared workspaces                                   |
 | Sessions                     | Create with resources, files, Skills, tools, a goal, and a compute target; list, get, archive, cancel                             |
 | Input and control            | Send, Steer, queue management, Pause and Resume, approval decisions, human-input answers                                          |
 | Events                       | Replay by sequence, bounded event pages, and a streaming iterator with reconnect, resume, gap backfill, and duplicate suppression |
@@ -52,20 +102,25 @@ What it covers:
 
 Full reference: [packages/sdk/README.md](https://github.com/Cloudgeni-ai/opengeni/blob/main/packages/sdk/README.md).
 
+Organization session listings exclude Personal workspaces and Only me sessions. Each row includes its `workspaceId` for subsequent session, event, and file reads. Use `nextCursor` to determine whether another page exists, even when a page is shorter than the requested limit. [Read-only organization keys](/reference/authentication#organization-key-access) support this reporting path but cannot create chats or send messages.
+
 ## @opengeni/react
 
 Hooks and styled components built on the SDK: live session streaming, a composer, a timeline that renders streaming deltas, tool calls, approvals, and child-session status, session status badges, and workspace fleet tiles. Every visual decision routes through `--og-*` CSS variables, so a host rebrands by overriding tokens. Dark mode is the default; light is opt-in.
 
 Subpaths keep the root import lean:
 
-| Import                     | Contents                                             |
-| -------------------------- | ---------------------------------------------------- |
-| `@opengeni/react`          | Timeline, composer, hooks, and the sandbox workbench |
-| `@opengeni/react/composer` | Advanced composer composition                        |
-| `@opengeni/react/machines` | Connected Machines dashboard and enrollment flow     |
-| `@opengeni/react/realtime` | Voice controls, lazily loadable                      |
+| Import                     | Contents                                                               |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `@opengeni/react`          | Timeline, composer, hooks, and the sandbox workbench                   |
+| `@opengeni/react/chat`     | `OpenGeniChat`, using your host handler with no provider or SDK client |
+| `@opengeni/react/composer` | Advanced composer composition                                          |
+| `@opengeni/react/machines` | Connected Machines dashboard and enrollment flow                       |
+| `@opengeni/react/realtime` | Voice controls, lazily loadable                                        |
 
 Full reference: [packages/react/README.md](https://github.com/Cloudgeni-ai/opengeni/blob/main/packages/react/README.md).
+
+`OpenGeniChat` takes `handlerUrl`, a stable `conversation`, and optional authentication headers. With cookie authentication, also provide `authKey` from your authenticated user and tenant, update it on identity changes, and unmount on sign-out. Changed headers or `authKey` clear private UI state and abort old requests before restoring the new history. `authKey` is never sent to the server. Import `@opengeni/react/compiled.css` for the supplied styles. See the [React integration example](/guides/integrate-your-product#render-the-chat).
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

The public site still taught manual session orchestration after #2310 introduced the chat facade. Update the integration guide, SDK reference, authentication, sessions, and memory pages so readers can find the handler and React component, register all three routes, authenticate each product user, and choose agent access separately from memory and human visibility.

Document restored history and decisions, `authKey` on identity switches, text-adapter limits, and read-only organization keys and session inventory. Preserve links to the full SDK and canonical integration guide.

Availability is explicit: stable npm 3.3.2 lacks `/chat`; React 3.8.0-canary.0 advertises a missing `dist/chat.tsx`. Point readers to the source workspace quickstart and a compatible deployment instead of a broken npm installation. The published React export and server rollout are tracked as follow-ups in OPE-460.

## Testing

- [x] Mintlify build validation and broken-link checks pass.
- [x] `bun scripts/check-docs-refs.ts`, changed-file formatting, and `git diff --check` pass.
- [x] Local Mintlify browser preview of integration, SDK, and authentication pages; desktop and mobile layout checked, with working section anchors and no page-width overflow.
- [x] Four TypeScript/React examples typecheck against the published SDK and React source matching main exactly. The source alias is necessary because the actual canary React export fails resolution; the fresh npm consumer reproduced that release defect.
- Full runtime suites are not needed for this five-page documentation-only change; CI run 34315025014 passed the full impact pipeline: 38 successful jobs and 10 conditional skips.

## Delivery integrity

- [x] Branch created from main `6ae37a3c69ce44f8aecea8cdcc27a775e53a8b51`; candidate stays frozen during CI and review.
- [x] No runtime code, package metadata, migrations, or CI configuration changed.
- Fresh mergeability and material compatibility passed before merge; the merge tree matched the reviewed candidate. Mintlify Deployment succeeded on merge commit 9e1ffcfc64818caef8ef5d6b25de837be56df30a, and fresh HTTP reads confirmed the new content on all five docs.opengeni.ai pages.

## Notes

OPE-460. This closes the hosted-documentation gap; it does not publish npm packages or deploy the API.
