### PR TITLE
docs: separate agent harness and product integration from hosting

### DIFF
--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -7,19 +7,24 @@ icon: "house"
 
 OpenGeni is the platform layer that makes long-running AI agents safe to trust with real work: durable, replayable sessions; human approvals; governed credentials and memory; and a choice of where every session runs, either a managed sandbox or your own hardware.
 
-OpenGeni is the runtime, not the agent. It exposes a session-based API for creating, steering, observing, interrupting, and replaying agent runs, agnostic to what the agent does. The included web app is one client for that API. Your own products call the same API and let OpenGeni own durable session state, event history, approvals, and outputs.
+The included web app lets you use OpenGeni directly as an agent harness. Your own products can use the same session-based API to create, steer, observe, interrupt, and replay agent runs, with OpenGeni owning durable session state, event history, approvals, and outputs.
 
 ## Two ways to use it
 
 <CardGroup cols={2}>
-  <Card title="Managed" icon="cloud" href="/quickstart">
-    Sign in at app.opengeni.ai, connect a model, and start a session in minutes.
+  <Card title="Agent harness" icon="robot" href="/quickstart">
+    Use the OpenGeni app to give agents work, follow their progress, steer sessions, approve tool
+    use, and answer questions. Start with your own tasks or work with your team.
   </Card>
-  <Card title="Self-hosted" icon="server" href="/guides/self-host">
-    Run the whole control plane yourself. Apache-2.0, a Helm chart, and reference Terraform for
-    Azure, AWS, and GCP.
+  <Card title="Integrate into your product" icon="plug" href="/guides/integrate-your-product">
+    Add agent capabilities to your product with the API, SDK, and React components. Your product
+    owns its users and interface; OpenGeni handles agent execution and durable sessions.
   </Card>
 </CardGroup>
+
+## Choose a deployment
+
+For either usage mode, choose where OpenGeni runs. Use the managed service at [app.opengeni.ai](https://app.opengeni.ai), or [self-host OpenGeni](/guides/self-host) in your own infrastructure.
 
 ## What you get
 
@@ -35,8 +40,8 @@ OpenGeni is the runtime, not the agent. It exposes a session-based API for creat
   <Card title="Concepts" icon="book" href="/concepts/sessions">
     Sessions, turns, goals, approvals, compute targets, and memory.
   </Card>
-  <Card title="Integrate your product" icon="plug" href="/guides/integrate-your-product">
-    Put agent sessions behind your own backend with the TypeScript SDK and React components.
+  <Card title="SDK reference" icon="code" href="/reference/sdk">
+    Explore the chat integration, full session API, and React components for your product.
   </Card>
   <Card title="Connect a machine" icon="laptop" href="/guides/connect-a-machine">
     Enroll a laptop, build server, or GPU box and run sessions on it directly.

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -26,6 +26,8 @@ The included web app lets you use OpenGeni directly as an agent harness. Your ow
 
 For either usage mode, choose where OpenGeni runs. Use the managed service at [app.opengeni.ai](https://app.opengeni.ai), or [self-host OpenGeni](/guides/self-host) in your own infrastructure.
 
+For product integrations, check which features your chosen deployment supports. The [new chat setup](/guides/integrate-your-product#connect-your-backend) currently requires a compatible API deployment and source workspace packages; the hosted API does not yet support that setup.
+
 ## What you get
 
 - **Durable, replayable sessions.** Every event lands in a Postgres event log. Live streams backfill from it, so a browser reload, a new client, or an audit replays the same history.

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -1,10 +1,12 @@
 ---
 title: "Quickstart"
-description: "Run your first agent session on app.opengeni.ai."
+description: "Use OpenGeni as an agent harness and run your first session."
 icon: "rocket"
 ---
 
-The managed version at [app.opengeni.ai](https://app.opengeni.ai) is the fastest way to try OpenGeni. There is nothing to deploy.
+Use OpenGeni as an agent harness to give agents work, follow their progress, and steer their sessions from the app. This quickstart uses the managed service at [app.opengeni.ai](https://app.opengeni.ai), with nothing to deploy. You can also [self-host the same platform](/guides/self-host).
+
+To add agent capabilities to your own app, start with [Integrate your product](/guides/integrate-your-product).
 
 <Steps>
   <Step title="Create an account and organization">


### PR DESCRIPTION
## Summary

The introduction presented managed and self-hosted deployments as the two ways to use OpenGeni. Present the actual usage paths: use OpenGeni as an agent harness, or integrate agent capabilities into your product. Move hosting into a separate deployment section available to either mode, and align the quickstart with the harness path.

The cards link directly to the harness quickstart and product integration guide. The next-step links now include the SDK reference. Deployment guidance explicitly qualifies the new chat setup: it requires a compatible API and source packages and is not yet supported by the hosted API.

## Testing

- [x] Mintlify build validation and broken-link checks.
- [x] Documentation-reference guard, changed-file formatting and `git diff --check`.
- [x] Local Mintlify desktop/mobile preview of the cards and quickstart, including link destinations and page-width overflow.

## Delivery integrity

- [x] Two MDX pages only; no runtime or CI changes.
- [x] Started from current main `a7a60271ae8a4581a74255a8e786a882e4fbf185`; keeping the reviewed candidate frozen while CI runs.
- [x] Fresh main mergeability passed. CI run 34316677035 passed (38 successful jobs, 10 conditional skips), and Sourcery approved the final head. Mintlify Deployment succeeded on merge commit 49d558d57bfad93a98b0e79409f709a3dfceeeef; fresh HTTP reads confirmed the new homepage and quickstart wording on docs.opengeni.ai.

## Notes

OPE-460. Follow-up to #2335 based on product framing feedback.
