### PR TITLE
Align message actions and sidebar controls; fork chats from a message

### DIFF
--- a/.changeset/message-feedback-and-fork-actions.md
+++ b/.changeset/message-feedback-and-fork-actions.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/core": patch
+"@opengeni/db": minor
+"@opengeni/react": minor
+"@opengeni/sdk": patch
+---
+
+Add message action slots and an optional source message boundary for managed-human forks. The web UI places turn feedback and Fork from here beside Copy and the timestamp. Message forks preserve existing authorization and idempotency, copy only the selected canonical history prefix, and reject ambiguous, compacted, or incomplete boundaries.
+
+Migration 0429 requires draining the API and both worker pools and provisioning the updated runtime routine contract before starting the new binary.

--- a/apps/web/src/components/feedback.tsx
+++ b/apps/web/src/components/feedback.tsx
@@ -20,6 +20,7 @@ export function FeedbackDialog(props: {
   client: FeedbackClient;
   workspaceId: string;
   sessionId?: string;
+  turnId?: string;
   sentiment?: FeedbackSentiment;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -35,6 +36,7 @@ export function FeedbackDialog(props: {
     if (submitting.current) return;
     const payload = {
       sessionId: props.sessionId,
+      turnId: props.turnId,
       sentiment: props.sentiment,
       comment: comment || undefined,
     };
@@ -42,6 +44,7 @@ export function FeedbackDialog(props: {
     if (
       !previous ||
       previous.sessionId !== payload.sessionId ||
+      previous.turnId !== payload.turnId ||
       previous.sentiment !== payload.sentiment ||
       previous.comment !== payload.comment
     ) {
@@ -72,7 +75,13 @@ export function FeedbackDialog(props: {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{props.sessionId ? "Rate this session" : "Send feedback"}</DialogTitle>
+          <DialogTitle>
+            {props.turnId
+              ? "Rate this reply"
+              : props.sessionId
+                ? "Rate this session"
+                : "Send feedback"}
+          </DialogTitle>
           <DialogDescription>
             {props.sessionId
               ? "Share what worked or what could be better."
@@ -117,6 +126,10 @@ export function SessionFeedback(props: {
   client: FeedbackClient;
   workspaceId: string;
   sessionId: string;
+  turnId?: string;
+  compact?: boolean;
+  savedSentiment?: FeedbackSentiment | null;
+  onRated?: (sentiment: FeedbackSentiment) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [choice, setChoice] = useState<FeedbackSentiment>();
@@ -124,15 +137,23 @@ export function SessionFeedback(props: {
   const [notice, setNotice] = useState("");
   const savedRevision = useRef(0);
   useEffect(() => {
+    if (props.savedSentiment !== undefined) {
+      setSaved(props.savedSentiment ?? undefined);
+      return;
+    }
     let current = true;
     const revision = savedRevision.current;
     void props.client
-      .listOwnFeedback(props.workspaceId, { sessionId: props.sessionId, includeTurns: false })
+      .listOwnFeedback(props.workspaceId, {
+        sessionId: props.sessionId,
+        includeTurns: Boolean(props.turnId),
+      })
       .then(({ feedback }) => {
         if (current && revision === savedRevision.current)
           setSaved(
-            feedback.find((item) => item.turnId === null && item.sentiment !== null)?.sentiment ??
-              undefined,
+            feedback.find(
+              (item) => item.turnId === (props.turnId ?? null) && item.sentiment !== null,
+            )?.sentiment ?? undefined,
           );
       })
       .catch(() => {
@@ -141,17 +162,25 @@ export function SessionFeedback(props: {
     return () => {
       current = false;
     };
-  }, [props.client, props.workspaceId, props.sessionId]);
+  }, [props.client, props.workspaceId, props.sessionId, props.turnId, props.savedSentiment]);
   return (
     <div
-      className="flex items-center gap-1 px-4 py-2 text-xs text-muted-foreground sm:px-6"
-      aria-label="Session feedback"
+      className={
+        props.compact
+          ? "inline-flex items-center gap-1.5"
+          : "flex items-center gap-1 text-xs text-fg-muted"
+      }
+      aria-label={props.turnId ? "Reply feedback" : "Session feedback"}
     >
-      <span className="mr-1">Was this helpful?</span>
       <Button
         variant="ghost"
         size="icon"
-        className="pointer-coarse:min-h-11 pointer-coarse:min-w-11 aria-pressed:bg-accent aria-pressed:text-foreground"
+        className={
+          props.compact
+            ? "size-7 rounded-sm text-fg-subtle opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:size-11 pointer-coarse:opacity-70 aria-pressed:opacity-100 aria-pressed:bg-accent aria-pressed:text-foreground"
+            : "pointer-coarse:min-h-11 pointer-coarse:min-w-11 aria-pressed:bg-accent aria-pressed:text-foreground"
+        }
+        title="Thumbs up"
         aria-label="Thumbs up"
         aria-pressed={saved === "positive"}
         onClick={() => {
@@ -159,12 +188,17 @@ export function SessionFeedback(props: {
           setOpen(true);
         }}
       >
-        <ThumbsUpIcon className="size-4" />
+        <ThumbsUpIcon className={props.compact ? "size-3.5" : "size-4"} />
       </Button>
       <Button
         variant="ghost"
         size="icon"
-        className="pointer-coarse:min-h-11 pointer-coarse:min-w-11 aria-pressed:bg-accent aria-pressed:text-foreground"
+        className={
+          props.compact
+            ? "size-7 rounded-sm text-fg-subtle opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:size-11 pointer-coarse:opacity-70 aria-pressed:opacity-100 aria-pressed:bg-accent aria-pressed:text-foreground"
+            : "pointer-coarse:min-h-11 pointer-coarse:min-w-11 aria-pressed:bg-accent aria-pressed:text-foreground"
+        }
+        title="Thumbs down"
         aria-label="Thumbs down"
         aria-pressed={saved === "negative"}
         onClick={() => {
@@ -172,9 +206,11 @@ export function SessionFeedback(props: {
           setOpen(true);
         }}
       >
-        <ThumbsDownIcon className="size-4" />
+        <ThumbsDownIcon className={props.compact ? "size-3.5" : "size-4"} />
       </Button>
-      <span role="status">{notice}</span>
+      <span role="status" className={props.compact ? "sr-only" : undefined}>
+        {notice}
+      </span>
       <FeedbackDialog
         {...props}
         open={open}
@@ -183,6 +219,7 @@ export function SessionFeedback(props: {
         onSubmitted={(value) => {
           savedRevision.current += 1;
           setSaved(value);
+          if (value) props.onRated?.(value);
           setNotice("Thanks for your feedback");
         }}
       />

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -13,6 +13,7 @@ import {
 import { lazy, Suspense, useState } from "react";
 import { toast } from "sonner";
 
+import { cn } from "@/lib/utils";
 import { AppearanceMenu } from "@/components/appearance-menu";
 import {
   accountMenuAriaLabel,
@@ -92,16 +93,22 @@ export function RailFooter() {
               onSubmitted={() => toast.success("Thanks for your feedback")}
             />
           </Suspense>
-          <Button
-            variant="ghost"
-            size="sm"
+          <button
+            type="button"
+            className={cn(
+              "mb-1 flex h-8 items-center rounded-md text-sm font-medium text-fg-muted outline-none transition-colors pointer-coarse:h-10",
+              "hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/50",
+              rail.collapsed
+                ? "mx-auto w-8 justify-center pointer-coarse:w-10"
+                : "w-full gap-2.5 px-2.5 text-left",
+            )}
             aria-label="Send feedback"
             title="Send feedback"
             onClick={() => setFeedbackOpen(true)}
           >
-            <FeedbackIcon className="size-4" />
-            {rail.collapsed ? null : "Send feedback"}
-          </Button>
+            <FeedbackIcon className="size-4 shrink-0" />
+            {rail.collapsed ? null : <span className="min-w-0 truncate">Send feedback</span>}
+          </button>
         </>
       ) : null}
       <div

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -449,9 +449,8 @@ export function SessionList() {
     await Promise.all([refresh(), refreshArchivedSessions(), refreshGlobalPins()]);
   }, [refresh, refreshArchivedSessions, refreshGlobalPins]);
   // Ordinary rows page independently of the complete pinned section. The
-  // polled hook owns the shared discovery page; every visible folder/group
-  // owns an independent filtered continuation so reaching one section's end
-  // cannot silently add rows to another section.
+  // polled hook owns the shared discovery page. Projects share a workspace
+  // continuation; filtered browsing and Archived retain their own cursors.
   const paginationDate = new Date();
   const paginationKey = sessionPageKey(
     rail.workspaceId,
@@ -2378,6 +2377,12 @@ export function SessionList() {
             ? [bucket]
             : [];
         });
+  // The discovery cursor is workspace-wide, so it cannot prove that any
+  // individual project contains older rows. Keep its control outside projects.
+  const workspacePagination = paginationForGroup(
+    { key: "workspace", label: "this workspace", kind: "results" },
+    nextCursor,
+  );
   const activePagination = paginationForGroup(
     { key: "activity:active", label: "Active", kind: "activity", group: "active" },
     nextCursor,
@@ -2812,15 +2817,6 @@ export function SessionList() {
                   sectionExpanded={!collapsedChannelSections.has(section.key)}
                   onToggleSection={() => toggleChannelSection(section.key)}
                   nodes={section.sessions}
-                  pagination={paginationForGroup(
-                    {
-                      key: `channel:${section.key}`,
-                      label: section.name,
-                      kind: "channel",
-                      channelId: section.channelId,
-                    },
-                    nextCursor,
-                  )}
                   localDeliveryAttention={localDeliveryAttention}
                   flat={flat}
                   activeSessionId={activeSessionId}
@@ -2928,6 +2924,9 @@ export function SessionList() {
                 ) : null}
               </>
             )}
+            {channelMode && workspacePagination ? (
+              <SessionGroupPaginationControl {...workspacePagination} />
+            ) : null}
             {channelMode ? (
               <SessionGroup
                 label="Archived"
@@ -3066,7 +3065,9 @@ function SessionGroupPaginationControl(
             ? "Loading older…"
             : failed
               ? "Retry older"
-              : "Load older"}
+              : group.kind === "results"
+                ? "Load older sessions"
+                : "Load older"}
       </button>
       {failed ? (
         <p role="status" className="mt-1 text-2xs text-status-failed">

--- a/apps/web/src/components/session/message-actions.tsx
+++ b/apps/web/src/components/session/message-actions.tsx
@@ -1,0 +1,51 @@
+import { GitForkIcon } from "lucide-react";
+import type { AgentMessageItem, UserMessageItem } from "@opengeni/react/session";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import { SessionFeedback } from "@/components/feedback";
+
+/** Host-owned actions share the timeline's existing Copy hover/focus row. */
+export default function MessageActions(props: {
+  item: AgentMessageItem | UserMessageItem;
+  client: OpenGeniBrowserClient;
+  workspaceId: string;
+  sessionId: string;
+  mayRate: boolean;
+  mayFork: boolean;
+  savedSentiment: "positive" | "negative" | null;
+  onRated: (turnId: string, sentiment: "positive" | "negative") => void;
+  onFork: (eventId: string) => void;
+}) {
+  const { item } = props;
+  if (
+    (item.kind === "agent-message" && item.streaming) ||
+    (item.kind === "user-message" && item.delivery)
+  )
+    return null;
+  const eventId = item.annotationSource?.eventId;
+  return (
+    <>
+      {props.mayRate && item.kind === "agent-message" && item.turnId ? (
+        <SessionFeedback
+          compact
+          client={props.client}
+          workspaceId={props.workspaceId}
+          sessionId={props.sessionId}
+          turnId={item.turnId}
+          savedSentiment={props.savedSentiment}
+          onRated={(sentiment) => props.onRated(item.turnId!, sentiment)}
+        />
+      ) : null}
+      {props.mayFork && eventId ? (
+        <button
+          type="button"
+          aria-label="Fork from here"
+          title="Fork from here"
+          onClick={() => props.onFork(eventId)}
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-fg-subtle opacity-0 transition-opacity hover:bg-surface-2 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:size-11 pointer-coarse:opacity-70"
+        >
+          <GitForkIcon className="size-3.5" />
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/components/session/session-tenancy-control.test.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.test.tsx
@@ -399,6 +399,76 @@ describe("SessionTenancyControl", () => {
     container.remove();
   });
 
+  test("forks from the selected message through the existing visibility confirmation", async () => {
+    const privateSession = {
+      ...baseSession,
+      tenancy: { ...baseSession.tenancy!, visibility: "private" as const, authorityEpoch: 5 },
+    };
+    const requests: unknown[] = [];
+    const forkSession = mock(async (_workspaceId, _sessionId, request) => {
+      requests.push(request);
+      return {
+        operationId: crypto.randomUUID(),
+        eventId: crypto.randomUUID(),
+        eventSequence: 1,
+        sessionId: "session-fork",
+        workspaceId: "workspace-a",
+        visibility: "workspace" as const,
+        authorityEpoch: 1 as const,
+        copiedHistoryItemCount: 3,
+        replay: false,
+      };
+    });
+    const getSession = mock(async () => ({
+      ...baseSession,
+      id: "session-fork",
+      tenancy: {
+        ...baseSession.tenancy!,
+        visibility: "workspace" as const,
+        authorityEpoch: 1,
+      },
+    }));
+    const onOpenSession = mock((_workspaceId: string, _sessionId: string) => undefined);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <SessionTenancyControl
+          sourceEventId="selected-message-event"
+          session={privateSession}
+          client={{ forkSession, getSession } as unknown as OpenGeniBrowserClient}
+          managedSession
+          canForkPrivately
+          scopeLabel="Engineering"
+          captureWorkspaceInvocation={() => ({ workspaceId: "workspace-a", revision: 1 })}
+          ownsWorkspaceInvocation={() => true}
+          {...operationAuthority()}
+          onOpenSession={onOpenSession}
+        />,
+      );
+    });
+
+    await act(async () => dialogButton(container, "Workspace").click());
+    expect(container.textContent).toContain("selected message");
+    await act(async () => dialogButton(container, "Fork for workspace").click());
+    await flush();
+
+    expect(requests).toEqual([
+      {
+        sourceEventId: "selected-message-event",
+        visibility: "workspace",
+        workspaceSharedAcknowledged: true,
+        idempotencyKey: expect.any(String),
+      },
+    ]);
+    expect(getSession).toHaveBeenCalledWith("workspace-a", "session-fork", { fresh: true });
+    expect(onOpenSession).toHaveBeenCalledWith("workspace-a", "session-fork");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
   test("offers no private fork destination when the organization has not enabled private sessions", async () => {
     // Migration 0336 fails a private fork into a shared workspace closed with
     // SQLSTATE 55000 when the organization has not enabled private sessions, so

--- a/apps/web/src/components/session/session-tenancy-control.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.tsx
@@ -123,9 +123,13 @@ function usePrivateForkCapability(options: {
 export function SessionTenancyRouteControl({
   session,
   events,
+  sourceEventId,
+  onForkClose,
 }: {
   session: Session;
   events: SessionEvent[];
+  sourceEventId?: string;
+  onForkClose?: () => void;
 }) {
   const context = useAppContext();
   const navigate = useNavigate();
@@ -150,6 +154,8 @@ export function SessionTenancyRouteControl({
       key={`${context.accessContext.subjectId}:${transition.revision}:${session.workspaceId}:${session.id}`}
       session={session}
       events={events}
+      sourceEventId={sourceEventId}
+      onForkClose={onForkClose}
       client={context.client}
       managedSession={managedSession}
       canForkPrivately={canForkPrivately}
@@ -174,6 +180,8 @@ export function SessionTenancyRouteControl({
 }
 
 export function SessionTenancyControl({
+  sourceEventId,
+  onForkClose,
   session,
   events,
   client,
@@ -188,6 +196,8 @@ export function SessionTenancyControl({
 }: {
   session: Session;
   events?: SessionEvent[] | undefined;
+  sourceEventId?: string | undefined;
+  onForkClose?: (() => void) | undefined;
   client: OpenGeniBrowserClient;
   managedSession: boolean;
   /** False also covers "not yet known": a private fork is never offered on a
@@ -214,7 +224,16 @@ export function SessionTenancyControl({
   const pendingVisibility = operationSnapshot.visibility;
   const pendingFork = operationSnapshot.fork;
   const [override, setOverride] = useState(session.tenancy);
-  const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
+  const [confirmation, setConfirmation] = useState<Confirmation | null>(() =>
+    sourceEventId
+      ? {
+          kind: "fork",
+          visibility:
+            operationSnapshot.fork?.visibility ??
+            (canForkPrivately ? (session.tenancy?.visibility ?? "workspace") : "workspace"),
+        }
+      : null,
+  );
   const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState("");
@@ -232,8 +251,8 @@ export function SessionTenancyControl({
     operationSequenceRef.current += 1;
     setBusy(false);
     setFailure(null);
-    setConfirmation(null);
-  }, [session.id, session.workspaceId]);
+    if (!sourceEventId) setConfirmation(null);
+  }, [session.id, session.workspaceId, sourceEventId]);
 
   useEffect(() => {
     if (!session.tenancy) {
@@ -486,6 +505,12 @@ export function SessionTenancyControl({
   const forkSession = useCallback(
     async (visibility: SessionVisibility): Promise<boolean> => {
       if (!displayedTenancy || !mayFork) return true;
+      if (sourceEventId && pendingFork && pendingFork.sourceEventId !== sourceEventId) {
+        setFailure(
+          "A previous fork still needs a retry. Resolve it from the session menu before choosing another message.",
+        );
+        return false;
+      }
       const acceptedTransition = captureWorkspaceInvocation(target.workspaceId);
       if (!acceptedTransition) return true;
       const operationSequence = operationSequenceRef.current + 1;
@@ -494,7 +519,7 @@ export function SessionTenancyControl({
         displayedTenancy.visibility === "private" && visibility === "workspace";
       const attempt = operationController.prepareFork(
         operationScope,
-        { visibility, workspaceSharedAcknowledged },
+        { visibility, workspaceSharedAcknowledged, ...(sourceEventId ? { sourceEventId } : {}) },
         () => crypto.randomUUID(),
       );
       setBusy(true);
@@ -505,6 +530,7 @@ export function SessionTenancyControl({
           isCurrent: () => isCurrentInvocation(target, acceptedTransition, operationSequence),
           request: async () =>
             await client.forkSession(target.workspaceId, target.sessionId, {
+              ...(attempt.sourceEventId ? { sourceEventId: attempt.sourceEventId } : {}),
               visibility: attempt.visibility,
               workspaceSharedAcknowledged: attempt.workspaceSharedAcknowledged,
               idempotencyKey: attempt.idempotencyKey,
@@ -545,9 +571,13 @@ export function SessionTenancyControl({
           classified.retainAttempt ||
           (receiptConfirmed && retryableSessionTenancyReconciliationFailure(error));
         if (!retainAttempt) operationController.settleFork(operationScope, attempt);
-        setFailure(classified.message);
-        setAnnouncement(classified.message);
-        return !retainAttempt;
+        const message =
+          sourceEventId && isApiErrorStatus(error, 400)
+            ? "This message cannot be used as a fork point. Its history may have been compacted, or it may not have a unique, complete saved boundary. Choose another message or fork the whole session."
+            : classified.message;
+        setFailure(message);
+        setAnnouncement(message);
+        return sourceEventId ? false : !retainAttempt;
       } finally {
         if (isCurrentInvocation(target, acceptedTransition, operationSequence)) setBusy(false);
       }
@@ -558,6 +588,8 @@ export function SessionTenancyControl({
       displayedTenancy,
       isCurrentInvocation,
       mayFork,
+      sourceEventId,
+      pendingFork,
       onOpenSession,
       operationController,
       operationScope,
@@ -603,7 +635,10 @@ export function SessionTenancyControl({
 
   return (
     <TooltipProvider delayDuration={300}>
-      <section aria-label="Session access" className="flex shrink-0 items-center">
+      <section
+        aria-label="Session access"
+        className={sourceEventId ? "hidden" : "flex shrink-0 items-center"}
+      >
         {mayFork ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild disabled={busy}>
@@ -688,7 +723,10 @@ export function SessionTenancyControl({
       <ConfirmDialog
         open={confirmation !== null}
         onOpenChange={(open) => {
-          if (!open) setConfirmation(null);
+          if (!open) {
+            setConfirmation(null);
+            onForkClose?.();
+          }
         }}
         title={
           confirmation?.kind === "fork"
@@ -700,17 +738,19 @@ export function SessionTenancyControl({
               : "Limit this session to you?"
         }
         description={
-          confirmation?.kind === "fork" &&
-          displayedTenancy.visibility === "private" &&
-          confirmation.visibility === "workspace"
-            ? `This private session's complete conversation will be copied into a new session visible to people in ${scopeLabel}. Live credentials, connections, tools, goals, and processes are not copied.`
-            : confirmation?.kind === "fork"
-              ? confirmation.visibility === "workspace"
-                ? `Create an independent copy visible to people in ${scopeLabel}. Live credentials, connections, tools, goals, and processes are not copied.`
-                : "Create an independent copy visible only to you. Live credentials, connections, tools, goals, and processes are not copied."
-              : confirmation?.visibility === "workspace"
-                ? "People who can access this workspace will be able to open the session after all current work has settled."
-                : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
+          (pendingFork ? pendingFork.sourceEventId : sourceEventId)
+            ? `Copy the conversation through the selected message${confirmation?.visibility === "workspace" ? ` into a session visible to people in ${scopeLabel}` : " into a session visible only to you"}. Later messages are excluded. Live credentials, tools, goals, and processes are not copied.`
+            : confirmation?.kind === "fork" &&
+                displayedTenancy.visibility === "private" &&
+                confirmation.visibility === "workspace"
+              ? `This private session's complete conversation will be copied into a new session visible to people in ${scopeLabel}. Live credentials, connections, tools, goals, and processes are not copied.`
+              : confirmation?.kind === "fork"
+                ? confirmation.visibility === "workspace"
+                  ? `Create an independent copy visible to people in ${scopeLabel}. Live credentials, connections, tools, goals, and processes are not copied.`
+                  : "Create an independent copy visible only to you. Live credentials, connections, tools, goals, and processes are not copied."
+                : confirmation?.visibility === "workspace"
+                  ? "People who can access this workspace will be able to open the session after all current work has settled."
+                  : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
         }
         confirmLabel={
           confirmation?.kind === "fork"
@@ -730,7 +770,7 @@ export function SessionTenancyControl({
             : confirmation?.visibility === "workspace"
         }
         cancelAutoFocus
-        restoreFocusRef={accessTriggerRef}
+        restoreFocusRef={sourceEventId ? undefined : accessTriggerRef}
         onConfirm={() => {
           if (!confirmation) return true;
           return confirmation.kind === "visibility"

--- a/apps/web/src/lib/session-feedback.test.ts
+++ b/apps/web/src/lib/session-feedback.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, jest, mock, test } from "bun:test";
+import { loadSessionFeedback } from "./session-feedback";
+
+afterEach(() => jest.useRealTimers());
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+test("a failed shared ratings read recovers without a request per message", async () => {
+  jest.useFakeTimers();
+  const result = { feedback: [] };
+  const listOwnFeedback = mock()
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockResolvedValue(result);
+  const onLoaded = mock();
+  const dispose = loadSessionFeedback({ listOwnFeedback }, "workspace", "session", onLoaded);
+  await flush();
+  expect(onLoaded).not.toHaveBeenCalled();
+  jest.advanceTimersByTime(1_000);
+  await flush();
+  expect(listOwnFeedback).toHaveBeenCalledTimes(2);
+  expect(listOwnFeedback).toHaveBeenLastCalledWith("workspace", {
+    sessionId: "session",
+    includeTurns: true,
+  });
+  expect(onLoaded).toHaveBeenCalledWith(result);
+  jest.advanceTimersByTime(60_000);
+  expect(listOwnFeedback).toHaveBeenCalledTimes(2);
+  dispose();
+});
+
+test("leaving the session cancels pending retries and ignores in-flight results", async () => {
+  jest.useFakeTimers();
+  const onLoaded = mock();
+  const failedRead = mock().mockRejectedValue(new Error("offline"));
+  const dispose = loadSessionFeedback(
+    { listOwnFeedback: failedRead },
+    "workspace",
+    "old",
+    onLoaded,
+  );
+  await flush();
+  dispose();
+  jest.advanceTimersByTime(60_000);
+  expect(failedRead).toHaveBeenCalledTimes(1);
+  let resolve!: (value: { feedback: [] }) => void;
+  const pendingRead = mock(
+    () =>
+      new Promise<{ feedback: [] }>((done) => {
+        resolve = done;
+      }),
+  );
+  const disposePending = loadSessionFeedback(
+    { listOwnFeedback: pendingRead },
+    "workspace",
+    "old",
+    onLoaded,
+  );
+  disposePending();
+  resolve({ feedback: [] });
+  await flush();
+  expect(onLoaded).not.toHaveBeenCalled();
+});

--- a/apps/web/src/lib/session-feedback.ts
+++ b/apps/web/src/lib/session-feedback.ts
@@ -1,0 +1,30 @@
+import type { OpenGeniClient } from "@opengeni/sdk";
+
+/** One shared read per session, with recovery after a transient network failure. */
+export function loadSessionFeedback(
+  client: Pick<OpenGeniClient, "listOwnFeedback">,
+  workspaceId: string,
+  sessionId: string,
+  onLoaded: (result: Awaited<ReturnType<OpenGeniClient["listOwnFeedback"]>>) => void,
+): () => void {
+  let current = true;
+  let delay = 1_000;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const load = () => {
+    void client.listOwnFeedback(workspaceId, { sessionId, includeTurns: true }).then(
+      (result) => {
+        if (current) onLoaded(result);
+      },
+      () => {
+        if (!current) return;
+        timer = setTimeout(load, delay);
+        delay = Math.min(delay * 2, 30_000);
+      },
+    );
+  };
+  load();
+  return () => {
+    current = false;
+    clearTimeout(timer);
+  };
+}

--- a/apps/web/src/lib/session-tenancy-operation-controller.ts
+++ b/apps/web/src/lib/session-tenancy-operation-controller.ts
@@ -64,6 +64,7 @@ export class SessionTenancyOperationController {
     input: {
       visibility: SessionVisibility;
       workspaceSharedAcknowledged: boolean;
+      sourceEventId?: string;
     },
     createIdempotencyKey: () => string,
   ): PendingSessionForkAttempt {

--- a/apps/web/src/lib/session-tenancy.ts
+++ b/apps/web/src/lib/session-tenancy.ts
@@ -30,6 +30,7 @@ export type PendingSessionVisibilityAttempt = SessionTenancyTarget & {
 };
 
 export type PendingSessionForkAttempt = SessionTenancyTarget & {
+  sourceEventId?: string;
   visibility: SessionVisibility;
   workspaceSharedAcknowledged: boolean;
   idempotencyKey: string;

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -149,9 +149,13 @@ import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
 
 const FAILURE_CONTINUATION_MESSAGE =
   "Continue from the last failure. Check current progress before repeating work.";
-const SessionFeedback = lazy(() =>
-  import("@/components/feedback").then((module) => ({ default: module.SessionFeedback })),
+const MessageForkDialog = lazy(() =>
+  import("@/components/session/session-tenancy-control").then((module) => ({
+    default: module.SessionTenancyRouteControl,
+  })),
 );
+
+const MessageActions = lazy(() => import("@/components/session/message-actions"));
 
 const LazyFailedSessionBanner = lazy(() =>
   import("@/components/session/failed-session-banner").then((module) => ({
@@ -1826,6 +1830,80 @@ function SessionChatPane(props: {
     ],
   );
 
+  const [forkEventId, setForkEventId] = useState<string | null>(null);
+  const [turnRatings, setTurnRatings] = useState<Record<string, "positive" | "negative">>({});
+  const mayRate = hasWorkspacePermission(
+    context.accessContext,
+    props.session.workspaceId,
+    "sessions:create",
+  );
+  useEffect(() => {
+    let current = true;
+    setTurnRatings({});
+    setForkEventId(null);
+    if (mayRate)
+      void context.client
+        .listOwnFeedback(props.session.workspaceId, {
+          sessionId: props.session.id,
+          includeTurns: true,
+        })
+        .then(({ feedback }) => {
+          if (!current) return;
+          const ratings: Record<string, "positive" | "negative"> = {};
+          for (const entry of feedback) {
+            if (entry.turnId && entry.sentiment && !ratings[entry.turnId])
+              ratings[entry.turnId] = entry.sentiment;
+          }
+          setTurnRatings((saved) => ({ ...ratings, ...saved }));
+        })
+        .catch(() => {});
+    return () => {
+      current = false;
+    };
+  }, [
+    context.client,
+    props.session.workspaceId,
+    props.session.id,
+    mayRate,
+    context.accessContext.subjectId,
+  ]);
+  const mayForkMessage =
+    context.clientConfig.auth.mode === "managedSession" &&
+    context.authSession !== null &&
+    Boolean(props.session.tenancy) &&
+    mayRate;
+  const onMessageRated = useCallback((turnId: string, sentiment: "positive" | "negative") => {
+    setTurnRatings((saved) => ({ ...saved, [turnId]: sentiment }));
+  }, []);
+  const renderMessageActions = useCallback(
+    (item: AgentMessageItem | UserMessageItem) => (
+      <Suspense fallback={null}>
+        <MessageActions
+          item={item}
+          client={context.client}
+          workspaceId={props.session.workspaceId}
+          sessionId={props.session.id}
+          mayRate={mayRate}
+          mayFork={mayForkMessage}
+          savedSentiment={
+            item.kind === "agent-message" && item.turnId ? (turnRatings[item.turnId] ?? null) : null
+          }
+          onRated={onMessageRated}
+          onFork={setForkEventId}
+        />
+      </Suspense>
+    ),
+    [
+      context.client,
+      props.session.workspaceId,
+      props.session.id,
+      mayRate,
+      mayForkMessage,
+      turnRatings,
+      onMessageRated,
+    ],
+  );
+
   const renderMessageText = useCallback(
     (text: string, item: AgentMessageItem | UserMessageItem) => {
       if (item.kind === "user-message") {
@@ -1925,6 +2003,7 @@ function SessionChatPane(props: {
               status={props.session.status}
               computeLabel={computeLabel}
               renderMessageText={renderMessageText}
+              renderMessageActions={renderMessageActions}
               onAnnotate={composer.addAnnotation}
               onOpenSession={props.onOpenSession}
               onMemoryClick={props.onMemoryClick}
@@ -2004,17 +2083,14 @@ function SessionChatPane(props: {
         </>
       )}
 
-      {hasWorkspacePermission(
-        context.accessContext,
-        props.session.workspaceId,
-        "sessions:create",
-      ) ? (
+      {forkEventId ? (
         <Suspense fallback={null}>
-          <SessionFeedback
-            key={props.session.id}
-            client={context.client}
-            workspaceId={props.session.workspaceId}
-            sessionId={props.session.id}
+          <MessageForkDialog
+            key={forkEventId}
+            session={props.session}
+            events={props.events}
+            sourceEventId={forkEventId}
+            onForkClose={() => setForkEventId(null)}
           />
         </Suspense>
       ) : null}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,3 +1,4 @@
+import { loadSessionFeedback } from "../lib/session-feedback";
 import { PersonalResourceAttachmentSurface } from "@/components/personal-resource-attachment-surface";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
 import { getComposerSendBlocker } from "@/lib/composer-send-blocking";
@@ -1838,28 +1839,22 @@ function SessionChatPane(props: {
     "sessions:create",
   );
   useEffect(() => {
-    let current = true;
     setTurnRatings({});
     setForkEventId(null);
-    if (mayRate)
-      void context.client
-        .listOwnFeedback(props.session.workspaceId, {
-          sessionId: props.session.id,
-          includeTurns: true,
-        })
-        .then(({ feedback }) => {
-          if (!current) return;
-          const ratings: Record<string, "positive" | "negative"> = {};
-          for (const entry of feedback) {
-            if (entry.turnId && entry.sentiment && !ratings[entry.turnId])
-              ratings[entry.turnId] = entry.sentiment;
-          }
-          setTurnRatings((saved) => ({ ...ratings, ...saved }));
-        })
-        .catch(() => {});
-    return () => {
-      current = false;
-    };
+    if (!mayRate) return;
+    return loadSessionFeedback(
+      context.client,
+      props.session.workspaceId,
+      props.session.id,
+      ({ feedback }) => {
+        const ratings: Record<string, "positive" | "negative"> = {};
+        for (const entry of feedback) {
+          if (entry.turnId && entry.sentiment && !ratings[entry.turnId])
+            ratings[entry.turnId] = entry.sentiment;
+        }
+        setTurnRatings((saved) => ({ ...ratings, ...saved }));
+      },
+    );
   }, [
     context.client,
     props.session.workspaceId,

--- a/apps/web/test/feedback-fixture.tsx
+++ b/apps/web/test/feedback-fixture.tsx
@@ -1,6 +1,12 @@
 import { createRoot } from "react-dom/client";
 import { useState } from "react";
-import { FeedbackDialog, SessionFeedback } from "../src/components/feedback";
+import { MessageTimeline } from "@opengeni/react/session-ui";
+import MessageActions from "../src/components/session/message-actions";
+import { SessionTenancyControl } from "../src/components/session/session-tenancy-control";
+import { SessionTenancyOperationController } from "../src/lib/session-tenancy-operation-controller";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type { Session } from "../src/types";
+import { FeedbackDialog } from "../src/components/feedback";
 import { Button } from "../src/components/ui/button";
 import type { CreateFeedbackRequest, Feedback } from "@opengeni/sdk";
 import "../src/styles.css";
@@ -39,6 +45,40 @@ const client = {
 function Fixture() {
   const [open, setOpen] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [rating, setRating] = useState<"positive" | "negative" | null>(null);
+  const [forkPoint, setForkPoint] = useState<string | null>(null);
+  const [forkedPoint, setForkedPoint] = useState<string | null>(null);
+  const [controller] = useState(() => new SessionTenancyOperationController());
+  const turnId = "33333333-3333-4333-8333-333333333333";
+  const session = {
+    id: sessionId,
+    workspaceId,
+    status: "idle",
+    tenancy: {
+      visibility: "private",
+      authorityEpoch: 1,
+      ownedByCurrentUser: true,
+      fork: null,
+    },
+  } as Session;
+  const forkClient = {
+    async forkSession(
+      _workspace: string,
+      _session: string,
+      request: { sourceEventId?: string; visibility: string },
+    ) {
+      setForkedPoint(request.sourceEventId ?? null);
+      return {
+        workspaceId,
+        sessionId: "fork-preview",
+        visibility: request.visibility,
+        replay: false,
+      };
+    },
+    async getSession() {
+      return { ...session, id: "fork-preview" };
+    },
+  } as unknown as OpenGeniBrowserClient;
   return (
     <main className="mx-auto max-w-3xl p-8">
       <h1 className="mb-6 text-xl">Feedback component preview</h1>
@@ -47,11 +87,83 @@ function Fixture() {
           Send feedback
         </Button>
       </div>
-      <section className="rounded-lg border p-5">
-        <h2 className="mb-3 text-lg">Your session</h2>
-        <p className="mb-4 text-sm">I created the requested report and checked the totals.</p>
-        <SessionFeedback client={client} workspaceId={workspaceId} sessionId={sessionId} />
+      <section className="h-[380px] rounded-lg border">
+        <MessageTimeline
+          items={[
+            {
+              kind: "user-message",
+              id: "44444444-4444-4444-8444-444444444444",
+              text: "Create the report",
+              resources: [],
+              tools: [],
+              occurredAt: "2026-09-09T07:00:00Z",
+            },
+            {
+              kind: "agent-message",
+              id: "55555555-5555-4555-8555-555555555555",
+              turnId,
+              text: "I created the requested report and checked the totals.",
+              streaming: false,
+              occurredAt: "2026-09-09T07:01:00Z",
+            },
+            {
+              kind: "agent-message",
+              id: "66666666-6666-4666-8666-666666666666",
+              turnId,
+              text: "This later reply should not be included when forking from the first answer.",
+              streaming: false,
+              occurredAt: "2026-09-09T07:02:00Z",
+            },
+          ]}
+          renderMessageActions={(item) => (
+            <MessageActions
+              item={{
+                ...item,
+                annotationSource: {
+                  kind: item.kind === "user-message" ? "user_message" : "assistant_message",
+                  eventType:
+                    item.kind === "user-message" ? "user.message" : "agent.message.completed",
+                  eventId: item.id,
+                  turnId,
+                  sequence: 1,
+                  text: item.text,
+                },
+              }}
+              client={client as unknown as OpenGeniBrowserClient}
+              workspaceId={workspaceId}
+              sessionId={sessionId}
+              mayRate
+              mayFork
+              savedSentiment={rating}
+              onRated={(_turnId, sentiment) => setRating(sentiment)}
+              onFork={setForkPoint}
+            />
+          )}
+        />
       </section>
+      {forkPoint ? (
+        <SessionTenancyControl
+          key={forkPoint}
+          sourceEventId={forkPoint}
+          onForkClose={() => setForkPoint(null)}
+          session={session}
+          client={forkClient}
+          managedSession
+          canForkPrivately
+          scopeLabel="Preview workspace"
+          captureWorkspaceInvocation={() => ({ workspaceId, revision: 1 })}
+          ownsWorkspaceInvocation={() => true}
+          operationController={controller}
+          operationScope={{
+            principalId: "preview-user",
+            workspaceId,
+            sessionId,
+            workspaceTransitionRevision: 1,
+          }}
+          onOpenSession={() => setForkPoint(null)}
+        />
+      ) : null}
+      {forkedPoint ? <p role="status">Forked through message {forkedPoint}</p> : null}
       <Button
         variant="ghost"
         className="mt-8"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -667,11 +667,8 @@ path.
 
 `packages/db/src/session-execution-policy.ts` derives execution/display policy from the latest started turn, otherwise creation defaults.
 
-A human message-point fork resolves its durable source event to a unique
-canonical history prefix under the existing session-tenancy lifecycle locks.
-It never rebuilds conversation memory from timeline events; ambiguous,
-compacted, or protocol-incomplete boundaries fail closed. The whole-session
-fork remains available. See [organization tenancy](organization-tenancy.md#forking-at-a-message).
+Message-point forks copy canonical history through an unambiguous, uncompacted,
+protocol-complete boundary. See [organization tenancy](organization-tenancy.md#forking-at-a-message).
 
 ### 5.2 Lifecycle overview
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -667,6 +667,12 @@ path.
 
 `packages/db/src/session-execution-policy.ts` derives execution/display policy from the latest started turn, otherwise creation defaults.
 
+A human message-point fork resolves its durable source event to a unique
+canonical history prefix under the existing session-tenancy lifecycle locks.
+It never rebuilds conversation memory from timeline events; ambiguous,
+compacted, or protocol-incomplete boundaries fail closed. The whole-session
+fork remains available. See [organization tenancy](organization-tenancy.md#forking-at-a-message).
+
 ### 5.2 Lifecycle overview
 
 ```mermaid

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3074,3 +3074,13 @@ Migration `0425_feedback_submissions.sql` extends the exact runtime table/privil
 contract. Stop old API and both worker types, migrate, run `db:provision-roles`,
 and start the feedback-aware binary. Do not restart an older binary afterward.
 See [Feedback](feedback.md) for API, privacy, and retention behavior.
+
+## Message-point fork activation
+
+Migration `0429_message_boundary_session_forks.sql` adds the exact runtime
+routine for message-boundary forks. Stop API, control-worker, and turn-worker
+processes before migrating, run `db:provision-roles`, and start only the new
+binary afterward. Do not use an older binary as the rollback image after this
+routine contract changes. Whole-session forks retain their existing signature.
+See [Forking at a message](organization-tenancy.md#forking-at-a-message) for
+boundary validation and compacted-history limitations.

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -37,10 +37,11 @@ only the authenticated principal's general feedback, newest first. Pass
 by the web rating indicator. `limit` is 1-100 (default 50); this is a bounded recent list, not a full export.
 The SDK equivalent is `client.listOwnFeedback(workspaceId, { sessionId, limit })`.
 
-The web sidebar offers **Send feedback**. Session controls open a thumbs-up/down
-form with an optional comment and explicit submission. These rate the whole
-session; SDK callers may attach an exact turn. The UI's current thumb is the
-latest session-level rating returned for the viewer.
+The web sidebar offers **Send feedback**. Completed assistant messages show
+thumbs up/down beside Copy and the timestamp on hover, keyboard focus, or touch.
+The optional-comment form submits the selected reply's exact turn. Messages from
+the same turn share the current rating. The route loads the viewer's recent
+ratings once; it does not fetch separately for every message.
 
 ## Authority and analysis
 

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -1377,6 +1377,30 @@ Null owner/authority/grant fields are non-authority. Contract parsing likewise
 defaults omitted resource scope to `workspace`; `user` scope requires one
 complete opaque delegation.
 
+## Forking at a message
+
+The managed-human fork request accepts an optional `sourceEventId`. The stock
+message action row supplies the selected durable user message or completed
+assistant message. Omission keeps the whole-session fork contract. The event id
+is included in the idempotency hash and resolved under the existing quiescent
+source locks to a unique canonical history boundary. Only history through that
+boundary is copied; events are never converted into model input. Runtime setup
+replacement cannot be combined with a message boundary.
+
+The first boundary implementation rejects compacted histories, ambiguous or
+missing message/history matches, and boundaries splitting a tool exchange.
+Those cases remain eligible for the ordinary whole-session fork; there is no
+silent fallback. A committed message fork still replays after compaction or a
+source authorization change. The same actor, visibility, acknowledgement,
+workspace, and grant rules apply to both fork forms.
+
+Migration `0429_message_boundary_session_forks.sql` adds an overload to the exact
+runtime routine contract. Drain API/control/turn workers, migrate, provision the
+runtime role, and start the message-boundary-aware binary. Do not restart an
+older binary after activation. The SQL overload clones the current lifecycle
+body with checked anchors, preserving its authority, locks, receipt ordering,
+and fresh-session configuration while narrowing the history spool.
+
 ## Session-visibility and fork public activation
 
 `0225_session_visibility_fork_activation.sql` shipped the first database

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1513,6 +1513,7 @@ export type UpdateSessionVisibilityResponse = z.infer<typeof UpdateSessionVisibi
 
 export const ForkSessionRequest = z
   .object({
+    sourceEventId: z.string().uuid().optional(),
     idempotencyKey: SessionTenancyIdempotencyKey,
     visibility: SessionVisibility,
     workspaceSharedAcknowledged: z.boolean(),
@@ -1523,6 +1524,13 @@ export const ForkSessionRequest = z
   })
   .strict()
   .superRefine((value, context) => {
+    if (value.sourceEventId && (value.rigId !== undefined || value.variableSetIds !== undefined)) {
+      context.addIssue({
+        code: "custom",
+        path: ["sourceEventId"],
+        message: "Message forks cannot replace runtime setup",
+      });
+    }
     if (value.visibility === "private" && value.workspaceSharedAcknowledged) {
       context.addIssue({
         code: "custom",

--- a/packages/contracts/test/session-tenancy-contracts.test.ts
+++ b/packages/contracts/test/session-tenancy-contracts.test.ts
@@ -12,6 +12,24 @@ const sessionId = "33333333-3333-4333-8333-333333333333";
 const workspaceId = "44444444-4444-4444-8444-444444444444";
 
 describe("session tenancy public contracts", () => {
+  test("accepts an exact message boundary without changing whole-session fork requests", () => {
+    const request = {
+      idempotencyKey: "fork-point",
+      visibility: "private",
+      workspaceSharedAcknowledged: false,
+    };
+    expect(ForkSessionRequest.parse({ ...request, sourceEventId: eventId }).sourceEventId).toBe(
+      eventId,
+    );
+    expect(ForkSessionRequest.parse(request).sourceEventId).toBeUndefined();
+    expect(
+      ForkSessionRequest.safeParse({ ...request, sourceEventId: "not-an-event-id" }).success,
+    ).toBe(false);
+    expect(
+      ForkSessionRequest.safeParse({ ...request, sourceEventId: eventId, variableSetIds: [] })
+        .success,
+    ).toBe(false);
+  });
   test("normalizes the required bounded idempotency key and epoch", () => {
     expect(
       UpdateSessionVisibilityRequest.parse({

--- a/packages/core/src/application/session-tenancy.ts
+++ b/packages/core/src/application/session-tenancy.ts
@@ -287,6 +287,7 @@ export async function forkManagedHumanSession(
   const forkInput = {
     sourceWorkspaceId: workspaceId,
     sourceSessionId,
+    ...(request.sourceEventId ? { sourceEventId: request.sourceEventId } : {}),
     actorSubjectId: authorization.grant.subjectId,
     destinationWorkspaceId: workspaceId,
     destinationVisibility:

--- a/packages/db/drizzle/0429_message_boundary_session_forks.sql
+++ b/packages/db/drizzle/0429_message_boundary_session_forks.sql
@@ -1,0 +1,526 @@
+-- deployment-mode: maintenance
+-- Drain API and both worker pools before updating the exact routine posture.
+-- Add a message-boundary overload. Authority, locking, receipt replay and
+-- destination creation retain the existing whole-session lifecycle; only the
+-- selected boundary validation and history spool predicate differ.
+CREATE OR REPLACE FUNCTION fork_session_content(p_account_id uuid, p_source_workspace_id uuid, p_source_session_id uuid, p_actor_subject_id text, p_destination_workspace_id uuid, p_destination_visibility text, p_workspace_shared_acknowledged boolean, p_operation_key text, p_canonical_request_hash text, p_activation_version integer, p_source_event_id uuid)
+ RETURNS TABLE(operation_id uuid, event_id uuid, event_sequence integer, session_id uuid, workspace_id uuid, visibility text, authority_epoch integer, copied_history_item_count integer, replay boolean)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path FROM CURRENT
+AS $function$
+DECLARE
+  selected_event session_events%ROWTYPE;
+  selected_turn_id uuid;
+  boundary_position numeric;
+  boundary_matches integer;
+  actor_membership organization_memberships%ROWTYPE;
+  source_session sessions%ROWTYPE;
+  destination_workspace workspaces%ROWTYPE;
+  receipt_row session_command_receipts%ROWTYPE;
+  destination_session_id uuid;
+  history_count integer := 0;
+  destination_activity_revision bigint;
+  destination_depth integer;
+  destination_depth_source text;
+  destination_resources jsonb := '[]'::jsonb;
+  event_row_id uuid;
+  public_destination_visibility text;
+  visibility_write_capability_id uuid := gen_random_uuid();
+  previous_lifecycle text := current_setting('opengeni.organization_tenancy_lifecycle', true);
+  previous_gate_state text := current_setting('opengeni.session_activity_gate_state', true);
+  previous_gate_workspace text := current_setting(
+    'opengeni.session_activity_gate_workspace_id', true
+  );
+  previous_visibility_capability text := current_setting(
+    'opengeni.session_visibility_write_capability', true
+  );
+BEGIN
+  IF p_account_id IS NULL OR p_source_workspace_id IS NULL
+    OR p_source_session_id IS NULL OR p_actor_subject_id IS NULL
+    OR p_destination_workspace_id IS NULL OR p_destination_visibility IS NULL
+    OR p_workspace_shared_acknowledged IS NULL
+    OR p_operation_key IS NULL OR p_canonical_request_hash IS NULL
+    OR p_activation_version IS NULL
+  THEN RAISE EXCEPTION 'session fork requires complete authority'
+    USING ERRCODE = '42501'; END IF;
+  IF p_account_id IS DISTINCT FROM opengeni_private.current_account_id()
+    OR p_source_workspace_id IS DISTINCT FROM opengeni_private.current_workspace_id()
+    OR p_actor_subject_id IS DISTINCT FROM opengeni_private.current_subject_id()
+  THEN RAISE EXCEPTION 'session fork authority is invalid'
+    USING ERRCODE = '42501'; END IF;
+  IF p_destination_workspace_id IS DISTINCT FROM p_source_workspace_id
+    OR p_destination_visibility NOT IN ('user_private', 'workspace_shared')
+    OR (p_destination_visibility = 'user_private' AND p_workspace_shared_acknowledged)
+    OR p_actor_subject_id <> btrim(p_actor_subject_id)
+    OR length(p_actor_subject_id) NOT BETWEEN 1 AND 1024
+    OR p_operation_key <> btrim(p_operation_key)
+    OR length(p_operation_key) NOT BETWEEN 1 AND 1024
+    OR p_canonical_request_hash !~ '^[0-9a-f]{64}$'
+    OR p_activation_version <> 1
+  THEN RAISE EXCEPTION 'session fork request is invalid'
+    USING ERRCODE = '22023'; END IF;
+  IF nullif(previous_gate_state, '') IS NOT NULL
+    OR nullif(previous_gate_workspace, '') IS NOT NULL
+  THEN RAISE EXCEPTION 'session fork requires ownership of the activity gate'
+    USING ERRCODE = '55000'; END IF;
+  IF NOT session_tenancy_product_activated(p_account_id, p_activation_version) THEN
+    RAISE EXCEPTION 'session tenancy product surface is not activated for this organization'
+      USING ERRCODE = '55000';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
+    'organization-membership:' || p_account_id::text, 0
+  ));
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
+    'session-tenancy:' || p_source_workspace_id::text, 0
+  ));
+
+  PERFORM set_config('opengeni.organization_tenancy_lifecycle',
+    'session_visibility_activation', true);
+  SELECT * INTO destination_workspace FROM workspaces workspace_row
+  WHERE workspace_row.account_id = p_account_id
+    AND workspace_row.id = p_source_workspace_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'session fork workspace is unavailable'
+    USING ERRCODE = '42501'; END IF;
+
+  SELECT membership.* INTO actor_membership
+  FROM organization_memberships membership
+  WHERE membership.account_id = p_account_id
+    AND membership.subject_id = p_actor_subject_id
+    AND membership.status = 'active'
+  FOR UPDATE;
+  IF NOT FOUND OR NOT (
+    actor_membership.personal_workspace_id = p_source_workspace_id
+    OR EXISTS (
+      SELECT 1 FROM workspace_memberships workspace_membership
+      WHERE workspace_membership.account_id = p_account_id
+        AND workspace_membership.workspace_id = p_source_workspace_id
+        AND workspace_membership.subject_id = p_actor_subject_id
+    )
+  ) THEN RAISE EXCEPTION 'session fork requires active workspace authority'
+    USING ERRCODE = '42501'; END IF;
+
+  -- Resolve an already-applied receipt before inspecting mutable source state.
+  -- The same still-authorized workspace actor can therefore recover the exact
+  -- destination after a lost response even if the source owner later makes the
+  -- source private. A new key still reaches the current source authorization
+  -- check below and is denied.
+  SELECT receipt.* INTO receipt_row FROM session_command_receipts receipt
+  WHERE receipt.account_id = p_account_id
+    AND receipt.workspace_id = p_source_workspace_id
+    AND receipt.actor_type = 'human' AND receipt.actor_subject_id = p_actor_subject_id
+    AND receipt.actor_attempt_id IS NULL AND receipt.action = 'session.fork'
+    AND receipt.target_session_id = p_source_session_id
+    AND receipt.target_turn_id IS NULL AND receipt.operation_key = p_operation_key
+    AND receipt.result ->> 'status' = 'applied';
+  IF receipt_row.canonical_request_hash <> p_canonical_request_hash THEN
+    RAISE EXCEPTION 'session fork idempotency conflict' USING ERRCODE = '23505';
+  END IF;
+  IF receipt_row.result ->> 'status' = 'applied' THEN
+    operation_id := receipt_row.id;
+    event_id := nullif(receipt_row.result ->> 'eventId', '')::uuid;
+    event_sequence := (receipt_row.result ->> 'eventSequence')::integer;
+    session_id := (receipt_row.result ->> 'sessionId')::uuid;
+    workspace_id := (receipt_row.result ->> 'workspaceId')::uuid;
+    visibility := receipt_row.result ->> 'visibility'; authority_epoch := 1;
+    copied_history_item_count :=
+      (receipt_row.result ->> 'copiedHistoryItemCount')::integer;
+    replay := true; RETURN NEXT; RETURN;
+  END IF;
+
+  -- Product decision, distinct from authority, and the same one migration 0323
+  -- makes on the create path: a private destination inside a shared workspace
+  -- requires the organization's private-session setting. A personal workspace
+  -- is exempt exactly as it is there. This is deliberately placed after the
+  -- keyed replay above and before any source read, so a fork that already
+  -- committed still replays byte-identically after an owner disables the
+  -- setting, while a fresh key fails closed with the same SQLSTATE the create
+  -- path raises.
+  IF p_destination_visibility = 'user_private'
+    AND actor_membership.personal_workspace_id IS DISTINCT FROM p_source_workspace_id
+    AND NOT organization_private_sessions_enabled(p_account_id)
+  THEN
+    RAISE EXCEPTION
+      'private sessions are not enabled for this organization''s shared workspaces'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT session.* INTO source_session FROM sessions session
+  WHERE session.account_id = p_account_id
+    AND session.workspace_id = p_source_workspace_id
+    AND session.id = p_source_session_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'session fork source session is unavailable'
+    USING ERRCODE = 'P0002'; END IF;
+  -- A private source remains owner-only. A workspace-shared source follows
+  -- current workspace authority, and the fork becomes a fresh session owned
+  -- by the actor. This is what lets any authorized collaborator fork shared
+  -- work privately without retaining the source owner's authority.
+  IF source_session.visibility = 'user_private' AND (
+    source_session.owner_organization_membership_id IS DISTINCT FROM actor_membership.id
+    OR source_session.owner_subject_id IS DISTINCT FROM actor_membership.subject_id
+  )
+  THEN RAISE EXCEPTION 'session fork source session is private'
+    USING ERRCODE = '42501'; END IF;
+
+  INSERT INTO session_command_receipts (
+    account_id, workspace_id, actor_type, actor_subject_id, action,
+    target_session_id, operation_key, canonical_request_hash
+  ) VALUES (
+    p_account_id, p_source_workspace_id, 'human', p_actor_subject_id,
+    'session.fork', p_source_session_id, p_operation_key, p_canonical_request_hash
+  ) ON CONFLICT DO NOTHING;
+  SELECT receipt.* INTO receipt_row FROM session_command_receipts receipt
+  WHERE receipt.account_id = p_account_id
+    AND receipt.workspace_id = p_source_workspace_id
+    AND receipt.actor_type = 'human' AND receipt.actor_subject_id = p_actor_subject_id
+    AND receipt.actor_attempt_id IS NULL AND receipt.action = 'session.fork'
+    AND receipt.target_session_id = p_source_session_id
+    AND receipt.target_turn_id IS NULL AND receipt.operation_key = p_operation_key
+  FOR UPDATE;
+  IF receipt_row.canonical_request_hash <> p_canonical_request_hash THEN
+    RAISE EXCEPTION 'session fork idempotency conflict' USING ERRCODE = '23505';
+  END IF;
+  IF receipt_row.result ->> 'status' = 'applied' THEN
+    operation_id := receipt_row.id;
+    event_id := nullif(receipt_row.result ->> 'eventId', '')::uuid;
+    event_sequence := (receipt_row.result ->> 'eventSequence')::integer;
+    session_id := (receipt_row.result ->> 'sessionId')::uuid;
+    workspace_id := (receipt_row.result ->> 'workspaceId')::uuid;
+    visibility := receipt_row.result ->> 'visibility'; authority_epoch := 1;
+    copied_history_item_count :=
+      (receipt_row.result ->> 'copiedHistoryItemCount')::integer;
+    replay := true; RETURN NEXT; RETURN;
+  END IF;
+
+  -- The acknowledgement is content-exposure evidence, not a blanket checkbox:
+  -- it is required only when private source content crosses into workspace scope.
+  IF source_session.visibility = 'user_private'
+    AND p_destination_visibility = 'workspace_shared'
+    AND NOT p_workspace_shared_acknowledged
+  THEN RAISE EXCEPTION 'private-to-workspace fork requires explicit acknowledgement'
+    USING ERRCODE = '22023'; END IF;
+
+  PERFORM assert_session_tenancy_quiescent(
+    p_account_id, p_source_workspace_id, p_source_session_id, true
+  );
+
+  SELECT coalesce(jsonb_agg(
+    CASE WHEN resource.value ->> 'connectionType' = 'github_personal'
+      THEN resource.value
+        - 'provider' - 'connectionType' - 'credentialBindingId' - 'access'
+        - 'repositoryId' - 'installationId' - 'projectId' - 'connectionId'
+        - 'githubInstallationId' - 'githubRepositoryId'
+      ELSE resource.value
+        - 'credentialBindingId' - 'connectionId' - 'installationId'
+        - 'projectId' - 'githubInstallationId'
+    END
+    ORDER BY resource.ordinality
+  ), '[]'::jsonb) INTO destination_resources
+  FROM jsonb_array_elements(source_session.resources)
+    WITH ORDINALITY AS resource(value, ordinality);
+
+
+  -- Authority, source locks, keyed replay, and quiescence have already been
+  -- established by the unchanged lifecycle prefix. Never infer a history
+  -- boundary from timestamps or manufacture model input from audit events.
+  SELECT event.* INTO selected_event FROM session_events event
+    WHERE event.account_id = p_account_id
+      AND event.workspace_id = p_source_workspace_id
+      AND event.session_id = p_source_session_id AND event.id = p_source_event_id
+      AND event.type IN ('user.message', 'agent.message.completed');
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'The selected message is not available for forking' USING ERRCODE = '22023';
+  END IF;
+  IF selected_event.type = 'user.message' THEN
+    SELECT turn.id INTO selected_turn_id FROM session_turns turn
+      WHERE turn.account_id = p_account_id AND turn.workspace_id = p_source_workspace_id
+        AND turn.session_id = p_source_session_id AND turn.trigger_event_id = selected_event.id;
+    SELECT min(history.position), count(*) INTO boundary_position, boundary_matches
+      FROM session_history_items history
+      WHERE history.account_id = p_account_id AND history.workspace_id = p_source_workspace_id
+        AND history.session_id = p_source_session_id AND history.turn_id = selected_turn_id
+        AND history.item ->> 'role' = 'user';
+  ELSE
+    SELECT min(history.position), count(*) INTO boundary_position, boundary_matches
+      FROM session_history_items history
+      WHERE history.account_id = p_account_id AND history.workspace_id = p_source_workspace_id
+        AND history.session_id = p_source_session_id AND history.turn_id = selected_event.turn_id
+        AND history.item ->> 'role' = 'assistant'
+        AND CASE WHEN jsonb_typeof(history.item -> 'content') = 'array' THEN
+          (SELECT string_agg(part.value ->> 'text', '' ORDER BY part.ordinality)
+           FROM jsonb_array_elements(history.item -> 'content') WITH ORDINALITY part(value, ordinality)
+           WHERE part.value ->> 'type' IN ('output_text', 'text'))
+          ELSE history.item ->> 'content' END = selected_event.payload ->> 'text';
+  END IF;
+  IF boundary_matches <> 1 OR boundary_position IS NULL THEN
+    RAISE EXCEPTION 'This message has no unambiguous retained conversation boundary' USING ERRCODE = '22023';
+  END IF;
+  -- Compaction can replace an earlier prefix with a summary containing later
+  -- messages. Fail closed rather than leak those later messages into this fork.
+  IF EXISTS (SELECT 1 FROM session_history_items history
+    WHERE history.account_id = p_account_id AND history.workspace_id = p_source_workspace_id
+      AND history.session_id = p_source_session_id
+      AND (NOT history.active OR history.position <> trunc(history.position)
+        OR history.item ->> 'type' = 'compaction')) THEN
+    RAISE EXCEPTION 'Forking at a message is unavailable after conversation compaction' USING ERRCODE = '22023';
+  END IF;
+  -- A selected assistant message must not split an in-flight tool exchange.
+  IF EXISTS (
+    WITH prefix AS (
+      SELECT history.position, history.item ->> 'type' AS item_type,
+        (SELECT identity.value #>> '{}' FROM (VALUES
+          (1, history.item -> 'callId'), (2, history.item -> 'call_id'),
+          (3, history.item #> '{providerData,callId}'),
+          (4, history.item #> '{providerData,call_id}'), (5, history.item -> 'id')
+        ) AS identity(priority, value)
+        WHERE jsonb_typeof(identity.value) = 'string' AND identity.value #>> '{}' <> ''
+        ORDER BY identity.priority LIMIT 1) AS call_id
+      FROM session_history_items history
+      WHERE history.account_id = p_account_id AND history.workspace_id = p_source_workspace_id
+        AND history.session_id = p_source_session_id AND history.position <= boundary_position
+    )
+    SELECT 1 FROM prefix call
+    WHERE call.item_type IN ('function_call', 'computer_call', 'shell_call', 'apply_patch_call', 'tool_search_call')
+      AND NOT EXISTS (SELECT 1 FROM prefix result
+        WHERE result.position > call.position AND result.call_id = call.call_id
+          AND result.item_type = ANY (CASE call.item_type
+            WHEN 'function_call' THEN ARRAY['function_call_result', 'function_call_output']
+            WHEN 'computer_call' THEN ARRAY['computer_call_result', 'computer_call_output']
+            WHEN 'shell_call' THEN ARRAY['shell_call_output']
+            WHEN 'apply_patch_call' THEN ARRAY['apply_patch_call_output']
+            WHEN 'tool_search_call' THEN ARRAY['tool_search_output']
+          END))
+  ) THEN
+    RAISE EXCEPTION 'This message splits an unfinished tool exchange' USING ERRCODE = '22023';
+  END IF;
+  DROP TABLE IF EXISTS pg_temp.opengeni_session_fork_history_spool;
+
+  CREATE TEMP TABLE opengeni_session_fork_history_spool (
+    position numeric NOT NULL,
+    item jsonb NOT NULL,
+    item_codec_version integer,
+    active boolean NOT NULL,
+    provider_artifact_invalidated_at timestamptz,
+    provider_artifact_invalidation_reason text,
+    provider_artifact_invalidated_by_attempt_id uuid,
+    created_at timestamptz NOT NULL
+  ) ON COMMIT DROP;
+  INSERT INTO pg_temp.opengeni_session_fork_history_spool (
+    position, item, item_codec_version, active,
+    provider_artifact_invalidated_at, provider_artifact_invalidation_reason,
+    provider_artifact_invalidated_by_attempt_id, created_at
+  ) SELECT source_item.position, source_item.item,
+      source_item.item_codec_version, source_item.active,
+      source_item.provider_artifact_invalidated_at,
+      source_item.provider_artifact_invalidation_reason,
+      source_item.provider_artifact_invalidated_by_attempt_id,
+      source_item.created_at
+    FROM session_history_items source_item
+    WHERE source_item.account_id = p_account_id
+      AND source_item.workspace_id = p_source_workspace_id
+      AND source_item.session_id = p_source_session_id AND source_item.position <= boundary_position
+    ORDER BY source_item.position;
+  GET DIAGNOSTICS history_count = ROW_COUNT;
+
+  SELECT coalesce(
+      CASE WHEN (destination_workspace.settings ->> 'maxNestedAgentDepth') ~ '^\d+$'
+        THEN (destination_workspace.settings ->> 'maxNestedAgentDepth')::integer END,
+      configuration.max_nested_agent_depth
+    ),
+    CASE WHEN (destination_workspace.settings ->> 'maxNestedAgentDepth') ~ '^\d+$'
+      THEN 'workspace' ELSE configuration.policy_source END
+  INTO destination_depth, destination_depth_source
+  FROM nested_agent_depth_configuration configuration
+  WHERE configuration.singleton = true;
+  IF destination_depth IS NULL OR destination_depth_source IS NULL THEN
+    RAISE EXCEPTION 'session fork destination depth policy is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  destination_session_id := gen_random_uuid();
+  public_destination_visibility := CASE p_destination_visibility
+    WHEN 'user_private' THEN 'private' ELSE 'workspace' END;
+  INSERT INTO session_visibility_write_capabilities (
+    backend_pid, transaction_id, capability_id
+  ) VALUES (pg_backend_pid(), pg_current_xact_id(), visibility_write_capability_id);
+  PERFORM set_config('opengeni.session_visibility_write_capability',
+    visibility_write_capability_id::text, true);
+  PERFORM set_config('opengeni.session_activity_gate_state', 'open', true);
+  PERFORM set_config('opengeni.session_activity_gate_workspace_id',
+    p_source_workspace_id::text, true);
+
+  -- This one insert establishes fresh ownership, authority epoch, provenance,
+  -- root identity and singleton sandbox group. No live source authority is copied.
+  INSERT INTO sessions (
+    id, account_id, workspace_id, status,
+    initial_message, initial_message_codec_version,
+    title, title_source, instructions, policy_role,
+    resources, skills, tools, metadata,
+    created_by_kind, created_by_subject_id, created_by_context,
+    owner_organization_membership_id, owner_subject_id,
+    visibility, create_requested_visibility, authority_epoch,
+    forked_from_session_id, forked_from_authority_epoch,
+    forked_from_visibility, forked_at, forked_by_organization_membership_id,
+    model, reasoning_effort, latency_mode, sandbox_backend, sandbox_os, sandbox_group_id,
+    first_party_mcp_permissions, first_party_mcp_tools,
+    initial_personal_connection_delegations, tool_policy,
+    root_session_id, nested_agent_depth,
+    max_nested_agent_depth_override, effective_max_nested_agent_depth,
+    nested_agent_depth_policy_source, nested_agent_depth_policy_session_id,
+    temporal_workflow_id, active_turn_id, variable_set_id,
+    rig_id, rig_version_id, active_sandbox_id, active_epoch,
+    working_dir, codex_pinned_credential_id, codex_last_credential_id,
+    codex_pin_source, codex_compaction_mode,
+    queue_version, queue_head_position, queue_tail_position, last_sequence
+  ) VALUES (
+    destination_session_id, p_account_id, p_source_workspace_id, 'idle',
+    source_session.initial_message, source_session.initial_message_codec_version,
+    source_session.title, source_session.title_source,
+    source_session.instructions, source_session.policy_role,
+    destination_resources, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb,
+    'subject', p_actor_subject_id, jsonb_build_object(
+      'fork', true,
+      'sourceSessionId', p_source_session_id, 'sourceEventId', p_source_event_id,
+      'sourceAuthorityEpoch', source_session.authority_epoch,
+      'sourceVisibility', CASE source_session.visibility
+        WHEN 'user_private' THEN 'private' ELSE 'workspace' END,
+      'workspaceSharedAcknowledged', p_workspace_shared_acknowledged
+    ),
+    actor_membership.id, actor_membership.subject_id,
+    -- create_requested_visibility mirrors the destination the caller actually
+    -- asked for. Leaving it at the column default made a private fork row
+    -- internally inconsistent with its own visibility.
+    p_destination_visibility, p_destination_visibility, 1,
+    p_source_session_id, source_session.authority_epoch,
+    source_session.visibility, clock_timestamp(), actor_membership.id,
+    source_session.model, source_session.reasoning_effort, source_session.latency_mode,
+    source_session.sandbox_backend, source_session.sandbox_os, destination_session_id,
+    NULL, '[]'::jsonb, '[]'::jsonb,
+    '{"mode":"explicit","inheritedFromSessionId":null}'::jsonb,
+    destination_session_id, 0, NULL, destination_depth,
+    destination_depth_source, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL,
+    source_session.codex_compaction_mode,
+    0, 0, 0, 1
+  );
+
+  INSERT INTO session_history_items (
+    account_id, workspace_id, session_id, turn_id,
+    position, item, item_codec_version, active,
+    provider_artifact_invalidated_at, provider_artifact_invalidation_reason,
+    provider_artifact_invalidated_by_attempt_id, created_at
+  ) SELECT p_account_id, p_source_workspace_id, destination_session_id, NULL,
+      source_item.position, source_item.item, source_item.item_codec_version,
+      source_item.active, source_item.provider_artifact_invalidated_at,
+      source_item.provider_artifact_invalidation_reason,
+      source_item.provider_artifact_invalidated_by_attempt_id, source_item.created_at
+    FROM pg_temp.opengeni_session_fork_history_spool source_item
+    ORDER BY source_item.position;
+
+  INSERT INTO session_events (
+    account_id, workspace_id, session_id, sequence, type, payload, occurred_at
+  ) VALUES (
+    p_account_id, p_source_workspace_id, destination_session_id, 1,
+    'session.created', jsonb_build_object(
+      'forked', true, 'sourceSessionId', p_source_session_id, 'sourceEventId', p_source_event_id,
+      'sourceAuthorityEpoch', source_session.authority_epoch,
+      'sourceVisibility', CASE source_session.visibility
+        WHEN 'user_private' THEN 'private' ELSE 'workspace' END,
+      'visibility', public_destination_visibility,
+      'workspaceSharedAcknowledged', p_workspace_shared_acknowledged,
+      'copiedHistoryItemCount', history_count
+    ), clock_timestamp()
+  ) RETURNING id INTO event_row_id;
+
+  PERFORM set_config('opengeni.session_activity_gate_state', 'preparing', true);
+  SET CONSTRAINTS ALL IMMEDIATE;
+  SET CONSTRAINTS sessions_activity_insert_commit_guard,
+    sessions_activity_update_commit_guard DEFERRED;
+  PERFORM set_config('opengeni.session_activity_gate_state', 'finalizing', true);
+  UPDATE workspace_session_activity_revisions counter
+  SET revision = counter.revision + 1
+  WHERE counter.workspace_id = p_source_workspace_id
+  RETURNING counter.revision INTO destination_activity_revision;
+  IF destination_activity_revision IS NULL THEN
+    RAISE EXCEPTION 'session fork destination activity counter is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+  UPDATE sessions destination_session SET
+    activity_revision = destination_activity_revision,
+    activity_revision_pending_xid = NULL
+  WHERE destination_session.id = destination_session_id
+    AND destination_session.activity_revision_pending_xid
+      = pg_current_xact_id()::text::bigint;
+  IF NOT FOUND THEN RAISE EXCEPTION 'session fork activity was not finalized'
+    USING ERRCODE = '55000'; END IF;
+  SET CONSTRAINTS sessions_activity_insert_commit_guard,
+    sessions_activity_update_commit_guard IMMEDIATE;
+
+  PERFORM set_config('opengeni.session_activity_gate_state', '', true);
+  PERFORM set_config('opengeni.session_activity_gate_workspace_id', '', true);
+  DELETE FROM session_visibility_write_capabilities capability
+  WHERE capability.backend_pid = pg_backend_pid()
+    AND capability.transaction_id = pg_current_xact_id()
+    AND capability.capability_id = visibility_write_capability_id;
+  PERFORM set_config('opengeni.session_visibility_write_capability',
+    CASE WHEN previous_visibility_capability IS NULL THEN '' ELSE previous_visibility_capability END,
+    true);
+
+  UPDATE session_command_receipts SET result = jsonb_build_object(
+    'status', 'applied', 'eventId', event_row_id, 'eventSequence', 1,
+    'sessionId', destination_session_id, 'workspaceId', p_source_workspace_id,
+    'visibility', p_destination_visibility, 'authorityEpoch', 1,
+    'workspaceSharedAcknowledged', p_workspace_shared_acknowledged,
+    'copiedHistoryItemCount', history_count
+  ), updated_at = clock_timestamp() WHERE id = receipt_row.id;
+
+  operation_id := receipt_row.id; event_id := event_row_id; event_sequence := 1;
+  session_id := destination_session_id; workspace_id := p_source_workspace_id;
+  visibility := p_destination_visibility; authority_epoch := 1;
+  copied_history_item_count := history_count; replay := false;
+  PERFORM set_config('opengeni.organization_tenancy_lifecycle',
+    CASE WHEN previous_lifecycle IS NULL THEN '' ELSE previous_lifecycle END, true);
+  RETURN NEXT;
+EXCEPTION WHEN OTHERS THEN
+  PERFORM set_config('opengeni.organization_tenancy_lifecycle',
+    CASE WHEN previous_lifecycle IS NULL THEN '' ELSE previous_lifecycle END, true);
+  PERFORM set_config('opengeni.session_activity_gate_state',
+    CASE WHEN previous_gate_state IS NULL THEN '' ELSE previous_gate_state END, true);
+  PERFORM set_config('opengeni.session_activity_gate_workspace_id',
+    CASE WHEN previous_gate_workspace IS NULL THEN '' ELSE previous_gate_workspace END, true);
+  PERFORM set_config('opengeni.session_visibility_write_capability',
+    CASE WHEN previous_visibility_capability IS NULL THEN '' ELSE previous_visibility_capability END,
+    true);
+  RAISE;
+END
+$function$;
+-- Keep the same trusted schema path and owner as the existing authority seam,
+-- including migrations executed in a dedicated test or deployment schema.
+DO $posture$
+DECLARE
+  source_function regprocedure := 'fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer)'::regprocedure;
+  destination_function regprocedure := 'fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer,uuid)'::regprocedure;
+  function_owner text;
+  trusted_path text;
+BEGIN
+  SELECT pg_get_userbyid(proowner),
+    (SELECT substr(setting, length('search_path=') + 1)
+      FROM unnest(proconfig) setting WHERE setting LIKE 'search_path=%')
+    INTO function_owner, trusted_path FROM pg_proc WHERE oid = source_function;
+  IF trusted_path IS NULL THEN RAISE EXCEPTION 'fork authority search path is missing'; END IF;
+  EXECUTE format('ALTER FUNCTION %s SET search_path TO %s', destination_function, trusted_path);
+  EXECUTE format('ALTER FUNCTION %s OWNER TO %I', destination_function, function_owner);
+END
+$posture$;
+REVOKE ALL ON FUNCTION fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer,uuid) FROM PUBLIC;
+DO $grant$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer,uuid) TO opengeni_app;
+  END IF;
+END
+$grant$;

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -1458,6 +1458,22 @@ BEGIN
     END IF;
     IF to_regprocedure(
       format(
+        '%I.fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer,uuid)',
+        ${literal(schema)}
+      )
+    ) IS NOT NULL THEN
+      EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.fork_session_content(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer, uuid) FROM PUBLIC',
+        ${literal(schema)}
+      );
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION %I.fork_session_content(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer, uuid) TO %I',
+        ${literal(schema)},
+        ${literal(role)}
+      );
+    END IF;
+    IF to_regprocedure(
+      format(
         '%I.replay_applied_session_fork(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer)',
         ${literal(schema)}
       )

--- a/packages/db/src/runtime-posture.ts
+++ b/packages/db/src/runtime-posture.ts
@@ -490,6 +490,8 @@ const LEGACY_FORK_SESSION_CONTENT_ROUTINE =
   "fork_session_content(uuid, uuid, uuid, text, uuid, text, text, text, integer)";
 const FORK_SESSION_CONTENT_ROUTINE =
   "fork_session_content(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer)";
+const MESSAGE_FORK_SESSION_CONTENT_ROUTINE =
+  "fork_session_content(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer, uuid)";
 const REPLAY_APPLIED_SESSION_FORK_ROUTINE =
   "replay_applied_session_fork(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer)";
 const SESSION_TENANCY_ACTIVATED_ROUTINE = "session_tenancy_product_activated(uuid, integer)";
@@ -512,6 +514,7 @@ const PRIVATE_SESSION_CREATE_CAPABILITY_ROUTINES = [
 const SESSION_AUTHORITY_ROUTINES = new Set<string>([
   LEGACY_FORK_SESSION_CONTENT_ROUTINE,
   FORK_SESSION_CONTENT_ROUTINE,
+  MESSAGE_FORK_SESSION_CONTENT_ROUTINE,
   REPLAY_APPLIED_SESSION_FORK_ROUTINE,
   SESSION_TENANCY_ACTIVATED_ROUTINE,
   SESSION_TENANCY_ANY_ACTIVATION_ROUTINE,
@@ -556,6 +559,7 @@ export const RUNTIME_TARGET_SCHEMA_CAPABILITY_ROUTINES = [
   ...GOVERNED_LEARNING_ACTIVATION_ROUTINES,
   ...GOVERNED_LEARNING_INSPECTION_ROUTINES,
   FORK_SESSION_CONTENT_ROUTINE,
+  MESSAGE_FORK_SESSION_CONTENT_ROUTINE,
   LEGACY_FORK_SESSION_CONTENT_ROUTINE,
   REPLAY_APPLIED_SESSION_FORK_ROUTINE,
   SESSION_TENANCY_ACTIVATED_ROUTINE,

--- a/packages/db/src/session-tenancy.ts
+++ b/packages/db/src/session-tenancy.ts
@@ -114,6 +114,7 @@ export type TransitionSessionVisibilityResult = {
 };
 
 export type ForkSessionContentInput = {
+  sourceEventId?: string;
   sourceWorkspaceId: string;
   sourceSessionId: string;
   actorSubjectId: string;
@@ -346,8 +347,23 @@ export function canonicalSessionForkHash(
     | "destinationVisibility"
     | "workspaceSharedAcknowledged"
     | "runtimeRequest"
+    | "sourceEventId"
   >,
 ): string {
+  if (input.sourceEventId) {
+    return createHash("sha256")
+      .update(
+        JSON.stringify({
+          version: 4,
+          sourceSessionId: input.sourceSessionId,
+          destinationWorkspaceId: input.destinationWorkspaceId,
+          destinationVisibility: input.destinationVisibility,
+          workspaceSharedAcknowledged: input.workspaceSharedAcknowledged,
+          sourceEventId: input.sourceEventId,
+        }),
+      )
+      .digest("hex");
+  }
   if (input.runtimeRequest) {
     return createHash("sha256")
       .update(
@@ -471,6 +487,9 @@ export async function forkSessionContent(
   if (input.destinationWorkspaceId !== input.sourceWorkspaceId) {
     throw new Error("The first session fork contract is same-workspace only");
   }
+  if (input.sourceEventId && input.runtimeRequest) {
+    throw new Error("Message forks cannot replace runtime setup");
+  }
   if (Boolean(input.runtimeRequest) !== Boolean(input.runtimeConfiguration)) {
     throw new Error("A fresh session fork runtime request requires its resolved configuration");
   }
@@ -553,6 +572,7 @@ export async function forkSessionContent(
           ${input.operationKey},
           ${requestHash},
           ${SESSION_TENANCY_ACTIVATION_VERSION}
+          ${input.sourceEventId ? sql`, ${input.sourceEventId}::uuid` : sql``}
         )`,
         );
         const result = rows[0];

--- a/packages/db/test/migration-0225-session-visibility-fork-activation.test.ts
+++ b/packages/db/test/migration-0225-session-visibility-fork-activation.test.ts
@@ -416,6 +416,7 @@ describe("migration 0303 session tenancy product activation", () => {
     expect(Array.from(functions)).toEqual([
       { name: "fork_session_content", securityDefiner: true },
       { name: "fork_session_content", securityDefiner: true },
+      { name: "fork_session_content", securityDefiner: true },
       { name: "transition_session_visibility", securityDefiner: true },
     ]);
     const [constraint] = await shared.admin<Array<{ definition: string }>>`

--- a/packages/db/test/migration-0303-session-tenancy-product-activation.test.ts
+++ b/packages/db/test/migration-0303-session-tenancy-product-activation.test.ts
@@ -296,6 +296,12 @@ describe("migration 0303 session tenancy product activation", () => {
         runtimeExecutable: true,
       },
       {
+        name: "fork_session_content",
+        argumentCount: 11,
+        defaultCount: 0,
+        runtimeExecutable: true,
+      },
+      {
         name: "replay_applied_session_fork",
         argumentCount: 10,
         defaultCount: 0,

--- a/packages/db/test/migration-0345-tenant-scoped-session-tenancy-fence.test.ts
+++ b/packages/db/test/migration-0345-tenant-scoped-session-tenancy-fence.test.ts
@@ -58,6 +58,7 @@ const directHotMutatorInventory = [
   "detach_scoped_machine_dependent_sessions(uuid,uuid,uuid)",
   "finalize_organization_retention_deletion(uuid,uuid,uuid,text)",
   "fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer)",
+  "fork_session_content(uuid,uuid,uuid,text,uuid,text,boolean,text,text,integer,uuid)",
   "materialize_scheduled_task_reusable_session_from_run(uuid,uuid,uuid,uuid,uuid,bigint,text)",
   "materialize_scheduled_task_reusable_session_from_run_0252(uuid,uuid,uuid,uuid,uuid,bigint,text)",
   "opengeni_private.claim_terminal_retained_processes(uuid,integer,bigint)",

--- a/packages/db/test/migration-0353-automatic-session-title-policy-fence.test.ts
+++ b/packages/db/test/migration-0353-automatic-session-title-policy-fence.test.ts
@@ -987,7 +987,8 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
     // today's schema. A database frozen immediately after 0353 predates the
     // 0361 Memory materialization table/function and the 0380 company-profile
     // autonomy policy tables/functions, the 0400 model-context snapshot table,
-    // the 0401 setup-delivery transport routines, and the 0422 Codex inventory.
+    // the 0401 setup-delivery transport routines, the 0422 Codex inventory,
+    // and the 0429 message-boundary fork overload.
     // Preserve those exact expected boundary gaps while continuing to
     // reject every other posture violation in this
     // rolling-compatibility test.
@@ -1004,6 +1005,7 @@ describe("migrations 0353-0355 automatic session title policy fence", () => {
       "target-schema runtime capability confirm_remember_knowledge_claim(uuid, uuid, uuid, uuid, integer, uuid, uuid, uuid) authority tables are missing: remember_knowledge_memory_materializations",
       "target-schema runtime capability materialize_remember_knowledge_memory(uuid, uuid, uuid) is missing or ambiguous",
       "target-schema runtime capability undo_governed_learning_activation(uuid, uuid, uuid, uuid) authority tables are missing: remember_knowledge_memory_materializations",
+      "target-schema runtime capability fork_session_content(uuid, uuid, uuid, text, uuid, text, boolean, text, text, integer, uuid) is missing or ambiguous",
       "target-schema runtime capability list_organization_workspace_ids(uuid) is missing or ambiguous",
       "target-schema runtime capability list_organization_codex_workspace_ids(uuid) is missing or ambiguous",
       "target-schema runtime capability authorize_organization_shared_workspace_administration(uuid, uuid, text) is missing or ambiguous",

--- a/packages/db/test/personal-workspace-session-tenancy.test.ts
+++ b/packages/db/test/personal-workspace-session-tenancy.test.ts
@@ -792,6 +792,143 @@ describe("session tenancy SQL seams inside a managed human's own personal worksp
     expect(event).toMatchObject({ id: result.eventId, sequence: result.eventSequence });
   }, 180_000);
 
+  test("message fork copies the exact prefix and replays the same boundary", async () => {
+    if (!shared || !client) return;
+    const human = await provisionManagedHuman();
+    const workspaceId = human.personalWorkspaceId;
+    const sourceSessionId = await ownedSession(human, workspaceId);
+    const turnId = crypto.randomUUID();
+    const userEventId = crypto.randomUUID();
+    const replyEventId = crypto.randomUUID();
+    await shared.admin`insert into session_turns (
+      id, account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+      status, position, prompt, model, reasoning_effort, sandbox_backend
+    ) values (${turnId}, ${human.accountId}, ${workspaceId}, ${sourceSessionId},
+      ${userEventId}, 'message-fork-test', 'completed', 1, 'First question', 'test-model', 'medium', 'none')`;
+    for (const [index, event] of [
+      { id: userEventId, type: "user.message", text: "First question" },
+      { id: replyEventId, type: "agent.message.completed", text: "First answer" },
+    ].entries()) {
+      await shared.admin`insert into session_events (id, account_id, workspace_id, session_id, turn_id, sequence, type, payload)
+        values (${event.id}, ${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, ${index + 1}, ${event.type}, ${shared.admin.json({ text: event.text })})`;
+    }
+    for (const [index, item] of [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "First question" }] },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "First answer" }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Later answer must not be copied" }],
+      },
+    ].entries()) {
+      await shared.admin`insert into session_history_items (account_id, workspace_id, session_id, turn_id, position, item)
+        values (${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, ${index + 1}, ${shared.admin.json(item)})`;
+    }
+    const input = {
+      sourceWorkspaceId: workspaceId,
+      sourceSessionId,
+      actorSubjectId: human.subjectId,
+      destinationWorkspaceId: workspaceId,
+      destinationVisibility: "user_private" as const,
+      workspaceSharedAcknowledged: false,
+      operationKey: crypto.randomUUID(),
+      sourceEventId: replyEventId,
+    };
+    const fork = await forkSessionContent(client.db, input);
+    expect(fork.copiedHistoryItemCount).toBe(2);
+    const rows =
+      await shared.admin`select item from session_history_items where session_id = ${fork.sessionId} order by position`;
+    expect(rows).toHaveLength(2);
+    expect(JSON.stringify(rows)).not.toContain("Later answer");
+    expect((await forkSessionContent(client.db, input)).sessionId).toBe(fork.sessionId);
+    await expect(
+      forkSessionContent(client.db, { ...input, sourceEventId: userEventId }),
+    ).rejects.toThrow();
+    const userFork = await forkSessionContent(client.db, {
+      ...input,
+      sourceEventId: userEventId,
+      operationKey: crypto.randomUUID(),
+    });
+    expect(userFork.copiedHistoryItemCount).toBe(1);
+    await expect(
+      forkSessionContent(client.db, {
+        ...input,
+        sourceEventId: crypto.randomUUID(),
+        operationKey: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow();
+    // Exercise persisted SDK identities, provider identities, and all supported tool pairs.
+    const completedPairs: [Record<string, unknown>, Record<string, unknown>][] = [
+      [
+        { type: "function_call", callId: "fn", name: "test", arguments: "{}" },
+        { type: "function_call_result", callId: "fn", name: "test", output: "done" },
+      ],
+      [
+        { type: "computer_call", callId: "pc", action: { type: "screenshot" } },
+        { type: "computer_call_result", callId: "pc", output: "done" },
+      ],
+      [
+        { type: "shell_call", call_id: "sh" },
+        { type: "shell_call_output", call_id: "sh", output: [] },
+      ],
+      [
+        { type: "apply_patch_call", id: "patch" },
+        { type: "apply_patch_call_output", callId: "patch", output: "done" },
+      ],
+      [
+        { type: "tool_search_call", id: "item-search", providerData: { call_id: "search" } },
+        { type: "tool_search_output", providerData: { callId: "search" }, tools: [] },
+      ],
+    ];
+    for (const [call, result] of completedPairs) {
+      await shared.admin`insert into session_history_items (account_id, workspace_id, session_id, turn_id, position, item)
+        values (${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, -2, ${shared.admin.json(call)})`;
+      await expect(
+        forkSessionContent(client.db, { ...input, operationKey: crypto.randomUUID() }),
+      ).rejects.toThrow();
+      // A matching result before its call cannot settle this prefix.
+      await shared.admin`insert into session_history_items (account_id, workspace_id, session_id, turn_id, position, item)
+        values (${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, -3, ${shared.admin.json(result)})`;
+      await expect(
+        forkSessionContent(client.db, { ...input, operationKey: crypto.randomUUID() }),
+      ).rejects.toThrow();
+      await shared.admin`update session_history_items set position = -1 where session_id = ${sourceSessionId} and position = -3`;
+      const pairedFork = await forkSessionContent(client.db, {
+        ...input,
+        operationKey: crypto.randomUUID(),
+      });
+      expect(pairedFork.copiedHistoryItemCount).toBe(4);
+      await shared.admin`delete from session_history_items where session_id = ${sourceSessionId} and position < 0`;
+    }
+    await shared.admin`insert into session_history_items (account_id, workspace_id, session_id, turn_id, position, item)
+      values (${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, 0,
+        ${shared.admin.json({ type: "function_call", call_id: "unfinished", name: "test", arguments: "{}" })})`;
+    await expect(
+      forkSessionContent(client.db, { ...input, operationKey: crypto.randomUUID() }),
+    ).rejects.toThrow();
+    await shared.admin`delete from session_history_items where session_id = ${sourceSessionId} and position = 0`;
+    await shared.admin`insert into session_history_items (account_id, workspace_id, session_id, turn_id, position, item)
+      values (${human.accountId}, ${workspaceId}, ${sourceSessionId}, ${turnId}, 4,
+        ${shared.admin.json({ type: "message", role: "assistant", content: [{ type: "output_text", text: "First answer" }] })})`;
+    await expect(
+      forkSessionContent(client.db, { ...input, operationKey: crypto.randomUUID() }),
+    ).rejects.toThrow();
+    await shared.admin`delete from session_history_items where session_id = ${sourceSessionId} and position = 4`;
+    const [count] =
+      await shared.admin`select count(*)::integer as total from sessions where forked_from_session_id = ${sourceSessionId}`;
+    expect(count?.total).toBe(2 + completedPairs.length);
+    await shared.admin`update session_history_items set active = false where session_id = ${sourceSessionId} and position = 1`;
+    await expect(
+      forkSessionContent(client.db, { ...input, operationKey: crypto.randomUUID() }),
+    ).rejects.toThrow();
+    // An already committed receipt remains recoverable after source compaction.
+    expect((await forkSessionContent(client.db, input)).sessionId).toBe(fork.sessionId);
+  }, 180_000);
+
   test("fork_session_content accepts the owner's own personal workspace as source", async () => {
     if (!shared || !client) return;
     const human = await provisionManagedHuman();

--- a/packages/db/test/personal-workspace-session-tenancy.test.ts
+++ b/packages/db/test/personal-workspace-session-tenancy.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import { sql } from "drizzle-orm";
+import type postgres from "postgres";
 import {
   addSessionSystemUpdate,
   claimSessionWorkForAttempt,
@@ -862,7 +863,7 @@ describe("session tenancy SQL seams inside a managed human's own personal worksp
       }),
     ).rejects.toThrow();
     // Exercise persisted SDK identities, provider identities, and all supported tool pairs.
-    const completedPairs: [Record<string, unknown>, Record<string, unknown>][] = [
+    const completedPairs: [postgres.JSONValue, postgres.JSONValue][] = [
       [
         { type: "function_call", callId: "fn", name: "test", arguments: "{}" },
         { type: "function_call_result", callId: "fn", name: "test", output: "done" },

--- a/packages/db/test/session-tenancy.test.ts
+++ b/packages/db/test/session-tenancy.test.ts
@@ -48,6 +48,21 @@ describe("session tenancy domain", () => {
     );
   });
 
+  test("binds the selected message into fork idempotency", () => {
+    const input = {
+      sourceSessionId: "source",
+      destinationWorkspaceId: "workspace",
+      destinationVisibility: "user_private" as const,
+      workspaceSharedAcknowledged: false,
+    };
+    expect(canonicalSessionForkHash({ ...input, sourceEventId: "first" })).not.toBe(
+      canonicalSessionForkHash(input),
+    );
+    expect(canonicalSessionForkHash({ ...input, sourceEventId: "first" })).not.toBe(
+      canonicalSessionForkHash({ ...input, sourceEventId: "second" }),
+    );
+  });
+
   test("binds ordered restart runtime intent without changing legacy fork hashes", () => {
     const input = {
       sourceSessionId: "2dbf723a-cb9b-45e1-9c37-d51fcb73b32c",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -844,3 +844,9 @@ thinking labels through `messages`, and override payment descriptions through
 Subscription descriptions appear once per provider group. Free models carry a
 Free badge. Pass `hasImageAttachments` for the current draft to show an image
 compatibility warning only when the selected model cannot view those images.
+
+`MessageTimeline.renderMessageActions(item)` places host-owned controls beside
+Copy and the timestamp for user messages and completed assistant messages.
+The host owns feedback, fork authorization, and mutations; streaming assistant
+messages omit this slot. Use the `group/copy` hover/focus state and preserve
+visible touch targets when styling actions.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -130,6 +130,8 @@ export type MessageTimelineProps = {
   items?: TimelineItem[] | undefined;
   /** Current session status (reserved; tip "Working…" chrome removed for now). */
   status?: SessionStatus | null | undefined;
+  /** Host-owned controls beside Copy and the timestamp on settled message rows. */
+  renderMessageActions?: ((item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   /** Plug a markdown renderer for message bodies (e.g. streamdown). */
   renderMessageText?:
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
@@ -389,6 +391,7 @@ export function MessageTimeline({
   events,
   items,
   status: _status,
+  renderMessageActions,
   renderMessageText,
   onOpenSession,
   onMemoryClick,
@@ -889,6 +892,7 @@ export function MessageTimeline({
     () => ({
       userMessageDisclosureContext,
       behavior: {
+        renderMessageActions,
         renderMessageText,
         onOpenSession,
         onMemoryClick,
@@ -908,6 +912,7 @@ export function MessageTimeline({
       onMemoryClick,
       onOpenSession,
       onReconnect,
+      renderMessageActions,
       renderMessageText,
       resolveProviderLogo,
       toolRegistry,
@@ -2269,6 +2274,7 @@ type TimelineGroupEntryContext = {
 };
 
 type TimelineGroupBehaviorProps = {
+  renderMessageActions: MessageTimelineProps["renderMessageActions"];
   renderMessageText: MessageTimelineProps["renderMessageText"];
   onOpenSession: MessageTimelineProps["onOpenSession"];
   onMemoryClick: MessageTimelineProps["onMemoryClick"];
@@ -2332,6 +2338,7 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
 // streaming and host updates still invalidate immediately.
 const TimelineGroupView = memo(function TimelineGroupView({
   group,
+  renderMessageActions,
   renderMessageText,
   onOpenSession,
   onMemoryClick,
@@ -2349,6 +2356,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   contextCompactionCount,
 }: {
   group: TimelineGroup;
+  renderMessageActions?: ((item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   renderMessageText?:
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
     | undefined;
@@ -2507,6 +2515,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
             key={key}
             resetKeys={[
               child,
+              renderMessageActions,
               renderMessageText,
               onOpenSession,
               onMemoryClick,
@@ -2521,6 +2530,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           >
             <TimelineGroupView
               group={child}
+              renderMessageActions={renderMessageActions}
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
               onMemoryClick={onMemoryClick}
@@ -2567,6 +2577,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
       return (
         <TimelineRow
           item={group.item}
+          renderMessageActions={renderMessageActions}
           renderMessageText={renderMessageText}
           onReconnect={onReconnect}
           resolveProviderLogo={resolveProviderLogo}
@@ -2818,6 +2829,7 @@ function durationBetween(startedAt: string, endedAt: string): number | undefined
  */
 export function TimelineRow({
   item,
+  renderMessageActions,
   renderMessageText,
   onReconnect,
   resolveProviderLogo,
@@ -2825,6 +2837,7 @@ export function TimelineRow({
   loadVideoArtifactPlayback,
 }: {
   item: TimelineItem;
+  renderMessageActions?: ((item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   renderMessageText?:
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
     | undefined;
@@ -2835,11 +2848,23 @@ export function TimelineRow({
 }) {
   switch (item.kind) {
     case "user-message":
-      return <UserMessageRow item={item} renderMessageText={renderMessageText} />;
+      return (
+        <UserMessageRow
+          item={item}
+          renderMessageActions={renderMessageActions}
+          renderMessageText={renderMessageText}
+        />
+      );
     case "human-input":
       return <HumanInputConversationRow item={item} />;
     case "agent-message":
-      return <AgentMessageRow item={item} renderMessageText={renderMessageText} />;
+      return (
+        <AgentMessageRow
+          item={item}
+          renderMessageActions={renderMessageActions}
+          renderMessageText={renderMessageText}
+        />
+      );
     case "worker-completion":
       return <WorkerCompletionRow item={item} onOpenSession={onOpenSession} />;
     case "session-status":
@@ -2965,9 +2990,11 @@ function MessageFooterTime({ occurredAt }: { occurredAt: string }) {
 
 function UserMessageRow({
   item,
+  renderMessageActions,
   renderMessageText,
 }: {
   item: UserMessageItem;
+  renderMessageActions?: ((item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   renderMessageText?:
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
     | undefined;
@@ -2986,7 +3013,12 @@ function UserMessageRow({
           }
           label="Copy message"
           className="w-fit max-w-full min-w-0"
-          trailing={<MessageFooterTime occurredAt={item.occurredAt} />}
+          trailing={
+            <>
+              {renderMessageActions?.(item)}
+              <MessageFooterTime occurredAt={item.occurredAt} />
+            </>
+          }
         >
           <div className={MESSAGE_BUBBLE_CLASS}>
             {item.text ? (
@@ -3177,9 +3209,11 @@ function humanInputConversationCopyText(item: HumanInputItem, settledLabel: stri
 
 function AgentMessageRow({
   item,
+  renderMessageActions,
   renderMessageText,
 }: {
   item: AgentMessageItem;
+  renderMessageActions?: ((item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   renderMessageText?:
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
     | undefined;
@@ -3201,7 +3235,14 @@ function AgentMessageRow({
         label="Copy message"
         align="start"
         className={cn(enter && "animate-og-enter", "min-w-0 text-og-md leading-7 text-og-fg")}
-        trailing={item.streaming ? null : <MessageFooterTime occurredAt={item.occurredAt} />}
+        trailing={
+          item.streaming ? null : (
+            <>
+              {renderMessageActions?.(item)}
+              <MessageFooterTime occurredAt={item.occurredAt} />
+            </>
+          )
+        }
       >
         {body}
       </CopyHoverFrame>

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -199,6 +199,45 @@ afterEach(() => {
 });
 
 describe("MessageTimeline pagination affordances", () => {
+  test("places host message actions beside Copy and suppresses them while streaming", async () => {
+    const selected: string[] = [];
+    const r = await renderComponent(
+      <MessageTimeline
+        items={[
+          userItem("prompt", "Question"),
+          {
+            kind: "agent-message",
+            id: "reply",
+            turnId: "turn",
+            text: "Answer",
+            streaming: false,
+            occurredAt: "2026-09-09T07:00:00Z",
+          },
+          {
+            kind: "agent-message",
+            id: "stream",
+            turnId: "next",
+            text: "Working",
+            streaming: true,
+            occurredAt: "2026-09-09T07:01:00Z",
+          },
+        ]}
+        renderMessageActions={(item) => (
+          <button data-message-action={item.id} onClick={() => selected.push(item.id)}>
+            Fork from here
+          </button>
+        )}
+      />,
+    );
+    const buttons = r.container.querySelectorAll<HTMLButtonElement>("[data-message-action]");
+    expect([...buttons].map((button) => button.dataset.messageAction)).toEqual(["prompt", "reply"]);
+    for (const button of buttons)
+      expect(button.parentElement?.querySelector("[data-og-copy]")).not.toBeNull();
+    await actRun(() => buttons[1]!.click());
+    expect(selected).toEqual(["reply"]);
+    await r.unmount();
+  });
+
   test("can reveal a known-fresh first message without blanking the scroller", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -26,6 +26,7 @@ async function buildSchemaContract(directory?: string) {
         "0401_organization_user_setup_token_transport.sql",
         "0402_session_input_wait_and_background_command_results.sql",
         "0403_codex_unconditional_credential_leasing.sql",
+        "0429_message_boundary_session_forks.sql",
       ])
     : await buildCompleteSchemaContract(directory);
 }
@@ -131,7 +132,19 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
-    expect(completeSourceContract.latestMigration).toBe("0428_scheduled_task_creator_policy.sql");
+    const messageBoundarySessionForks = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0429_message_boundary_session_forks.sql",
+    );
+    expect(completeSourceContract).toMatchObject({
+      fileCount: 437 + (messageBoundarySessionForks ? 1 : 0),
+      latestMigration: messageBoundarySessionForks
+        ? "0429_message_boundary_session_forks.sql"
+        : "0428_scheduled_task_creator_policy.sql",
+    });
+    expect(completeSourceContract.migrations.at(-1)).toMatchObject({
+      path: "0429_message_boundary_session_forks.sql",
+      deploymentMode: "maintenance",
+    });
     expect(
       completeSourceContract.migrations.find(
         (migration) =>
@@ -1558,6 +1571,7 @@ describe("release schema contract", () => {
       "0419_background_command_launch_authority.sql",
       "0421_recovery_notification_claim_snapshot.sql",
       "0422_personal_workspace_organization_codex_inheritance.sql",
+      "0429_message_boundary_session_forks.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -4306,7 +4320,11 @@ async function contractWithoutMigrations(excludedPaths: readonly string[]) {
   const source = join(import.meta.dir, "../packages/db/drizzle");
   const directory = await mkdtemp(join(tmpdir(), "opengeni-schema-contract-filtered-"));
   directories.push(directory);
-  const excluded = new Set([...excludedPaths, "0397_sandbox_deadline_rotation_preemption.sql"]);
+  const excluded = new Set([
+    ...excludedPaths,
+    "0397_sandbox_deadline_rotation_preemption.sql",
+    "0429_message_boundary_session_forks.sql",
+  ]);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     if (!entry.isFile() || !entry.name.endsWith(".sql") || excluded.has(entry.name)) continue;
     await copyFile(join(source, entry.name), join(directory, entry.name));

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -348,7 +348,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     }
   }, 120_000);
 
-  test("loads older sessions only when the project's pagination button is pressed", async () => {
+  test("loads older workspace sessions once without pagination on empty projects", async () => {
     const context = await configuredContext(browser, {
       viewport: { width: 1280, height: 800 },
       extraHTTPHeaders: ownerHeaders,
@@ -369,6 +369,12 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         apiBaseUrl,
         workspaceId,
         `Pagination project B ${suffix}`,
+      );
+      const emptyProject = await createChannelThroughApi(
+        page,
+        apiBaseUrl,
+        workspaceId,
+        `Empty pagination project ${suffix}`,
       );
       for (let index = 0; index < 56; index += 1) {
         await createSession(dbClient.db, {
@@ -410,31 +416,38 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       expect(initialProjectBCount).toBeGreaterThan(0);
       expect(initialProjectACount + initialProjectBCount).toBe(50);
 
-      const filteredRequests: URL[] = [];
+      const paginationRequests: URL[] = [];
       page.on("request", (request) => {
         const url = new URL(request.url());
         if (
           request.method() === "GET" &&
           url.pathname === `/v1/workspaces/${workspaceId}/sessions` &&
-          url.searchParams.get("view") === "page" &&
-          url.searchParams.has("channelId")
+          url.searchParams.get("view") === "page"
         ) {
-          filteredRequests.push(url);
+          paginationRequests.push(url);
         }
       });
-      const loadProjectA = projectAGroup.getByRole("button", {
-        name: `Load older sessions in ${projectA.name}`,
+      expect(await projectAGroup.getByRole("button", { name: /Load older/ }).count()).toBe(0);
+      expect(await projectBGroup.getByRole("button", { name: /Load older/ }).count()).toBe(0);
+      expect(
+        await page
+          .getByRole("group", { name: emptyProject.name })
+          .getByRole("button", { name: /Load older/ })
+          .count(),
+      ).toBe(0);
+      const loadWorkspace = page.getByRole("button", {
+        name: "Load older sessions in this workspace",
       });
-      await loadProjectA.waitFor();
+      await loadWorkspace.waitFor();
       const footerBefore = await page
         .getByRole("link", { name: "Settings", exact: true })
         .boundingBox();
-      await loadProjectA.scrollIntoViewIfNeeded();
+      await loadWorkspace.scrollIntoViewIfNeeded();
       // Scrolling through folders must not grow the rail and hide Archived.
       await page.waitForTimeout(500);
-      expect(filteredRequests).toHaveLength(0);
+      expect(paginationRequests).toHaveLength(0);
       expect(await projectARows.count()).toBe(initialProjectACount);
-      await loadProjectA.click();
+      await loadWorkspace.click();
       await waitFor(async () => (await projectARows.count()) > initialProjectACount, {
         timeoutMs: 30_000,
       });
@@ -453,13 +466,13 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         .getByRole("link", { name: "Settings", exact: true })
         .boundingBox();
       expect(footerAfter?.y).toBe(footerBefore?.y);
-      expect(await projectBRows.count()).toBe(initialProjectBCount);
-      expect(filteredRequests.length).toBeGreaterThan(0);
+      expect(await projectBRows.count()).toBeGreaterThan(initialProjectBCount);
+      expect(paginationRequests.length).toBeGreaterThan(0);
+      expect(paginationRequests.every((request) => !request.searchParams.has("channelId"))).toBe(
+        true,
+      );
       expect(
-        filteredRequests.every((request) => request.searchParams.get("channelId") === projectA.id),
-      ).toBe(true);
-      expect(
-        filteredRequests.some((request) => request.searchParams.get("channelId") === projectB.id),
+        paginationRequests.some((request) => request.searchParams.get("channelId") === projectB.id),
       ).toBe(false);
     } finally {
       await context.close();

--- a/test/session-visibility-contract-surface.test.ts
+++ b/test/session-visibility-contract-surface.test.ts
@@ -53,6 +53,7 @@ const SQL_ENTRY_POINT_ALLOWLIST = new Set([
   "packages/db/drizzle/0336_atomic_session_fork_visibility.sql",
   "packages/db/drizzle/0345_tenant_scoped_session_tenancy_fence.sql",
   "packages/db/drizzle/0352_session_variable_set_attachments.sql",
+  "packages/db/drizzle/0429_message_boundary_session_forks.sql",
   "packages/db/src/session-tenancy.ts",
   "packages/db/src/provision-roles.ts",
   "packages/db/src/runtime-posture.ts",


### PR DESCRIPTION
## Summary

Move reply ratings into the message hover toolbar beside Copy and the timestamp, and add “Fork from here” so a new chat includes history only through the selected message. Replace misleading per-project pagination with one workspace-level “Load older sessions” control and match Send feedback to Settings styling.

The fork API accepts an optional source event and preserves the existing authorization and idempotent replay lifecycle. It rejects ambiguous, compacted, or incomplete tool history instead of copying later messages. Ratings remain per turn.

## Testing

- [x] Typechecks for web, React, SDK, DB, and core
- [x] Message timeline and tenancy UI tests
- [x] Real browser checks for hover actions, feedback submission, selected-message fork, and sidebar pagination
- [x] PostgreSQL tests for exact history prefixes, replay, authorization, completed tool exchanges, split exchanges, and compaction rejection
- [x] Migration ordinal, schema registration, FORCE-RLS, and timeout-budget guards
- [x] Independent agent review approved after the tool-pair matching finding was fixed and re-reviewed
- [x] GitHub CI: 39 passed, 0 failed. The isolated Firefox navigation-abort failure passed on an identical-commit retry.

## Delivery integrity

- [x] Candidate represents substantive source changes.
- [x] Resolved the actual conflict with main’s annotation update, preserving its body-only source wrapper and this PR’s hover actions. Independent review approved the integration; 90 timeline/annotation tests, React/web typechecks, and production build passed.

## Notes

Migration 0429 is a maintenance migration. Deployment must drain API and both worker pools, apply the migration, provision roles, and start the matching release. This PR does not deploy it.
