### PR TITLE
fix(runtime): prevent false Modal command-loss settlement

### DIFF
--- a/.changeset/modal-retained-command-observation.md
+++ b/.changeset/modal-retained-command-observation.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Preserve unknown Modal command observations instead of falsely settling local SDK handle loss as physical process loss. Retain exact command holders with explicit deferred/quarantine diagnostics while allowing the original owner's terminal proof to settle normally.

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -294,7 +294,8 @@ export type RetainedProcessProbeResult =
         | "provider_timeout"
         | "provider_error"
         | "provider_binding_missing"
-        | "provider_binding_mismatch";
+        | "provider_binding_mismatch"
+        | "process_observation_unavailable";
     };
 
 export type RetainedProcessProbeFn = (
@@ -1652,14 +1653,18 @@ export function retainedProcessReconciliationDeferral(
 } {
   const bindingQuarantine =
     process.reconcileAttempts >= RETAINED_PROCESS_BINDING_QUARANTINE_AFTER_ATTEMPTS &&
-    (outcome === "provider_binding_missing" || outcome === "provider_binding_mismatch");
+    (outcome === "provider_binding_missing" ||
+      outcome === "provider_binding_mismatch" ||
+      outcome === "process_observation_unavailable");
   if (bindingQuarantine) {
     return {
       durableOutcome: `quarantined_${outcome}`,
       metricOutcome:
         outcome === "provider_binding_missing"
           ? "quarantined_binding_missing"
-          : "quarantined_binding_mismatch",
+          : outcome === "provider_binding_mismatch"
+            ? "quarantined_binding_mismatch"
+            : "quarantined_process_observation_unavailable",
       retryAfterMs: RETAINED_PROCESS_BINDING_QUARANTINE_RETRY_MS,
       quarantined: true,
     };
@@ -1869,6 +1874,11 @@ export async function probeRetainedProcessAtProvider(
     ) {
       return { status: "deferred", reason: "provider_binding_mismatch" };
     }
+    // Modal resume recovers the sandbox, not the SDK's adapter-local numeric
+    // process map. Polling this fresh adapter would falsely report a live
+    // owner's command lost. Keep the holder until the owner supplies terminal
+    // proof or the exact bound provider instance is independently proved gone.
+    return { status: "deferred", reason: "process_observation_unavailable" };
   }
 
   let result: unknown;

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -1278,6 +1278,8 @@ export const RETAINED_PROCESS_RECONCILIATION_OUTCOMES = [
   "provider_binding_missing",
   "provider_binding_mismatch",
   "provider_binding_adopted",
+  "process_observation_unavailable",
+  "quarantined_process_observation_unavailable",
   "quarantined_binding_missing",
   "quarantined_binding_mismatch",
   "defer_failed",

--- a/apps/worker/test/retained-process-reconciliation.test.ts
+++ b/apps/worker/test/retained-process-reconciliation.test.ts
@@ -1144,6 +1144,46 @@ describe("retained-process terminal-owner reconciliation", () => {
     });
   }, 60_000);
 
+  test("unavailable Modal process observation remains visible and cannot release its holder", async () => {
+    if (!available) return;
+    const fixture = await promoteTurnProcess({ outcome: "completed", backgroundCommand: "work" });
+    await admin`
+      update sandbox_retained_processes set
+        reconcile_attempts = ${RETAINED_PROCESS_BINDING_QUARANTINE_AFTER_ATTEMPTS - 1},
+        reconcile_after = now()
+      where id = ${fixture.process.id}`;
+    const before = await settlementProjection(fixture);
+    const observability = await runReaper(async () => ({
+      status: "deferred",
+      reason: "process_observation_unavailable",
+    }));
+    expect(await durableProcess(fixture)).toMatchObject({
+      state: "active",
+      lastReconcileOutcome: "quarantined_process_observation_unavailable",
+      reconcileProofOutcome: null,
+      reconcileClaimId: null,
+    });
+    expect(await settlementProjection(fixture)).toEqual(before);
+    expect(await observability.prometheusMetrics()).toContain(
+      'outcome="quarantined_process_observation_unavailable"',
+    );
+    // Quarantine is only a probe schedule: exact owner exit proof still wins now.
+    const current = await durableProcess(fixture);
+    const settled = await settleRetainedProcess(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      sessionId: fixture.sessionId,
+      processId: fixture.process.id,
+      expected: retainedProcessSettlementIdentity(current),
+      outcome: "exited",
+      exitCode: 0,
+      reason: "provider_exit_banner",
+      idleGraceMs: SETTINGS.sandboxIdleGraceMs,
+    });
+    expect(settled.process.state).toBe("exited");
+    expect(settled.process.exitCode).toBe(0);
+  }, 60_000);
+
   test("repeated missing Modal binding is quarantined without releasing its blocker", async () => {
     if (!available) return;
     const fixture = await promoteTurnProcess({ outcome: "completed" });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1418,7 +1418,7 @@ process, admission, PTY, and holder remain capture blockers. Quarantine never
 becomes exit/loss proof and never authorizes capture, rotation, provider
 termination, or replay.
 
-Modal command handles are observer-local; see `docs/run-lifecycle.md`.
+Modal command observation: `docs/run-lifecycle.md`.
 
 Desktop/browser capability is layered on a compute target. The stock desktop
 image and browser daemon are separate from the ordinary headless image and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1418,6 +1418,13 @@ process, admission, PTY, and holder remain capture blockers. Quarantine never
 becomes exit/loss proof and never authorizes capture, rotation, provider
 termination, or replay.
 
+Resumed Modal adapters restore the sandbox, not their local numeric command
+handles. Retained-command reconciliation defers unavailable process observation
+and applies the same explicit quarantine schedule after five probes. It never
+uses an SDK map miss as physical loss proof. Owner exit receipts and exact bound
+provider-instance loss remain authoritative; cross-worker process reattachment
+is not provided by this containment. See `docs/run-lifecycle.md`.
+
 Desktop/browser capability is layered on a compute target. The stock desktop
 image and browser daemon are separate from the ordinary headless image and
 control-plane release lifecycle. Connected Machine desktop and terminal data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1418,8 +1418,7 @@ process, admission, PTY, and holder remain capture blockers. Quarantine never
 becomes exit/loss proof and never authorizes capture, rotation, provider
 termination, or replay.
 
-Modal handle-map misses cannot prove command loss; resumed observers defer reconciliation.
-See `docs/run-lifecycle.md` for containment and remaining reattachment limitations.
+Modal command handles are observer-local; see `docs/run-lifecycle.md`.
 
 Desktop/browser capability is layered on a compute target. The stock desktop
 image and browser daemon are separate from the ordinary headless image and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1418,12 +1418,8 @@ process, admission, PTY, and holder remain capture blockers. Quarantine never
 becomes exit/loss proof and never authorizes capture, rotation, provider
 termination, or replay.
 
-Resumed Modal adapters restore the sandbox, not their local numeric command
-handles. Retained-command reconciliation defers unavailable process observation
-and applies the same explicit quarantine schedule after five probes. It never
-uses an SDK map miss as physical loss proof. Owner exit receipts and exact bound
-provider-instance loss remain authoritative; cross-worker process reattachment
-is not provided by this containment. See `docs/run-lifecycle.md`.
+Modal handle-map misses cannot prove command loss; resumed observers defer reconciliation.
+See `docs/run-lifecycle.md` for containment and remaining reattachment limitations.
 
 Desktop/browser capability is layered on a compute target. The stock desktop
 image and browser daemon are separate from the ordinary headless image and

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1490,6 +1490,25 @@ stdin is a separate capability, explicitly unsupported when the provider has no
 interactive transport. A longer wait uses session-level `wait_for_input`,
 whose timeout never cancels the command.
 
+### Modal retained-command observation
+
+A resumed Modal SDK session restores the sandbox but not the adapter-local
+numeric process handles. The reaper reports `process_observation_unavailable`
+for that observation boundary, retaining the exact process/admission/holder.
+After five probes it records `quarantined_process_observation_unavailable` and
+rechecks after 24 hours through the existing reconciliation diagnostics/metrics.
+A current owner's exact exit proof still settles immediately; independently
+verified loss of the bound provider instance remains authoritative. Neither a
+missing SDK map entry nor failure to recover terminal output proves command loss,
+including when a completed entry aged out in its original adapter.
+
+This is safe containment, not cross-worker command reattachment. A command whose
+owner cannot recover its terminal receipt remains a visible capture blocker;
+operators must reconcile the exact command/provider identity rather than replay
+unknown side effects or clear holders by age. Durable provider execution IDs and
+output reattachment remain separate work. No new process is launched by probing.
+
+
 Migration 0419 records the exact launch turn, attempt, and execution generation
 when either provider adopts a background command under the existing attempt
 fence. Terminal results resolve that immutable receipt, copy only eligible

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -69,6 +69,7 @@ import {
   resolveConnectedMachinePath,
 } from "./selfhosted/workspace-path";
 import {
+  hasTypedExecHandleLoss,
   isExecSessionLostBanner,
   parseExecBannerExitCode,
   parseExecBannerSessionId,
@@ -170,6 +171,7 @@ export type ChannelASession = {
   }): Promise<string>;
   cancelExecCommand?(opId: string): Promise<boolean>;
   hasRetainedProcess?(providerSessionId: number): boolean;
+  retainedProcessHasTypedHandleLoss?(providerSessionId: number): boolean;
   execCommandForProcessControl?(providerSessionId: number, args: ChannelAExecArgs): Promise<string>;
   createEditor?(runAs?: string): ChannelAEditor;
   supportsPty?(): boolean;
@@ -2382,6 +2384,12 @@ export class SandboxChannelAService {
     if (!write) {
       throw new ChannelAUnsupportedError("interactive terminal unsupported on this backend");
     }
+    // Capture the pinned source contract before the write settles and removes
+    // its retained route. Guarded adapters throw on handle loss; their returned
+    // output may legitimately contain the same text as a legacy loss banner.
+    const typedHandleLoss =
+      hasTypedExecHandleLoss(this.session) ||
+      this.session.retainedProcessHasTypedHandleLoss?.(execSessionId) === true;
     const out = await write({
       sessionId: execSessionId,
       chars: data,
@@ -2395,7 +2403,7 @@ export class SandboxChannelAService {
     // rollover after the PTY opened. Surface it as a typed CONFLICT so the route
     // returns 409 and the client cleanly RE-OPENS the PTY against the live box,
     // instead of writing a raw "session not found: 1" into the user's xterm.
-    if (isExecSessionLostBanner(out, execSessionId)) {
+    if (!typedHandleLoss && isExecSessionLostBanner(out, execSessionId)) {
       throw new ChannelAConflictError("pty session lost on the live box; reopen the terminal");
     }
     return stripExecBanner(out);

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -2388,9 +2388,7 @@ export class SandboxChannelAService {
     // Capture the pinned source contract before the write settles and removes
     // its retained route. Guarded adapters throw on handle loss; their returned
     // output may legitimately contain the same text as a legacy loss banner.
-    const typedHandleLoss =
-      hasTypedExecHandleLoss(this.session) ||
-      this.session.retainedProcessHasTypedHandleLoss?.(execSessionId) === true;
+    const typedHandleLoss = hasTypedExecHandleLoss(this.session, execSessionId);
     const out = await this.withPtyHandleConflict("write", () =>
       write({ sessionId: execSessionId, chars: data, yieldTimeMs: 250 }),
     );

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -2391,22 +2391,9 @@ export class SandboxChannelAService {
     const typedHandleLoss =
       hasTypedExecHandleLoss(this.session) ||
       this.session.retainedProcessHasTypedHandleLoss?.(execSessionId) === true;
-    let out: string;
-    try {
-      out = await write({ sessionId: execSessionId, chars: data, yieldTimeMs: 250 });
-    } catch (error) {
-      // Only the interactive terminal may reopen its missing handle. This does
-      // not settle a retained command as lost or authorize replay of its input.
-      if (
-        error instanceof ModalProcessObservationUnavailableError &&
-        error.reason === "missing_handle"
-      ) {
-        throw new ChannelAConflictError(
-          "pty handle unavailable; reopen the terminal without replaying input",
-        );
-      }
-      throw error;
-    }
+    const out = await this.withPtyHandleConflict("write", () =>
+      write({ sessionId: execSessionId, chars: data, yieldTimeMs: 250 }),
+    );
     // The Modal exec surface reports a vanished exec-session as a NON-throwing
     // string ("write_stdin failed: session not found: N") that we used to stream
     // verbatim into the terminal. That happens when the persisted exec-session no
@@ -2429,11 +2416,13 @@ export class SandboxChannelAService {
       this.session.writeStdin?.bind(this.session);
     if (!write) return;
     // Send a stty in-band on the same pty session.
-    await write({
-      sessionId: execSessionId,
-      chars: `stty cols ${req.cols} rows ${req.rows}\n`,
-      yieldTimeMs: 50,
-    });
+    await this.withPtyHandleConflict("resize", () =>
+      write({
+        sessionId: execSessionId,
+        chars: `stty cols ${req.cols} rows ${req.rows}\n`,
+        yieldTimeMs: 50,
+      }),
+    );
   }
 
   /** Ask an open PTY to exit and return the exact provider banner. The routing
@@ -2444,7 +2433,33 @@ export class SandboxChannelAService {
       this.session.writeStdinForProcessControl?.bind(this.session) ??
       this.session.writeStdin?.bind(this.session);
     if (execSessionId === null || !write) return "";
-    return await write({ sessionId: execSessionId, chars: "", yieldTimeMs: 250 }); // EOF
+    return await this.withPtyHandleConflict(
+      "close",
+      () => write({ sessionId: execSessionId, chars: "\u0004", yieldTimeMs: 250 }), // EOF
+    );
+  }
+
+  private async withPtyHandleConflict<T>(
+    operation: "write" | "resize" | "close",
+    run: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await run();
+    } catch (error) {
+      // A terminal handle conflict is not retained-command loss or exit proof.
+      // In particular, failed close must not mark metadata closed or reopen it.
+      if (
+        error instanceof ModalProcessObservationUnavailableError &&
+        error.reason === "missing_handle"
+      ) {
+        throw new ChannelAConflictError(
+          operation === "close"
+            ? "pty handle unavailable; close cannot be confirmed without provider exit proof"
+            : "pty handle unavailable; reopen the terminal without replaying input",
+        );
+      }
+      throw error;
+    }
   }
 
   // ──────────────────────────── helpers ──────────────────────────────────────

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -68,6 +68,7 @@ import {
   relativeConnectedMachinePath,
   resolveConnectedMachinePath,
 } from "./selfhosted/workspace-path";
+import { ModalProcessObservationUnavailableError } from "./errors";
 import {
   hasTypedExecHandleLoss,
   isExecSessionLostBanner,
@@ -2390,11 +2391,22 @@ export class SandboxChannelAService {
     const typedHandleLoss =
       hasTypedExecHandleLoss(this.session) ||
       this.session.retainedProcessHasTypedHandleLoss?.(execSessionId) === true;
-    const out = await write({
-      sessionId: execSessionId,
-      chars: data,
-      yieldTimeMs: 250,
-    });
+    let out: string;
+    try {
+      out = await write({ sessionId: execSessionId, chars: data, yieldTimeMs: 250 });
+    } catch (error) {
+      // Only the interactive terminal may reopen its missing handle. This does
+      // not settle a retained command as lost or authorize replay of its input.
+      if (
+        error instanceof ModalProcessObservationUnavailableError &&
+        error.reason === "missing_handle"
+      ) {
+        throw new ChannelAConflictError(
+          "pty handle unavailable; reopen the terminal without replaying input",
+        );
+      }
+      throw error;
+    }
     // The Modal exec surface reports a vanished exec-session as a NON-throwing
     // string ("write_stdin failed: session not found: N") that we used to stream
     // verbatim into the terminal. That happens when the persisted exec-session no

--- a/packages/runtime/src/sandbox/errors.ts
+++ b/packages/runtime/src/sandbox/errors.ts
@@ -133,3 +133,23 @@ export class SandboxProviderUnavailableError extends Error {
     this.backend = backend;
   }
 }
+
+/** A numeric Modal SDK session id names an adapter-local handle, not a durable
+ * process. Only missing_handle is a reopenable PTY conflict; other observation
+ * failures retain their unknown outcome and must not request input replay. */
+export class ModalProcessObservationUnavailableError extends Error {
+  readonly name = "ModalProcessObservationUnavailableError";
+  readonly reason: "missing_handle" | "unsupported_handle_map" | "terminal_recovery_failed";
+  constructor(
+    providerSessionId: number,
+    options?: ErrorOptions & {
+      reason?: "missing_handle" | "unsupported_handle_map" | "terminal_recovery_failed";
+    },
+  ) {
+    super(
+      `Modal command ${providerSessionId} observation unavailable; its SDK handle is missing or terminal output could not be recovered. Do not replay the command or treat it as exited.`,
+      options,
+    );
+    this.reason = options?.reason ?? "terminal_recovery_failed";
+  }
+}

--- a/packages/runtime/src/sandbox/exec-banner.ts
+++ b/packages/runtime/src/sandbox/exec-banner.ts
@@ -3,6 +3,16 @@
 // output. Terminal status is authoritative only in the metadata header; the
 // output body is untrusted and may contain exact copies of SDK banner lines.
 
+// Only adapter code that throws on a missing handle before polling may opt in.
+// Its successful responses contain command output, never missing-handle proof.
+const typedHandleLossSessions = new WeakSet<object>();
+export function markTypedExecHandleLoss(session: object): void {
+  typedHandleLossSessions.add(session);
+}
+export function hasTypedExecHandleLoss(session: object): boolean {
+  return typedHandleLossSessions.has(session);
+}
+
 const EXEC_BANNER_HEADER_MAX_CHARS = 16 * 1024;
 const OUTPUT_DELIMITER = /\r?\nOutput:\r?\n/u;
 const SDK_METADATA_LINE =
@@ -69,7 +79,12 @@ export function parseExecBannerExitCode(raw: string): number | null {
 // Detect the Modal "the exec-session you're writing to no longer exists" fact.
 // This is process-lifetime authority, so classify only the complete known
 // banner (or its bare provider form) carrying the exact tracked numeric id.
-export function isExecSessionLostBanner(out: string, execSessionId: number): boolean {
+export function isExecSessionLostBanner(
+  out: string,
+  execSessionId: number,
+  source?: object,
+): boolean {
+  if (source && typedHandleLossSessions.has(source)) return false;
   if (!out || !Number.isSafeInteger(execSessionId) || execSessionId < 0) return false;
   const delimiter = OUTPUT_DELIMITER.exec(out);
   if (delimiter && delimiter.index > EXEC_BANNER_HEADER_MAX_CHARS) return false;

--- a/packages/runtime/src/sandbox/exec-banner.ts
+++ b/packages/runtime/src/sandbox/exec-banner.ts
@@ -9,8 +9,17 @@ const typedHandleLossSessions = new WeakSet<object>();
 export function markTypedExecHandleLoss(session: object): void {
   typedHandleLossSessions.add(session);
 }
-export function hasTypedExecHandleLoss(session: object): boolean {
-  return typedHandleLossSessions.has(session);
+export function hasTypedExecHandleLoss(
+  session: object | null | undefined,
+  providerSessionId?: number,
+): boolean {
+  if (!session) return false;
+  if (typedHandleLossSessions.has(session)) return true;
+  const routed = session as { retainedProcessHasTypedHandleLoss?: (id: number) => boolean };
+  return (
+    providerSessionId !== undefined &&
+    routed.retainedProcessHasTypedHandleLoss?.(providerSessionId) === true
+  );
 }
 
 const EXEC_BANNER_HEADER_MAX_CHARS = 16 * 1024;

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -13,7 +13,8 @@ import {
 } from "@opengeni/contracts";
 import { CAPABILITY_DESCRIPTORS } from "../capabilities";
 import { SandboxChannelAService, type ChannelASession } from "../channel-a";
-import { SandboxConfigError } from "../errors";
+import { ModalProcessObservationUnavailableError, SandboxConfigError } from "../errors";
+export { ModalProcessObservationUnavailableError } from "../errors";
 import { markTypedExecHandleLoss } from "../exec-banner";
 import {
   REPEATABLE_CONFIGURED_WORKSPACE_CAPTURE,
@@ -399,18 +400,6 @@ function installModalNativeSnapshotRetention(session: MutableModalSandboxSession
   modalDirectoryRetentionWrappedSandboxes.add(sandbox);
 }
 
-/** A numeric SDK session id names an adapter-local map entry, not a durable
- * Modal process. Its absence proves neither process exit nor provider loss. */
-export class ModalProcessObservationUnavailableError extends Error {
-  readonly name = "ModalProcessObservationUnavailableError";
-  constructor(providerSessionId: number, options?: ErrorOptions) {
-    super(
-      `Modal command ${providerSessionId} observation unavailable; its SDK handle is missing or terminal output could not be recovered. Do not replay the command or treat it as exited.`,
-      options,
-    );
-  }
-}
-
 function installModalExecCompletionRecovery(session: MutableModalSandboxSession): void {
   const writeStdin = session.writeStdin;
   if (typeof writeStdin !== "function") return;
@@ -420,8 +409,15 @@ function installModalExecCompletionRecovery(session: MutableModalSandboxSession)
     // is observer-state loss, while a real command may print the exact missing
     // handle banner at ANY exit code. Never classify its output as authority.
     // An SDK shape change must fail closed rather than reintroduce that guess.
-    if (!(session.activeProcesses instanceof Map) || !session.activeProcesses.has(args.sessionId)) {
-      throw new ModalProcessObservationUnavailableError(args.sessionId);
+    if (!(session.activeProcesses instanceof Map)) {
+      throw new ModalProcessObservationUnavailableError(args.sessionId, {
+        reason: "unsupported_handle_map",
+      });
+    }
+    if (!session.activeProcesses.has(args.sessionId)) {
+      throw new ModalProcessObservationUnavailableError(args.sessionId, {
+        reason: "missing_handle",
+      });
     }
     return await writeStdin.call(session, args);
   };

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -14,6 +14,7 @@ import {
 import { CAPABILITY_DESCRIPTORS } from "../capabilities";
 import { SandboxChannelAService, type ChannelASession } from "../channel-a";
 import { SandboxConfigError } from "../errors";
+import { isExecSessionLostBanner } from "../exec-banner";
 import {
   REPEATABLE_CONFIGURED_WORKSPACE_CAPTURE,
   providerWorkspacePersistence,
@@ -396,12 +397,31 @@ function installModalNativeSnapshotRetention(session: MutableModalSandboxSession
   modalDirectoryRetentionWrappedSandboxes.add(sandbox);
 }
 
+/** A numeric SDK session id names an adapter-local map entry, not a durable
+ * Modal process. Its absence proves neither process exit nor provider loss. */
+export class ModalProcessObservationUnavailableError extends Error {
+  readonly name = "ModalProcessObservationUnavailableError";
+  constructor(providerSessionId: number, options?: ErrorOptions) {
+    super(
+      `Modal command ${providerSessionId} observation unavailable; its SDK handle is missing or terminal output could not be recovered. Do not replay the command or treat it as exited.`,
+      options,
+    );
+  }
+}
+
 function installModalExecCompletionRecovery(session: MutableModalSandboxSession): void {
   const writeStdin = session.writeStdin;
   if (typeof writeStdin !== "function") return;
+  const observe = async (args: Parameters<typeof writeStdin>[0]) => {
+    const result = await writeStdin.call(session, args);
+    if (isExecSessionLostBanner(result, args.sessionId)) {
+      throw new ModalProcessObservationUnavailableError(args.sessionId);
+    }
+    return result;
+  };
   session.writeStdin = async (args) => {
     try {
-      return await writeStdin.call(session, args);
+      return await observe(args);
     } catch (error) {
       if (
         !isModalExecAlreadyCompletedError(error) ||
@@ -410,19 +430,13 @@ function installModalExecCompletionRecovery(session: MutableModalSandboxSession)
       ) {
         throw error;
       }
-      // Agents Extensions checks its local active-process map before writing,
-      // but the process can finish before Modal receives TaskExecStdinWrite.
-      // An empty retry performs no side effect: it lets the adapter observe the
-      // already-terminal process, delete its stale map entry, and return the
-      // ordinary exact exit banner consumed by OpenGeni's durable settlement.
-      // If that cleanup poll itself loses transport, the original typed
-      // completion is still authoritative and the canonical lost-session
-      // result lets OpenGeni close the exact retained process without failing
-      // the turn or replaying stdin.
+      // The process can finish between the SDK lookup and the provider stdin
+      // write. An empty poll may recover its exact terminal result; never replay
+      // stdin, and never turn failure to observe that result into loss proof.
       try {
-        return await writeStdin.call(session, { ...args, chars: "" });
-      } catch {
-        return `write_stdin failed: session not found: ${args.sessionId}`;
+        return await observe({ ...args, chars: "" });
+      } catch (cause) {
+        throw new ModalProcessObservationUnavailableError(args.sessionId, { cause });
       }
     }
   };

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -14,7 +14,7 @@ import {
 import { CAPABILITY_DESCRIPTORS } from "../capabilities";
 import { SandboxChannelAService, type ChannelASession } from "../channel-a";
 import { SandboxConfigError } from "../errors";
-import { isExecSessionLostBanner } from "../exec-banner";
+import { markTypedExecHandleLoss } from "../exec-banner";
 import {
   REPEATABLE_CONFIGURED_WORKSPACE_CAPTURE,
   providerWorkspacePersistence,
@@ -94,6 +94,8 @@ type ModalWorkspaceCaptureOptions = {
 };
 
 type MutableModalSandboxSession = {
+  // Pinned Agents Extensions 0.14.3 uses this synchronous adapter-local map.
+  activeProcesses?: unknown;
   modal?: {
     version?: () => string;
     sandboxes?: {
@@ -413,12 +415,17 @@ function installModalExecCompletionRecovery(session: MutableModalSandboxSession)
   const writeStdin = session.writeStdin;
   if (typeof writeStdin !== "function") return;
   const observe = async (args: Parameters<typeof writeStdin>[0]) => {
-    const result = await writeStdin.call(session, args);
-    if (isExecSessionLostBanner(result, args.sessionId)) {
+    // The pinned SDK looks up this map before its first await. Check the same
+    // handle synchronously, with no await before calling it: a missing entry
+    // is observer-state loss, while a real command may print the exact missing
+    // handle banner at ANY exit code. Never classify its output as authority.
+    // An SDK shape change must fail closed rather than reintroduce that guess.
+    if (!(session.activeProcesses instanceof Map) || !session.activeProcesses.has(args.sessionId)) {
       throw new ModalProcessObservationUnavailableError(args.sessionId);
     }
-    return result;
+    return await writeStdin.call(session, args);
   };
+  markTypedExecHandleLoss(session);
   session.writeStdin = async (args) => {
     try {
       return await observe(args);

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -28,6 +28,7 @@
 // `@opengeni/db`.
 
 import type { ExposedPortEndpoint } from "../stream-port";
+import { hasTypedExecHandleLoss } from "../exec-banner";
 import { CAPABILITY_DESCRIPTORS, type SandboxBackend } from "@opengeni/contracts";
 import { SelfhostedControlError } from "../selfhosted/control-rpc";
 import {
@@ -539,8 +540,9 @@ function providerSessionIdFromArgs(args: unknown): number | null {
 function retainedProcessTerminalProof(
   result: string,
   providerSessionId: number,
+  source?: object,
 ): RoutingRetainedProcessTerminalProof | null {
-  if (isExecSessionLostBanner(result, providerSessionId)) {
+  if (isExecSessionLostBanner(result, providerSessionId, source)) {
     return {
       outcome: "lost",
       exitCode: null,
@@ -1054,7 +1056,11 @@ export class RoutingSandboxSession implements RoutableBackendSession {
       );
     }
     if (pending.outcome === "resolved" && typeof pending.result === "string") {
-      const proof = retainedProcessTerminalProof(pending.result, record.process.providerSessionId);
+      const proof = retainedProcessTerminalProof(
+        pending.result,
+        record.process.providerSessionId,
+        record.backend.session,
+      );
       if (proof) record.pendingTerminal ??= { proof, result: pending.result };
       await this.captureRetainedOutput(record, pending.result);
       if (proof) {
@@ -1155,7 +1161,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
         );
       }
     }
-    const proof = retainedProcessTerminalProof(result, providerSessionId);
+    const proof = retainedProcessTerminalProof(result, providerSessionId, record?.backend.session);
     if (proof) record.pendingTerminal ??= { proof, result };
     await this.captureRetainedOutput(record, result);
     if (proof) {
@@ -1183,7 +1189,10 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     const pending = (async () => {
       if (existing) {
         const result = await existing.catch(() => null);
-        if (result !== null && retainedProcessTerminalProof(result, providerSessionId)) {
+        if (
+          result !== null &&
+          retainedProcessTerminalProof(result, providerSessionId, record?.backend.session)
+        ) {
           if (modelVisible && record) await this.deps.observeProcessTerminal?.(record);
           return result;
         }
@@ -1221,7 +1230,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     const result = await this.invokeProviderOperation("writeStdin", record.backend, () =>
       write.call(record.backend.session, args),
     );
-    const proof = retainedProcessTerminalProof(result, providerSessionId);
+    const proof = retainedProcessTerminalProof(result, providerSessionId, record?.backend.session);
     if (proof) record.pendingTerminal ??= { proof, result };
     await this.captureRetainedOutput(record, result);
     if (proof) {
@@ -1256,7 +1265,11 @@ export class RoutingSandboxSession implements RoutableBackendSession {
       }
     } else if (result !== undefined) {
       const banner = formatExecResult(result);
-      const chunk = isExecSessionLostBanner(banner, record.process.providerSessionId)
+      const chunk = isExecSessionLostBanner(
+        banner,
+        record.process.providerSessionId,
+        record.backend.session,
+      )
         ? ""
         : stripExecBanner(banner);
       if (chunk)
@@ -1731,6 +1744,13 @@ export class RoutingSandboxSession implements RoutableBackendSession {
       }
       return s.writeStdin(args);
     });
+  }
+
+  /** Capture the exact pinned adapter's observation contract before a terminal
+   * write removes its route. This is not process completion or liveness proof. */
+  retainedProcessHasTypedHandleLoss(providerSessionId: number): boolean {
+    const record = this.retainedProcesses.get(providerSessionId);
+    return record !== undefined && hasTypedExecHandleLoss(record.backend.session);
   }
 
   /** Whether a positive provider session locator is still pinned to the exact

--- a/packages/runtime/src/sandbox/turn-tool-cancellation.ts
+++ b/packages/runtime/src/sandbox/turn-tool-cancellation.ts
@@ -1,5 +1,6 @@
 import { runWithToolCallCorrelation, sanitizeOpIdToken } from "./op-correlation";
 import {
+  hasTypedExecHandleLoss,
   isExecSessionLostBanner,
   parseExecBannerExitCode,
   parseExecBannerSessionId,
@@ -69,6 +70,9 @@ type ActiveShellSession = {
   execInvoke: FunctionToolInvoke;
   writeInvoke: FunctionToolInvoke | null;
   processSession: CommandCancellationSession | null;
+  // Capture before a terminal read removes the retained route; this describes
+  // the adapter's error contract, never current process liveness.
+  typedHandleLoss: boolean;
   identity: ShellProcessIdentity | null;
   identityValidated: boolean;
   cancellation: Promise<void> | null;
@@ -85,6 +89,7 @@ type CommandCancellationSession = {
   supportsPty?(): boolean;
   supportsCommandInput?(providerSessionId: number): boolean;
   hasRetainedProcess?(providerSessionId: number): boolean;
+  retainedProcessHasTypedHandleLoss?(providerSessionId: number): boolean;
   /** Whether the provider locator remains controllable from another worker
    * process after this turn returns. */
   canAdoptRetainedProcessAsBackgroundCommand?(providerSessionId: number): boolean;
@@ -886,6 +891,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
             execInvoke: invokeExec,
             writeInvoke: invokeWrite,
             processSession,
+            typedHandleLoss: hasTypedExecHandleLoss(session, retainedProcess.providerSessionId),
             identity: null,
             identityValidated: false,
             cancellation: null,
@@ -945,6 +951,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
         execInvoke: invokeExec,
         writeInvoke: invokeWrite,
         processSession: retainedProcessSession(session, sessionId),
+        typedHandleLoss: hasTypedExecHandleLoss(session, sessionId),
         identity: null,
         identityValidated: false,
         cancellation: null,
@@ -1191,6 +1198,10 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
                   execInvoke: tool.invoke,
                   writeInvoke: this.rawWriteInvoke,
                   processSession,
+                  typedHandleLoss: hasTypedExecHandleLoss(
+                    cancellationSession,
+                    retainedProcess.providerSessionId,
+                  ),
                   identity: null,
                   identityValidated: false,
                   cancellation: null,
@@ -1216,6 +1227,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
                 execInvoke: tool.invoke,
                 writeInvoke: this.rawWriteInvoke,
                 processSession: retainedProcessSession(cancellationSession, sessionId),
+                typedHandleLoss: hasTypedExecHandleLoss(cancellationSession, sessionId),
                 identity: null,
                 identityValidated: false,
                 cancellation: null,
@@ -1262,6 +1274,10 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
               : input;
             const directProcessSession =
               sessionId === null ? null : retainedProcessSession(cancellationSession, sessionId);
+            const typedHandleLoss =
+              sessionId !== null &&
+              (hasTypedExecHandleLoss(cancellationSession, sessionId) ||
+                this.shellSessions.get(sessionId)?.typedHandleLoss === true);
             let output: Awaited<ReturnType<FunctionToolInvoke>>;
             if (sessionId !== null && directProcessSession?.writeStdinForProcessMutation) {
               // This bypasses the SDK-built tool, whose default errorFunction
@@ -1287,11 +1303,10 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
               output = await tool.invoke(runContext, cappedInput, details);
             }
             if (sessionId !== null && typeof output === "string") {
-              if (isExecSessionLostBanner(output, sessionId)) {
-                // Modal reports a vanished exec session as a non-throwing
-                // string. The matching provider banner is positive evidence
-                // that this exact tracked PTY no longer exists; a different id
-                // or an ambiguous error must leave the registration fenced.
+              if (!typedHandleLoss && isExecSessionLostBanner(output, sessionId)) {
+                // Legacy adapters may report a missing handle as a banner.
+                // Guarded adapters throw instead; their command output must
+                // never be reinterpreted as process-loss proof.
                 this.shellSessions.delete(sessionId);
               } else if (parseExecBannerSessionId(output) === sessionId) {
                 if (
@@ -1307,6 +1322,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
                     execInvoke: this.rawExecInvoke ?? tool.invoke,
                     writeInvoke: tool.invoke,
                     processSession: directProcessSession,
+                    typedHandleLoss,
                     identity: null,
                     identityValidated: false,
                     cancellation: null,
@@ -1333,6 +1349,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
                         execInvoke: this.rawExecInvoke ?? tool.invoke,
                         writeInvoke: tool.invoke,
                         processSession: directProcessSession,
+                        typedHandleLoss,
                         identity: null,
                         identityValidated: false,
                         cancellation: null,
@@ -1371,7 +1388,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
     const { state, startedAt, waitMs, maxOutputTokens } = input;
     const canAdoptInBackground =
       state.processSession?.canAdoptRetainedProcessAsBackgroundCommand?.(state.sessionId) ?? true;
-    if (isExecSessionLostBanner(input.initialOutput, state.sessionId)) {
+    if (!state.typedHandleLoss && isExecSessionLostBanner(input.initialOutput, state.sessionId)) {
       this.shellSessions.delete(state.sessionId);
       return input.initialOutput;
     }
@@ -1426,7 +1443,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
       if (this.cancelled) throw cancellationError(this.reason);
       if (typeof next !== "string")
         throw new Error("Retained command read returned no provider status");
-      if (isExecSessionLostBanner(next, state.sessionId)) {
+      if (!state.typedHandleLoss && isExecSessionLostBanner(next, state.sessionId)) {
         this.shellSessions.delete(state.sessionId);
         return next;
       }
@@ -1879,10 +1896,9 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
             undefined,
           );
       if (typeof output !== "string") return false;
-      // Marker files can already be gone when a process exited outside the
-      // model-facing write path. Modal's exact matching lost-session banner is
-      // then the only positive provider proof that this tracked PTY is absent.
-      if (isExecSessionLostBanner(output, state.sessionId)) return true;
+      // Preserve legacy missing-handle classification only where the adapter
+      // has no typed loss contract. Otherwise only metadata can prove exit.
+      if (!state.typedHandleLoss && isExecSessionLostBanner(output, state.sessionId)) return true;
       if (parseExecBannerSessionId(output) === state.sessionId) return false;
       if (parseExecBannerExitCode(output) !== null) return true;
     } catch {

--- a/packages/runtime/test/modal-retained-observation.test.ts
+++ b/packages/runtime/test/modal-retained-observation.test.ts
@@ -2,10 +2,117 @@ import { describe, expect, test } from "bun:test";
 import { Manifest } from "@openai/agents/sandbox";
 import { ModalSandboxSession } from "@openai/agents-extensions/sandbox/modal";
 import { installOpenGeniModalSnapshotPolicy } from "../src/sandbox/providers/modal";
+import { RoutingSandboxSession } from "../src/sandbox/routing/routing-session";
+import { SandboxChannelAService } from "../src/sandbox/channel-a";
 
 // Exercise the pinned SDK process map, exec yielding, and terminal output. Only
 // the remote transport is replaced; two adapters share one physical command.
 describe("Modal retained-command observation", () => {
+  test.each([undefined, {}, { has: () => true }])(
+    "rejects unsupported SDK process-map shape before observing",
+    async (activeProcesses) => {
+      const owner = installOpenGeniModalSnapshotPolicy(
+        new ModalSandboxSession({
+          state: {
+            sandboxId: "sb-unsupported-map",
+            manifest: new Manifest({ root: "/workspace" }),
+            environment: {},
+            workspacePersistence: "tar",
+          },
+          sandbox: {},
+          modal: { version: () => "0.9.0" },
+          app: {},
+        } as never),
+      );
+      Object.assign(owner, { activeProcesses });
+      await expect(
+        owner.writeStdin({ sessionId: 1, chars: "input", yieldTimeMs: 1 }),
+      ).rejects.toThrow("observation unavailable");
+    },
+  );
+
+  test.each([
+    [0, "control"],
+    [1, "control"],
+    [0, "pty"],
+    [1, "pty"],
+  ] as const)(
+    "preserves a real exit %i through %s whose output resembles a missing SDK handle",
+    async (exitCode, surface) => {
+      let finish!: (code: number) => void;
+      const exited = new Promise<number>((resolve) => {
+        finish = resolve;
+      });
+      let output!: ReadableStreamDefaultController<string>;
+      const sandbox = {
+        exec: async () => ({
+          stdout: new ReadableStream<string>({
+            start(controller) {
+              output = controller;
+            },
+          }),
+          stderr: new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          wait: () => exited,
+        }),
+      };
+      const owner = installOpenGeniModalSnapshotPolicy(
+        new ModalSandboxSession({
+          state: {
+            sandboxId: "sb-output-collision",
+            manifest: new Manifest({ root: "/workspace" }),
+            environment: {},
+            workspacePersistence: "tar",
+          },
+          sandbox,
+          modal: { version: () => "0.9.0" },
+          app: {},
+        } as never),
+      );
+      const proofs: unknown[] = [];
+      const chunks: string[] = [];
+      const routed = new RoutingSandboxSession({
+        readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+        resolveActiveBackend: async () => ({ session: owner, sandboxId: null, kind: "modal" }),
+        beforeMutation: async () => "parent",
+        afterMutation: async () => undefined,
+        settleProcess: async ({ proof }) => {
+          proofs.push(proof);
+        },
+        captureProcessOutput: async ({ chunk }) => {
+          chunks.push(chunk);
+        },
+      });
+      const started = await routed.execCommand({
+        cmd: "print-lost-looking-output",
+        yieldTimeMs: 1,
+      });
+      expect(started).toContain("Process running with session ID 1");
+      output.enqueue("session not found: 1");
+      output.close();
+      finish(exitCode);
+      const result =
+        surface === "pty"
+          ? await new SandboxChannelAService({ session: routed }).ptyWrite(
+              { ptyId: "test-pty", data: "" },
+              1,
+              "",
+            )
+          : await routed.writeStdinForProcessControl({ sessionId: 1, chars: "", yieldTimeMs: 10 });
+      if (surface === "control") expect(result).toContain(`Process exited with code ${exitCode}`);
+      expect(result).toContain("session not found: 1");
+      expect(proofs).toEqual([{ outcome: "exited", exitCode, reason: "provider_exit_banner" }]);
+      expect(chunks.join("")).toBe("session not found: 1");
+      expect(routed.hasRetainedProcess(1)).toBe(false);
+      await expect(owner.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 1 })).rejects.toThrow(
+        "observation unavailable",
+      );
+    },
+  );
+
   test("a second adapter cannot declare the owner's still-running command lost", async () => {
     let finish!: (code: number) => void;
     const exited = new Promise<number>((resolve) => {

--- a/packages/runtime/test/modal-retained-observation.test.ts
+++ b/packages/runtime/test/modal-retained-observation.test.ts
@@ -38,6 +38,13 @@ describe("Modal retained-command observation", () => {
           "input",
         ),
       ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
+      const terminal = new SandboxChannelAService({ session: owner });
+      await expect(
+        terminal.ptyResize({ ptyId: "unsupported-pty", cols: 80, rows: 24 }, 1),
+      ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
+      await expect(terminal.ptyClose({ ptyId: "unsupported-pty" }, 1)).rejects.toBeInstanceOf(
+        ModalProcessObservationUnavailableError,
+      );
     },
   );
 
@@ -184,6 +191,13 @@ describe("Modal retained-command observation", () => {
           "do-not-replay",
         ),
       ).rejects.toBeInstanceOf(ChannelAConflictError);
+      const terminal = new SandboxChannelAService({ session: observer });
+      await expect(
+        terminal.ptyResize({ ptyId: "resumed-pty", cols: 80, rows: 24 }, 1),
+      ).rejects.toBeInstanceOf(ChannelAConflictError);
+      await expect(terminal.ptyClose({ ptyId: "resumed-pty" }, 1)).rejects.toBeInstanceOf(
+        ChannelAConflictError,
+      );
       expect(starts).toBe(1);
       expect(stdinWrites).toBe(0);
     } finally {

--- a/packages/runtime/test/modal-retained-observation.test.ts
+++ b/packages/runtime/test/modal-retained-observation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { Manifest } from "@openai/agents/sandbox";
+import { ModalSandboxSession } from "@openai/agents-extensions/sandbox/modal";
+import { installOpenGeniModalSnapshotPolicy } from "../src/sandbox/providers/modal";
+
+// Exercise the pinned SDK process map, exec yielding, and terminal output. Only
+// the remote transport is replaced; two adapters share one physical command.
+describe("Modal retained-command observation", () => {
+  test("a second adapter cannot declare the owner's still-running command lost", async () => {
+    let finish!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      finish = resolve;
+    });
+    let starts = 0;
+    let stdinWrites = 0;
+    const sandbox = {
+      exec: async () => {
+        starts += 1;
+        return {
+          stdout: new ReadableStream({
+            start(controller) {
+              controller.enqueue("retained output\n");
+              controller.close();
+            },
+          }),
+          stderr: new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          wait: () => exited,
+          stdin: {
+            writeText: async () => {
+              stdinWrites += 1;
+            },
+          },
+        };
+      },
+    };
+    const state = {
+      sandboxId: "sb-same-instance",
+      manifest: new Manifest({ root: "/workspace" }),
+      environment: {},
+      workspacePersistence: "tar",
+    };
+    const adapter = () =>
+      installOpenGeniModalSnapshotPolicy(
+        new ModalSandboxSession({
+          state,
+          sandbox,
+          modal: { version: () => "0.9.0" },
+          app: {},
+        } as never),
+      );
+    const owner = adapter();
+    const observer = adapter();
+    const started = await owner.execCommand({ cmd: "long-running-test", yieldTimeMs: 1 });
+    expect(started).toContain("Process running with session ID 1");
+    try {
+      await expect(
+        observer.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 1 }),
+      ).rejects.toThrow("observation unavailable");
+      expect(starts).toBe(1);
+      expect(stdinWrites).toBe(0);
+    } finally {
+      finish(0);
+    }
+    expect(await owner.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 10 })).toContain(
+      "Process exited with code 0",
+    );
+    // Completed-map eviction is not physical loss proof either.
+    await expect(owner.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 1 })).rejects.toThrow(
+      "observation unavailable",
+    );
+  });
+});

--- a/packages/runtime/test/modal-retained-observation.test.ts
+++ b/packages/runtime/test/modal-retained-observation.test.ts
@@ -6,11 +6,98 @@ import {
   ModalProcessObservationUnavailableError,
 } from "../src/sandbox/providers/modal";
 import { RoutingSandboxSession } from "../src/sandbox/routing/routing-session";
+import { createTurnToolCancellationController } from "../src/sandbox/turn-tool-cancellation";
+import type { Tool } from "@openai/agents";
 import { ChannelAConflictError, SandboxChannelAService } from "../src/sandbox/channel-a";
 
 // Exercise the pinned SDK process map, exec yielding, and terminal output. Only
 // the remote transport is replaced; two adapters share one physical command.
 describe("Modal retained-command observation", () => {
+  test.each([
+    [0, false],
+    [1, false],
+    [0, true],
+    [1, true],
+  ] as const)(
+    "model shell polling preserves earlier output with exit %i (routed=%s)",
+    async (exitCode, useRouting) => {
+      let finish!: (code: number) => void;
+      const exited = new Promise<number>((resolve) => {
+        finish = resolve;
+      });
+      let output!: ReadableStreamDefaultController<string>;
+      const owner = installOpenGeniModalSnapshotPolicy(
+        new ModalSandboxSession({
+          state: {
+            sandboxId: "sb-shell-output",
+            manifest: new Manifest({ root: "/workspace" }),
+            environment: {},
+            workspacePersistence: "tar",
+          },
+          sandbox: {
+            exec: async () => ({
+              stdout: new ReadableStream<string>({
+                start(controller) {
+                  output = controller;
+                  output.enqueue("earlier output|");
+                },
+              }),
+              stderr: new ReadableStream({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+              wait: () => exited,
+            }),
+          },
+          modal: { version: () => "0.9.0" },
+          app: {},
+        } as never),
+      );
+      const proofs: unknown[] = [];
+      const routed = new RoutingSandboxSession({
+        readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+        resolveActiveBackend: async () => ({ session: owner, sandboxId: null, kind: "modal" }),
+        beforeMutation: async () => "parent",
+        afterMutation: async () => undefined,
+        settleProcess: async ({ proof }) => {
+          proofs.push(proof);
+        },
+      });
+      const session = useRouting ? routed : owner;
+      const controller = createTurnToolCancellationController();
+      const tools = controller.wrapTools(
+        [
+          {
+            type: "function",
+            name: "exec_command",
+            invoke: async () => {
+              const initial = await session.execCommand({ cmd: "print-output", yieldTimeMs: 1 });
+              output.enqueue("session not found: 1");
+              output.close();
+              finish(exitCode);
+              return initial;
+            },
+          },
+          {
+            type: "function",
+            name: "write_stdin",
+            invoke: async () =>
+              await session.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 10 }),
+          },
+        ] as never,
+        session,
+      ) as Array<Extract<Tool<unknown>, { type: "function" }>>;
+      const result = await tools
+        .find((tool) => tool.name === "exec_command")!
+        .invoke({} as never, JSON.stringify({ cmd: "print-output", yield_time_ms: 1000 }));
+      expect(result).toContain(`Process exited with code ${exitCode}`);
+      expect(result).toContain("earlier output|session not found: 1");
+      if (useRouting)
+        expect(proofs).toEqual([{ outcome: "exited", exitCode, reason: "provider_exit_banner" }]);
+    },
+  );
+
   test.each([undefined, {}, { has: () => true }])(
     "rejects unsupported SDK process-map shape before observing",
     async (activeProcesses) => {

--- a/packages/runtime/test/modal-retained-observation.test.ts
+++ b/packages/runtime/test/modal-retained-observation.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { Manifest } from "@openai/agents/sandbox";
 import { ModalSandboxSession } from "@openai/agents-extensions/sandbox/modal";
-import { installOpenGeniModalSnapshotPolicy } from "../src/sandbox/providers/modal";
+import {
+  installOpenGeniModalSnapshotPolicy,
+  ModalProcessObservationUnavailableError,
+} from "../src/sandbox/providers/modal";
 import { RoutingSandboxSession } from "../src/sandbox/routing/routing-session";
-import { SandboxChannelAService } from "../src/sandbox/channel-a";
+import { ChannelAConflictError, SandboxChannelAService } from "../src/sandbox/channel-a";
 
 // Exercise the pinned SDK process map, exec yielding, and terminal output. Only
 // the remote transport is replaced; two adapters share one physical command.
@@ -28,6 +31,13 @@ describe("Modal retained-command observation", () => {
       await expect(
         owner.writeStdin({ sessionId: 1, chars: "input", yieldTimeMs: 1 }),
       ).rejects.toThrow("observation unavailable");
+      await expect(
+        new SandboxChannelAService({ session: owner }).ptyWrite(
+          { ptyId: "unsupported-pty", data: "input" },
+          1,
+          "input",
+        ),
+      ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
     },
   );
 
@@ -167,6 +177,13 @@ describe("Modal retained-command observation", () => {
       await expect(
         observer.writeStdin({ sessionId: 1, chars: "", yieldTimeMs: 1 }),
       ).rejects.toThrow("observation unavailable");
+      await expect(
+        new SandboxChannelAService({ session: observer }).ptyWrite(
+          { ptyId: "resumed-pty", data: "do-not-replay" },
+          1,
+          "do-not-replay",
+        ),
+      ).rejects.toBeInstanceOf(ChannelAConflictError);
       expect(starts).toBe(1);
       expect(stdinWrites).toBe(0);
     } finally {

--- a/packages/runtime/test/modal-snapshot-retention.test.ts
+++ b/packages/runtime/test/modal-snapshot-retention.test.ts
@@ -514,7 +514,7 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
     expect(replacementDetach).not.toHaveBeenCalled();
   });
 
-  test("falls back to the exact lost-session result after typed completion cleanup fails", async () => {
+  test("preserves unknown terminal observation after typed completion cleanup fails", async () => {
     let call = 0;
     const writeStdin = mock(async () => {
       call += 1;
@@ -532,8 +532,8 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
 
     installOpenGeniModalSnapshotPolicy(session);
 
-    await expect(session.writeStdin({ sessionId: 11, chars: "input" })).resolves.toBe(
-      "write_stdin failed: session not found: 11",
+    await expect(session.writeStdin({ sessionId: 11, chars: "input" })).rejects.toThrow(
+      "observation unavailable",
     );
   });
 

--- a/packages/runtime/test/modal-snapshot-retention.test.ts
+++ b/packages/runtime/test/modal-snapshot-retention.test.ts
@@ -16,6 +16,8 @@ import {
   modalProvider,
 } from "../src/sandbox/providers/modal";
 import { discoverWorkspaceSkills } from "../src/workspace-skills";
+import { SandboxChannelAService } from "../src/sandbox/channel-a";
+import { ModalProcessObservationUnavailableError } from "../src/sandbox/errors";
 
 type Persistence = "tar" | "snapshot_filesystem" | "snapshot_directory";
 const SNAPSHOT_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
@@ -541,6 +543,14 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
     await expect(session.writeStdin({ sessionId: 11, chars: "input" })).rejects.toThrow(
       "observation unavailable",
     );
+    call = 0;
+    await expect(
+      new SandboxChannelAService({ session }).ptyWrite(
+        { ptyId: "uncertain-pty", data: "input" },
+        11,
+        "input",
+      ),
+    ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
   });
 
   test("does not reinterpret other Modal or untyped stdin failures as terminal proof", async () => {

--- a/packages/runtime/test/modal-snapshot-retention.test.ts
+++ b/packages/runtime/test/modal-snapshot-retention.test.ts
@@ -443,7 +443,10 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
       }
       return terminal;
     });
-    const session = Object.assign(fakeSession("tar"), { writeStdin });
+    const session = Object.assign(fakeSession("tar"), {
+      writeStdin,
+      activeProcesses: new Map([[7, {}]]),
+    });
 
     installOpenGeniModalSnapshotPolicy(session);
 
@@ -528,7 +531,10 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
       }
       throw new Error("cleanup transport failed");
     });
-    const session = Object.assign(fakeSession("tar"), { writeStdin });
+    const session = Object.assign(fakeSession("tar"), {
+      writeStdin,
+      activeProcesses: new Map([[11, {}]]),
+    });
 
     installOpenGeniModalSnapshotPolicy(session);
 
@@ -561,7 +567,10 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
     const writeStdin = mock(async () => {
       throw failure;
     });
-    const session = Object.assign(fakeSession("tar"), { writeStdin });
+    const session = Object.assign(fakeSession("tar"), {
+      writeStdin,
+      activeProcesses: new Map([[13, {}]]),
+    });
     installOpenGeniModalSnapshotPolicy(session);
 
     await expect(session.writeStdin({ sessionId: 13, chars: "input" })).rejects.toBe(failure);

--- a/packages/runtime/test/modal-snapshot-retention.test.ts
+++ b/packages/runtime/test/modal-snapshot-retention.test.ts
@@ -551,6 +551,15 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
         "input",
       ),
     ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
+    const terminal = new SandboxChannelAService({ session });
+    call = 0;
+    await expect(
+      terminal.ptyResize({ ptyId: "uncertain-pty", cols: 80, rows: 24 }, 11),
+    ).rejects.toBeInstanceOf(ModalProcessObservationUnavailableError);
+    call = 0;
+    await expect(terminal.ptyClose({ ptyId: "uncertain-pty" }, 11)).rejects.toBeInstanceOf(
+      ModalProcessObservationUnavailableError,
+    );
   });
 
   test("does not reinterpret other Modal or untyped stdin failures as terminal proof", async () => {


### PR DESCRIPTION
A retained command can still be running in Modal when the control worker resumes a second SDK adapter. That adapter has no local numeric process handle, so its missing-session banner was accepted as physical command loss. The false settlement could then conflict with the owner's real exit result and fail the agent turn.

Resumed Modal reconciliation now records observation unavailable and preserves the exact process, admission and holder. The owner adapter checks its pinned SDK handle map before polling; command output that resembles a missing-handle banner remains ordinary output, including genuine exit codes 0 and 1. Routing and cancellation preserve that distinction, accumulated foreground output and the real terminal result. Interactive terminal write, resize and close report the existing conflict response for a confirmed missing handle, without replaying failed input or confirming a close without exact provider exit proof. Unsupported adapter state and failed output recovery remain explicitly unknown.

Exact owner exit results and independently verified loss of the bound provider instance remain authoritative. Repeated unavailable observations use the existing visible quarantine/backoff path. This contains false loss; it does not implement cross-worker command reattachment or repair historical false settlements. If the owner cannot recover a terminal receipt, the command remains a reconciliation blocker.

Validation: pinned Modal SDK regressions with shared simulated provider transport reproduce the cold-adapter defect and cover output collisions, routing settlement and terminal reopening. The focused runtime, routing, ChannelA and cancellation suite passed 234 tests; 28 real-PostgreSQL retained-process tests passed. Runtime/worker typechecks and focused lint/format checks passed. Independent review approved final commit a2adba6fecb8c9fb38e97df4367d37fd8dcc3a63. A disposable merge with current main passed the documentation guard and 33 SDK/snapshot tests (139 assertions). Automated review and CI are tracked on the PR.

Tracks [OPE-465](https://linear.app/cloudgeni/issue/OPE-465). Follow-up to OPE-118. No deployment or live-session mutation performed.

## Summary by Sourcery

Prevent false Modal command-loss settlement by preserving unknown observations until exact owner exit or provider-loss proof is available.

Bug Fixes:
- Prevent Modal adapter-local handle loss from being misclassified as physical command loss or terminal exit.
- Preserve command output and authoritative owner exit results when output resembles a missing-session banner, including exit codes 0 and 1.
- Return explicit terminal conflicts for confirmed missing handles without replaying input or falsely confirming closure.

Enhancements:
- Retain exact process, admission, and holder identity when Modal command observation is unavailable, with visible deferred and quarantine diagnostics.
- Treat unsupported adapter state and failed terminal-output recovery as unknown rather than settlement proof.

Documentation:
- Document Modal retained-command observation behavior, quarantine semantics, and the limits of reconciliation.

Tests:
- Add Modal, routing, terminal, cancellation, and retained-process coverage for unavailable observations, output collisions, owner settlement, and terminal conflict handling.