### PR TITLE
fix(worker): distinguish wake signals from durable admission

### DIFF
--- a/.changeset/truthful-wake-admission.md
+++ b/.changeset/truthful-wake-admission.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/worker-bundle": patch
+"@opengeni/core": patch
+---
+
+Preserve durable wake acknowledgment receipts through API and worker signalers. Report pending admission and unconfirmed legacy signal delivery separately from acknowledged revisions, so transport acceptance cannot be mistaken for agent execution progress. Existing wake retries and admission fences remain authoritative.

--- a/.changeset/truthful-wake-admission.md
+++ b/.changeset/truthful-wake-admission.md
@@ -1,6 +1,7 @@
 ---
 "@opengeni/worker-bundle": patch
 "@opengeni/core": patch
+"@opengeni/api-router": patch
 ---
 
 Preserve durable wake acknowledgment receipts through API and worker signalers. Report pending admission and unconfirmed legacy signal delivery separately from acknowledged revisions, so transport acceptance cannot be mistaken for agent execution progress. Existing wake retries and admission fences remain authoritative.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -123,6 +123,7 @@ export async function createTemporalWorkflowClient(
       workflowId,
       wakeRevision,
       interruptionRequested,
+      onSignalAccepted,
     }) => {
       await temporal.workflow.signalWithStart("sessionWorkflow", {
         taskQueue: settings.temporalTaskQueue,
@@ -131,6 +132,7 @@ export async function createTemporalWorkflowClient(
         args: [{ accountId, workspaceId, sessionId }],
         signal: interruptionRequested ? "sessionControl" : "queueChanged",
       });
+      onSignalAccepted?.();
       return await markSessionWorkflowWakeDelivered(db, {
         accountId,
         workspaceId,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -131,7 +131,7 @@ export async function createTemporalWorkflowClient(
         args: [{ accountId, workspaceId, sessionId }],
         signal: interruptionRequested ? "sessionControl" : "queueChanged",
       });
-      await markSessionWorkflowWakeDelivered(db, {
+      return await markSessionWorkflowWakeDelivered(db, {
         accountId,
         workspaceId,
         sessionId,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -331,17 +331,50 @@ export async function reconcileAutomaticSessionTitleFanout(
   return { claimed: rows.length, delivered, failed };
 }
 
+export type WorkflowWakeReconciliationResult = {
+  claimed: number;
+  /** Transport acceptance is not durable admission. */
+  signaled: number;
+  /** Revisions acknowledged by the durable admission guard. */
+  delivered: number;
+  pendingAdmission: number;
+  /** Legacy/embedding signalers may not return an acknowledgment receipt. */
+  unconfirmed: number;
+  failed: number;
+  pendingAdmissionBlockers: Partial<
+    Record<
+      Extract<
+        import("@opengeni/db").SessionWorkflowWakeDeliveryResult,
+        { action: "pending_admission" }
+      >["blocker"],
+      number
+    >
+  >;
+};
+
 export async function reconcilePendingSessionWorkflowWakes(
   svc: NotifyServices,
   limit = 1_000,
   overrides: ReconcileSessionWorkflowWakeOverrides = {},
-): Promise<{ claimed: number; delivered: number; failed: number }> {
+): Promise<WorkflowWakeReconciliationResult> {
   const claimPendingSessionWorkflowWakesFn =
     overrides.claimPendingSessionWorkflowWakes ?? claimPendingSessionWorkflowWakes;
   if (!svc.wakeSessionWorkflow) {
-    return { claimed: 0, delivered: 0, failed: 0 };
+    return {
+      claimed: 0,
+      signaled: 0,
+      delivered: 0,
+      pendingAdmission: 0,
+      unconfirmed: 0,
+      failed: 0,
+      pendingAdmissionBlockers: {},
+    };
   }
   const repairs = await claimPendingSessionWorkflowWakesFn(svc.db, limit);
+  let signaled = 0;
+  let pendingAdmission = 0;
+  let unconfirmed = 0;
+  const pendingAdmissionBlockers: WorkflowWakeReconciliationResult["pendingAdmissionBlockers"] = {};
   let delivered = 0;
   let failed = 0;
   const queue = [...repairs];
@@ -350,7 +383,7 @@ export async function reconcilePendingSessionWorkflowWakes(
       const repair = queue.shift();
       if (!repair) return;
       try {
-        await svc.wakeSessionWorkflow!({
+        const receipt = await svc.wakeSessionWorkflow!({
           accountId: repair.accountId,
           workspaceId: repair.workspaceId,
           sessionId: repair.sessionId,
@@ -358,7 +391,18 @@ export async function reconcilePendingSessionWorkflowWakes(
           wakeRevision: repair.wakeRevision,
           ...(repair.interruptionRequested ? { interruptionRequested: true } : {}),
         });
-        delivered += 1;
+        signaled += 1;
+        if (receipt?.action === "acknowledged") {
+          delivered += 1;
+        } else if (receipt?.action === "pending_admission") {
+          pendingAdmission += 1;
+          pendingAdmissionBlockers[receipt.blocker] =
+            (pendingAdmissionBlockers[receipt.blocker] ?? 0) + 1;
+        } else {
+          // A successful legacy signal is not proof of acknowledgment. The
+          // committed outbox obligation remains owned by the existing guard.
+          unconfirmed += 1;
+        }
       } catch (error) {
         failed += 1;
         await markSessionWorkflowWakeFailed(
@@ -370,7 +414,15 @@ export async function reconcilePendingSessionWorkflowWakes(
     }
   });
   await Promise.all(workers);
-  return { claimed: repairs.length, delivered, failed };
+  return {
+    claimed: repairs.length,
+    signaled,
+    delivered,
+    pendingAdmission,
+    unconfirmed,
+    failed,
+    pendingAdmissionBlockers,
+  };
 }
 
 function childCompletionPayload(

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -382,6 +382,12 @@ export async function reconcilePendingSessionWorkflowWakes(
     for (;;) {
       const repair = queue.shift();
       if (!repair) return;
+      let signalAccepted = false;
+      const onSignalAccepted = () => {
+        if (signalAccepted) return;
+        signalAccepted = true;
+        signaled += 1;
+      };
       try {
         const receipt = await svc.wakeSessionWorkflow!({
           accountId: repair.accountId,
@@ -390,8 +396,11 @@ export async function reconcilePendingSessionWorkflowWakes(
           workflowId: repair.temporalWorkflowId,
           wakeRevision: repair.wakeRevision,
           ...(repair.interruptionRequested ? { interruptionRequested: true } : {}),
+          onSignalAccepted,
         });
-        signaled += 1;
+        // Older embeddings do not invoke the optional transport observer.
+        // Their successful return still proves a signal call, never an ACK.
+        onSignalAccepted();
         if (receipt?.action === "acknowledged") {
           delivered += 1;
         } else if (receipt?.action === "pending_admission") {

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -28,6 +28,8 @@ export type WakeSessionWorkflowSignal = (input: {
   workflowId: string;
   wakeRevision: number;
   interruptionRequested?: boolean;
+  /** Called after transport acceptance, before the fallible durable ACK. */
+  onSignalAccepted?: () => void;
 }) => Promise<SessionWorkflowWakeDeliveryResult | void>;
 
 export type SignalCodexCapacityWorkflow = (input: {

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -6,7 +6,7 @@ import type {
   ScheduledTaskTriggerType,
   TurnInitiator,
 } from "@opengeni/contracts";
-import type { Database } from "@opengeni/db";
+import type { Database, SessionWorkflowWakeDeliveryResult } from "@opengeni/db";
 import type { DocumentServices } from "@opengeni/documents";
 import type { EventBus } from "@opengeni/events";
 import type { Observability } from "@opengeni/observability";
@@ -28,7 +28,7 @@ export type WakeSessionWorkflowSignal = (input: {
   workflowId: string;
   wakeRevision: number;
   interruptionRequested?: boolean;
-}) => Promise<void>;
+}) => Promise<SessionWorkflowWakeDeliveryResult | void>;
 
 export type SignalCodexCapacityWorkflow = (input: {
   accountId: string;

--- a/apps/worker/src/activities/workflow-wake.ts
+++ b/apps/worker/src/activities/workflow-wake.ts
@@ -10,16 +10,14 @@ import type { ControlActivityServices } from "./types";
 import {
   reconcileAutomaticSessionTitleFanout,
   reconcilePendingSessionWorkflowWakes,
+  type WorkflowWakeReconciliationResult,
 } from "./parent-wake";
 
 const BATCH_SIZE = 1_000;
 const MAX_DELIVERIES_PER_ACTIVITY = 10_000;
 const MAX_TITLE_FANOUT_PER_ACTIVITY = 1_000;
 
-export type DispatchSessionWorkflowWakesResult = {
-  claimed: number;
-  delivered: number;
-  failed: number;
+export type DispatchSessionWorkflowWakesResult = WorkflowWakeReconciliationResult & {
   exhaustedBatchLimit: boolean;
 };
 
@@ -61,6 +59,11 @@ export function createWorkflowWakeActivities(services: () => Promise<ControlActi
         }
       }
       let claimed = 0;
+      let signaled = 0;
+      let pendingAdmission = 0;
+      let unconfirmed = 0;
+      const pendingAdmissionBlockers: WorkflowWakeReconciliationResult["pendingAdmissionBlockers"] =
+        {};
       let delivered = 0;
       let failed = 0;
       let exhaustedBatchLimit = false;
@@ -73,7 +76,14 @@ export function createWorkflowWakeActivities(services: () => Promise<ControlActi
         const limit = Math.min(BATCH_SIZE, remaining);
         const batch = await reconcilePendingSessionWorkflowWakes(service, limit);
         claimed += batch.claimed;
+        signaled += batch.signaled;
         delivered += batch.delivered;
+        pendingAdmission += batch.pendingAdmission;
+        unconfirmed += batch.unconfirmed;
+        for (const [blocker, count] of Object.entries(batch.pendingAdmissionBlockers)) {
+          const key = blocker as keyof typeof pendingAdmissionBlockers;
+          pendingAdmissionBlockers[key] = (pendingAdmissionBlockers[key] ?? 0) + count;
+        }
         failed += batch.failed;
         if (batch.claimed < limit) break;
       }
@@ -95,7 +105,23 @@ export function createWorkflowWakeActivities(services: () => Promise<ControlActi
           failed: titleFanout.failed,
         });
       }
-      return { claimed, delivered, failed, exhaustedBatchLimit };
+      const result = {
+        claimed,
+        signaled,
+        delivered,
+        pendingAdmission,
+        unconfirmed,
+        failed,
+        pendingAdmissionBlockers,
+        exhaustedBatchLimit,
+      };
+      if (claimed > 0) {
+        service.observability.info("session workflow wake delivery reconciled", {
+          ...result,
+          pendingAdmissionBlockers: JSON.stringify(pendingAdmissionBlockers),
+        });
+      }
+      return result;
     },
   };
 }

--- a/apps/worker/src/activities/workflow-wake.ts
+++ b/apps/worker/src/activities/workflow-wake.ts
@@ -117,8 +117,19 @@ export function createWorkflowWakeActivities(services: () => Promise<ControlActi
       };
       if (claimed > 0) {
         service.observability.info("session workflow wake delivery reconciled", {
-          ...result,
-          pendingAdmissionBlockers: JSON.stringify(pendingAdmissionBlockers),
+          claimed,
+          signaled,
+          delivered,
+          pendingAdmission,
+          unconfirmed,
+          failed,
+          exhaustedBatchLimit,
+          ...Object.fromEntries(
+            Object.entries(pendingAdmissionBlockers).map(([blocker, count]) => [
+              `pendingAdmissionBlockers.${blocker}`,
+              count,
+            ]),
+          ),
         });
       }
       return result;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -395,7 +395,7 @@ export async function createWorkerWorkflowSignaler(
           signal: "queueChanged",
         });
       }
-      await markSessionWorkflowWakeDelivered(db, {
+      return await markSessionWorkflowWakeDelivered(db, {
         accountId,
         workspaceId,
         sessionId,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -376,6 +376,7 @@ export async function createWorkerWorkflowSignaler(
       workflowId,
       wakeRevision,
       interruptionRequested,
+      onSignalAccepted,
     }) => {
       if (interruptionRequested) {
         await temporal.workflow.signalWithStart("sessionWorkflow", {
@@ -395,6 +396,7 @@ export async function createWorkerWorkflowSignaler(
           signal: "queueChanged",
         });
       }
+      onSignalAccepted?.();
       return await markSessionWorkflowWakeDelivered(db, {
         accountId,
         workspaceId,

--- a/apps/worker/test/parent-wake.test.ts
+++ b/apps/worker/test/parent-wake.test.ts
@@ -40,45 +40,78 @@ function durableFanoutBus(methods: Record<string, unknown>): EventBus {
   } as unknown as EventBus;
 }
 
-test("workflow-wake repair delivers an outstanding session receipt", async () => {
-  const wakeSessionWorkflow = mock(async () => undefined);
-  const claimPendingSessionWorkflowWakes = mock(async () => [
-    {
+for (const scenario of [
+  {
+    receipt: { action: "acknowledged" } as const,
+    delivered: 1,
+    pendingAdmission: 0,
+    unconfirmed: 0,
+  },
+  ...(
+    [
+      "pending_agent_steer",
+      "pending_prompt_turn",
+      "pending_quiescence",
+      "pending_machine_input",
+      "pending_input_wait",
+    ] as const
+  ).map((blocker) => ({
+    receipt: { action: "pending_admission", blocker } as const,
+    delivered: 0,
+    pendingAdmission: 1,
+    unconfirmed: 0,
+  })),
+  { receipt: undefined, delivered: 0, pendingAdmission: 0, unconfirmed: 1 },
+]) {
+  test(`workflow-wake repair preserves ${JSON.stringify(scenario.receipt)} receipt`, async () => {
+    const wakeSessionWorkflow = mock(async () => scenario.receipt);
+    const claimPendingSessionWorkflowWakes = mock(async () => [
+      {
+        accountId: "11111111-1111-4111-8111-111111111111",
+        workspaceId: "22222222-2222-4222-8222-222222222222",
+        sessionId: "33333333-3333-4333-8333-333333333333",
+        temporalWorkflowId: "session-33333333-3333-4333-8333-333333333333",
+        wakeRevision: 7,
+        interruptionRequested: false,
+      },
+    ]);
+    const db = {} as Database;
+
+    const result = await reconcilePendingSessionWorkflowWakes(
+      {
+        db,
+        bus: { publish: async () => undefined } as unknown as EventBus,
+        settings: {} as Settings,
+        observability: {
+          info: () => undefined,
+          error: () => undefined,
+        } as unknown as NotifyServices["observability"],
+        wakeSessionWorkflow,
+      },
+      17,
+      { claimPendingSessionWorkflowWakes },
+    );
+
+    expect(result).toEqual({
+      claimed: 1,
+      signaled: 1,
+      delivered: scenario.delivered,
+      pendingAdmission: scenario.pendingAdmission,
+      unconfirmed: scenario.unconfirmed,
+      failed: 0,
+      pendingAdmissionBlockers:
+        scenario.receipt?.action === "pending_admission" ? { [scenario.receipt.blocker]: 1 } : {},
+    });
+    expect(claimPendingSessionWorkflowWakes).toHaveBeenCalledWith(db, 17);
+    expect(wakeSessionWorkflow).toHaveBeenCalledWith({
       accountId: "11111111-1111-4111-8111-111111111111",
       workspaceId: "22222222-2222-4222-8222-222222222222",
       sessionId: "33333333-3333-4333-8333-333333333333",
-      temporalWorkflowId: "session-33333333-3333-4333-8333-333333333333",
+      workflowId: "session-33333333-3333-4333-8333-333333333333",
       wakeRevision: 7,
-      interruptionRequested: false,
-    },
-  ]);
-  const db = {} as Database;
-
-  const result = await reconcilePendingSessionWorkflowWakes(
-    {
-      db,
-      bus: { publish: async () => undefined } as unknown as EventBus,
-      settings: {} as Settings,
-      observability: {
-        info: () => undefined,
-        error: () => undefined,
-      } as unknown as NotifyServices["observability"],
-      wakeSessionWorkflow,
-    },
-    17,
-    { claimPendingSessionWorkflowWakes },
-  );
-
-  expect(result).toEqual({ claimed: 1, delivered: 1, failed: 0 });
-  expect(claimPendingSessionWorkflowWakes).toHaveBeenCalledWith(db, 17);
-  expect(wakeSessionWorkflow).toHaveBeenCalledWith({
-    accountId: "11111111-1111-4111-8111-111111111111",
-    workspaceId: "22222222-2222-4222-8222-222222222222",
-    sessionId: "33333333-3333-4333-8333-333333333333",
-    workflowId: "session-33333333-3333-4333-8333-333333333333",
-    wakeRevision: 7,
+    });
   });
-});
+}
 
 test("automatic-title migration fanout publishes and acknowledges the durable event", async () => {
   const publish = mock(async () => undefined);

--- a/apps/worker/test/parent-wake.test.ts
+++ b/apps/worker/test/parent-wake.test.ts
@@ -109,6 +109,7 @@ for (const scenario of [
       sessionId: "33333333-3333-4333-8333-333333333333",
       workflowId: "session-33333333-3333-4333-8333-333333333333",
       wakeRevision: 7,
+      onSignalAccepted: expect.any(Function),
     });
   });
 }

--- a/apps/worker/test/workflow-wake-admission.test.ts
+++ b/apps/worker/test/workflow-wake-admission.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import {
+  bootstrapWorkspace,
+  claimPendingSessionWorkflowWakes,
+  claimSessionWorkForAttempt,
+  createDb,
+  createSession,
+  listSessionTurns,
+  markSessionWorkflowWakeDelivered,
+  submitHumanPromptInTransaction,
+  withWorkspaceSessionActivityRls as withWorkspaceRls,
+  withWorkspaceSubjectSessionActivityRls as withWorkspaceSubjectRls,
+} from "@opengeni/db";
+import * as schema from "../../../packages/db/src/schema";
+
+import {
+  reconcilePendingSessionWorkflowWakes,
+  type NotifyServices,
+} from "../src/activities/parent-wake";
+
+let shared: SharedTestDatabase;
+let client: ReturnType<typeof createDb>;
+
+beforeAll(async () => {
+  const acquired = await acquireSharedTestDatabase("workflow-wake-admission");
+  if (!acquired) throw new Error("PostgreSQL test database unavailable");
+  shared = acquired;
+  client = createDb(shared.appUrl);
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+async function fixture() {
+  const suffix = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "wake-test",
+    accountExternalId: `account-${suffix}`,
+    accountName: "Wake outbox test",
+    workspaceExternalSource: "wake-test",
+    workspaceExternalId: `workspace-${suffix}`,
+    workspaceName: "Wake outbox test",
+    subjectId: `subject-${suffix}`,
+  });
+  const grant = access.workspaceGrants[0]!;
+  const session = await createSession(client.db, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId!,
+    initialMessage: "initial",
+    resources: [],
+    metadata: {},
+    model: "scripted-model",
+    reasoningEffort: "medium" as const,
+    latencyMode: "standard" as const,
+    sandboxBackend: "none",
+  });
+  return { grant, session };
+}
+
+type WakeFixture = Awaited<ReturnType<typeof fixture>>;
+
+async function send(
+  wakeFixture: WakeFixture,
+  text: string,
+  delivery: "send" | "steer" = "send",
+  clientEventId = crypto.randomUUID(),
+) {
+  return await withWorkspaceSubjectRls(
+    client.db,
+    wakeFixture.grant.workspaceId!,
+    wakeFixture.grant.subjectId,
+    (db) =>
+      db.transaction((tx) =>
+        submitHumanPromptInTransaction(tx as unknown as typeof db, {
+          accountId: wakeFixture.grant.accountId,
+          workspaceId: wakeFixture.grant.workspaceId!,
+          sessionId: wakeFixture.session.id,
+          subjectId: wakeFixture.grant.subjectId,
+          actor: { type: "human", subjectId: wakeFixture.grant.subjectId },
+          operationKey: clientEventId,
+          delivery,
+          text,
+          resources: [],
+          reasoningEffortFallback: "low",
+          source: "user",
+        }),
+      ),
+  );
+}
+
+async function wakeRow(workspaceId: string, sessionId: string) {
+  return await withWorkspaceRls(client.db, workspaceId, async (db) => {
+    const [row] = await db
+      .select()
+      .from(schema.sessionWorkflowWakeOutbox)
+      .where(
+        and(
+          eq(schema.sessionWorkflowWakeOutbox.workspaceId, workspaceId),
+          eq(schema.sessionWorkflowWakeOutbox.sessionId, sessionId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+test("accepted Send stays pending in supervision until the actual durable claim", async () => {
+  const ctx = await fixture();
+  const queued = await send(ctx, "finish the outstanding work");
+  const wake = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
+    (row) => row.sessionId === ctx.session.id,
+  )!;
+  let signals = 0;
+  const service = {
+    db: client.db,
+    observability: { info: () => {}, error: () => {} },
+    wakeSessionWorkflow: async () => {
+      signals++;
+      return await markSessionWorkflowWakeDelivered(client.db, wake);
+    },
+  } as unknown as NotifyServices;
+  const dispatch = () =>
+    reconcilePendingSessionWorkflowWakes(service, 1, {
+      claimPendingSessionWorkflowWakes: async () => [wake],
+    });
+  const first = await dispatch();
+  expect(first).toMatchObject({
+    signaled: 1,
+    delivered: 0,
+    pendingAdmission: 1,
+    pendingAdmissionBlockers: { pending_prompt_turn: 1 },
+  });
+  expect(await wakeRow(ctx.grant.workspaceId!, ctx.session.id)).toMatchObject({
+    wakeRevision: queued.wakeRevision,
+    deliveredRevision: 0,
+  });
+  const turns = await listSessionTurns(client.db, ctx.grant.workspaceId!, ctx.session.id, 10);
+  expect(turns[0]).toMatchObject({ status: "queued", executionGeneration: 0 });
+  const claim = await claimSessionWorkForAttempt(client.db, ctx.grant.workspaceId!, {
+    sessionId: ctx.session.id,
+    workflowId: wake.temporalWorkflowId,
+    workflowRunId: crypto.randomUUID(),
+    attemptId: crypto.randomUUID(),
+    dispatchId: crypto.randomUUID(),
+    trigger: { kind: "next" },
+  });
+  expect(claim.action).toBe("claimed");
+  expect(await dispatch()).toMatchObject({ signaled: 1, delivered: 1, pendingAdmission: 0 });
+  expect(await wakeRow(ctx.grant.workspaceId!, ctx.session.id)).toMatchObject({
+    deliveredRevision: queued.wakeRevision,
+  });
+  expect(signals).toBe(2);
+});

--- a/apps/worker/test/workflow-wake-admission.test.ts
+++ b/apps/worker/test/workflow-wake-admission.test.ts
@@ -118,8 +118,9 @@ test("accepted Send stays pending in supervision until the actual durable claim"
   const service = {
     db: client.db,
     observability: { info: () => {}, error: () => {} },
-    wakeSessionWorkflow: async () => {
+    wakeSessionWorkflow: async ({ onSignalAccepted }: { onSignalAccepted?: () => void }) => {
       signals++;
+      onSignalAccepted?.();
       return await markSessionWorkflowWakeDelivered(client.db, wake);
     },
   } as unknown as NotifyServices;
@@ -154,4 +155,51 @@ test("accepted Send stays pending in supervision until the actual durable claim"
     deliveredRevision: queued.wakeRevision,
   });
   expect(signals).toBe(2);
+});
+
+test("transport acceptance survives a failed acknowledgment without consuming the wake", async () => {
+  const ctx = await fixture();
+  const queued = await send(ctx, "continue after the database recovers");
+  const wake = (await claimPendingSessionWorkflowWakes(client.db, 1000)).find(
+    (row) => row.sessionId === ctx.session.id,
+  )!;
+  const service = {
+    db: client.db,
+    observability: { info: () => {}, error: () => {} },
+    wakeSessionWorkflow: async ({ onSignalAccepted }: { onSignalAccepted?: () => void }) => {
+      // Fault at the acknowledgment boundary after transport accepted the signal.
+      onSignalAccepted?.();
+      throw new Error("acknowledgment database unavailable");
+    },
+  } as unknown as NotifyServices;
+  const result = await reconcilePendingSessionWorkflowWakes(service, 1, {
+    claimPendingSessionWorkflowWakes: async () => [wake],
+  });
+  expect(result).toMatchObject({ signaled: 1, delivered: 0, failed: 1 });
+  expect(await wakeRow(ctx.grant.workspaceId!, ctx.session.id)).toMatchObject({
+    wakeRevision: queued.wakeRevision,
+    deliveredRevision: 0,
+    lastError: "acknowledgment database unavailable",
+  });
+  const transportFailure = await reconcilePendingSessionWorkflowWakes(
+    {
+      ...service,
+      wakeSessionWorkflow: async () => {
+        throw new Error("transport unavailable");
+      },
+    },
+    1,
+    { claimPendingSessionWorkflowWakes: async () => [wake] },
+  );
+  expect(transportFailure).toMatchObject({ signaled: 0, delivered: 0, failed: 1 });
+  // An immediate caller still sees the original failure instead of a false ACK.
+  await expect(
+    service.wakeSessionWorkflow!({
+      accountId: wake.accountId,
+      workspaceId: wake.workspaceId,
+      sessionId: wake.sessionId,
+      workflowId: wake.temporalWorkflowId,
+      wakeRevision: wake.wakeRevision,
+    }),
+  ).rejects.toThrow("acknowledgment database unavailable");
 });

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -367,3 +367,16 @@ arguments is rejected as `IDEMPOTENCY_KEY_REUSED`.
 | `OPENGENI_GOAL_IDLE_BACKOFF_MS` | `3000,30000,120000,300000` | Comma-separated pacing delays (ms) before the n-th consecutive no-input continuation, measured from when the previous continuation turn finished; the last entry repeats. Not a cap: any new input wakes the session immediately. |
 | `OPENGENI_GOAL_IDLE_BACKOFF_MAX_MS` | `600000` | Upper bound on every idle-backoff delay; schedule entries above it are rejected at boot. |
 | `OPENGENI_CHILD_LIFECYCLE_NOTICES_ENABLED` | `false` | Produce the child lifecycle notices (`child_requires_action`, its resolution, `child_paused`, `child_waiting_capacity`, `child_progress`) for parent sessions. Enable only after the whole fleet runs an image that understands the new kinds. The goal-continuation prompt teaches the orchestrator what each notice means and, when `session_human_input_respond` is in its effective first-party selection, that it may answer a worker's blocking question itself. |
+
+
+### Interpreting wake delivery
+
+A successful Temporal signal only confirms transport acceptance. The durable
+wake acknowledgment guard may still return `pending_admission` with a queued
+prompt, machine input, input wait, Agent Steer, or quiescence blocker. The wake
+dispatcher's result and structured reconciliation log separate `signaled`,
+`delivered` (acknowledged revisions), `pendingAdmission` by blocker, and
+`unconfirmed` legacy signal-only responses. None is proof of a model turn:
+verify the durable attempt claim and `turn.started` before reporting execution.
+Pending revisions keep the existing outbox backoff and admission rules; these
+counters neither resume paused work nor authorize a new attempt.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -380,3 +380,9 @@ dispatcher's result and structured reconciliation log separate `signaled`,
 verify the durable attempt claim and `turn.started` before reporting execution.
 Pending revisions keep the existing outbox backoff and admission rules; these
 counters neither resume paused work nor authorize a new attempt.
+
+Transport acceptance is reported before attempting the database acknowledgment.
+If that acknowledgment fails, a batch can report both `signaled` and `failed`
+for the same revision; `delivered` remains zero and the original error propagates
+to immediate callers. Older embedding clients may omit the optional transport
+observer; successful void responses remain `unconfirmed`, not acknowledged.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -379,7 +379,9 @@ dispatcher's result and structured reconciliation log separate `signaled`,
 `unconfirmed` legacy signal-only responses. None is proof of a model turn:
 verify the durable attempt claim and `turn.started` before reporting execution.
 Pending revisions keep the existing outbox backoff and admission rules; these
-counters neither resume paused work nor authorize a new attempt.
+counters neither resume paused work nor authorize a new attempt. Logs emit each
+blocker count as a numeric `pendingAdmissionBlockers.<blocker>` attribute; the
+activity result retains the blocker object.
 
 Transport acceptance is reported before attempting the database acknowledgment.
 If that acknowledgment fails, a batch can report both `signaled` and `failed`

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -9,7 +9,7 @@ import type {
   SessionAuthorizationPort,
   TurnInitiator,
 } from "@opengeni/contracts";
-import type { Database } from "@opengeni/db";
+import type { Database, SessionWorkflowWakeDeliveryResult } from "@opengeni/db";
 import type { DocumentServices } from "@opengeni/documents";
 import type { EventBus } from "@opengeni/events";
 import type { Observability } from "@opengeni/observability";
@@ -44,7 +44,7 @@ export type SessionWorkflowClient = {
     workflowId: string;
     wakeRevision: number;
     interruptionRequested?: boolean;
-  }) => Promise<void>;
+  }) => Promise<SessionWorkflowWakeDeliveryResult | void>;
   /** Trigger one bounded drain of already-committed workflow-wake revisions. */
   requestSessionWorkflowWakeDispatch: () => Promise<void>;
   // Dedicated, revision-carrying nudge for a durable Codex capacity waiter.

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -44,6 +44,8 @@ export type SessionWorkflowClient = {
     workflowId: string;
     wakeRevision: number;
     interruptionRequested?: boolean;
+    /** Called after transport acceptance, before the fallible durable ACK. */
+    onSignalAccepted?: () => void;
   }) => Promise<SessionWorkflowWakeDeliveryResult | void>;
   /** Trigger one bounded drain of already-committed workflow-wake revisions. */
   requestSessionWorkflowWakeDispatch: () => Promise<void>;

--- a/test/integration/durable-queue-control.integration.ts
+++ b/test/integration/durable-queue-control.integration.ts
@@ -547,7 +547,12 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
         expect(repair.failed).toBe(0);
         expect(repair.exhaustedBatchLimit).toBe(false);
         expect(repair.claimed).toBeGreaterThanOrEqual(1);
-        expect(repair.delivered).toBe(repair.claimed);
+        expect(repair.signaled).toBe(repair.claimed);
+        expect(repair.unconfirmed).toBe(0);
+        // Signal acceptance can race the actual claim. Every receipt must be
+        // either acknowledged or truthfully pending; the model/turn checks
+        // below establish that this specific session actually executed.
+        expect(repair.delivered + repair.pendingAdmission).toBe(repair.claimed);
         let observedSession: Awaited<ReturnType<typeof getSession>> | null = null;
         await waitFor(
           async () => {
@@ -1430,7 +1435,7 @@ function sessionWorkflowClient(
         ],
         signal: input.interruptionRequested ? "sessionControl" : "queueChanged",
       });
-      await markSessionWorkflowWakeDelivered(db, {
+      return await markSessionWorkflowWakeDelivered(db, {
         accountId: input.accountId,
         workspaceId: input.workspaceId,
         sessionId: input.sessionId,

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -2057,7 +2057,11 @@ describe("Temporal workflow integration", () => {
       let dispatches = 0;
       const expected = {
         claimed: 4,
-        delivered: 4,
+        signaled: 4,
+        delivered: 1,
+        pendingAdmission: 2,
+        unconfirmed: 1,
+        pendingAdmissionBlockers: { pending_prompt_turn: 2 },
         failed: 0,
         exhaustedBatchLimit: false,
       };


### PR DESCRIPTION
The wake supervisor counted a successful signal helper call as delivered even when the database acknowledgment guard returned pending_admission. A queued prompt could therefore remain unclaimed while supervision reported successful delivery.

API and worker signalers now return the existing durable acknowledgment receipt. The dispatcher separates signaled calls, acknowledged revisions, pending admission by blocker, and unconfirmed legacy/embedding responses in its result and structured log. Existing outbox retries, admission guards and pause/quiescence authority are unchanged.

Validation: reproduced a real-PostgreSQL accepted Send being falsely reported delivered before its attempt claim. The regression now remains pending until claim. 19 database tests, 16 focused unit tests and 3 real-Temporal cases passed; worker/API/core typechecks and focused lint/format checks passed. Independent review performed before publication.

This fixes misleading supervision evidence. It does not claim to resolve the historical staging queue stall: generation-zero evidence cannot distinguish an unpolled activity from a preclaim failure. That operational cause still requires correlated dispatch and turn-worker admission evidence. No model retry, runtime timeout, UI change or live-session action is added.

Tracks [OPE-467](https://linear.app/cloudgeni/issue/OPE-467); preserves OPE-59's existing goal-wake implementation.

## Summary by Sourcery

Distinguish transport signal acceptance from durable wake admission so supervision reports only acknowledged revisions as delivered.

Bug Fixes:
- Prevent wake supervision from treating transport signal acceptance as durable delivery before admission or execution claim.
- Preserve pending wake obligations when durable acknowledgment fails, enabling truthful retry and failure reporting.

Enhancements:
- Expose separate reconciliation outcomes for signaled, acknowledged, pending-admission, unconfirmed, and failed wakes, including admission blockers.
- Propagate durable wake acknowledgment receipts through API, worker, and core signaler interfaces and add structured reconciliation logging.
- Document how to interpret wake delivery evidence and distinguish it from actual turn execution.

Documentation:
- Document wake-delivery counters, admission blockers, retry behavior, and the requirement to verify attempt and turn-start evidence for execution.

Tests:
- Add unit, PostgreSQL, and Temporal coverage for acknowledged, pending-admission, unconfirmed, and acknowledgment-failure scenarios.