### PR TITLE
fix(codex): apply account switches to blocked turns

### DIFF
--- a/.changeset/codex-waiting-account-override.md
+++ b/.changeset/codex-waiting-account-override.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/db": patch
+"@opengeni/contracts": patch
+"@opengeni/sdk": patch
+"@opengeni/react": patch
+---
+
+Apply explicit Codex account switches and unpins to capacity-blocked turns, preserving the same turn and history through recovery. Display current account selection separately from future preferences and report when a switch requests a capacity recheck.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -141,8 +141,7 @@ import {
   projectSessionForRelatedAccess,
   recordStreamAcknowledgment,
   requestSessionCompaction,
-  setSessionCodexPinInTransaction,
-  withSessionCodexCapacityMutation,
+  switchSessionCodexAccount,
   setSessionChannel,
   updateSessionVariableSets,
   ChannelNotFoundError,
@@ -1898,8 +1897,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // Pin (or unpin) the session's Codex account. body { target: "auto" | "<id>" }:
   // "auto" clears the pin (the session follows the workspace active pointer); a
-  // uuid pins the session to that specific account. The pin applies to the NEXT
-  // turn (the worker reads it at turn start). 404 when the session or the target
+  // uuid pins the session to that specific account. Overrides a capacity-blocked
+  // turn; a running attempt keeps its account. 404 when the session or the target
   // account id isn't in the workspace.
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/codex-account", async (c) => {
     const workspaceId = c.req.param("workspaceId");
@@ -1924,15 +1923,13 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       }
     }
     const pinned = target === "auto" ? null : target;
-    const mutation = await withSessionCodexCapacityMutation(
-      db,
-      { workspaceId, reason: "codex_manual_session_pin_changed" },
-      async (tx) => {
-        const changed = await setSessionCodexPinInTransaction(tx, workspaceId, sessionId, pinned);
-        return { result: changed, changed };
-      },
-    );
-    const ok = mutation.result;
+    const mutation = await switchSessionCodexAccount(db, {
+      workspaceId,
+      sessionId,
+      credentialId: pinned,
+      subjectId: grant.subjectId,
+    });
+    const ok = mutation.result.changed;
     if (!ok) {
       throw new HTTPException(404, {
         message: "session or codex account not found",
@@ -1958,7 +1955,11 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
             }),
       ),
     );
-    return c.json({ pinned: target === "auto" ? "auto" : target });
+    await publishDurableSessionEvents(bus, workspaceId, sessionId, mutation.result.events);
+    return c.json({
+      pinned: target === "auto" ? "auto" : target,
+      appliedTo: mutation.result.appliedTo,
+    });
   });
 
   // Re-file the session into a workspace channel (rail organization only;

--- a/apps/web/src/components/session/codex-account-indicator.test.tsx
+++ b/apps/web/src/components/session/codex-account-indicator.test.tsx
@@ -1,0 +1,89 @@
+import { afterAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { fakeClient, WORKSPACE_ID } from "../../../../../packages/react/test/fake-client";
+
+{
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+}
+const { OpenGeniProvider } = await import("@opengeni/react");
+const { CodexAccountIndicator } = await import("./codex-account-indicator");
+afterAll(() => GlobalRegistrator.unregister());
+
+test("shows the blocked account instead of a healthy default and permits repeating Auto", async () => {
+  const calls: string[] = [];
+  const client = Object.assign(fakeClient({}), {
+    getSession: async () => ({
+      codexPinnedCredentialId: null,
+      codexCurrentSelection: { credentialId: "blocked", waiting: true },
+    }),
+    listCodexAccounts: async () => ({
+      accounts: [
+        {
+          id: "blocked",
+          label: "Blocked account",
+          status: "active",
+          plan: "pro",
+          allocatorEnabled: true,
+        },
+        {
+          id: "healthy",
+          label: "Healthy default",
+          status: "active",
+          plan: "pro",
+          allocatorEnabled: true,
+        },
+      ],
+      activeAccountId: "healthy",
+      settings: {
+        rotationEnabled: true,
+        rotationStrategy: "sharded",
+        activeCredentialId: "healthy",
+      },
+    }),
+    pinSessionCodexAccount: async (_workspace: string, _session: string, target: string) => {
+      calls.push(target);
+      return { pinned: target, appliedTo: "waiting_turn" };
+    },
+  });
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  try {
+    await act(async () =>
+      root.render(
+        <OpenGeniProvider client={client} workspaceId={WORKSPACE_ID}>
+          <CodexAccountIndicator
+            workspaceId={WORKSPACE_ID}
+            sessionId="session"
+            model="codex/gpt-5.6-sol"
+            events={[]}
+          />
+        </OpenGeniProvider>,
+      ),
+    );
+    const trigger = container.querySelector("button")!;
+    expect(trigger.getAttribute("aria-label")).toContain("Waiting for capacity · Blocked account");
+    await act(async () =>
+      trigger.dispatchEvent(
+        new MouseEvent("pointerdown", { bubbles: true, button: 0, ctrlKey: false }),
+      ),
+    );
+    expect(document.body.textContent).toContain("Retry with");
+    const auto = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((el) =>
+      el.textContent?.includes("Auto"),
+    );
+    expect(auto).toBeDefined();
+    await act(async () => auto!.click());
+    expect(calls).toEqual(["auto"]);
+    expect(document.body.textContent).toContain("Selection saved. Capacity is being rechecked.");
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+  }
+});

--- a/apps/web/src/components/session/codex-account-indicator.tsx
+++ b/apps/web/src/components/session/codex-account-indicator.tsx
@@ -113,8 +113,23 @@ export function CodexAccountIndicator({
     return null;
   }
 
+  const current = codex.currentSelection;
   const effective =
-    codex.accounts.find((account) => account.id === codex.effectiveAccountId) ?? null;
+    codex.accounts.find(
+      (account) => account.id === (current ? current.credentialId : codex.pinnedAccountId),
+    ) ?? null;
+  const selectionLabel = current
+    ? current.waiting
+      ? "Waiting for capacity"
+      : "Current account"
+    : "Account selection";
+  const displayName = effective
+    ? accountLabel(effective)
+    : current?.credentialId
+      ? "Account unavailable"
+      : current && !current.waiting
+        ? "Selecting account"
+        : "Automatic selection";
   const accountsPending = codex.loading && !effective;
   if (accountsPending) {
     return (
@@ -124,9 +139,7 @@ export function CodexAccountIndicator({
 
   const tone = statusTone(effective);
   const hasAccounts = codex.accounts.length > 0;
-  const ariaLabel = effective
-    ? `Switch Codex account · ${accountLabel(effective)}${effective.plan ? ` · ${effective.plan}` : ""}`
-    : "Switch Codex account";
+  const ariaLabel = `Switch Codex account · ${selectionLabel} · ${displayName}`;
 
   return (
     <DropdownMenu>
@@ -177,7 +190,8 @@ export function CodexAccountIndicator({
               <ChatGptMark className="size-4" />
             </span>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-fg">{accountLabel(effective)}</p>
+              <p className="text-2xs text-fg-subtle">{selectionLabel}</p>
+              <p className="truncate text-sm font-medium text-fg">{displayName}</p>
               <p className="truncate text-2xs text-fg-subtle">
                 {[effective?.plan, effective?.status === "active" ? null : effective?.status]
                   .filter(Boolean)
@@ -196,7 +210,7 @@ export function CodexAccountIndicator({
         <DropdownMenuSeparator className="shrink-0" />
 
         <DropdownMenuLabel className="shrink-0 px-2 pt-1 pb-1 text-xs font-normal text-fg-subtle">
-          Run next turn on
+          {current?.waiting ? "Retry with" : "Use for next turn"}
         </DropdownMenuLabel>
 
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
@@ -204,7 +218,7 @@ export function CodexAccountIndicator({
             disabled={codex.pinning}
             onSelect={(event) => {
               event.preventDefault();
-              if (codex.pinnedAccountId === null) return;
+              if (codex.pinnedAccountId === null && !current?.waiting) return;
               void codex.pin(AUTO);
             }}
             className="flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 text-sm"
@@ -218,7 +232,7 @@ export function CodexAccountIndicator({
           </DropdownMenuItem>
 
           {codex.accounts.map((account) => {
-            const isEffective = account.id === codex.effectiveAccountId;
+            const isSelected = account.id === codex.pinnedAccountId;
             const isPinning = codex.pinningTarget === account.id;
             return (
               <DropdownMenuItem
@@ -226,7 +240,7 @@ export function CodexAccountIndicator({
                 disabled={codex.pinning}
                 onSelect={(event) => {
                   event.preventDefault();
-                  if (codex.pinnedAccountId === account.id) return;
+                  if (codex.pinnedAccountId === account.id && !current?.waiting) return;
                   void codex.pin(account.id);
                 }}
                 className="flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 text-sm"
@@ -243,7 +257,7 @@ export function CodexAccountIndicator({
                 ) : null}
                 {isPinning ? (
                   <Loader2Icon className="ml-1 size-4 shrink-0 animate-spin" />
-                ) : isEffective ? (
+                ) : isSelected ? (
                   <CheckIcon className="ml-1 size-4 shrink-0" />
                 ) : null}
               </DropdownMenuItem>
@@ -258,7 +272,15 @@ export function CodexAccountIndicator({
               Switch failed: {codex.mutationError.message}
             </p>
           ) : (
-            <p className="px-2 pt-1 text-2xs text-fg-subtle">Applies next turn.</p>
+            <p className="px-2 pt-1 text-2xs text-fg-subtle">
+              {codex.switchAppliedTo === "waiting_turn"
+                ? "Selection saved. Capacity is being rechecked."
+                : codex.switchAppliedTo === "next_turn"
+                  ? "Selection saved for the next turn."
+                  : current?.waiting
+                    ? "Changing accounts retries the waiting turn."
+                    : "Applies next turn. The current turn keeps its account."}
+            </p>
           )}
         </div>
       </DropdownMenuContent>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -915,13 +915,7 @@ Canonical: [`knowledge-retrieval.md`](knowledge-retrieval.md),
 
 ### 5.7 Usage, limits, and billing
 
-Explicit session Codex account switches can override a capacity-blocked turn's
-accepted account selection through `switchSessionCodexAccount` in `packages/db`.
-The allocator lock serializes the closed-attempt override with reconciliation
-and lease claim; source/authority, turn identity, and history are preserved.
-Background policy changes and running attempts retain their accepted settings.
-Session detail exposes current-turn selection separately from future preference
-so account controls do not display available future capacity as current capacity.
+Blocked account switches: [Codex rotation](codex-subscription-rotation.md).
 
 Usage is normalized at the provider boundary and recorded per authoritative
 model call. Admission limits and entitlements are domain policy; provider

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -915,6 +915,14 @@ Canonical: [`knowledge-retrieval.md`](knowledge-retrieval.md),
 
 ### 5.7 Usage, limits, and billing
 
+Explicit session Codex account switches can override a capacity-blocked turn's
+accepted account selection through `switchSessionCodexAccount` in `packages/db`.
+The allocator lock serializes the closed-attempt override with reconciliation
+and lease claim; source/authority, turn identity, and history are preserved.
+Background policy changes and running attempts retain their accepted settings.
+Session detail exposes current-turn selection separately from future preference
+so account controls do not display available future capacity as current capacity.
+
 Usage is normalized at the provider boundary and recorded per authoritative
 model call. Admission limits and entitlements are domain policy; provider
 telemetry, comparison pricing, and dashboards do not independently debit or

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -93,7 +93,8 @@ relevant locks are acquired.
    definitive-failure settlement reuse its active pointer, rotation state,
    effective strategy, source, and session pin/last-used state while re-reading
    current account health and cooldowns. Later workspace/session policy changes
-   therefore do not change the constraints of an already accepted logical turn.
+   therefore do not change the constraints of an already accepted logical turn,
+   except an explicit in-session account switch while the turn is capacity-blocked.
    Pre-source snapshots remain readable and use their historical live-source
    behavior; all newly accepted turns persist the source explicitly.
 
@@ -103,8 +104,18 @@ awaiting action, recovering, or in `waiting_capacity`, or while a credential
 lease is still live. This prevents an accepted capacity waiter from resuming
 against a different workspace or organization pool; cancel or finish that
 turn before changing its effective source. Same-source pointer, rotation, and
-pin mutations may wake a waiter for re-evaluation, but they never rewrite its
-accepted snapshot.
+background pin mutations may wake a waiter for re-evaluation, but they never rewrite its
+accepted snapshot. The explicit session account-switch command is different:
+under the allocator/session/turn/waiter locks, it revises a capacity-blocked
+turn's account selection and records `codex.account.selection.changed` in the
+same transaction as the session preference and wake obligation. The attempt
+must be closed, with the matching waiting generation. Auto uses current
+rotation defaults within the same accepted pool; a manual selection overrides
+the old pin. Initiator, account authority, model, history, and turn identity stay
+unchanged. Reconciliation, lease reacquisition, and failure recovery all read
+the revised selection. Running attempts retain their lease and use the new
+preference only on a subsequent turn. Selecting the same preference again is
+allowed, including recovery of waits created before this override existed.
 
 Stored legacy strategy values are normalized at every worker read to the
 effective `sharded` behavior. The old column values and API input compatibility
@@ -406,9 +417,11 @@ selected account, the quarantined holder arms the same durable capacity waiter
 used by proactive admission. Quota/rate-limit cooldowns, reconnects that leave
 the effective source unchanged, status repairs, allocator changes, and
 same-source rotation-policy writes wake that exact turn for a recheck. The
-accepted source, active pointer, rotation setting, and session pin remain
-immutable for that turn, so a policy write that does not make the accepted pool
-eligible leaves it waiting. An effective-source change is fenced while the
+accepted source remains immutable. Background active-pointer, rotation-setting,
+and pin writes do not revise accepted turn selection, so a background policy
+write that does not make the accepted pool eligible leaves it waiting. Explicit
+in-session switching can override the blocked selection as described above.
+An effective-source change is fenced while the
 turn/waiter is live; cancel or finish it before changing source. An
 auth/forbidden refusal is terminal only when the pool is truly empty or has no
 allocatable account to wait for.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -631,8 +631,12 @@ five-hour reset semantics, and rollout fence are canonical in
 The first successful lease also stores a bounded accepted Codex allocator-policy
 snapshot in turn metadata. Re-acquisition and definitive-failure settlement use
 that snapshot for active-pointer, rotation, strategy, and pin constraints while
-using current account health/cooldowns; mutable policy changes affect later
-logical turns. Immediately before provider dispatch, a missing or expired
+using current account health/cooldowns; background policy changes affect later
+logical turns. An explicit session account switch may revise selection for a
+capacity-blocked turn under the allocator/session/turn/waiter locks, with a
+closed attempt and matching wait generation. It preserves the accepted
+credential source, authority, conversation history, and logical turn identity.
+Immediately before provider dispatch, a missing or expired
 last-confirmed lease deadline is treated as lease loss and follows lease-loss
 settlement instead of reaching the provider.
 
@@ -677,10 +681,12 @@ Ordinary prompts queued during the wait remain behind the current turn. Pause
 leaves the waiter intact and lets the workflow close; Resume's revisioned
 `signalWithStart` wake reconstructs it. Steer, cancellation, and changes to the
 optional goal, downstream accepted credential-policy hash, or blocked-turn
-generation supersede the waiter/turn under their durable fences. Mutable Codex
-rotation or pin settings do not replace the accepted snapshot for this turn, so
-no stale timer or signal can produce double inference or silently change its
-policy.
+generation supersede the waiter/turn under their durable fences. Background
+Codex rotation or pin settings do not replace the accepted snapshot. An explicit
+account switch uses `switchSessionCodexAccount` to update a blocked selection,
+record its control receipt, and request a capacity recheck atomically. Ordinary
+lease claim reads that same revised selection; no new turn or automatic model
+retry is created by the switch itself.
 
 Provider context-window overflow is also handled inside the activity, not by a
 Temporal retry. When an OpenAI/Azure context overflow is classified,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12289,6 +12289,14 @@ export const Session = z.object({
   // "Running on:" indicator's source). Both are credential-row ids, null until set.
   codexPinnedCredentialId: z.string().uuid().nullable(),
   codexLastCredentialId: z.string().uuid().nullable(),
+  /** Detail-read projection of the accepted current turn; never a future-account prediction. */
+  codexCurrentSelection: z
+    .object({
+      credentialId: z.string().nullable(),
+      waiting: z.boolean(),
+    })
+    .nullable()
+    .optional(),
   // Frozen at session create. remote_v2 ⇒ Codex remote compaction + Codex-only
   // model admission for the life of the session; portable ⇒ plaintext compaction
   // and free mid-session provider switching (today's behavior).
@@ -12573,6 +12581,7 @@ export const SessionEventType = z.enum([
   // (manual switch in P1; failover/rotation in P3 reuse the same event). Drives
   // the in-session "Running on:" indicator's live flip.
   "codex.account.switched",
+  "codex.account.selection.changed",
   // credential allocator per-turn selection audit. Payload is metadata only: credential row
   // id, bounded strategy/reason, and pool counts — never token material.
   "codex.credential.selected",
@@ -12797,6 +12806,7 @@ export const SESSION_EVENT_SEMANTIC_CLASS_TYPES = {
   provider_account: [
     "agent.model.usage",
     "codex.account.switched",
+    "codex.account.selection.changed",
     "codex.credential.selected",
     "codex.capacity.waiting",
     "codex.capacity.resumed",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29203,15 +29203,12 @@ export async function switchSessionCodexAccount(
       const events: SessionEvent[] = [];
       let appliedTo: "waiting_turn" | "next_turn" = "next_turn";
       if (!changed) return { result: { changed, appliedTo, events }, changed };
-      const [session] = await tx
-        .select()
-        .from(schema.sessions)
-        .where(
-          and(
-            eq(schema.sessions.workspaceId, input.workspaceId),
-            eq(schema.sessions.id, input.sessionId),
-          ),
-        );
+      const locks = await lockSessionEventWriteRows(tx, {
+        workspaceId: input.workspaceId,
+        controlLock: "none",
+        sessionIds: [input.sessionId],
+      });
+      const session = locks.sessions[0];
       if (!session) throw new Error("Codex account switch lost its locked session");
       if (session.status === "waiting_capacity" && session.activeTurnId) {
         const [turn] = await tx
@@ -29304,6 +29301,15 @@ export async function switchSessionCodexAccount(
           ),
         )
         .returning();
+      await tx
+        .update(schema.sessions)
+        .set({ lastSequence: session.lastSequence + 1 })
+        .where(
+          and(
+            eq(schema.sessions.workspaceId, input.workspaceId),
+            eq(schema.sessions.id, input.sessionId),
+          ),
+        );
       events.push(...inserted.map(mapEvent));
       return { result: { changed, appliedTo, events }, changed };
     },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29178,6 +29178,138 @@ export async function setSessionCodexPinInTransaction(
   return updated.length > 0;
 }
 
+/** Explicit session control, unlike background pin/pool bookkeeping. The allocator
+ * lock serializes this override with both waiter reconciliation and lease claim.
+ * Only a closed capacity attempt may change its accepted selection. */
+export async function switchSessionCodexAccount(
+  db: Database,
+  input: { workspaceId: string; sessionId: string; credentialId: string | null; subjectId: string },
+) {
+  return await withSessionCodexCapacityMutation<{
+    changed: boolean;
+    appliedTo: "waiting_turn" | "next_turn";
+    events: SessionEvent[];
+  }>(
+    db,
+    { workspaceId: input.workspaceId, reason: "codex_manual_session_pin_changed" },
+    async (tx) => {
+      const rotation = await lockExistingCodexRotationSettingsForCapacity(tx, input.workspaceId);
+      const changed = await setSessionCodexPinInTransaction(
+        tx,
+        input.workspaceId,
+        input.sessionId,
+        input.credentialId,
+      );
+      const events: SessionEvent[] = [];
+      let appliedTo: "waiting_turn" | "next_turn" = "next_turn";
+      if (!changed) return { result: { changed, appliedTo, events }, changed };
+      const [session] = await tx
+        .select()
+        .from(schema.sessions)
+        .where(
+          and(
+            eq(schema.sessions.workspaceId, input.workspaceId),
+            eq(schema.sessions.id, input.sessionId),
+          ),
+        );
+      if (!session) throw new Error("Codex account switch lost its locked session");
+      if (session.status === "waiting_capacity" && session.activeTurnId) {
+        const [turn] = await tx
+          .select()
+          .from(schema.sessionTurns)
+          .where(
+            and(
+              eq(schema.sessionTurns.workspaceId, input.workspaceId),
+              eq(schema.sessionTurns.sessionId, input.sessionId),
+              eq(schema.sessionTurns.id, session.activeTurnId),
+            ),
+          )
+          .for("update");
+        const [waiter] = await tx
+          .select()
+          .from(schema.codexCapacityWaiters)
+          .where(
+            and(
+              eq(schema.codexCapacityWaiters.workspaceId, input.workspaceId),
+              eq(schema.codexCapacityWaiters.sessionId, input.sessionId),
+              eq(schema.codexCapacityWaiters.status, "waiting"),
+            ),
+          )
+          .for("update");
+        if (
+          turn?.status === "waiting_capacity" &&
+          turn.activeAttemptId === null &&
+          waiter &&
+          waiter.blockedTurnId === turn.id &&
+          waiter.blockedTurnGeneration === turn.executionGeneration
+        ) {
+          const accepted = readCodexCredentialPolicySnapshotV1(turn.metadata);
+          if (accepted.kind === "valid") {
+            // Never use an explicit pin override to cross the accepted authority/pool boundary.
+            if (
+              !rotation ||
+              (accepted.policy.source && accepted.policy.source !== rotation.source)
+            ) {
+              throw new Error("Cannot switch a waiting Codex turn across credential sources");
+            }
+            const policy = {
+              ...accepted.policy,
+              pinnedCredentialId: input.credentialId,
+              pinSource: input.credentialId === null ? null : ("manual" as const),
+              // Auto explicitly requests the current defaults within the SAME accepted pool.
+              ...(input.credentialId === null
+                ? {
+                    activeCredentialId: rotation.activeCredentialId,
+                    rotationEnabled: rotation.rotationEnabled,
+                    rotationStrategy: rotation.rotationStrategy,
+                    lastCredentialId: null,
+                  }
+                : {}),
+            };
+            await tx
+              .update(schema.sessionTurns)
+              .set({
+                metadata: metadataWithCodexCredentialPolicySnapshotV1(turn.metadata, policy),
+                version: turn.version + 1,
+                updatedAt: new Date(),
+              })
+              .where(eq(schema.sessionTurns.id, turn.id));
+          }
+          appliedTo = "waiting_turn";
+        }
+      }
+      const inserted = await tx
+        .insert(schema.sessionEvents)
+        .values(
+          withLosslessContentWriteVersion(
+            [
+              {
+                accountId: session.accountId,
+                workspaceId: input.workspaceId,
+                sessionId: input.sessionId,
+                sequence: session.lastSequence + 1,
+                type: "codex.account.selection.changed",
+                payload: {
+                  credentialId: input.credentialId,
+                  appliedTo,
+                  turnId: appliedTo === "waiting_turn" ? session.activeTurnId : null,
+                  subjectId: input.subjectId,
+                },
+                // This is a user control receipt, not output from a running attempt.
+                occurredAt: new Date(),
+              },
+            ],
+            "payload",
+            "payloadCodecVersion",
+          ),
+        )
+        .returning();
+      events.push(...inserted.map(mapEvent));
+      return { result: { changed, appliedTo, events }, changed };
+    },
+  );
+}
+
 export async function setSessionCodexPin(
   db: Database,
   workspaceId: string,
@@ -75961,7 +76093,63 @@ async function mapSessionWithControl(
     row.workspaceId,
     await withCurrentSessionInputWait(db, row.workspaceId, [row]),
   );
-  return mapSession(effective!, control, mcpServers, pin, attention, archive, tenancyViewer);
+  const mapped = mapSession(
+    effective!,
+    control,
+    mcpServers,
+    pin,
+    attention,
+    archive,
+    tenancyViewer,
+  );
+  mapped.codexCurrentSelection = null;
+  if (row.activeTurnId) {
+    const [turn] = await db
+      .select({
+        metadata: schema.sessionTurns.metadata,
+        status: schema.sessionTurns.status,
+        credentialId: schema.codexCredentialLeases.credentialId,
+      })
+      .from(schema.sessionTurns)
+      .leftJoin(
+        schema.codexCredentialLeases,
+        and(
+          eq(schema.codexCredentialLeases.workspaceId, schema.sessionTurns.workspaceId),
+          eq(schema.codexCredentialLeases.turnId, schema.sessionTurns.id),
+          sql`${schema.codexCredentialLeases.leasedUntil} > clock_timestamp()`,
+        ),
+      )
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, row.workspaceId),
+          eq(schema.sessionTurns.sessionId, row.id),
+          eq(schema.sessionTurns.id, row.activeTurnId),
+          sql`${schema.sessionTurns.model} like 'codex/%'`,
+        ),
+      )
+      .limit(1);
+    if (
+      turn &&
+      ["running", "recovering", "waiting_capacity", "requires_action"].includes(turn.status)
+    ) {
+      const accepted = readCodexCredentialPolicySnapshotV1(turn.metadata);
+      const policy = accepted.kind === "valid" ? accepted.policy : null;
+      mapped.codexCurrentSelection = {
+        waiting: turn.status === "waiting_capacity",
+        credentialId:
+          turn.status === "waiting_capacity"
+            ? !policy && row.codexPinSource !== "policy"
+              ? row.codexPinnedCredentialId
+              : policy?.pinSource === "manual"
+                ? policy.pinnedCredentialId
+                : policy?.rotationEnabled === false
+                  ? policy.activeCredentialId
+                  : null
+            : turn.credentialId,
+      };
+    }
+  }
+  return mapped;
 }
 
 function mapSessionTenancy(

--- a/packages/db/test/codex-credential-leases.test.ts
+++ b/packages/db/test/codex-credential-leases.test.ts
@@ -13,6 +13,7 @@ import {
   type RotationDecision,
 } from "../../../apps/worker/src/activities/codex-rotation";
 import { codexCredentialLeaseHolderId } from "../../../apps/worker/src/activities/agent-turn/claim";
+import { codexCapacityDecision } from "../../../apps/worker/src/activities/codex-capacity";
 import * as schema from "../src/schema";
 import {
   acquireCodexCredentialLease,
@@ -39,6 +40,8 @@ import {
   setCodexCredentialStatusById,
   setActiveCodexCredential,
   setSessionCodexPinInTransaction,
+  switchSessionCodexAccount,
+  getSession,
   updateCodexRotationSettings,
   upsertCodexSubscriptionCredential,
   withCodexCredentialRefreshLock,
@@ -335,6 +338,214 @@ afterAll(async () => {
 }, 180_000);
 
 describe("credential allocator atomic Codex credential allocation", () => {
+  async function pinnedCapacityWait() {
+    const [ws] = await freshAccount();
+    const exhausted = await connectCredential(ws!, "exhausted@example.test");
+    const healthy = await connectCredential(ws!, "healthy@example.test");
+    const turnId = await seedTurn(ws!, 1);
+    const fence = await attemptFenceForTurn(turnId);
+    await withSessionCodexCapacityMutation(
+      dbA,
+      { workspaceId: ws!.workspaceId, reason: "test_pin" },
+      async (tx) => {
+        const changed = await setSessionCodexPinInTransaction(
+          tx,
+          ws!.workspaceId,
+          fence.sessionId,
+          exhausted,
+        );
+        return { result: changed, changed };
+      },
+    );
+    await admin`update codex_subscription_credentials set secondary_used_percent = 100,
+      secondary_reset_at = now() + interval '1 day', exhausted_until = now() + interval '1 day',
+      exhausted_kind = 'quota' where id = ${exhausted}`;
+    const first = await acquireCodexCredentialLease(
+      dbA,
+      {
+        accountId: ws!.accountId,
+        workspaceId: ws!.workspaceId,
+        ...fence,
+        turnId,
+        holderId: "blocked-first",
+        advanceActivePointer: true,
+      },
+      (context, state) =>
+        selectCodexCredentialLeaseForTurn({
+          context,
+          sessionId: fence.sessionId,
+          sessionPinnedCredentialId: state.pinnedCredentialId,
+          sessionPinSource: state.pinSource,
+          sessionLastCredentialId: state.lastCredentialId,
+          now: new Date(),
+        }),
+    );
+    expect(first.credentialId).toBeNull();
+    expect(first.codexPolicySnapshot?.pinnedCredentialId).toBe(exhausted);
+    const armed = await armCodexCapacityWait(dbA, {
+      accountId: ws!.accountId,
+      workspaceId: ws!.workspaceId,
+      sessionId: fence.sessionId,
+      turnId,
+      attemptId: fence.attemptId,
+      workflowId: fence.workflowId,
+      earliestResetAt: new Date(Date.now() + 86_400_000),
+      resetKind: "bounded_refresh",
+      failurePayload: { code: "codex_usage_limit_reached", error: "synthetic quota refusal" },
+    });
+    if (armed.action !== "waiting") throw new Error("Expected capacity wait");
+    return { ws: ws!, turnId, fence, exhausted, healthy, waiter: armed.waiter };
+  }
+
+  for (const selection of ["pin", "auto", "repeat_auto"] as const) {
+    test(`explicit ${selection} overrides a snapshot-bearing wait through reconciliation and reacquisition`, async () => {
+      if (!available) return;
+      const { ws, turnId, fence, exhausted, healthy, waiter } = await pinnedCapacityWait();
+      const before = await getSession(dbA, ws.workspaceId, fence.sessionId);
+      expect(before?.codexCurrentSelection).toEqual({ credentialId: exhausted, waiting: true });
+      // Reproduce a previously saved unpin that did not update the accepted turn.
+      if (selection === "repeat_auto") {
+        await withSessionCodexCapacityMutation(
+          dbA,
+          { workspaceId: ws.workspaceId, reason: "legacy_unpin" },
+          async (tx) => {
+            const changed = await setSessionCodexPinInTransaction(
+              tx,
+              ws.workspaceId,
+              fence.sessionId,
+              null,
+            );
+            return { result: changed, changed };
+          },
+        );
+      }
+      const metadataBefore = (
+        await admin`select metadata from session_turns where id = ${turnId}`
+      )[0]!.metadata;
+      const switched = await switchSessionCodexAccount(dbA, {
+        workspaceId: ws.workspaceId,
+        sessionId: fence.sessionId,
+        credentialId: selection === "pin" ? healthy : null,
+        subjectId: "test-user",
+      });
+      expect(switched.result.appliedTo).toBe("waiting_turn");
+      expect(switched.wakeTargets.some((target) => target.sessionId === fence.sessionId)).toBe(
+        true,
+      );
+      expect(switched.result.events[0]?.type).toBe("codex.account.selection.changed");
+      const [afterSwitch] = await admin`select metadata from session_turns where id = ${turnId}`;
+      for (const [key, value] of Object.entries(metadataBefore)) {
+        if (key !== "codexCredentialPolicySnapshotV1")
+          expect(afterSwitch!.metadata[key]).toEqual(value);
+      }
+      const reconciled = await reconcileCodexCapacityWait(
+        dbB,
+        {
+          accountId: ws.accountId,
+          workspaceId: ws.workspaceId,
+          sessionId: fence.sessionId,
+          waiterId: waiter.id,
+          generation: waiter.generation,
+        },
+        (context) => codexCapacityDecision(context),
+      );
+      expect(reconciled.action).toBe("resumed");
+      // A duplicate signal cannot create another turn or attempt.
+      expect(
+        (
+          await reconcileCodexCapacityWait(
+            dbA,
+            {
+              accountId: ws.accountId,
+              workspaceId: ws.workspaceId,
+              sessionId: fence.sessionId,
+              waiterId: waiter.id,
+              generation: waiter.generation,
+            },
+            (context) => codexCapacityDecision(context),
+          )
+        ).action,
+      ).toBe("stale");
+      await startRecoveryAttempt(ws, turnId);
+      const acquired = await acquireCodexCredentialLease(
+        dbA,
+        {
+          accountId: ws.accountId,
+          workspaceId: ws.workspaceId,
+          ...(await attemptFenceForTurn(turnId)),
+          turnId,
+          holderId: "override-recovery",
+          advanceActivePointer: true,
+        },
+        (context, state) =>
+          selectCodexCredentialLeaseForTurn({
+            context,
+            sessionId: fence.sessionId,
+            sessionPinnedCredentialId: state.pinnedCredentialId,
+            sessionPinSource: state.pinSource,
+            sessionLastCredentialId: state.lastCredentialId,
+            now: new Date(),
+          }),
+      );
+      expect(acquired.credentialId).toBe(healthy);
+      expect(acquired.codexPolicySnapshotReused).toBe(true);
+      const rows =
+        await admin`select id, metadata from session_turns where session_id = ${fence.sessionId}`;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe(turnId);
+      expect(
+        (await getSession(dbA, ws.workspaceId, fence.sessionId))?.codexCurrentSelection,
+      ).toEqual({ credentialId: healthy, waiting: false });
+    }, 60_000);
+  }
+
+  test("foreign account is rejected without changing the waiting pin or snapshot", async () => {
+    if (!available) return;
+    const { ws, fence, exhausted, turnId } = await pinnedCapacityWait();
+    const [foreign] = await freshAccount();
+    const foreignCredential = await connectCredential(foreign!, "foreign@example.test");
+    const result = await switchSessionCodexAccount(dbA, {
+      workspaceId: ws.workspaceId,
+      sessionId: fence.sessionId,
+      credentialId: foreignCredential,
+      subjectId: "test-user",
+    });
+    expect(result.result.changed).toBe(false);
+    expect(result.wakeTargets).toEqual([]);
+    expect(
+      (await getSessionCodexState(dbA, ws.workspaceId, fence.sessionId))?.pinnedCredentialId,
+    ).toBe(exhausted);
+    const [row] = await admin`select metadata from session_turns where id = ${turnId}`;
+    expect(readCodexCredentialPolicySnapshotV1(row!.metadata)).toMatchObject({
+      kind: "valid",
+      policy: { pinnedCredentialId: exhausted },
+    });
+  }, 60_000);
+
+  test("concurrent explicit switches keep the session preference and waiting snapshot consistent", async () => {
+    if (!available) return;
+    const { ws, fence, healthy, turnId } = await pinnedCapacityWait();
+    await Promise.all(
+      [dbA, dbB].map((db, index) =>
+        switchSessionCodexAccount(db, {
+          workspaceId: ws.workspaceId,
+          sessionId: fence.sessionId,
+          credentialId: index === 0 ? healthy : null,
+          subjectId: "test-user",
+        }),
+      ),
+    );
+    const state = await getSessionCodexState(dbA, ws.workspaceId, fence.sessionId);
+    const [row] = await admin`select metadata from session_turns where id = ${turnId}`;
+    expect(readCodexCredentialPolicySnapshotV1(row!.metadata)).toMatchObject({
+      kind: "valid",
+      policy: {
+        pinnedCredentialId: state!.pinnedCredentialId,
+        pinSource: state!.pinSource,
+      },
+    });
+  }, 60_000);
+
   test("persists the first accepted policy and reuses it after pin and rotation mutate", async () => {
     if (!available) return;
     const [ws] = await freshAccount();
@@ -373,6 +584,13 @@ describe("credential allocator atomic Codex credential allocation", () => {
       pinnedCredentialId: null,
       pinSource: null,
     });
+    const runningSwitch = await switchSessionCodexAccount(dbB, {
+      workspaceId: ws!.workspaceId,
+      sessionId: (await attemptFenceForTurn(turnId)).sessionId,
+      credentialId: laterPinned,
+      subjectId: "test-user",
+    });
+    expect(runningSwitch.result.appliedTo).toBe("next_turn");
 
     const [storedTurn] = await admin<{ metadata: Record<string, unknown> | null }[]>`
       select metadata from session_turns where id = ${turnId}`;

--- a/packages/db/test/codex-credential-leases.test.ts
+++ b/packages/db/test/codex-credential-leases.test.ts
@@ -433,6 +433,9 @@ describe("credential allocator atomic Codex credential allocation", () => {
         true,
       );
       expect(switched.result.events[0]?.type).toBe("codex.account.selection.changed");
+      const [cursor] =
+        await admin`select last_sequence from sessions where id = ${fence.sessionId}`;
+      expect(cursor!.last_sequence).toBe(switched.result.events[0]!.sequence);
       const [afterSwitch] = await admin`select metadata from session_turns where id = ${turnId}`;
       for (const [key, value] of Object.entries(metadataBefore)) {
         if (key !== "codexCredentialPolicySnapshotV1")

--- a/packages/db/test/session-event-writer-audit.test.ts
+++ b/packages/db/test/session-event-writer-audit.test.ts
@@ -106,6 +106,10 @@ function parseSourceFile(path: string, source: string): SourceFile {
 }
 
 const expectedWriters: Record<string, ExpectedWriter> = {
+  "packages/db/src/index.ts#switchSessionCodexAccount": {
+    inserts: 1,
+    contract: "canonical",
+  },
   "packages/db/src/index.ts#armCodexCapacityWait": {
     inserts: 1,
     contract: "canonical",
@@ -339,6 +343,8 @@ const expectedWriters: Record<string, ExpectedWriter> = {
 };
 
 const genericControlWriters = new Set([
+  // Preference changes do not admit inference; waiter reconciliation rechecks Pause.
+  "packages/db/src/index.ts#switchSessionCodexAccount",
   "packages/db/src/index.ts#acceptSessionApprovalDecision",
   "packages/db/src/index.ts#acceptSessionHumanInputResponse",
   "packages/db/src/index.ts#appendSessionEvents",
@@ -905,6 +911,7 @@ describe("session_events writer inventory", () => {
       "retrySessionActivityRls",
       "withWorkspaceSessionEventActivityRls",
       "retryWorkspaceSessionEventActivityPersistence",
+      "withSessionCodexCapacityMutation",
     ];
 
     for (const path of productionTypeScriptFiles()) {

--- a/packages/react/src/hooks/use-codex-accounts.ts
+++ b/packages/react/src/hooks/use-codex-accounts.ts
@@ -15,7 +15,16 @@ import {
 
 /** Events that change which Codex account a session runs on (or just ran). */
 export function isCodexAccountEvent(event: Pick<SessionEvent, "type">): boolean {
-  return event.type === "codex.account.switched";
+  return [
+    "codex.account.switched",
+    "codex.account.selection.changed",
+    "codex.capacity.waiting",
+    "codex.capacity.resumed",
+    "codex.capacity.superseded",
+    "turn.completed",
+    "turn.failed",
+    "turn.cancelled",
+  ].includes(event.type);
 }
 
 /**
@@ -30,12 +39,16 @@ export type CodexAccountsClientLike = {
   getSession?: (
     workspaceId: string,
     sessionId: string,
-  ) => Promise<{ codexPinnedCredentialId?: string | null; codexLastCredentialId?: string | null }>;
+  ) => Promise<{
+    codexPinnedCredentialId?: string | null;
+    codexLastCredentialId?: string | null;
+    codexCurrentSelection?: { credentialId: string | null; waiting: boolean } | null;
+  }>;
   pinSessionCodexAccount?: (
     workspaceId: string,
     sessionId: string,
     target: string,
-  ) => Promise<{ pinned: string }>;
+  ) => Promise<{ pinned: string; appliedTo?: "waiting_turn" | "next_turn" }>;
   /** Optional (absent ⇒ the card hides live refresh): batched live /wham/usage refresh. */
   refreshCodexUsage?: (workspaceId: string) => Promise<{ usage: Record<string, unknown> }>;
 };
@@ -55,8 +68,10 @@ export type UseCodexAccountsResult = {
   activeAccountId: string | null;
   /** The session's PINNED account (null ⇒ following workspace active). */
   pinnedAccountId: string | null;
-  /** The account the next turn will run on: pin > workspace active. */
+  /** Current preference only; automatic allocation can choose another account. */
   effectiveAccountId: string | null;
+  currentSelection: { credentialId: string | null; waiting: boolean } | null;
+  switchAppliedTo: "waiting_turn" | "next_turn" | null;
   /** The account the session's last turn ACTUALLY ran on (the "Running on:" source). */
   lastAccountId: string | null;
   settings: CodexRotationSettings;
@@ -85,6 +100,7 @@ const EMPTY_SETTINGS: CodexRotationSettings = {
 };
 
 type CodexAccountsState = {
+  currentSelection: { credentialId: string | null; waiting: boolean } | null;
   accounts: CodexAccount[];
   activeAccountId: string | null;
   settings: CodexRotationSettings;
@@ -93,6 +109,7 @@ type CodexAccountsState = {
 };
 
 const EMPTY_STATE: CodexAccountsState = {
+  currentSelection: null,
   accounts: [],
   activeAccountId: null,
   settings: EMPTY_SETTINGS,
@@ -121,6 +138,7 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
         : Promise.resolve(null);
     const [acc, session] = await Promise.all([accountsP, sessionP]);
     return {
+      currentSelection: session?.codexCurrentSelection ?? null,
       accounts: acc.accounts,
       activeAccountId: acc.activeAccountId,
       settings: acc.settings,
@@ -140,6 +158,10 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
   const { run: runMutation, mutating: pinning, mutationError } = useMutationRunner();
   const { run: runUsageMutation, mutating: refreshingUsage } = useMutationRunner();
   const [pinningTarget, setPinningTarget] = useState<string | null>(null);
+  const [switchReceipt, setSwitchReceipt] = useState<{
+    sessionId: string;
+    appliedTo: "waiting_turn" | "next_turn";
+  } | null>(null);
 
   // Refresh only after the durable post-selection event. `turn.started` is
   // emitted before account selection settles and races this authoritative read.
@@ -161,8 +183,10 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
         return false;
       }
       setPinningTarget(target);
+      setSwitchReceipt(null);
       const result = await runMutation(async () => {
-        await codexClient.pinSessionCodexAccount!(workspaceId, sessionId, target);
+        const receipt = await codexClient.pinSessionCodexAccount!(workspaceId, sessionId, target);
+        setSwitchReceipt({ sessionId, appliedTo: receipt.appliedTo ?? "next_turn" });
         return true;
       });
       setPinningTarget(null);
@@ -191,6 +215,9 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
   const effectiveAccountId = data.pinnedAccountId ?? data.activeAccountId;
 
   return {
+    currentSelection: data.currentSelection,
+    switchAppliedTo:
+      switchReceipt?.sessionId === sessionId ? (switchReceipt?.appliedTo ?? null) : null,
     accounts: data.accounts,
     activeAccountId: data.activeAccountId,
     pinnedAccountId: data.pinnedAccountId,

--- a/packages/react/test/use-codex-accounts.test.tsx
+++ b/packages/react/test/use-codex-accounts.test.tsx
@@ -72,6 +72,48 @@ describe("useCodexAccounts — cached usage + refreshUsage", () => {
   test("refreshes only after the durable post-selection event", () => {
     expect(isCodexAccountEvent({ type: "turn.started" })).toBe(false);
     expect(isCodexAccountEvent({ type: "codex.account.switched" })).toBe(true);
+    expect(isCodexAccountEvent({ type: "codex.account.selection.changed" })).toBe(true);
+    expect(isCodexAccountEvent({ type: "codex.capacity.waiting" })).toBe(true);
+  });
+
+  test("keeps blocked selection separate from future preference and exposes override acknowledgement", async () => {
+    let selected: string | null = null;
+    let blocked = "a";
+    const codexClient: CodexAccountsClientLike = {
+      listCodexAccounts: async () => ({
+        ...response([account("a"), account("b")]),
+        activeAccountId: "b",
+      }),
+      getSession: async () => ({
+        codexPinnedCredentialId: selected,
+        codexCurrentSelection: { credentialId: blocked, waiting: true },
+      }),
+      pinSessionCodexAccount: async (_workspaceId, _sessionId, target) => {
+        selected = target;
+        blocked = target;
+        return { pinned: target, appliedTo: "waiting_turn" };
+      },
+    };
+    const hook = await renderHook(
+      () =>
+        useCodexAccounts({
+          client,
+          workspaceId: WORKSPACE_ID,
+          sessionId: "test-session",
+          codexClient,
+          events: [],
+          pollIntervalMs: 0,
+        }),
+      undefined,
+    );
+    await flush();
+    expect(hook.result.current.effectiveAccountId).toBe("b");
+    expect(hook.result.current.currentSelection).toEqual({ credentialId: "a", waiting: true });
+    await actRun(() => hook.result.current.pin("b"));
+    await flush();
+    expect(hook.result.current.currentSelection).toEqual({ credentialId: "b", waiting: true });
+    expect(hook.result.current.switchAppliedTo).toBe("waiting_turn");
+    await hook.unmount();
   });
 
   test("an empty shared feed never opens a fallback session stream", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7689,13 +7689,13 @@ export class OpenGeniClient {
     );
   }
 
-  /** Pin (or unpin via "auto") a session's Codex account. Applies on the next turn. */
+  /** Pin/unpin a Codex account. Overrides a capacity-blocked turn; otherwise applies next turn. */
   async pinSessionCodexAccount(
     workspaceId: string,
     sessionId: string,
     target: string,
-  ): Promise<{ pinned: string }> {
-    return await this.requestJson<{ pinned: string }>(
+  ): Promise<{ pinned: string; appliedTo?: "waiting_turn" | "next_turn" }> {
+    return await this.requestJson<{ pinned: string; appliedTo?: "waiting_turn" | "next_turn" }>(
       "POST",
       `/v1/workspaces/${workspaceId}/sessions/${sessionId}/codex-account`,
       { target },

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1405,6 +1405,8 @@ export type Session = {
   codexPinnedCredentialId?: string | null;
   /** Multi-account Codex (P1): the account the most recent turn ran on (the "Running on:" indicator). */
   codexLastCredentialId?: string | null;
+  /** Accepted current-turn account, separate from future session preferences. */
+  codexCurrentSelection?: { credentialId: string | null; waiting: boolean } | null | undefined;
   /**
    * Frozen at create. `remote_v2` ⇒ Codex remote compaction + Codex-only model
    * admission; `portable` ⇒ plaintext compaction and free provider switching.
@@ -1897,6 +1899,7 @@ export const SESSION_EVENT_TYPES = [
   "session.tool_policy.updated",
   // Multi-account Codex (P1): the session's inference account changed.
   "codex.account.switched",
+  "codex.account.selection.changed",
   // credential allocator metadata-only per-turn credential selection audit.
   "codex.credential.selected",
   // Bounded, identity-free deterministic shadow/replay decision.


### PR DESCRIPTION
## Summary

Changing a Codex account while a turn waits for capacity saved the preference and woke the workflow, but reconciliation kept using the old frozen pin. Explicit account switches and Auto now revise the blocked selection atomically, so reconciliation and lease reacquisition resume the same logical turn using the requested account policy. Running attempts retain their leases; background policy changes retain snapshot semantics.

The account menu now displays the current turn's account separately from future preferences, permits repeating Auto to recover an older wait, and reports whether a change rechecks the waiting turn or applies next turn. Credential-source and authority boundaries remain intact.

## Testing

- 48 real-PostgreSQL credential lease/capacity-wait tests pass, including manual switch, Auto, repeated unpin, concurrent switches, foreign-account rejection, duplicate wakes, same-turn recovery, and running-turn preservation.
- 165 contract, SDK, API-route, and React-hook tests pass.
- Account-menu DOM regression passes; desktop browser inspection with synthetic data verifies blocked-account display and Auto acknowledgement.
- Affected package/app typechecks and changed-file lint pass.

## Delivery integrity

- [x] Substantive source changes with a package changeset.
- [x] Isolated worktree; only generic code, documentation, and synthetic fixtures included.

## Notes

No database migration. The new session projection and switch acknowledgement are additive. No deployment or customer-specific data is included.

## Summary by Sourcery

Apply explicit Codex account changes to capacity-blocked turns while preserving turn identity, lease safety, and snapshot boundaries.

New Features:
- Allow explicit Codex account switches and Auto unpins to update turns blocked on capacity without creating a new turn.
- Expose the current turn's Codex account separately from the session's future account preference and report whether a switch applies to the waiting or next turn.

Bug Fixes:
- Ensure blocked-turn reconciliation and lease reacquisition use the newly requested account policy while preserving running attempts and accepted credential boundaries.

Enhancements:
- Add durable account-selection change events and refresh account indicators when capacity or turn state changes.
- Document the exception that explicit in-session account switches may revise capacity-blocked turn selection while background policy changes retain snapshot semantics.

Documentation:
- Document blocked Codex account-switch behavior in the architecture, subscription-rotation, and run-lifecycle guides.

Tests:
- Add coverage for manual switches, Auto and repeated unpins, concurrent changes, foreign-account rejection, duplicate wakes, recovery, and preservation of running-turn leases.
- Add React and account-menu regression coverage for blocked-account display and switch acknowledgement.

Chores:
- Add package changesets for the database, contracts, SDK, and React updates.