### PR TITLE
test(web): make attachment-consent delivery checks deterministic

### DIFF
--- a/.changeset/session-personal-variable-set-continuations.md
+++ b/.changeset/session-personal-variable-set-continuations.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Repair protocol-0 continuation admission to consider every explicitly selected personal Variable Set, preserving current-owner, grant, authority-epoch and causal-attempt fences. Include rolling migration 0430 in the published database package.

--- a/apps/web/test/real-personal-access/check.ts
+++ b/apps/web/test/real-personal-access/check.ts
@@ -17,6 +17,38 @@ try {
     viewport: { width: 1440, height: 1000 },
     reducedMotion: "reduce",
   });
+  // Wait for the rendered frame we inspect, not an assumed machine speed.
+  const waitForLayout = async (expectedWidth?: number) => {
+    await page.waitForFunction(
+      async (viewportWidth) => {
+        if (
+          document.fonts.status !== "loaded" ||
+          (viewportWidth !== undefined && innerWidth !== viewportWidth)
+        )
+          return false;
+        const footer = document.querySelector(".og-composer-footer");
+        if (!footer || footer.getBoundingClientRect().width === 0) return false;
+        const geometry = () =>
+          JSON.stringify([
+            document.documentElement.scrollWidth,
+            ...Array.from(
+              document.querySelectorAll(
+                '.og-composer-footer, .og-composer-footer button, [data-testid="model-picker-menu"]',
+              ),
+              (element) => {
+                const { x, y, width, height } = element.getBoundingClientRect();
+                return [x, y, width, height];
+              },
+            ),
+          ]);
+        const before = geometry();
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        return before === geometry();
+      },
+      expectedWidth,
+      { timeout: 5_000, polling: "raf" },
+    );
+  };
   const errors: string[] = [];
   const network: string[] = [];
   page.on("pageerror", (error) => errors.push(error.message));
@@ -35,7 +67,7 @@ try {
   await page.goto(server.url.toString());
   const send = page.getByRole("button", { name: "Send message", exact: true });
   await send.waitFor();
-  await page.waitForTimeout(600);
+  await waitForLayout();
   assert.equal(await page.locator("[data-personal-resource-attachment]").count(), 0);
   assert.equal(await page.getByRole("radio").count(), 0);
   await page.screenshot({ path: path.join(output, "implemented-desktop.png"), fullPage: true });
@@ -48,7 +80,8 @@ try {
   assert.equal(await send.isDisabled(), true);
   assert.equal(await page.locator("[data-personal-resource-attachment]").count(), 0);
   await page.getByRole("button", { name: "Model and effort", exact: true }).click();
-  await page.waitForTimeout(600);
+  await page.getByTestId("model-picker-menu").waitFor({ state: "visible" });
+  await waitForLayout();
   await page.screenshot({ path: path.join(output, "model-picker.png"), fullPage: true });
   await page.keyboard.press("Escape");
   await page.getByRole("button", { name: "Session tools", exact: true }).click();
@@ -56,7 +89,7 @@ try {
   await page.keyboard.press("Escape");
   for (const width of [640, 375, 320]) {
     await page.setViewportSize({ width, height: 900 });
-    await page.waitForTimeout(600);
+    await waitForLayout(width);
     assert.equal(
       await page.evaluate(() => document.documentElement.scrollWidth > innerWidth),
       false,
@@ -79,7 +112,8 @@ try {
       await page.screenshot({ path: path.join(output, "implemented-mobile.png"), fullPage: true });
   }
   await page.getByRole("button", { name: "Theme", exact: true }).click();
-  await page.waitForTimeout(600);
+  await page.waitForFunction(() => document.documentElement.dataset.ogTheme === "dark");
+  await waitForLayout();
   await page.screenshot({ path: path.join(output, "implemented-mobile-dark.png"), fullPage: true });
   assert.deepEqual(errors, []);
   assert.deepEqual(network, []);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 > Whole-system orientation; code and focused docs own exact behavior.
 > Setup: [`../AGENTS.md`](../AGENTS.md). Documentation index: [`README.md`](README.md).
 
-## How to use this document
+## Navigation
 
 1. **New here?** Read §2–4; skim §6.
 2. **Changing a subsystem?** Start with §13 and its canonical sources.


### PR DESCRIPTION
PR #2343 added migration 0430 without a database-package changeset, and its retained preview check relied on fixed 600 ms sleeps. Add the patch release metadata so the published database package includes the continuation repair, and wait for fonts, visible menus, the selected theme and stable responsive layout before assertions and screenshots.

The follow-up preserves the merged attachment-consent behavior and authorization fences. It also addresses the remaining Sourcery preview-test finding on #2343. Shorten the architecture navigation heading to repair the inherited 12,003-word document limit failure; the guard remains unchanged.

Validation: production preview build and browser checks passed before and after the readiness correction; fixture TypeScript, focused lint/format and whitespace checks passed. On the merged main baseline, release-schema contract tests passed (8 tests, 264 assertions). Independent final review and CI tracked here.

Tracks [OPE-464](https://linear.app/cloudgeni/issue/OPE-464). No deployment performed.

## Summary by Sourcery

Publish the continuation repair and make attachment-consent preview validation deterministic across themes, menus, and responsive layouts.

Bug Fixes:
- Make attachment-consent browser checks wait for fonts, controls, theme state, and stable responsive layout instead of fixed delays.
- Publish database migration 0430 in the database package to repair protocol-0 continuation admission for explicitly selected personal Variable Sets while preserving authorization safeguards.

Enhancements:
- Shorten the architecture document navigation heading to remain within the inherited document size limit.

Tests:
- Improve real-personal-access preview checks with deterministic readiness conditions for assertions and screenshots.