### PR TITLE
fix(runtime): preserve governance prompt cache across turns

### DIFF
--- a/.changeset/governance-prompt-cache-stability.md
+++ b/.changeset/governance-prompt-cache-stability.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Preserve prompt-cache reuse across turns with unchanged governance by keeping attempt-specific snapshot receipt UUIDs out of system instructions. Stable content hashes, policy revisions, and skill retrieval handles remain model-visible; exact-attempt snapshot IDs remain in durable audit records.

--- a/packages/runtime/src/workspace-governance.ts
+++ b/packages/runtime/src/workspace-governance.ts
@@ -95,18 +95,22 @@ export function renderWorkspaceGovernanceContext(
     ),
   ].filter((section): section is string => Boolean(section));
 
+  // Receipt UUIDs identify an accepted attempt, not policy content. Keep them in
+  // durable snapshots / contribution receipts: putting them before the history
+  // invalidates the provider's prompt prefix on every turn. Content hashes and
+  // revision identities below still change when the effective authority changes.
   const preferenceEvidence = context.preferences
-    ? `Skill snapshot evidence (structured preference authority): id=${context.preferences.id}; sha256=${context.preferences.descriptorHash}; descriptors=${context.preferences.descriptors.length}/${PREFERENCE_REGISTRY_DESCRIPTOR_MAX_COUNT}; descriptorUtf8Limit=${PREFERENCE_REGISTRY_DESCRIPTOR_MAX_UTF8_BYTES}; truncated=${context.preferences.truncated}.`
+    ? `Skill snapshot evidence (structured preference authority): sha256=${context.preferences.descriptorHash}; descriptors=${context.preferences.descriptors.length}/${PREFERENCE_REGISTRY_DESCRIPTOR_MAX_COUNT}; descriptorUtf8Limit=${PREFERENCE_REGISTRY_DESCRIPTOR_MAX_UTF8_BYTES}; truncated=${context.preferences.truncated}.`
     : "Skill snapshot evidence: unavailable for this service-initiated attempt.";
   const companyProfileEvidence = companyProfile
-    ? `Company-profile snapshot evidence: id=${companyProfile.id}; sha256=${companyProfile.snapshotHash}; revision=${companyProfile.profile!.revision}; activationVersion=${companyProfile.profile!.activationVersion}.`
+    ? `Company-profile snapshot evidence: sha256=${companyProfile.snapshotHash}; revision=${companyProfile.profile!.revision}; activationVersion=${companyProfile.profile!.activationVersion}.`
     : null;
   const rendered = [
     companyProfile
       ? "Active organization and workspace governance for this exact accepted attempt follows. Apply it after the non-bypassable CORE and in the section order shown. Later activations apply only to a new attempt."
       : "Active workspace governance for this exact accepted attempt follows. Apply it after the non-bypassable CORE and in the section order shown. Later activations apply only to a new attempt.",
     companyProfileEvidence,
-    `Instruction-policy snapshot evidence: id=${context.instructionPolicy.id}; sha256=${context.instructionPolicy.entryHash}; role=${context.instructionPolicy.policyRole ?? "none"}; roleSource=${context.instructionPolicy.roleSource}; entries=${context.instructionPolicy.entries.length}/3.`,
+    `Instruction-policy snapshot evidence: sha256=${context.instructionPolicy.entryHash}; role=${context.instructionPolicy.policyRole ?? "none"}; roleSource=${context.instructionPolicy.roleSource}; entries=${context.instructionPolicy.entries.length}/3.`,
     preferenceEvidence,
     ...sections,
     "Skill entries above are short descriptors only. Retrieve the full Skill instructions only when relevant through the exact preference_registry_get retrievalHandle; do not infer omitted content.",

--- a/packages/runtime/test/workspace-governance.test.ts
+++ b/packages/runtime/test/workspace-governance.test.ts
@@ -145,6 +145,77 @@ function preferenceSnapshot(
 }
 
 describe("exact-attempt workspace governance prompt", () => {
+  test("equivalent authority stays byte-identical across accepted attempts", () => {
+    const original = {
+      companyProfile: companyProfileSnapshot(),
+      instructionPolicy: policySnapshot([
+        policyEntry({ kind: "charter", scope: "global", content: "CHARTER_SENTINEL" }),
+      ]),
+      preferences: preferenceSnapshot([descriptor("user", "PERSONAL")]),
+    };
+    const next = structuredClone(original);
+    for (const snapshot of Object.values(next)) {
+      snapshot.id = crypto.randomUUID();
+      snapshot.turnId = crypto.randomUUID();
+      snapshot.attemptId = crypto.randomUUID();
+      snapshot.executionGeneration += 1;
+      snapshot.createdAt = "2026-09-09T12:00:00.000Z";
+    }
+    const before = renderWorkspaceGovernanceContext(original)!;
+    const after = renderWorkspaceGovernanceContext(next)!;
+    expect(after).toBe(before);
+    for (const snapshot of [...Object.values(original), ...Object.values(next)]) {
+      expect(after).not.toContain(snapshot.id);
+    }
+    // Revision identity and frozen retrieval authority remain model-visible.
+    expect(after).toContain(original.companyProfile.profile!.id);
+    expect(after).toContain(original.instructionPolicy.entries[0]!.revisionId);
+    expect(after).toContain(original.preferences.descriptors[0]!.retrievalHandle);
+    const settings = testSettings({ sandboxBackend: "none" });
+    const options = { sessionInstructions: "SESSION_SENTINEL" };
+    expect(
+      buildOpenGeniAgent(settings, [], { ...options, workspaceGovernance: after }).instructions,
+    ).toBe(
+      buildOpenGeniAgent(settings, [], { ...options, workspaceGovernance: before }).instructions,
+    );
+  });
+
+  test("real governance changes still change the rendered prompt", () => {
+    const original = {
+      companyProfile: companyProfileSnapshot(),
+      instructionPolicy: policySnapshot([
+        policyEntry({ kind: "charter", scope: "global", content: "CHARTER_SENTINEL" }),
+      ]),
+      preferences: preferenceSnapshot([descriptor("user", "PERSONAL")]),
+    };
+    const before = renderWorkspaceGovernanceContext(original);
+    const changes: Array<(next: typeof original) => void> = [
+      (next) => {
+        next.companyProfile.profile!.profile.mission = "New mission";
+      },
+      (next) => {
+        next.companyProfile.profile!.activationVersion += 1;
+      },
+      (next) => {
+        next.instructionPolicy.entries[0]!.content = "New charter";
+      },
+      (next) => {
+        next.instructionPolicy.policyRole = "operator";
+      },
+      (next) => {
+        next.preferences.descriptors[0]!.description = "New skill guidance";
+      },
+      (next) => {
+        next.preferences.descriptors[0]!.retrievalHandle += "&changed=1";
+      },
+    ];
+    for (const change of changes) {
+      const next = structuredClone(original);
+      change(next);
+      expect(renderWorkspaceGovernanceContext(next)).not.toBe(before);
+    }
+  });
+
   test("orders fixed authorities before session/task state and bounded memory", () => {
     const governance = renderWorkspaceGovernanceContext({
       companyProfile: companyProfileSnapshot(),


### PR DESCRIPTION
## Summary

Every accepted attempt creates fresh governance snapshot receipt UUIDs. Rendering those UUIDs in system instructions changes the prompt before the conversation history even when policy content is identical, preventing cross-turn prompt-cache reuse.

Remove only the company-profile, instruction-policy, and skill-preference snapshot receipt IDs from model-facing instructions. Keep content hashes, policy revision identities, activation versions, roles, and skill retrieval handles. Exact-attempt IDs remain in durable snapshots and contribution/audit receipts.

Regression tests require equivalent content with different attempt metadata to produce byte-identical governance and assembled agent instructions. They also verify that actual authority/content changes still change the prompt.

## Testing

- New regression failed before the renderer fix with exactly the three UUID differences.
- Governance, tool-search and worker contribution suites: 46 passed before base refresh.
- Related prefix/history/compaction/title checks: 28 passed before base refresh.
- Governance and worker contribution suites rerun on the current main base; runtime TypeScript check passed.
- Changed-file lint, formatting and whitespace checks passed.
- Provider cache-rate improvement still requires post-deployment measurement.

## Delivery integrity

- Three-file patch: renderer, regression tests and runtime patch changeset.
- Refreshed to current main before publishing the candidate; subsequent head remains frozen unless a material incompatibility requires a change.

## Notes

No database migration or authority change. Other possible cache mechanisms are outside this PR.

## Summary by Sourcery

Stabilize governance system instructions across equivalent attempts to enable prompt-cache reuse without weakening auditability or change detection.

Bug Fixes:
- Preserve provider prompt-cache reuse across turns when governance content is unchanged by removing attempt-specific snapshot receipt UUIDs from model-facing instructions.

Enhancements:
- Keep stable governance content hashes, policy revisions, activation versions, roles, and skill retrieval handles visible while retaining exact-attempt identifiers in durable audit records.

Tests:
- Add regression coverage for byte-identical governance and assembled agent instructions across equivalent attempts, while confirming real governance changes alter the prompt.