### PR TITLE
fix(react): keep answers visible when input waits settle

### DIFF
--- a/.changeset/visible-streamed-wait-answer.md
+++ b/.changeset/visible-streamed-wait-answer.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep the latest streamed answer visible outside collapsed steps when an input wait ends a turn without final output.

--- a/packages/react/demo/timeline-held-turn-test-harness.tsx
+++ b/packages/react/demo/timeline-held-turn-test-harness.tsx
@@ -22,9 +22,12 @@ function event(type: string, payload: unknown): SessionEvent {
 }
 
 const fallback = "The child is still running; I will resume when it finishes.";
+const streamed = new URLSearchParams(location.search).get("streamed") === "1";
 const events = [
   event("user.message", { text: "Wait for the child and keep me posted." }),
-  event("agent.message.completed", { text: fallback, phase: "commentary" }),
+  streamed
+    ? event("agent.message.delta", { text: fallback })
+    : event("agent.message.completed", { text: fallback, phase: "commentary" }),
   event("agent.toolCall.created", {
     id: "input-wait-call",
     name: "wait_for_input",
@@ -35,7 +38,7 @@ const events = [
     id: "input-wait-call",
     output: { status: "waiting_for_input" },
   }),
-  event("turn.completed", {}),
+  event("turn.completed", { output: "" }),
 ];
 
 createRoot(document.getElementById("root")!).render(

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1039,11 +1039,17 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           }
         }
         finalizeOpen(turnId, "complete", event.occurredAt);
-        items.push(turnEndItem(event, "complete", null));
+        const completedTurn = turnEndItem(event, "complete", null);
+        items.push(completedTurn);
         const hasCompletedFinalResponse =
           latestAgentResponse?.completed === true &&
           latestAgentResponse.item.phase !== "commentary" &&
           Boolean(visibleTrackedResponse);
+        if (!hasAuthoritativeFinalOutput && pendingWaitOutcome) {
+          // Preserve existing prose, including delta-only streams, when a
+          // trailing wait yields without a terminal output receipt.
+          completedTurn.preserveWaitResponse = true;
+        }
         if (!hasAuthoritativeFinalOutput && !hasCompletedFinalResponse && pendingWaitOutcome) {
           items.push({
             kind: "notice",
@@ -1808,7 +1814,31 @@ function foldSettledTurn(groups: TimelineGroup[], turnEnd: TurnEndItem): void {
     return;
   }
 
-  const finalMessage = extractFinalAgentMessage(collected, turnEnd);
+  // Resolve only inside this turn's collected suffix. A user/machine-input
+  // boundary or an interleaved foreign turn must never donate its answer.
+  const waitMessages = turnEnd.preserveWaitResponse
+    ? collected.filter(
+        (group): group is Extract<TimelineGroup, { kind: "item" }> =>
+          group.kind === "item" &&
+          group.item.kind === "agent-message" &&
+          !group.item.streaming &&
+          group.item.text.trim().length > 0 &&
+          belongsToTurn(group.item, turnEnd.turnId),
+      )
+    : [];
+  // A completed answer outranks later commentary. Otherwise use the latest
+  // visible existing prose, ignoring whitespace and opaque-only stream tails.
+  const waitResponse =
+    waitMessages
+      .slice()
+      .reverse()
+      .find(
+        (group) =>
+          group.item.kind === "agent-message" &&
+          group.item.phase !== "commentary" &&
+          group.item.annotationSource?.eventType === "agent.message.completed",
+      ) ?? waitMessages.at(-1);
+  const finalMessage = waitResponse ?? extractFinalAgentMessage(collected, turnEnd);
   const fallbackMessage =
     finalMessage || hasOrdinaryFinalAgentMessage(collected, turnEnd)
       ? null

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -451,6 +451,8 @@ export type TurnOutcome = "complete" | "failed" | "cancelled";
 
 export type TurnEndItem = {
   kind: "turn-end";
+  /** Keep an existing answer visible when a recorded input wait ends without final output. */
+  preserveWaitResponse?: true;
   id: string;
   turnId: string | null;
   outcome: TurnOutcome;

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1209,6 +1209,84 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
+  test.each([
+    "streamed",
+    "completed",
+    "completed-before-commentary",
+    "whitespace-tail",
+    "opaque-tail",
+  ])("a %s answer stays visible once when a trailing wait ends with empty output", async (mode) => {
+    resetTimelineEvents();
+    const answer = "Not yet. The browser test still times out; I have resumed the repair.";
+    const events = [
+      timelineEvent("user.message", { text: "Is it mergeable?" }),
+      timelineEvent("agent.message.delta", { text: "Checking CI now." }),
+      timelineEvent("agent.toolCall.created", {
+        id: "check",
+        name: "exec_command",
+        arguments: { cmd: "gh pr checks" },
+      }),
+      timelineEvent("agent.toolCall.output", { id: "check", output: "one failure" }),
+      timelineEvent("agent.message.delta", { text: answer.slice(0, 12) }),
+      timelineEvent("agent.message.delta", { text: answer.slice(12) }),
+      ...(mode === "streamed" || mode === "whitespace-tail" || mode === "opaque-tail"
+        ? []
+        : [timelineEvent("agent.message.completed", { text: answer, phase: "final_answer" })]),
+      ...(mode === "whitespace-tail" || mode === "opaque-tail"
+        ? [
+            timelineEvent("agent.toolCall.created", {
+              id: "tail",
+              name: "exec_command",
+              arguments: {},
+            }),
+            timelineEvent("agent.toolCall.output", { id: "tail", output: "ok" }),
+            timelineEvent("agent.message.delta", {
+              text: mode === "opaque-tail" ? "citeopaque-handle" : "  ",
+            }),
+          ]
+        : []),
+      ...(mode === "completed-before-commentary"
+        ? [
+            timelineEvent("agent.toolCall.created", {
+              id: "follow",
+              name: "exec_command",
+              arguments: {},
+            }),
+            timelineEvent("agent.toolCall.output", { id: "follow", output: "ok" }),
+            timelineEvent("agent.message.completed", {
+              text: "Waiting for the worker now.",
+              phase: "commentary",
+            }),
+          ]
+        : []),
+      timelineEvent("agent.toolCall.created", {
+        id: "wait",
+        name: "wait_for_input",
+        arguments: { reason: "Repair running", timeoutSeconds: 300 },
+      }),
+      timelineEvent("session.wait.started", { actor: "agent", reason: "Repair running" }),
+      timelineEvent("agent.toolCall.output", {
+        id: "wait",
+        output: { status: "waiting_for_input" },
+      }),
+      timelineEvent("turn.completed", { output: "" }),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+    const trigger = turnSummaryTrigger(r.container);
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(r.container.textContent?.split(answer)).toHaveLength(2);
+    expect(r.container.textContent).not.toContain("Checking CI now.");
+    if (mode !== "completed") expect(r.container.textContent).toContain("Waiting: Repair running");
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(r.container.textContent?.split(answer)).toHaveLength(2);
+    expect(r.container.textContent).toContain("Checking CI now.");
+    await r.unmount();
+  });
+
   test("empty wait turns keep their durable reason outside the collapsed steps", async () => {
     resetTimelineEvents();
     const reason = "Two delegated reviews are still running.";

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -2757,6 +2757,46 @@ describe("groupTimeline", () => {
     ).toHaveLength(0);
   });
 
+  test.each(["authoritative", "ordinary", "foreign", "user-boundary"])(
+    "wait answer promotion preserves %s precedence and boundaries",
+    (scenario) => {
+      reset();
+      const answer = "Exact streamed answer.\nSecond line.";
+      const events = [
+        event("agent.message.delta", { text: answer }),
+        ...(scenario === "foreign"
+          ? [event("agent.message.delta", { text: "Another turn's answer." }, { turnId: "other" })]
+          : scenario === "user-boundary"
+            ? [event("user.message", { text: "New direction" }, { turnId: "other" })]
+            : []),
+        event("agent.toolCall.created", { id: "wait", name: "wait_for_input", arguments: {} }),
+        ...(scenario === "ordinary"
+          ? []
+          : [event("session.wait.started", { actor: "agent", reason: "Awaiting result" })]),
+        event("agent.toolCall.output", { id: "wait", output: { status: "waiting_for_input" } }),
+        event("turn.completed", {
+          output: scenario === "authoritative" ? "Authoritative final." : "",
+        }),
+      ];
+      const items = buildTimeline(events);
+      const groups = groupTimeline(items);
+      const foldIndex = groups.findIndex(
+        (group) => group.kind === "turn" && group.id === "turn-turn-1",
+      );
+      const lifted = groups
+        .slice(foldIndex + 1)
+        .filter((group) => group.kind === "item" && group.item.kind === "agent-message");
+      expect(
+        lifted.map((group) =>
+          group.kind === "item" && group.item.kind === "agent-message" ? group.item.text : null,
+        ),
+      ).toEqual(scenario === "authoritative" ? ["Authoritative final."] : []);
+      expect(
+        items.filter((item) => item.kind === "agent-message" && item.text === answer),
+      ).toHaveLength(1);
+    },
+  );
+
   test("promotes the latest completed commentary when a tool turn settles without a final", () => {
     reset();
     const events = [

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -1443,39 +1443,48 @@ describe("timeline scroll ownership browser regression", () => {
     ).toBeGreaterThan(0);
   }, 30_000);
 
-  test("keeps one held-turn commentary reply visible across disclosure collapse and expand", async () => {
-    await page.setViewportSize({ width: 1280, height: 900 });
-    await page.goto(`${baseUrl}/timeline-held-turn-test.html`);
+  test.each(["commentary", "streamed"])(
+    "keeps one held-turn %s reply visible across disclosure collapse and expand",
+    async (mode) => {
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(
+        `${baseUrl}/timeline-held-turn-test.html?streamed=${mode === "streamed" ? "1" : "0"}`,
+      );
 
-    const fallback = page.getByText("The child is still running; I will resume when it finishes.", {
-      exact: true,
-    });
-    const disclosure = page.getByRole("button", { name: /steps?/ }).first();
+      const fallback = page.getByText(
+        "The child is still running; I will resume when it finishes.",
+        {
+          exact: true,
+        },
+      );
+      const disclosure = page.getByRole("button", { name: /steps?/ }).first();
 
-    await fallback.waitFor({ timeout: 5_000 });
-    expect(await fallback.count()).toBe(1);
-    expect(await fallback.isVisible()).toBe(true);
-    expect(await disclosure.getAttribute("aria-expanded")).toBe("false");
+      await fallback.waitFor({ timeout: 5_000 });
+      expect(await fallback.count()).toBe(1);
+      expect(await fallback.isVisible()).toBe(true);
+      expect(await disclosure.getAttribute("aria-expanded")).toBe("false");
 
-    await disclosure.click();
-    expect(await disclosure.getAttribute("aria-expanded")).toBe("true");
-    expect(await fallback.count()).toBe(1);
-    expect(await fallback.isVisible()).toBe(true);
-    expect(await page.getByText("Wait for input", { exact: false }).count()).toBe(1);
+      await disclosure.click();
+      expect(await disclosure.getAttribute("aria-expanded")).toBe("true");
+      expect(await fallback.count()).toBe(1);
+      expect(await fallback.isVisible()).toBe(true);
+      expect(await page.getByText("Wait for input", { exact: false }).count()).toBe(1);
 
-    await disclosure.click();
-    expect(await disclosure.getAttribute("aria-expanded")).toBe("false");
-    expect(await fallback.count()).toBe(1);
-    expect(await fallback.isVisible()).toBe(true);
+      await disclosure.click();
+      expect(await disclosure.getAttribute("aria-expanded")).toBe("false");
+      expect(await fallback.count()).toBe(1);
+      expect(await fallback.isVisible()).toBe(true);
 
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-      await page.screenshot({
-        path: `${artifactDir}/timeline-held-turn-commentary-visible.png`,
-        fullPage: true,
-      });
-    }
-  }, 30_000);
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          path: `${artifactDir}/timeline-held-turn-${mode}-visible.png`,
+          fullPage: true,
+        });
+      }
+    },
+    30_000,
+  );
 });
 
 async function visible(page: Page): Promise<VisibleRow> {


### PR DESCRIPTION
A streamed answer followed by wait_for_input could disappear inside collapsed steps when the turn completed with empty output. Keep the latest existing substantive answer outside the fold for that explicit wait settlement, preferring a completed answer over later commentary. Preserve exact text, final-output precedence, turn boundaries, and the existing wait notice.

Regression coverage includes delta-only answers, completed answers, later commentary, whitespace/opaque tails, authoritative output, ordinary turns, and foreign/user boundaries. The real MessageTimeline DOM test failed before the fix. Production Vite-build Chromium checks pass for both streamed and completed-commentary waits across collapse/expand.

Validation: projection + DOM suites 262 tests / 769 assertions passed, including all five final DOM variants. React typecheck, focused lint, formatting, and docs-reference/architecture guards pass. Production Chromium: 2 tests / 20 assertions pass. Includes a patch changeset for @opengeni/react.

Tracking: https://linear.app/cloudgeni/issue/OPE-468
