### PR TITLE
fix(db): allow disconnecting SuperGrok accounts pinned by sessions

### DIFF
--- a/.changeset/supergrok-disconnect-pins.md
+++ b/.changeset/supergrok-disconnect-pins.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+---
+
+Fix SuperGrok disconnect failing when sessions are pinned to the account. Clear
+the credential pin and its source atomically, preserving stale-update fencing.

--- a/docs/supergrok-subscription.md
+++ b/docs/supergrok-subscription.md
@@ -82,6 +82,10 @@ snapshot. Private work additionally requires the exact initiating human.
 
 ## Allocation, pins, and leases
 
+Disconnecting a workspace or personal credential clears its session pin and pin
+source atomically before deletion. Pin versions advance to reject stale edits;
+unrelated account pins remain unchanged.
+
 One rotation row serializes each organization, workspace, or exact-user pool. Credentials have
 separate health and allocator state: `status=active` is credential health, while
 `allocator_enabled` controls only new selection. Reconnect and refresh restore

--- a/packages/db/drizzle/0432_xai_disconnect_session_pins.sql
+++ b/packages/db/drizzle/0432_xai_disconnect_session_pins.sql
@@ -1,0 +1,79 @@
+-- deployment-mode: rolling
+-- Preserve the pin invariant when disconnecting an account referenced by sessions.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '1min';
+DO $disconnect_pins$
+DECLARE data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.disconnect_xai_subscription_credential(
+      p_account_id uuid,
+      p_workspace_id uuid,
+      p_subject_id text,
+      p_credential_id uuid,
+      p_snapshot jsonb
+    ) RETURNS boolean
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = %1$I, pg_catalog
+    AS $body$
+    DECLARE
+      credential_row record;
+    BEGIN
+      IF p_account_id IS DISTINCT FROM NULLIF(current_setting('opengeni.account_id', true), '')::uuid
+        OR p_workspace_id IS DISTINCT FROM NULLIF(current_setting('opengeni.workspace_id', true), '')::uuid
+        OR p_subject_id IS DISTINCT FROM NULLIF(current_setting('opengeni.subject_id', true), '')
+      THEN
+        RAISE EXCEPTION 'xAI credential lifecycle authority denied' USING ERRCODE = '42501';
+      END IF;
+
+      SELECT credential.* INTO credential_row
+      FROM revalidate_xai_subscription_authority(
+        p_workspace_id, p_subject_id, p_credential_id, p_snapshot
+      ) authorized
+      INNER JOIN xai_subscription_credentials credential ON credential.id = authorized.id
+      FOR UPDATE OF credential;
+      IF credential_row.id IS NULL THEN RETURN false; END IF;
+
+      INSERT INTO opengeni_private.xai_subscription_runtime_capabilities (
+        backend_pid, transaction_id, capability_kind
+      ) VALUES (pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'lifecycle')
+      ON CONFLICT DO NOTHING;
+
+      -- Clear the coupled pin fields before the foreign key nulls its id.
+      -- Keep the row/version so stale session pin edits still fail their CAS.
+      UPDATE xai_session_account_pins
+      SET pinned_credential_id = NULL, pin_source = NULL,
+          version = version + 1, updated_at = now()
+      WHERE account_id = credential_row.account_id
+        AND workspace_id = credential_row.workspace_id
+        AND pinned_credential_id = credential_row.id;
+
+      DELETE FROM xai_subscription_credentials WHERE id = credential_row.id;
+      IF credential_row.authority_scope = 'user' THEN
+        UPDATE organization_user_resource_authorities
+        SET status = 'revoked', revoked_at = now(), updated_at = now()
+        WHERE id = credential_row.organization_user_resource_authority_id
+          AND account_id = credential_row.account_id
+          AND organization_membership_id = credential_row.owner_organization_membership_id
+          AND resource_kind = 'xai_subscription'
+          AND resource_id = credential_row.id
+          AND generation = credential_row.organization_user_resource_authority_generation;
+      END IF;
+
+      DELETE FROM opengeni_private.xai_subscription_runtime_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'lifecycle';
+      RETURN true;
+    EXCEPTION WHEN OTHERS THEN
+      DELETE FROM opengeni_private.xai_subscription_runtime_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'lifecycle';
+      RAISE;
+    END
+    $body$;
+  $ddl$, data_schema);
+END
+$disconnect_pins$;
+-- CREATE OR REPLACE retains the existing owner and PUBLIC-revoked ACL.

--- a/packages/db/test/migration-0234-xai-subscription-authority.test.ts
+++ b/packages/db/test/migration-0234-xai-subscription-authority.test.ts
@@ -12,6 +12,7 @@ import {
   createDb,
   createXaiSubscriptionCredential,
   disconnectXaiSubscriptionCredential,
+  disconnectXaiSubscriptionCredentialAndRepick,
   getXaiCapacityWaitForSession,
   getXaiRotationSettings,
   getXaiSessionAccountPin,
@@ -390,6 +391,67 @@ describe("migration 0234 xAI subscription authority", () => {
         and resource_id = ${userAccount.account.id}`;
     expect(revoked?.status).toBe("revoked");
     expect(revoked?.revokedAt).toBeInstanceOf(Date);
+  }, 180_000);
+
+  test("disconnect clears manual and policy pins in workspace and user pools", async () => {
+    if (!shared || !client) return;
+    for (const scope of ["workspace", "user"] as const) {
+      const fixture = await seedWorkspace();
+      const subjectId = fixture.subjects[0]!;
+      const created = await createXaiSubscriptionCredential(client.db, {
+        ...fixture,
+        subjectId,
+        scope,
+        secret: { version: 1, accessToken: "disconnect-fixture" },
+        encryptionKey,
+        providerAccountId: crypto.randomUUID(),
+        label: "Disconnect fixture",
+      });
+      const pins = [];
+      for (const pinSource of ["manual", "policy"] as const) {
+        const session = await seedSessionTurn(fixture, created.authoritySnapshot);
+        const input = {
+          ...fixture,
+          subjectId,
+          sessionId: session.sessionId,
+          authoritySnapshot: created.authoritySnapshot,
+        };
+        const pin = await setXaiSessionAccountPin(client.db, {
+          ...input,
+          credentialId: created.account.id,
+          pinSource,
+        });
+        pins.push({ input, pin });
+      }
+      expect(
+        await disconnectXaiSubscriptionCredentialAndRepick(client.db, {
+          ...fixture,
+          subjectId,
+          credentialId: created.account.id,
+          authoritySnapshot: created.authoritySnapshot,
+        }),
+      ).toMatchObject({ disconnected: true, newActiveCredentialId: null });
+      for (const { input, pin } of pins) {
+        const [stored] = await shared.admin`
+          select pinned_credential_id, pin_source, version
+          from xai_session_account_pins where id = ${pin.id}`;
+        expect(stored).toMatchObject({
+          pinned_credential_id: null,
+          pin_source: null,
+          version: pin.version + 1,
+        });
+        if (scope === "workspace") {
+          await expect(
+            setXaiSessionAccountPin(client.db, {
+              ...input,
+              credentialId: null,
+              pinSource: null,
+              expectedVersion: pin.version,
+            }),
+          ).rejects.toThrow("xAI session pin changed");
+        }
+      }
+    }
   }, 180_000);
 
   test("serializes rotating OAuth refresh tokens across concurrent sessions", async () => {

--- a/packages/react/test/timeline-annotations.test.tsx
+++ b/packages/react/test/timeline-annotations.test.tsx
@@ -602,7 +602,10 @@ describe("timeline annotations", () => {
         onDraftAnnotationSelect={(id) => selected.push(id)}
       />,
     );
-    await flush();
+    await waitFor(
+      () => document.body.querySelectorAll("[data-og-annotation-badge]").length === 2,
+      "annotation badges did not render",
+    );
     const badges = [
       ...document.body.querySelectorAll<HTMLButtonElement>("[data-og-annotation-badge]"),
     ];

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -29,6 +29,7 @@ async function buildSchemaContract(directory?: string) {
         "0429_message_boundary_session_forks.sql",
         "0430_session_personal_variable_set_continuations.sql",
         "0431_retained_provider_commands.sql",
+        "0432_xai_disconnect_session_pins.sql",
       ])
     : await buildCompleteSchemaContract(directory);
 }
@@ -134,6 +135,9 @@ describe("release schema contract", () => {
 
   test("registers forward migrations in order after published history", async () => {
     const completeSourceContract = await buildCompleteSchemaContract();
+    const xaiDisconnectPins = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0432_xai_disconnect_session_pins.sql",
+    );
     const messageBoundarySessionForks = completeSourceContract.migrations.some(
       (migration) => migration.path === "0429_message_boundary_session_forks.sql",
     );
@@ -146,19 +150,22 @@ describe("release schema contract", () => {
     expect(completeSourceContract).toMatchObject({
       fileCount:
         437 +
+        (xaiDisconnectPins ? 1 : 0) +
         (messageBoundarySessionForks ? 1 : 0) +
         (sessionPersonalVariableSetContinuations ? 1 : 0) +
         (retainedProviderCommands ? 1 : 0),
-      latestMigration: retainedProviderCommands
-        ? "0431_retained_provider_commands.sql"
-        : sessionPersonalVariableSetContinuations
-          ? "0430_session_personal_variable_set_continuations.sql"
-          : messageBoundarySessionForks
-            ? "0429_message_boundary_session_forks.sql"
-            : "0428_scheduled_task_creator_policy.sql",
+      latestMigration: xaiDisconnectPins
+        ? "0432_xai_disconnect_session_pins.sql"
+        : retainedProviderCommands
+          ? "0431_retained_provider_commands.sql"
+          : sessionPersonalVariableSetContinuations
+            ? "0430_session_personal_variable_set_continuations.sql"
+            : messageBoundarySessionForks
+              ? "0429_message_boundary_session_forks.sql"
+              : "0428_scheduled_task_creator_policy.sql",
     });
     expect(completeSourceContract.migrations.at(-1)).toMatchObject({
-      path: "0431_retained_provider_commands.sql",
+      path: "0432_xai_disconnect_session_pins.sql",
       deploymentMode: "rolling",
     });
     expect(
@@ -1606,6 +1613,7 @@ describe("release schema contract", () => {
       "0429_message_boundary_session_forks.sql",
       "0430_session_personal_variable_set_continuations.sql",
       "0431_retained_provider_commands.sql",
+      "0432_xai_disconnect_session_pins.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -4360,6 +4368,7 @@ async function contractWithoutMigrations(excludedPaths: readonly string[]) {
     "0429_message_boundary_session_forks.sql",
     "0430_session_personal_variable_set_continuations.sql",
     "0431_retained_provider_commands.sql",
+    "0432_xai_disconnect_session_pins.sql",
   ]);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     if (!entry.isFile() || !entry.name.endsWith(".sql") || excluded.has(entry.name)) continue;


### PR DESCRIPTION
Disconnect returned HTTP 500 when a session had a manual or policy pin: the credential foreign key cleared its ID but left pin_source, violating the pin check constraint. Clear both fields atomically before deletion and advance the pin version to reject stale updates. Existing authorization and credential lifecycle boundaries remain unchanged. Includes a rolling migration and real PostgreSQL regression coverage for workspace and personal accounts. Validation: 11 database tests, 8 release-schema tests, DB typecheck, migration guards, and independent review passed.

## Summary by Sourcery

Allow SuperGrok workspace and personal credentials to disconnect safely when sessions are pinned to them.

Bug Fixes:
- Fix SuperGrok credential disconnection for accounts referenced by manually or policy-pinned sessions.
- Clear both session pin fields and advance their versions so stale pin updates are rejected while unrelated pins remain unchanged.

Deployment:
- Add a rolling database migration that preserves credential pin invariants during disconnection.

Documentation:
- Document session pin cleanup and stale-update fencing during workspace and personal credential disconnection.

Tests:
- Add PostgreSQL regression coverage for disconnecting pinned workspace and personal credentials.
- Update release schema contract coverage for the new migration.
- Make timeline annotation rendering test wait for badges deterministically.