### PR TITLE
fix(react): preserve interleaved prose and stable bounded history

### DIFF
--- a/.changeset/steady-history-message-identity.md
+++ b/.changeset/steady-history-message-identity.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/events": patch
+---
+
+Keep automatic history filling from evicting the latest reply or cycling between older and newer pages. Preserve explicit history navigation and stable jumps back to latest. Retain provider message identity so assistant chunks interleaved with tool activity remain one message without merging distinct replies.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1307,6 +1307,12 @@ immediately before React mutates the DOM; `message-timeline.tsx` applies only
 the residual correction after browser anchoring. Corrections cannot resume
 tip-follow, and continued upward input permits bounded sequential older-page
 loads even when collapsed content adds no scroll range.
+Automatic underfill loads preserve the retained tail; a window-budget refusal
+offers explicit earlier navigation instead of silently entering history mode.
+Underfilled history does not auto-page forward merely because both sentinels
+are visible. Explicit Jump to latest restores a stable live-tail window.
+Provider message identity survives runtime event normalization so the timeline
+can coalesce interleaved chunks without combining distinct assistant messages.
 
 Web imports `@opengeni/sdk/browser`. Operator Document-authority and tenancy
 backfills use `@opengeni/sdk/document-authority`; root/`core` retain compatibility.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1296,23 +1296,17 @@ Sites install exact SDK/React/Codemode/CLI versions from virtual skill file
 `OPENGENI_LOCAL_SITE_PACKAGES` builds unreleased archives at
 `/opt/opengeni/site-packages`; deployed images do not.
 
-Timeline history ownership stays in `packages/react`: `use-session-events.ts`
-fences history navigation by session/client lifetime, independently of SSE
-reconnects. The web route supplies source events alongside projected rows;
-it keys the timeline by session so pagination ownership and reading state cannot
-survive navigation to another session.
-Retained event identity determines window overlap because partial-message row
-IDs can change on prepend. `timeline-anchor.tsx` captures the reading position
-immediately before React mutates the DOM; `message-timeline.tsx` applies only
-the residual correction after browser anchoring. Corrections cannot resume
-tip-follow, and continued upward input permits bounded sequential older-page
-loads even when collapsed content adds no scroll range.
-Automatic underfill loads preserve the retained tail; a window-budget refusal
-offers explicit earlier navigation instead of silently entering history mode.
-Underfilled history does not auto-page forward merely because both sentinels
-are visible. Explicit Jump to latest restores a stable live-tail window.
-Provider message identity survives runtime event normalization so the timeline
-can coalesce interleaved chunks without combining distinct assistant messages.
+Timeline history belongs to `packages/react`. `use-session-events.ts` fences
+navigation by session/client lifetime, independently of SSE reconnects. The web
+route supplies source events and keys the timeline by session. Retained event
+identity determines overlap; partial-message row IDs can change on prepend.
+`timeline-anchor.tsx` captures pre-mutation position; `message-timeline.tsx`
+corrects only residual browser-anchor movement, without resuming tip-follow.
+Continued upward input permits bounded older-page loads despite collapsed rows.
+Automatic underfill preserves the tail and offers explicit earlier navigation
+at the window limit. Underfilled history never auto-pages forward; Jump to latest
+restores the live tail. Provider message identity survives normalization and
+coalescing, joining interleaved chunks without merging distinct messages.
 
 Web imports `@opengeni/sdk/browser`. Operator Document-authority and tenancy
 backfills use `@opengeni/sdk/document-authority`; root/`core` retain compatibility.

--- a/packages/events/src/coalesce.ts
+++ b/packages/events/src/coalesce.ts
@@ -28,6 +28,7 @@ type DeltaRun = {
   sandboxName: string | undefined;
   sandboxStream: string | undefined;
   sandboxCommandId: string | undefined;
+  messageId: string | undefined;
 };
 
 export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent[] {
@@ -59,6 +60,7 @@ export function coalesceSessionEventDeltasWithCoverage(
         : {
             text: run.text,
             coalescedUntil: run.lastSequence,
+            ...(run.messageId !== undefined ? { messageId: run.messageId } : {}),
           };
     coalesced.push({
       ...run.first,
@@ -84,11 +86,16 @@ export function coalesceSessionEventDeltasWithCoverage(
     const sandboxStream = isSandbox ? sandboxDeltaString(event.payload, "stream") : undefined;
     const sandboxCommandId = isSandbox ? sandboxDeltaString(event.payload, "commandId") : undefined;
     const text = deltaText(event);
+    const messageId =
+      event.type === "agent.message.delta" && typeof asRecord(event.payload).messageId === "string"
+        ? (asRecord(event.payload).messageId as string)
+        : undefined;
     if (
       run &&
       sameDeltaRun(run.first, event, run.sandboxName, sandboxName) &&
       run.sandboxStream === sandboxStream &&
-      run.sandboxCommandId === sandboxCommandId
+      run.sandboxCommandId === sandboxCommandId &&
+      run.messageId === messageId
     ) {
       const textBytes = encoder.encode(text).byteLength;
       if (
@@ -116,6 +123,7 @@ export function coalesceSessionEventDeltasWithCoverage(
       sandboxName,
       sandboxStream,
       sandboxCommandId,
+      messageId,
     };
   }
 

--- a/packages/events/test/coalesce.test.ts
+++ b/packages/events/test/coalesce.test.ts
@@ -34,6 +34,17 @@ function event(
 }
 
 describe("coalesceSessionEventDeltas", () => {
+  test("preserves message identities and never coalesces across their boundary", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "agent.message.delta", { text: "calc", messageId: "message-a" }),
+      event(2, "agent.message.delta", { text: "ulation", messageId: "message-a" }),
+      event(3, "agent.message.delta", { text: "next", messageId: "message-b" }),
+    ]);
+    expect(result.map((item) => item.payload)).toEqual([
+      { text: "calculation", messageId: "message-a", coalescedUntil: 2 },
+      { text: "next", messageId: "message-b", coalescedUntil: 3 },
+    ]);
+  });
   test("leaves empty and no-delta inputs untouched", () => {
     expect(coalesceSessionEventDeltas([])).toEqual([]);
     const events = [

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -293,13 +293,18 @@ function invokeOlderLoad(
   load: OlderHistoryLoader,
   noProgress: () => void,
   attempt: OlderLoadAttempt,
+  preserveTail = false,
 ): 1 | undefined {
   try {
     // Receipt creation is captured synchronously through legacy wrappers such
     // as `() => void loadOlder()`, even when the wrapper discards the return.
-    const result = invokeOlderHistoryLoaderWithReceiptCapture(load, (receipt) => {
-      attempt[2] = receipt;
-    }) as OlderHistoryLoadReceipt | PromiseLike<unknown> | unknown;
+    const result = invokeOlderHistoryLoaderWithReceiptCapture(
+      load,
+      (receipt) => {
+        attempt[2] = receipt;
+      },
+      preserveTail,
+    ) as OlderHistoryLoadReceipt | PromiseLike<unknown> | unknown;
     const receipt =
       attempt[2] ??
       (typeof (result as { committed?: unknown } | undefined)?.committed === "boolean"
@@ -978,7 +983,7 @@ export function MessageTimeline({
       // exact `false` is the first-party request-not-accepted receipt.
       // All other fulfillment retains this exact owner until its prepend
       // boundary commits; promise settlement alone cannot prove progress.
-      invokeOlderLoad(onLoadOlder, noProgress, attempt);
+      invokeOlderLoad(onLoadOlder, noProgress, attempt, !retry);
     },
     [hasOlder, loadingOlder, olderBoundaryKey, onLoadOlder],
   );
@@ -1536,7 +1541,9 @@ export function MessageTimeline({
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
+        // An underfilled history window has both sentinels visible. Advancing
+        // it automatically would undo an explicit older-page navigation.
+        if (maxScrollOf(root) > 1 && entries.some((entry) => entry.isIntersecting)) {
           onLoadNewer();
         }
       },
@@ -1959,7 +1966,9 @@ export function MessageTimeline({
                                     className="pointer-events-auto rounded-full border border-og-border px-3 py-1.5 text-og-control"
                                   >
                                     {underfillRetryReady
-                                      ? "Retry earlier activity"
+                                      ? underfillSettledAttempt?.[2]?.tailPreserved
+                                        ? "Load earlier activity"
+                                        : "Retry earlier activity"
                                       : "Jump to start"}
                                   </button>
                                 ) : null}

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -556,7 +556,7 @@ export function useSessionEvents(
 
   const loadOlder = useCallback(
     (): OlderHistoryLoadReceipt =>
-      createOlderHistoryLoadReceipt(async (markCommitted) => {
+      createOlderHistoryLoadReceipt(async (markCommitted, preserveTail, markTailPreserved) => {
         if (!sessionId || navigationBusy() || !hasOlderRef.current) {
           return false;
         }
@@ -592,11 +592,17 @@ export function useSessionEvents(
           // Freeze the live iterator before replacing its in-memory window. Rows
           // pending in the aborted iterator were never cursor-committed and will
           // be replayed from the retained high-water mark below.
-          streamAbortRef.current?.abort();
-          const status = observeSessionStatus(window.events, sessionStatusRef);
           const next = boundBrowserSessionEventWindow([...window.events, ...current.events], {
             direction: "oldest",
           });
+          if (preserveTail && maxResumeSequence(next.events) < maxResumeSequence(current.events)) {
+            // Automatic viewport filling must not navigate away from the
+            // reader's retained tail. Explicit history navigation may do so.
+            markTailPreserved();
+            return false;
+          }
+          streamAbortRef.current?.abort();
+          const status = observeSessionStatus(window.events, sessionStatusRef);
           const retained = {
             ...next,
             truncated: current.truncated || next.truncated,

--- a/packages/react/src/older-history.ts
+++ b/packages/react/src/older-history.ts
@@ -8,6 +8,7 @@
  */
 export type OlderHistoryLoadReceipt = Promise<boolean> & {
   readonly committed: boolean;
+  readonly tailPreserved?: boolean;
 };
 
 /**
@@ -22,23 +23,29 @@ export type OlderHistoryLoader = () => unknown;
 
 type MutableOlderHistoryLoadReceipt = Promise<boolean> & {
   committed: boolean;
+  tailPreserved: boolean;
 };
 
 type OlderHistoryReceiptCapture = (receipt: OlderHistoryLoadReceipt) => void;
 
 let activeReceiptCapture: OlderHistoryReceiptCapture | undefined;
+let preserveTailForAutomaticLoad = false;
 
 /** Bind a receipt before a synchronous forwarding stack can publish state. */
 export function invokeOlderHistoryLoaderWithReceiptCapture(
   load: OlderHistoryLoader,
   capture: OlderHistoryReceiptCapture,
+  preserveTail = false,
 ): unknown {
   const previousCapture = activeReceiptCapture;
+  const previousPreserveTail = preserveTailForAutomaticLoad;
   activeReceiptCapture = capture;
+  preserveTailForAutomaticLoad = preserveTail;
   try {
     return load();
   } finally {
     activeReceiptCapture = previousCapture;
+    preserveTailForAutomaticLoad = previousPreserveTail;
   }
 }
 
@@ -47,7 +54,11 @@ export function invokeOlderHistoryLoaderWithReceiptCapture(
  * Call `markCommitted` immediately before publishing an accepted older window.
  */
 export function createOlderHistoryLoadReceipt(
-  load: (markCommitted: () => void) => boolean | Promise<boolean>,
+  load: (
+    markCommitted: () => void,
+    preserveTail: boolean,
+    markTailPreserved: () => void,
+  ) => boolean | Promise<boolean>,
 ): OlderHistoryLoadReceipt {
   let resolveResult!: (value: boolean | PromiseLike<boolean>) => void;
   let rejectResult!: (reason?: unknown) => void;
@@ -56,11 +67,18 @@ export function createOlderHistoryLoadReceipt(
     rejectResult = reject;
   }) as MutableOlderHistoryLoadReceipt;
   result.committed = false;
+  result.tailPreserved = false;
   activeReceiptCapture?.(result);
   try {
-    const loaded = load(() => {
-      result.committed = true;
-    });
+    const loaded = load(
+      () => {
+        result.committed = true;
+      },
+      preserveTailForAutomaticLoad,
+      () => {
+        result.tailPreserved = true;
+      },
+    );
     Promise.resolve(loaded).then(resolveResult, rejectResult);
   } catch (error) {
     rejectResult(error);

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -135,6 +135,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   const ordered = orderTimelineEvents(events, prescan);
   const pendingWaitOutcomeByTurn = new Map<string | null, PendingWaitOutcome>();
   const latestAgentResponseByTurn = new Map<string | null, TrackedAgentResponse>();
+  const identifiedMessages = new Map<string, AgentMessageItem>();
   const humanInputRequests = humanInputRequestsById(events);
   const humanInputToolCallIds = new Set(
     [...humanInputRequests.values()]
@@ -408,8 +409,43 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         if (!text) {
           break;
         }
+        const messageId = stringValue(payload.messageId);
+        const messageKey = messageId ? JSON.stringify([turnId, messageId]) : null;
+        const identified = messageKey ? identifiedMessages.get(messageKey) : undefined;
+        if (identified) {
+          if (identified.annotationSource?.eventType !== "agent.message.completed") {
+            identified.text += text;
+            rememberAgentResponse(turnId, identified, false);
+          }
+          break;
+        }
         const open = last();
-        if (open?.kind === "agent-message" && open.streaming && open.turnId === turnId) {
+        if (!messageKey && open?.kind === "tool-call" && open.status === "running") {
+          const previous = latestAgentResponseByTurn.get(turnId);
+          const previousIndex = previous ? items.indexOf(previous.item) : -1;
+          if (
+            previous &&
+            !previous.completed &&
+            previousIndex >= 0 &&
+            items
+              .slice(previousIndex + 1)
+              .every(
+                (item) =>
+                  item.kind === "tool-call" && item.turnId === turnId && item.status === "running",
+              )
+          ) {
+            // Legacy deltas have no provider message identity. Tool creation
+            // alone is not a text boundary; completed output still is.
+            previous.item.text += text;
+            break;
+          }
+        }
+        if (
+          !messageKey &&
+          open?.kind === "agent-message" &&
+          open.streaming &&
+          open.turnId === turnId
+        ) {
           open.text += text;
           rememberAgentResponse(turnId, open, false);
           break;
@@ -424,18 +460,21 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           occurredAt: event.occurredAt,
         };
         items.push(item);
+        if (messageKey) identifiedMessages.set(messageKey, item);
         rememberAgentResponse(turnId, item, false);
         break;
       }
 
       case "agent.message.completed": {
         const text = stringValue(payload.text);
+        const messageId = stringValue(payload.messageId);
+        const messageKey = messageId ? JSON.stringify([turnId, messageId]) : null;
         const phase = assistantMessagePhase(payload.phase);
         // Reconcile the most recent same-turn agent message — even when
         // activity (tool calls, reasoning) landed after its deltas — so the
         // completed text never duplicates the streamed one.
-        let openIndex = -1;
-        for (let index = items.length - 1; index >= 0; index -= 1) {
+        let openIndex = messageKey ? items.indexOf(identifiedMessages.get(messageKey)!) : -1;
+        for (let index = messageKey ? -1 : items.length - 1; index >= 0; index -= 1) {
           const candidate = items[index];
           if (candidate?.kind === "agent-message" && candidate.turnId === turnId) {
             openIndex = index;
@@ -502,6 +541,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
             },
           };
           items.push(item);
+          if (messageKey) identifiedMessages.set(messageKey, item);
           rememberAgentResponse(turnId, item, true);
         }
         break;

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -486,10 +486,15 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           candidate?.kind === "agent-message" ? candidate : undefined;
         if (
           open &&
-          (open.streaming || !open.text || text === open.text || text.startsWith(open.text))
+          (messageKey ||
+            open.streaming ||
+            !open.text ||
+            text === open.text ||
+            text.startsWith(open.text))
         ) {
-          // The completed text is authoritative when it extends what streamed.
-          if (!open.text || (text && text.startsWith(open.text))) {
+          // Identity makes the final text authoritative even if it corrects the
+          // draft; legacy receipts still require an extension match.
+          if (!open.text || (text && (messageKey || text.startsWith(open.text)))) {
             open.text = text || open.text;
           }
           open.streaming = false;

--- a/packages/react/test/older-history.test.ts
+++ b/packages/react/test/older-history.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import {
+  createOlderHistoryLoadReceipt,
+  invokeOlderHistoryLoaderWithReceiptCapture,
+  type OlderHistoryLoadReceipt,
+} from "../src/older-history";
+
+test("automatic tail preservation survives void wrappers without leaking into manual loads", async () => {
+  const intents: boolean[] = [];
+  const load = () =>
+    createOlderHistoryLoadReceipt((_commit, preserveTail) => {
+      intents.push(preserveTail);
+      return false;
+    });
+  let captured: OlderHistoryLoadReceipt | undefined;
+  invokeOlderHistoryLoaderWithReceiptCapture(
+    () => {
+      void load();
+    },
+    (receipt) => {
+      captured = receipt;
+    },
+    true,
+  );
+  await captured;
+  expect(captured?.committed).toBe(false);
+  await load();
+  expect(intents).toEqual([true, false]);
+});
+
+test("throwing loader restores the prior automatic-load context", async () => {
+  expect(() =>
+    invokeOlderHistoryLoaderWithReceiptCapture(
+      () => {
+        throw new Error("load failed");
+      },
+      () => {},
+      true,
+    ),
+  ).toThrow("load failed");
+  await createOlderHistoryLoadReceipt((_commit, preserveTail) => {
+    expect(preserveTail).toBe(false);
+    return false;
+  });
+});

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1167,6 +1167,36 @@ describe("buildTimeline", () => {
     ]);
   });
 
+  test("identified completion replaces a draft closed by intervening activity", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.message.delta", {
+        text: "Draft calculation.",
+        messageId: "message-a",
+      }),
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "read_record",
+        arguments: {},
+      }),
+      event("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      event("agent.message.completed", {
+        text: "Corrected calculation.",
+        messageId: "message-a",
+      }),
+      event("agent.message.delta", {
+        text: "late draft",
+        messageId: "message-a",
+      }),
+    ]);
+    const messages = items.filter((item) => item.kind === "agent-message");
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      text: "Corrected calculation.",
+      streaming: false,
+    });
+  });
+
   test("legacy pending tool creation does not split an unfinished word", () => {
     reset();
     const items = buildTimeline([

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1148,6 +1148,38 @@ describe("buildTimeline", () => {
     expect((items[0] as AgentMessageItem).streaming).toBe(false);
   });
 
+  test("message identity joins interleaved chunks but preserves distinct replies", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.message.delta", { text: "Checking this calc", messageId: "message-a" }),
+      event("agent.toolCall.created", { id: "call-1", name: "read_record", arguments: {} }),
+      event("agent.message.delta", { text: "ulation.", messageId: "message-a" }),
+      event("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      event("agent.message.completed", {
+        text: "Checking this calculation.",
+        messageId: "message-a",
+      }),
+      event("agent.message.delta", { text: "Another reply.", messageId: "message-b" }),
+    ]);
+    expect(items.filter((item) => item.kind === "agent-message").map((item) => item.text)).toEqual([
+      "Checking this calculation.",
+      "Another reply.",
+    ]);
+  });
+
+  test("legacy pending tool creation does not split an unfinished word", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.message.delta", { text: "Checking this calc" }),
+      event("agent.toolCall.created", { id: "call-1", name: "read_record", arguments: {} }),
+      event("agent.message.delta", { text: "ulation before continuing." }),
+      event("agent.toolCall.output", { id: "call-1", output: "ok" }),
+    ]);
+    expect(items.filter((item) => item.kind === "agent-message").map((item) => item.text)).toEqual([
+      "Checking this calculation before continuing.",
+    ]);
+  });
+
   test("matches tool outputs to calls by id and marks them complete", () => {
     reset();
     const items = buildTimeline([

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -13,6 +13,10 @@ import {
   useSessionEvents,
 } from "../src/hooks/use-session-events";
 import { buildTimeline, type TimelineItem } from "../src/timeline";
+import {
+  invokeOlderHistoryLoaderWithReceiptCapture,
+  type OlderHistoryLoadReceipt,
+} from "../src/older-history";
 
 registerDom();
 
@@ -1266,6 +1270,28 @@ describe("useSessionEvents", () => {
     expect(hook.result.current.events[0]?.sequence).toBe(52);
     expect(hook.result.current.events.at(-1)?.sequence).toBe(10_051);
     expect(hook.result.current.lastSequence).toBe(10_051);
+
+    let automatic!: OlderHistoryLoadReceipt;
+    await actRun(async () => {
+      invokeOlderHistoryLoaderWithReceiptCapture(
+        () => {
+          void hook.result.current.loadOlder();
+        },
+        (receipt) => {
+          automatic = receipt;
+        },
+        true,
+      );
+      await automatic;
+    });
+    await flush();
+    expect(automatic.committed).toBe(false);
+    expect(automatic.tailPreserved).toBe(true);
+    expect(hook.result.current.events[0]?.sequence).toBe(52);
+    expect(hook.result.current.events.at(-1)?.sequence).toBe(10_051);
+    expect(hook.result.current.hasNewer).toBe(false);
+    expect(streamCalls).toEqual([0]);
+    listCalls.length = 0;
 
     const more = await actRun(() => hook.result.current.loadOlder());
     await flush(100);

--- a/packages/runtime/src/run-events.ts
+++ b/packages/runtime/src/run-events.ts
@@ -274,7 +274,13 @@ export function normalizeSdkEvent(
   if (event.type === "raw_model_stream_event") {
     const data = (event as any).data;
     if (data?.type === "output_text_delta" && typeof data.delta === "string") {
-      out.push({ type: "agent.message.delta", payload: { text: data.delta } });
+      out.push({
+        type: "agent.message.delta",
+        payload: {
+          text: data.delta,
+          ...(typeof data.itemId === "string" && data.itemId ? { messageId: data.itemId } : {}),
+        },
+      });
       return out;
     }
     if (data?.type === "response_done") {
@@ -382,6 +388,9 @@ export function normalizeSdkEvent(
         type: "agent.message.completed",
         payload: {
           text,
+          ...(typeof item.rawItem?.id === "string" && item.rawItem.id
+            ? { messageId: item.rawItem.id }
+            : {}),
           ...(phase === "commentary" || phase === "final_answer" ? { phase } : {}),
         },
       });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -798,6 +798,22 @@ describe("runtime event normalization", () => {
     });
   });
 
+  test("preserves provider message identity across text deltas and completion", () => {
+    const [delta] = normalizeSdkEvent(
+      new RunRawModelStreamEvent({
+        type: "output_text_delta",
+        delta: "partial",
+        itemId: "message-a",
+      } as any),
+    );
+    const [completed] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: { type: "message_output_item", text: "partial answer", rawItem: { id: "message-a" } },
+    } as any);
+    expect(delta?.payload).toEqual({ text: "partial", messageId: "message-a" });
+    expect(completed?.payload).toEqual({ text: "partial answer", messageId: "message-a" });
+  });
+
   test("extracts streamed usage without manufacturing a durable event", () => {
     const event = {
       type: "raw_model_stream_event",


### PR DESCRIPTION
## Summary

- Preserve provider message identity from SDK normalization through compact event pages and timeline projection. Join chunks from the same message across tool activity without merging distinct replies; retain compatibility for identity-less deltas interleaved with pending tool creation.
- Stop automatic viewport filling before it evicts the retained tail. Keep explicit older-history navigation available, distinguish deliberate deferral from failed loading, and prevent an underfilled history window from automatically paging forward again.
- Document the ownership and add regression coverage for event coalescing, message projection, receipt wrappers, and automatic-versus-explicit history loading.

## Verification

- Runtime normalization suite: 311 passing tests.
- Timeline and receipt suites: 179 passing tests.
- Hooks/timeline/receipt suites: 298 passing tests.
- Dedicated session-event and pagination suites: 102 passing tests.
- Rendered timeline suite: 87 passing tests.
- Event coalescing suite: 9 passing tests.
- React/runtime typechecks, targeted lint, whitespace, and documentation guards passed.
- Synthetic real-hook/component Chromium reproduction at 539×1243, 650×1274, and 1440×900 with default browser event budget: before the fix repeated pagination lost the final reply; after the fix initial loading settles with the final reply retained. Explicit earlier navigation stays in history, and Jump to latest returns to and remains at the tail.

The browser fixture uses synthetic events, contract-sized payloads and bounded pages; no customer data or deployment configuration is included.

## Summary by Sourcery

Preserve interleaved assistant messages and stabilize automatic bounded history loading without losing the latest reply.

Bug Fixes:
- Preserve provider message identity so interleaved assistant chunks remain grouped correctly without merging distinct replies.
- Prevent automatic history loading from evicting the latest reply or repeatedly paging between older and newer pages while retaining explicit history navigation and stable jumps to the latest content.

Enhancements:
- Extend history-load receipts to distinguish tail preservation from failed or deferred loading.
- Document timeline ownership, message identity handling, and bounded history behavior.

Documentation:
- Update the architecture documentation to describe stable tail preservation, explicit history navigation, and provider message identity across timeline processing.

Tests:
- Add regression coverage for message coalescing, interleaved message projection, legacy identity-less deltas, and automatic versus explicit history loading.