### PR TITLE
fix(react): let chat tables use available panel width

### DIFF
--- a/.changeset/chat-table-available-width.md
+++ b/.changeset/chat-table-available-width.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Let top-level assistant tables expand into available chat panel space while keeping surrounding text at its normal reading width. Tables remain contained when a side panel opens or the conversation is narrow, and keep horizontal scrolling when content still cannot fit.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -652,6 +652,11 @@ intentional changes should regenerate those snapshots and review the diff.
   runnable latency modes such as Fast. It accepts either `ClientModel[]` or
   catalog-backed `PickerModelRow[]`, and supports host-supplied labels.
 - `Markdown` — the timeline's markdown renderer (GFM), also usable standalone.
+  Top-level assistant tables in `MessageTimeline` can expand beyond the prose
+  column into the actual conversation panel's available space. Small tables,
+  paragraphs, user bubbles, and nested or standalone Markdown keep their normal
+  width; oversized tables retain table-only horizontal scrolling. No host prop
+  or viewport-wide layout override is required.
   With `onSandboxFile`, a valid `sandbox:<path>[:line]` application link becomes
   an in-session Open action. The callback receives the decoded path unchanged;
   the optional line is positive and 1-based. Invalid sandbox references render

--- a/packages/react/demo/timeline-table-test-harness.tsx
+++ b/packages/react/demo/timeline-table-test-harness.tsx
@@ -1,0 +1,88 @@
+import { MessageTimeline, type TimelineItem } from "@opengeni/react";
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+// Load only one consumer stylesheet: compiled mode must not be rescued by the
+// demo's Tailwind source scanning. Both run from the production Vite graph.
+if (new URLSearchParams(location.search).has("compiled")) {
+  await import("@opengeni/react/compiled.css");
+} else {
+  await import("./styles.css");
+}
+
+const small = "| Small | Value |\n| --- | --- |\n| Alpha | Beta |";
+const wide = [
+  "| Wide | Deployment region | Monthly allocation | Availability target | Primary maintainer | Recovery objective |",
+  "| --- | --- | --- | --- | --- | --- |",
+  "| Production | Northern Europe region | Reserved monthly allocation | Regional availability target | Infrastructure operations team | Documented recovery objective |",
+].join("\n");
+const oversized = `| Oversized | Value |\n| --- | --- |\n| ${"Unbreakable".repeat(80)} | Beta |`;
+const baseline = [
+  "Ordinary assistant prose stays in the readable text column before and after a wide table.",
+  wide,
+  "Prose after the table retains the same left and right edges.",
+  small,
+  wide
+    .replaceAll("Wide", "Quoted")
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n"),
+  `- Nested list table\n\n${wide
+    .replaceAll("Wide", "Listed")
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n")}`,
+  `\`\`\`text\n${"code stays prose width ".repeat(12)}\n\`\`\``,
+  oversized,
+].join("\n\n");
+
+type TableContent = "baseline" | "small" | "wide" | "oversized";
+declare global {
+  interface Window {
+    timelineTableHarness?: {
+      content: (value: TableContent) => void;
+      panel: (width: number | null) => void;
+    };
+  }
+}
+
+function Harness() {
+  const [content, setContent] = useState<TableContent>("baseline");
+  const [panel, setPanel] = useState<number | null>(null);
+  useEffect(() => {
+    window.timelineTableHarness = { content: setContent, panel: setPanel };
+    return () => {
+      delete window.timelineTableHarness;
+    };
+  }, []);
+  const items: TimelineItem[] = [
+    {
+      kind: "user-message",
+      id: "user",
+      text: "User bubble remains in the prose column.",
+      resources: [],
+      tools: [],
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      kind: "agent-message",
+      id: "assistant",
+      turnId: "table-turn",
+      text: { baseline, small, wide, oversized }[content],
+      streaming: content !== "baseline",
+      occurredAt: "2026-01-01T00:00:01.000Z",
+    },
+  ];
+  return (
+    <main
+      data-og-theme="light"
+      style={{ padding: "0 12px", display: "flex", justifyContent: "flex-end" }}
+    >
+      <section data-table-panel style={{ width: panel ?? "100%", maxWidth: "100%", minWidth: 0 }}>
+        <MessageTimeline className="table-test-shell" items={items} />
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Harness />);

--- a/packages/react/demo/timeline-table-test.html
+++ b/packages/react/demo/timeline-table-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en" data-og-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Timeline table regression</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        font: 14px sans-serif;
+      }
+      .table-test-shell {
+        display: flex;
+        height: 720px;
+        max-height: 100dvh;
+        flex-direction: column;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/timeline-table-test-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
       input: timelineScrollTestBuild
         ? {
             timelineScrollTest: resolve(__dirname, "timeline-scroll-test.html"),
+            timelineTableTest: resolve(__dirname, "timeline-table-test.html"),
             timelineScrollMergeTest: resolve(__dirname, "timeline-scroll-merge-test.html"),
             timelineCollapsedHistoryTest: resolve(
               __dirname,

--- a/packages/react/src/components/markdown-table-layout.ts
+++ b/packages/react/src/components/markdown-table-layout.ts
@@ -1,5 +1,3 @@
-import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
-
 export function markdownTableWidth({
   columnLeft,
   columnWidth,
@@ -18,83 +16,70 @@ export function markdownTableWidth({
   return Math.max(columnWidth, Math.min(preferredWidth, available));
 }
 
-/** Top-level assistant tables may borrow the timeline's unused side gutters.
- * Keep the prose column (and scroll owner) intact; never escape a bubble, quote,
- * nested list, or clipped disclosure. Standalone Markdown retains its layout.
- */
-export function useMarkdownTableLayout(children: ReactNode) {
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const tableRef = useRef<HTMLTableElement>(null);
-  const [width, setWidth] = useState<number | null>(null);
+/** Loaded only for assistant tables. Keep prose and nested scroll owners intact. */
+export function observeMarkdownTableLayout(wrapper: HTMLDivElement, table: HTMLTableElement) {
+  const body = wrapper.parentElement;
+  const scroller = body
+    ?.closest("[data-og-wide-table-message]")
+    ?.closest<HTMLElement>("[data-og-timeline-scroller]");
+  if (!body?.classList.contains("og-markdown-body") || !scroller) return;
 
-  useLayoutEffect(() => {
-    const wrapper = wrapperRef.current;
-    const table = tableRef.current;
-    const body = wrapper?.parentElement;
-    const message = body?.closest("[data-og-wide-table-message]");
-    const scroller = message?.closest<HTMLElement>("[data-og-timeline-scroller]");
-    if (!wrapper || table === null || !body?.classList.contains("og-markdown-body") || !scroller) {
-      setWidth(null);
-      return;
-    }
-
-    const measure = () => {
-      // Intermediate clipped/scrollable surfaces own their own content bounds.
-      for (
-        let ancestor: HTMLElement | null = body;
-        ancestor && ancestor !== scroller;
-        ancestor = ancestor.parentElement
-      ) {
-        if (getComputedStyle(ancestor).overflowX !== "visible") {
-          setWidth(null);
-          return;
-        }
+  let width: number | null = null;
+  const reset = () => {
+    width = null;
+    wrapper.style.width = "";
+    wrapper.style.maxWidth = "";
+    wrapper.style.marginInline = "";
+  };
+  const measure = () => {
+    // Intermediate clipped/scrollable surfaces own their own content bounds.
+    for (
+      let ancestor: HTMLElement | null = body;
+      ancestor && ancestor !== scroller;
+      ancestor = ancestor.parentElement
+    ) {
+      if (getComputedStyle(ancestor).overflowX !== "visible") {
+        reset();
+        return;
       }
-      const column = body.getBoundingClientRect();
-      const panel = scroller.getBoundingClientRect();
-      const panelStyle = getComputedStyle(scroller);
-      const left = panel.left + scroller.clientLeft + parseFloat(panelStyle.paddingLeft);
-      const right =
-        panel.left +
-        scroller.clientLeft +
-        scroller.clientWidth -
-        parseFloat(panelStyle.paddingRight);
+    }
+    const column = body.getBoundingClientRect();
+    const panel = scroller.getBoundingClientRect();
+    const panelStyle = getComputedStyle(scroller);
+    const left = panel.left + scroller.clientLeft + parseFloat(panelStyle.paddingLeft);
+    const right =
+      panel.left + scroller.clientLeft + scroller.clientWidth - parseFloat(panelStyle.paddingRight);
 
-      // Measure the same table's preferred width, then restore its normal fluid
-      // layout. This preserves wrapping and TSV copy without a duplicate DOM.
-      const previousWidth = table.style.width;
+    // Measure the original table, preserving its wrapping and TSV copy DOM.
+    const previousWidth = table.style.width;
+    let preferred: number;
+    try {
       table.style.width = "max-content";
-      const preferred = table.getBoundingClientRect().width;
+      preferred = table.getBoundingClientRect().width;
+    } finally {
       table.style.width = previousWidth;
-      const next = markdownTableWidth({
-        columnLeft: column.left,
-        columnWidth: column.width,
-        contentLeft: left,
-        contentRight: right,
-        preferredWidth: preferred,
-      });
-      setWidth((current) => (current !== null && Math.abs(current - next) < 0.5 ? current : next));
-    };
+    }
+    const next = markdownTableWidth({
+      columnLeft: column.left,
+      columnWidth: column.width,
+      contentLeft: left,
+      contentRight: right,
+      preferredWidth: preferred,
+    });
+    if (width !== null && Math.abs(width - next) < 0.5) return;
+    width = next;
+    wrapper.style.width = `${width}px`;
+    wrapper.style.maxWidth = "none";
+    wrapper.style.marginInline = `calc((100% - ${width}px) / 2)`;
+  };
 
-    measure();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(measure);
-    observer.observe(scroller);
-    observer.observe(body);
-    observer.observe(table);
-    return () => observer.disconnect();
-  }, [children]);
-
-  return {
-    wrapperRef,
-    tableRef,
-    style:
-      width === null
-        ? undefined
-        : {
-            width,
-            maxWidth: "none",
-            marginInline: `calc((100% - ${width}px) / 2)`,
-          },
+  measure();
+  const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(measure);
+  observer?.observe(scroller);
+  observer?.observe(body);
+  observer?.observe(table);
+  return () => {
+    observer?.disconnect();
+    reset();
   };
 }

--- a/packages/react/src/components/markdown-table-layout.ts
+++ b/packages/react/src/components/markdown-table-layout.ts
@@ -1,0 +1,100 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+export function markdownTableWidth({
+  columnLeft,
+  columnWidth,
+  contentLeft,
+  contentRight,
+  preferredWidth,
+}: {
+  columnLeft: number;
+  columnWidth: number;
+  contentLeft: number;
+  contentRight: number;
+  preferredWidth: number;
+}): number {
+  const center = columnLeft + columnWidth / 2;
+  const available = 2 * Math.min(center - contentLeft, contentRight - center);
+  return Math.max(columnWidth, Math.min(preferredWidth, available));
+}
+
+/** Top-level assistant tables may borrow the timeline's unused side gutters.
+ * Keep the prose column (and scroll owner) intact; never escape a bubble, quote,
+ * nested list, or clipped disclosure. Standalone Markdown retains its layout.
+ */
+export function useMarkdownTableLayout(children: ReactNode) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
+  const [width, setWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    const table = tableRef.current;
+    const body = wrapper?.parentElement;
+    const message = body?.closest("[data-og-wide-table-message]");
+    const scroller = message?.closest<HTMLElement>("[data-og-timeline-scroller]");
+    if (!wrapper || table === null || !body?.classList.contains("og-markdown-body") || !scroller) {
+      setWidth(null);
+      return;
+    }
+
+    const measure = () => {
+      // Intermediate clipped/scrollable surfaces own their own content bounds.
+      for (
+        let ancestor: HTMLElement | null = body;
+        ancestor && ancestor !== scroller;
+        ancestor = ancestor.parentElement
+      ) {
+        if (getComputedStyle(ancestor).overflowX !== "visible") {
+          setWidth(null);
+          return;
+        }
+      }
+      const column = body.getBoundingClientRect();
+      const panel = scroller.getBoundingClientRect();
+      const panelStyle = getComputedStyle(scroller);
+      const left = panel.left + scroller.clientLeft + parseFloat(panelStyle.paddingLeft);
+      const right =
+        panel.left +
+        scroller.clientLeft +
+        scroller.clientWidth -
+        parseFloat(panelStyle.paddingRight);
+
+      // Measure the same table's preferred width, then restore its normal fluid
+      // layout. This preserves wrapping and TSV copy without a duplicate DOM.
+      const previousWidth = table.style.width;
+      table.style.width = "max-content";
+      const preferred = table.getBoundingClientRect().width;
+      table.style.width = previousWidth;
+      const next = markdownTableWidth({
+        columnLeft: column.left,
+        columnWidth: column.width,
+        contentLeft: left,
+        contentRight: right,
+        preferredWidth: preferred,
+      });
+      setWidth((current) => (current !== null && Math.abs(current - next) < 0.5 ? current : next));
+    };
+
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(scroller);
+    observer.observe(body);
+    observer.observe(table);
+    return () => observer.disconnect();
+  }, [children]);
+
+  return {
+    wrapperRef,
+    tableRef,
+    style:
+      width === null
+        ? undefined
+        : {
+            width,
+            maxWidth: "none",
+            marginInline: `calc((100% - ${width}px) / 2)`,
+          },
+  };
+}

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -21,6 +21,7 @@ import { tableElementToTsv } from "../lib/clipboard";
 import { prefersReducedMotion } from "../lib/motion";
 import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
 import { CopyButton } from "./copy-button";
+import { useMarkdownTableLayout } from "./markdown-table-layout";
 import { softenStreamingMarkdown } from "./soften-streaming-markdown";
 import { createStreamReveal, rehypeStreamReveal, type StreamReveal } from "./stream-reveal";
 import { TooltipProvider } from "./tooltip";
@@ -411,9 +412,9 @@ function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
 }
 
 function MarkdownTable({ children, className, ...props }: ComponentPropsWithoutRef<"table">) {
-  const tableRef = useRef<HTMLTableElement | null>(null);
+  const { wrapperRef, tableRef, style } = useMarkdownTableLayout(children);
   return (
-    <div className="group/copy relative mt-3 max-w-full first:mt-0">
+    <div ref={wrapperRef} style={style} className="group/copy relative mt-3 max-w-full first:mt-0">
       <div className="pointer-events-none absolute top-0 right-0 z-10">
         <div className="pointer-events-auto">
           <CopyButton

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -21,7 +21,6 @@ import { tableElementToTsv } from "../lib/clipboard";
 import { prefersReducedMotion } from "../lib/motion";
 import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
 import { CopyButton } from "./copy-button";
-import { useMarkdownTableLayout } from "./markdown-table-layout";
 import { softenStreamingMarkdown } from "./soften-streaming-markdown";
 import { createStreamReveal, rehypeStreamReveal, type StreamReveal } from "./stream-reveal";
 import { TooltipProvider } from "./tooltip";
@@ -412,9 +411,27 @@ function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
 }
 
 function MarkdownTable({ children, className, ...props }: ComponentPropsWithoutRef<"table">) {
-  const { wrapperRef, tableRef, style } = useMarkdownTableLayout(children);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    const table = tableRef.current;
+    if (!wrapper?.closest("[data-og-wide-table-message]") || !table) return;
+    let disposed = false;
+    let cleanup: (() => void) | undefined;
+    // Ordinary tables remain usable even if this optional layout chunk fails.
+    void import("./markdown-table-layout")
+      .then(({ observeMarkdownTableLayout }) => {
+        if (!disposed) cleanup = observeMarkdownTableLayout(wrapper, table);
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, [children]);
   return (
-    <div ref={wrapperRef} style={style} className="group/copy relative mt-3 max-w-full first:mt-0">
+    <div ref={wrapperRef} className="group/copy relative mt-3 max-w-full first:mt-0">
       <div className="pointer-events-none absolute top-0 right-0 z-10">
         <div className="pointer-events-auto">
           <CopyButton

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -3273,7 +3273,12 @@ function AgentMessageRow({
         )
       }
     >
-      <div data-og-annotation-source-key={item.annotationSource?.eventId}>{body}</div>
+      <div
+        data-og-wide-table-message=""
+        data-og-annotation-source-key={item.annotationSource?.eventId}
+      >
+        {body}
+      </div>
     </CopyHoverFrame>
   );
 }

--- a/packages/react/test/markdown-table-layout.test.ts
+++ b/packages/react/test/markdown-table-layout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { markdownTableWidth } from "../src/components/markdown-table-layout";
+
+describe("chat table available width", () => {
+  const desktop = {
+    columnLeft: 336,
+    columnWidth: 768,
+    contentLeft: 24,
+    contentRight: 1416,
+  };
+
+  test("keeps small tables at prose width", () => {
+    expect(markdownTableWidth({ ...desktop, preferredWidth: 420 })).toBe(768);
+  });
+
+  test("uses only the width the table needs beyond prose", () => {
+    expect(markdownTableWidth({ ...desktop, preferredWidth: 1100 })).toBe(1100);
+  });
+
+  test("caps oversized tables at the panel's padded content edges", () => {
+    expect(markdownTableWidth({ ...desktop, preferredWidth: 1900 })).toBe(1392);
+  });
+
+  test("uses the nearer panel edge when the column is not centered", () => {
+    expect(markdownTableWidth({ ...desktop, contentLeft: 200, preferredWidth: 1900 })).toBe(1040);
+  });
+
+  test("does not borrow viewport space for a narrow embedded panel", () => {
+    expect(
+      markdownTableWidth({
+        columnLeft: 724,
+        columnWidth: 452,
+        contentLeft: 724,
+        contentRight: 1176,
+        preferredWidth: 1100,
+      }),
+    ).toBe(452);
+  });
+
+  test("recalculates smaller preferred widths without retaining the last expansion", () => {
+    expect(
+      [1100, 1900, 400].map((preferredWidth) => markdownTableWidth({ ...desktop, preferredWidth })),
+    ).toEqual([1100, 1392, 768]);
+  });
+});

--- a/packages/react/test/markdown-table-observer.test.tsx
+++ b/packages/react/test/markdown-table-observer.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { observeMarkdownTableLayout } from "../src/components/markdown-table-layout";
+import { registerDom } from "./render-hook";
+
+registerDom();
+
+function fixture() {
+  const scroller = document.createElement("div");
+  scroller.setAttribute("data-og-timeline-scroller", "");
+  scroller.style.paddingInline = "24px";
+  const message = document.createElement("div");
+  message.setAttribute("data-og-wide-table-message", "");
+  const body = document.createElement("div");
+  body.className = "og-markdown-body";
+  const wrapper = document.createElement("div");
+  const table = document.createElement("table");
+  wrapper.append(table);
+  body.append(wrapper);
+  message.append(body);
+  scroller.append(message);
+  document.body.append(scroller);
+  for (const element of [body, message]) element.style.overflowX = "visible";
+  scroller.style.paddingLeft = "24px";
+  scroller.style.paddingRight = "24px";
+  Object.defineProperty(scroller, "clientWidth", { value: 1440 });
+  scroller.getBoundingClientRect = () => new DOMRect(0, 0, 1440, 800);
+  body.getBoundingClientRect = () => new DOMRect(336, 0, 768, 100);
+  let preferred = 1100;
+  table.getBoundingClientRect = () => new DOMRect(0, 0, preferred, 100);
+  return {
+    scroller,
+    message,
+    body,
+    wrapper,
+    table,
+    resize: (value: number) => (preferred = value),
+  };
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe("lazy markdown table observer", () => {
+  test("expands, shrinks, restores inline table width, and cleans up observation", () => {
+    const original = globalThis.ResizeObserver;
+    let notify = () => {};
+    let disconnected = false;
+    const observed: Element[] = [];
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        notify = () => callback([], this);
+      }
+      observe(element: Element) {
+        observed.push(element);
+      }
+      unobserve() {}
+      disconnect() {
+        disconnected = true;
+      }
+    };
+    try {
+      const f = fixture();
+      f.table.style.width = "100%";
+      const cleanup = observeMarkdownTableLayout(f.wrapper, f.table);
+      expect(f.wrapper.style.width).toBe("1100px");
+      expect(f.table.style.width).toBe("100%");
+      expect(observed).toEqual([f.scroller, f.body, f.table]);
+      f.resize(1900);
+      notify();
+      expect(f.wrapper.style.width).toBe("1392px");
+      f.resize(400);
+      notify();
+      expect(f.wrapper.style.width).toBe("768px");
+      f.message.style.overflowX = "hidden";
+      notify();
+      expect(f.wrapper.style.width).toBe("");
+      cleanup?.();
+      expect(disconnected).toBe(true);
+      expect(f.wrapper.style.maxWidth).toBe("");
+      expect(f.wrapper.style.marginInline).toBe("");
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
+
+  test("keeps nested and standalone tables unchanged", () => {
+    const f = fixture();
+    const quote = document.createElement("blockquote");
+    f.body.append(quote);
+    quote.append(f.wrapper);
+    expect(observeMarkdownTableLayout(f.wrapper, f.table)).toBeUndefined();
+    expect(f.wrapper.style.width).toBe("");
+    f.body.append(f.wrapper);
+    f.message.removeAttribute("data-og-wide-table-message");
+    expect(observeMarkdownTableLayout(f.wrapper, f.table)).toBeUndefined();
+  });
+
+  test("still measures and cleans up without ResizeObserver", () => {
+    const original = globalThis.ResizeObserver;
+    Reflect.deleteProperty(globalThis, "ResizeObserver");
+    try {
+      const f = fixture();
+      const cleanup = observeMarkdownTableLayout(f.wrapper, f.table);
+      expect(f.wrapper.style.width).toBe("1100px");
+      cleanup?.();
+      expect(f.wrapper.style.width).toBe("");
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
+});

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -117,6 +117,167 @@ describe("timeline scroll ownership browser regression", () => {
     }
   });
 
+  for (const compiled of [false, true]) {
+    const consumer = compiled ? "compiled CSS" : "Tailwind source CSS";
+    const openTables = async () => {
+      const tablePage = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+      observeBrowserErrors(tablePage, browserErrors);
+      await tablePage.goto(`${baseUrl}/timeline-table-test.html${compiled ? "?compiled" : ""}`);
+      await tablePage.waitForFunction(() => window.timelineTableHarness !== undefined);
+      await tablePage.locator("table").first().waitFor();
+      await tablePage.evaluate(() => document.fonts.ready);
+      return tablePage;
+    };
+
+    test(`wide tables use panel gutters without widening prose or nested content (${consumer})`, async () => {
+      const tablePage = await openTables();
+      try {
+        await tablePage.waitForFunction(
+          () => {
+            const table = document.querySelector("table")!;
+            const prose = [...document.querySelectorAll("[data-og-timeline-scroller] p")].find(
+              (node) => node.textContent?.startsWith("Ordinary assistant prose"),
+            )!;
+            return (
+              table.parentElement!.getBoundingClientRect().width >
+              prose.getBoundingClientRect().width + 100
+            );
+          },
+          undefined,
+          { timeout: 5_000 },
+        );
+        const geometry = await tableGeometry(tablePage);
+        expect(geometry.prose.width).toBeCloseTo(768, 0);
+        expect(geometry.tables.Wide!.width).toBeGreaterThan(868);
+        expect(geometry.tables.Wide!.left).toBeLessThan(geometry.prose.left - 40);
+        expect(geometry.tables.Wide!.right).toBeGreaterThan(geometry.prose.right + 40);
+        expect(geometry.tables.Small!.width).toBeCloseTo(geometry.prose.width, 0);
+        for (const name of ["Small", "Quoted", "Listed"]) {
+          expect(geometry.tables[name]!.left).toBeGreaterThanOrEqual(geometry.prose.left - 1);
+          expect(geometry.tables[name]!.right).toBeLessThanOrEqual(geometry.prose.right + 1);
+        }
+        for (const block of geometry.ordinary) {
+          expect(block.left).toBeGreaterThanOrEqual(geometry.prose.left - 1);
+          expect(block.right).toBeLessThanOrEqual(geometry.prose.right + 1);
+        }
+        assertTableContainment(geometry);
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await tablePage.locator("table").first().scrollIntoViewIfNeeded();
+          await tablePage.screenshot({
+            path: `${artifactDir}/table-desktop-${compiled ? "compiled" : "source"}.png`,
+          });
+        }
+      } finally {
+        await tablePage.close();
+      }
+    }, 15_000);
+
+    test(`table overflow follows resize, an offset side panel, and mobile (${consumer})`, async () => {
+      const tablePage = await openTables();
+      try {
+        for (const state of [
+          { viewport: 1440, panel: 1100 },
+          { viewport: 1440, panel: 560 },
+          { viewport: 390, panel: null },
+          { viewport: 1440, panel: null },
+        ]) {
+          await tablePage.setViewportSize({ width: state.viewport, height: 900 });
+          await tablePage.evaluate(
+            (width) => window.timelineTableHarness!.panel(width),
+            state.panel,
+          );
+          await tablePage.waitForFunction(({ panel, viewport }) => {
+            const width = document
+              .querySelector("[data-table-panel]")!
+              .getBoundingClientRect().width;
+            return Math.abs(width - (panel ?? viewport - 24)) < 1;
+          }, state);
+          await tablePage.waitForTimeout(100); // ResizeObserver + layout measurement frames.
+          const geometry = await tableGeometry(tablePage);
+          assertTableContainment(geometry);
+          expect(geometry.tables.Oversized!.width).toBeCloseTo(geometry.right - geometry.left, 0);
+          expect(geometry.tables.Oversized!.scrollWidth).toBeGreaterThan(
+            geometry.tables.Oversized!.width + 100,
+          );
+          if (state.viewport === 390 && artifactDir) {
+            await mkdir(artifactDir, { recursive: true });
+            await tablePage.locator("table").first().scrollIntoViewIfNeeded();
+            await tablePage.screenshot({
+              path: `${artifactDir}/table-mobile-${compiled ? "compiled" : "source"}.png`,
+            });
+          }
+        }
+      } finally {
+        await tablePage.close();
+      }
+    }, 15_000);
+
+    test(`streaming table grows and shrinks in place (${consumer})`, async () => {
+      const tablePage = await openTables();
+      try {
+        for (const content of ["small", "wide", "oversized", "small"] as const) {
+          await tablePage.evaluate((value) => window.timelineTableHarness!.content(value), content);
+          await tablePage.waitForFunction(
+            ({ content: expectedContent }) => {
+              const table = document.querySelector("table")!;
+              if (table.querySelector("th")?.textContent?.toLowerCase() !== expectedContent)
+                return false;
+              const width = table.parentElement!.getBoundingClientRect().width;
+              return expectedContent === "small" ? Math.abs(width - 768) < 1 : width > 868;
+            },
+            { content },
+            { timeout: 5_000 },
+          );
+          assertTableContainment(await tableGeometry(tablePage));
+        }
+      } finally {
+        await tablePage.close();
+      }
+    }, 25_000);
+
+    test(`table TSV copy and focused keyboard scrolling remain local (${consumer})`, async () => {
+      const tablePage = await openTables();
+      try {
+        await tablePage.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+        const smallTable = tablePage
+          .locator("table")
+          .filter({ has: tablePage.getByRole("columnheader", { name: "Small", exact: true }) });
+        await smallTable
+          .locator("../..")
+          .getByRole("button", { name: "Copy table", exact: true })
+          .click();
+        expect(await tablePage.evaluate(() => navigator.clipboard.readText())).toBe(
+          "Small\tValue\nAlpha\tBeta",
+        );
+        const overflow = tablePage
+          .locator("table")
+          .filter({ has: tablePage.getByRole("columnheader", { name: "Oversized", exact: true }) })
+          .locator("..");
+        await overflow.scrollIntoViewIfNeeded();
+        await overflow.focus();
+        expect(
+          await overflow.evaluate((node) => node === document.activeElement && node.tabIndex === 0),
+        ).toBe(true);
+        const before = await tablePage
+          .locator("[data-og-timeline-scroller]")
+          .evaluate((node) => ({ left: node.scrollLeft, top: node.scrollTop }));
+        await tablePage.keyboard.press("ArrowRight");
+        await tablePage.waitForFunction(
+          () => (document.activeElement as HTMLElement).scrollLeft > 0,
+        );
+        const after = await tablePage
+          .locator("[data-og-timeline-scroller]")
+          .evaluate((node) => ({ left: node.scrollLeft, top: node.scrollTop }));
+        expect(after.left).toBe(before.left);
+        expect(after.top).toBeCloseTo(before.top, 0);
+        assertTableContainment(await tableGeometry(tablePage));
+      } finally {
+        await tablePage.close();
+      }
+    }, 15_000);
+  }
+
   test("keeps the reader's row and pixel anchor through prepend, wheel, resize, and append", async () => {
     if (artifactDir) {
       await mkdir(artifactDir, { recursive: true });
@@ -1604,8 +1765,55 @@ async function captureEvidenceMatrix(page: Page, outputDir: string): Promise<voi
   }
 }
 
+async function tableGeometry(page: Page) {
+  return page.evaluate(() => {
+    const bounds = (element: Element) => {
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right, width: rect.width };
+    };
+    const scroller = document.querySelector<HTMLElement>("[data-og-timeline-scroller]")!;
+    const style = getComputedStyle(scroller);
+    const rect = bounds(scroller);
+    const prose =
+      [...scroller.querySelectorAll("p")].find((node) =>
+        node.textContent?.startsWith("Ordinary assistant prose"),
+      ) ?? scroller.querySelector("table")!;
+    const tables = Object.fromEntries(
+      [...scroller.querySelectorAll("table")].map((table) => [
+        table.querySelector("th")!.textContent!,
+        { ...bounds(table.parentElement!), scrollWidth: table.parentElement!.scrollWidth },
+      ]),
+    );
+    return {
+      prose: bounds(prose),
+      tables,
+      ordinary: [...scroller.querySelectorAll("p, pre")].map(bounds),
+      left: rect.left + scroller.clientLeft + parseFloat(style.paddingLeft),
+      right:
+        rect.left + scroller.clientLeft + scroller.clientWidth - parseFloat(style.paddingRight),
+      scrollWidth: scroller.scrollWidth,
+      clientWidth: scroller.clientWidth,
+      documentWidth: document.documentElement.scrollWidth,
+      viewport: innerWidth,
+    };
+  });
+}
+
+function assertTableContainment(geometry: Awaited<ReturnType<typeof tableGeometry>>) {
+  for (const table of Object.values(geometry.tables)) {
+    expect(table.left).toBeGreaterThanOrEqual(geometry.left - 1);
+    expect(table.right).toBeLessThanOrEqual(geometry.right + 1);
+  }
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewport + 1);
+}
+
 declare global {
   interface Window {
+    timelineTableHarness?: {
+      content: (value: "baseline" | "small" | "wide" | "oversized") => void;
+      panel: (width: number | null) => void;
+    };
     timelineScrollHarness?: {
       append: () => void;
       growRowsAbove: () => void;


### PR DESCRIPTION
## Summary

- Let top-level assistant Markdown tables use spare space on either side of the reading column, capped by the actual timeline panel and its gutters.
- Preserve paragraph widths, small tables, nested Markdown, clipped disclosures and user bubbles; retain table-only overflow when content cannot fit.
- Recalculate for table content and panel resizing without changing the timeline scroll owner or duplicating table DOM.
- Add width-calculation coverage, package documentation and a React patch changeset. Real-browser regression coverage is being completed before merge.

## Validation

- 13 width-calculation and Markdown link tests passed.
- 9 compiled-CSS contract tests passed (no generated CSS changes required).
- Copy controls / table TSV and streaming Markdown tests passed.
- React package and web app typechecks passed.
- Browser regression coverage and exact-head independent review required before merge.

Implements the user-approved expanded table layout preview. No backend, auth, database or public API changes.

## Summary by Sourcery

Expand top-level assistant tables into available chat panel space while preserving readable surrounding content and local overflow behavior.

New Features:
- Allow top-level assistant Markdown tables to expand into unused chat panel width while preserving normal prose and nested content widths.

Bug Fixes:
- Keep expanded tables contained by panel gutters and retain local horizontal scrolling when table content exceeds the available space.
- Recalculate table sizing when content, embedded panel width, or viewport size changes without altering timeline scroll ownership or duplicating table markup.

Documentation:
- Document the available-width behavior and overflow handling for assistant tables in the React package README.

Tests:
- Add width-calculation and observer unit coverage for table expansion, containment, resizing, cleanup, and unchanged nested or standalone tables.
- Add browser regression coverage for source and compiled CSS across panel resizing, mobile layouts, streaming content, copy controls, and local keyboard scrolling.

Chores:
- Add a React patch changeset for the expanded assistant table layout.