### PR TITLE
Flush deferred constraints before ordered history backfill DDL

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -237,7 +237,7 @@ async function executeMigrationFile(
     await sql.unsafe(
       `SELECT
   pg_catalog.set_config('opengeni.sandbox_recovery_protocol_v2', '1', true),
-  pg_catalog.set_config('opengeni.session_variable_set_attachments_v1', '1', true);\n${sqlText}`,
+  pg_catalog.set_config('opengeni.session_variable_set_attachments_v1', '1', true);\n${file === "0434_ordered_model_history.sql" ? "SET CONSTRAINTS ALL IMMEDIATE;\n" : ""}${sqlText}`,
     );
     return;
   }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -168,7 +168,7 @@ export function parseBatchedBackfillMigration(
   };
 }
 
-async function executeMigrationFile(
+export async function executeMigrationFile(
   sql: postgres.Sql,
   file: string,
   sqlText: string,

--- a/packages/db/test/migration-0434-ordered-model-history.test.ts
+++ b/packages/db/test/migration-0434-ordered-model-history.test.ts
@@ -1,10 +1,14 @@
-import { expect, test } from "bun:test";
+import { beforeAll, expect, test } from "bun:test";
 import { acquireBlankTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
 import { fromPostgresLosslessJson, toPostgresLosslessJson } from "../src/lossless-json";
 
+let database: Awaited<ReturnType<typeof acquireBlankTestDatabase>>;
+beforeAll(async () => {
+  database = await acquireBlankTestDatabase("ordered-model-history");
+}, 600_000);
+
 test("ordered history survives PostgreSQL, nested schemas and legacy updates without read-time repair", async () => {
-  const database = await acquireBlankTestDatabase("ordered-model-history");
   if (!database) throw new Error("PostgreSQL is required for ordered-history verification");
   const sql = postgres(database.databaseUrl, { max: 1 });
   try {
@@ -17,7 +21,9 @@ test("ordered history survives PostgreSQL, nested schemas and legacy updates wit
     const migration = await Bun.file(
       new URL("../drizzle/0434_ordered_model_history.sql", import.meta.url),
     ).text();
-    await expect(sql.unsafe(migration)).rejects.toThrow("pending trigger events");
+    await expect((async () => await sql.unsafe(migration))()).rejects.toThrow(
+      "pending trigger events",
+    );
     const runner = await Bun.file(new URL("../src/migrate.ts", import.meta.url)).text();
     expect(runner).toContain('file === "0434_ordered_model_history.sql"');
     expect(runner).toContain("SET CONSTRAINTS ALL IMMEDIATE;");

--- a/packages/db/test/migration-0434-ordered-model-history.test.ts
+++ b/packages/db/test/migration-0434-ordered-model-history.test.ts
@@ -11,9 +11,17 @@ test("ordered history survives PostgreSQL, nested schemas and legacy updates wit
     await sql.unsafe(`CREATE TABLE session_history_items (id integer PRIMARY KEY, item jsonb NOT NULL, active boolean DEFAULT true);
       CREATE TABLE session_pending_tool_calls (id integer PRIMARY KEY, call_item jsonb NOT NULL, result_item jsonb, tied_reasoning_items jsonb NOT NULL DEFAULT '[]');
       INSERT INTO session_history_items(id,item) VALUES (1,'{"query":"old","names":[],"limit":5}');`);
-    await sql.unsafe(
-      await Bun.file(new URL("../drizzle/0434_ordered_model_history.sql", import.meta.url)).text(),
-    );
+    await sql.unsafe(`CREATE FUNCTION deferred_history_probe() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+      CREATE CONSTRAINT TRIGGER deferred_history_probe AFTER UPDATE ON session_pending_tool_calls DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION deferred_history_probe();
+      INSERT INTO session_pending_tool_calls(id,call_item) VALUES(9,'{"type":"function_call"}');`);
+    const migration = await Bun.file(
+      new URL("../drizzle/0434_ordered_model_history.sql", import.meta.url),
+    ).text();
+    await expect(sql.unsafe(migration)).rejects.toThrow("pending trigger events");
+    const runner = await Bun.file(new URL("../src/migrate.ts", import.meta.url)).text();
+    expect(runner).toContain('file === "0434_ordered_model_history.sql"');
+    expect(runner).toContain("SET CONSTRAINTS ALL IMMEDIATE;");
+    await sql.unsafe(`SET CONSTRAINTS ALL IMMEDIATE;\n${migration}`);
     const live = {
       type: "tool_search_call",
       arguments: { query: "x\u0000", names: ["tool"], limit: 5 },

--- a/packages/db/test/migration-0434-ordered-model-history.test.ts
+++ b/packages/db/test/migration-0434-ordered-model-history.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, expect, test } from "bun:test";
 import { acquireBlankTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
+import { executeMigrationFile } from "../src/migrate";
 import { fromPostgresLosslessJson, toPostgresLosslessJson } from "../src/lossless-json";
 
 let database: Awaited<ReturnType<typeof acquireBlankTestDatabase>>;
@@ -24,10 +25,7 @@ test("ordered history survives PostgreSQL, nested schemas and legacy updates wit
     await expect((async () => await sql.unsafe(migration))()).rejects.toThrow(
       "pending trigger events",
     );
-    const runner = await Bun.file(new URL("../src/migrate.ts", import.meta.url)).text();
-    expect(runner).toContain('file === "0434_ordered_model_history.sql"');
-    expect(runner).toContain("SET CONSTRAINTS ALL IMMEDIATE;");
-    await sql.unsafe(`SET CONSTRAINTS ALL IMMEDIATE;\n${migration}`);
+    await executeMigrationFile(sql, "0434_ordered_model_history.sql", migration);
     const live = {
       type: "tool_search_call",
       arguments: { query: "x\u0000", names: ["tool"], limit: 5 },


### PR DESCRIPTION
Migration 0434 updates pending tool rows between ALTER TABLE statements. Existing deferred constraint triggers leave pending events and PostgreSQL rejects the next ALTER. Run this migration with immediate constraints; retain the published SQL bytes. The regression seeds a deferred trigger, reproduces the failure, then verifies the immediate-constraint migration and ordered replay. Applied successfully to Lumen and Peloton during the drained rollout.

## Summary by Sourcery

Make ordered model history migration 0434 robust against deferred constraint events during backfill.

Bug Fixes:
- Ensure migration 0434 flushes deferred PostgreSQL constraint events before applying its DDL, preventing failures during ordered history backfill.

Enhancements:
- Expose migration file execution for targeted migration verification while preserving the published migration SQL.

Tests:
- Add regression coverage that reproduces deferred-trigger failure and verifies successful immediate-constraint execution with ordered history replay.