### PR TITLE
fix: restore compact Waiting badge in session header

### DIFF
--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -211,7 +211,15 @@ export function SessionHeader({
               paused, admission is the headline — hide lifecycle so we don't
               imply the session is still "Running"/"Idle" under a pause gate. */}
           {session.effectiveControl.state === "active" ? (
-            waiting ? null : (
+            waiting ? (
+              <span
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-surface-1 px-2 py-0.5 text-control font-medium text-fg-muted"
+                data-session-wait-badge=""
+              >
+                <span aria-hidden className="size-1.5 rounded-full bg-current" />
+                Waiting
+              </span>
+            ) : (
               <SessionStatusBadge status={status} />
             )
           ) : (

--- a/test/e2e/session-rail-row-metadata.browser.e2e.ts
+++ b/test/e2e/session-rail-row-metadata.browser.e2e.ts
@@ -54,6 +54,7 @@ describe("Session rail row metadata in Chromium", () => {
       await page.reload({ waitUntil: "networkidle" });
       expect(await preview.innerText()).toContain("Checks again at");
       expect(await preview.locator("header").innerText()).not.toContain("recheck");
+      expect(await preview.locator("header [data-session-wait-badge]").innerText()).toBe("Waiting");
       expect(await preview.locator("[data-session-wait-status]").count()).toBe(1);
       expect(await page.getByTestId("waiting-row").innerText()).toContain("Waiting · ");
       expect(await preview.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
@@ -69,6 +70,7 @@ describe("Session rail row metadata in Chromium", () => {
       expect(await preview.innerText()).not.toContain("Waiting ·");
       expect(await preview.innerText()).not.toContain("Checks again at");
       expect(await preview.locator("[data-session-wait-status]").count()).toBe(0);
+      expect(await preview.locator("[data-session-wait-badge]").count()).toBe(0);
     }
     await page.setViewportSize({ width: 1280, height: 800 });
   });


### PR DESCRIPTION
Restore the compact Waiting badge in the session header during an explicit input wait. The reason and next-check time remain beside the composer.

Validation: eight Chromium tests passed, including waiting-to-completed transitions; web typecheck passed; desktop screenshot inspected.

## Summary by Sourcery

Restore the compact Waiting indicator in the session header without changing the adjacent wait reason and next-check metadata.

Bug Fixes:
- Restore the compact Waiting badge in the session header during explicit input waits while removing it when the session completes.

Tests:
- Add Chromium coverage for the Waiting badge’s presence during waits and removal after completion.