### PR TITLE
fix: recover exact historical sandbox checkpoints with audited authorization

### DIFF
--- a/.changeset/tidy-checkpoint-recovery.md
+++ b/.changeset/tidy-checkpoint-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Allow explicitly audited operator recovery from an exact historical sandbox checkpoint while preserving generation gaps and existing restore verification.

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -33,6 +33,8 @@ import postgres from "postgres";
 import { getSettings, type Settings } from "@opengeni/config";
 import {
   acquireLease,
+  authorizeHistoricalSandboxCheckpointRecovery,
+  registerSandboxCheckpointArtifact,
   enrollUnobservableCommandIdleDrain,
   reapStaleLeaseHoldersGlobal,
   advanceWorkspaceGeneration,
@@ -6050,4 +6052,262 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
       drainReason: "provider_deadline",
     });
   }, 60_000);
+
+  for (const native of [false, true]) {
+    test(`historical checkpoint recovery preserves the audited gap; native=${native}`, async () => {
+      if (!available) throw new Error("Real PostgreSQL required");
+      const ids = await freshWorkspace();
+      const attempt = await freshWarmSnapshotAttempt(ids);
+      ids.groupId = attempt.sandboxGroupId;
+      const archive = Buffer.from(
+        native
+          ? `MODAL_SANDBOX_FS_SNAPSHOT_V1\n${JSON.stringify({ snapshot_id: "im-historical-recovery", workspace_persistence: "snapshot_filesystem" })}`
+          : "historical-archive",
+      ).toString("base64");
+      const tarDescriptor = archiveDescriptor(archive, 1_900_000_000_000);
+      const descriptor = native
+        ? {
+            version: 2 as const,
+            kind: "provider_snapshot" as const,
+            revision: `wa2:1900000000000:${tarDescriptor.archiveSha256}`,
+            archiveSha256: tarDescriptor.archiveSha256,
+            archiveBytes: tarDescriptor.archiveBytes,
+            capturedAt: tarDescriptor.capturedAt,
+            provider: "modal_snapshot_filesystem" as const,
+            snapshotId: "im-historical-recovery",
+            workspacePersistence: "snapshot_filesystem",
+          }
+        : tarDescriptor;
+      const leaseId = await insertLease(ids, {
+        liveness: "cold",
+        backend: "modal",
+        refcount: 0,
+        leaseEpoch: 1,
+        instanceId: null,
+        resumeBackendId: "modal",
+        resumeState: {
+          backendId: "modal",
+          sessionState: {
+            workspaceArchive: archive,
+            workspaceArchiveMeta: descriptor,
+          },
+        },
+      });
+      if (native) {
+        const binding = {
+          version: 1,
+          serverUrl: "https://modal.test",
+          workspaceName: "historical-recovery",
+          environment: "main",
+        };
+        const artifact = await registerSandboxCheckpointArtifact(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sandboxGroupId: ids.groupId,
+          sourceLeaseId: leaseId,
+          sourceLeaseEpoch: 1,
+          sourceInstanceId: "gone-provider",
+          sourceWorkspaceGeneration: 0,
+          providerBinding: binding,
+          providerBindingKey: JSON.stringify(binding),
+          workspaceArchive: archive,
+          workspaceArchiveMeta: descriptor,
+        });
+        await admin.begin(async (tx) => {
+          await tx`update sandbox_leases set archive_generation = 0, current_checkpoint_artifact_id = ${artifact.id} where id = ${leaseId}`;
+          await tx`update sandbox_checkpoint_artifacts set state = 'current' where id = ${artifact.id}`;
+        });
+      }
+      await admin`update sandbox_leases set workspace_generation = 3, archive_generation = 0 where id = ${leaseId}`;
+      const scope = {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+      };
+      const authorization = {
+        ...scope,
+        expectedEpoch: 1,
+        expectedWorkspaceGeneration: 3,
+        expectedArchiveGeneration: 0,
+        selectedRevision: descriptor.revision,
+        operationId: crypto.randomUUID(),
+        subjectId: "operator@example.test",
+        reason: "Recover the preserved checkpoint; subsequent writes are unavailable",
+        acceptHistoricalCheckpoint: true as const,
+      };
+      expect(await authorizeHistoricalSandboxCheckpointRecovery(db, authorization)).toEqual({
+        authorized: false,
+      });
+      await admin`update session_turn_attempts set state = 'closed', outcome = 'completed',
+      closed_at = now(), quiesced_at = now() where id = ${attempt.attemptId}`;
+      expect(
+        await authorizeHistoricalSandboxCheckpointRecovery(db, {
+          ...authorization,
+          expectedWorkspaceGeneration: 4,
+        }),
+      ).toEqual({ authorized: false });
+      await admin`update sandbox_leases set liveness = 'warming' where id = ${leaseId}`;
+      expect(
+        await beginSandboxRematerialization(db, {
+          ...scope,
+          expectedEpoch: 1,
+          rematerializationId: crypto.randomUUID(),
+        }),
+      ).toMatchObject({
+        status: "blocked",
+        code: "archive_generation_mismatch",
+      });
+      await admin`update sandbox_leases set liveness = 'cold' where id = ${leaseId}`;
+      expect(await authorizeHistoricalSandboxCheckpointRecovery(db, authorization)).toEqual({
+        authorized: true,
+      });
+      for (const mutation of [
+        "epoch",
+        "generation",
+        "pointer",
+        "revision",
+        "receipt-group",
+      ] as const) {
+        // Native revision mismatch is rejected by the existing SQL artifact fence.
+        if (native && mutation === "revision") continue;
+        if (mutation === "epoch")
+          await admin`update sandbox_leases set lease_epoch = 2 where id = ${leaseId}`;
+        if (mutation === "generation")
+          await admin`update sandbox_leases set workspace_generation = 4 where id = ${leaseId}`;
+        if (mutation === "pointer")
+          await admin`update sandbox_leases set resume_state = jsonb_set(resume_state,
+          '{opengeniHistoricalArchiveRecoveryId}', to_jsonb(${crypto.randomUUID()}::text)) where id = ${leaseId}`;
+        if (mutation === "revision")
+          await admin`update sandbox_leases set resume_state = jsonb_set(resume_state,
+          '{sessionState,workspaceArchiveMeta,revision}', to_jsonb('wa1:1900000000001:changed'::text)) where id = ${leaseId}`;
+        if (mutation === "receipt-group")
+          await admin`update audit_events set target_id = ${crypto.randomUUID()} where id = ${authorization.operationId}`;
+        expect(
+          await acquireLease(db, {
+            ...scope,
+            kind: "viewer",
+            holderId: "recovery-negative",
+            backend: "modal",
+            leaseTtlMs: 60_000,
+          }),
+        ).toMatchObject({ role: "blocked" });
+        await admin`update sandbox_leases set lease_epoch = 1, workspace_generation = 3,
+          resume_state = jsonb_set(resume_state, '{opengeniHistoricalArchiveRecoveryId}',
+          to_jsonb(${authorization.operationId}::text)) where id = ${leaseId}`;
+        await admin`update sandbox_leases set resume_state = jsonb_set(resume_state,
+          '{sessionState,workspaceArchiveMeta,revision}', to_jsonb(${descriptor.revision}::text)) where id = ${leaseId}`;
+        await admin`update audit_events set target_id = ${ids.groupId} where id = ${authorization.operationId}`;
+      }
+      expect(await authorizeHistoricalSandboxCheckpointRecovery(db, authorization)).toEqual({
+        authorized: true,
+      });
+      const elected = await acquireLease(db, {
+        ...scope,
+        kind: "viewer",
+        holderId: "recovery-verification",
+        backend: "modal",
+        leaseTtlMs: 60_000,
+      });
+      const rematerializationId = crypto.randomUUID();
+      const epoch = elected.lease.leaseEpoch;
+      if (native) {
+        // Even a fixture bypassing immutability cannot commit mismatched provenance.
+        await expect(
+          admin.begin(async (tx) => {
+            await tx`alter table sandbox_checkpoint_artifacts disable trigger sandbox_checkpoint_artifact_immutability_guard`;
+            await tx`update sandbox_checkpoint_artifacts set source_workspace_generation = 1
+            where id = (select current_checkpoint_artifact_id from sandbox_leases where id = ${leaseId})`;
+            await tx`update sandbox_leases set current_checkpoint_artifact_id = current_checkpoint_artifact_id where id = ${leaseId}`;
+            await tx`alter table sandbox_checkpoint_artifacts enable trigger sandbox_checkpoint_artifact_immutability_guard`;
+          }),
+        ).rejects.toThrow("current checkpoint artifact does not match its exact lease scope");
+      }
+      expect(
+        await beginSandboxRematerialization(db, {
+          ...scope,
+          expectedEpoch: epoch,
+          rematerializationId,
+        }),
+      ).toMatchObject({ status: "started" });
+      expect(
+        await recordWarmingSandboxCreated(db, {
+          ...scope,
+          expectedEpoch: epoch,
+          rematerializationId,
+          instanceId: "verified-recovery-box",
+          resumeBackendId: "modal",
+          resumeState: {
+            backendId: "modal",
+            sessionState: {
+              providerState: { sandboxId: "verified-recovery-box" },
+            },
+          },
+          leaseTtlMs: 60_000,
+        }),
+      ).toMatchObject({ recorded: true });
+      await markSandboxRestoreVerifying(db, {
+        ...scope,
+        expectedEpoch: epoch,
+        rematerializationId,
+      });
+      const committed = await commitWarmingToWarm(db, {
+        ...scope,
+        expectedEpoch: epoch,
+        instanceId: "verified-recovery-box",
+        resumeBackendId: "modal",
+        resumeState: {
+          backendId: "modal",
+          sessionState: {
+            providerState: { sandboxId: "verified-recovery-box" },
+          },
+        },
+        rematerialization: {
+          id: rematerializationId,
+          verifiedRevision: descriptor.revision,
+        },
+        leaseTtlMs: 60_000,
+      });
+      expect(committed.committed).toBe(true);
+      expect(committed.lease).toMatchObject({
+        workspaceGeneration: 3,
+        archiveGeneration: 0,
+        archiveComplete: false,
+      });
+      const [receipt] =
+        await admin`select metadata from audit_events where id = ${authorization.operationId}`;
+      expect(receipt?.metadata).toMatchObject({
+        workspaceGeneration: 3,
+        archiveGeneration: 0,
+        selectedRevision: descriptor.revision,
+      });
+      await releaseLeaseHolder(db, {
+        ...scope,
+        kind: "viewer",
+        holderId: "recovery-verification",
+        idleGraceMs: 1,
+      });
+      await admin`update sandbox_leases set expires_at = now() - interval '1 second' where id = ${leaseId}`;
+      const draining = await readLease(db, ids.workspaceId, ids.groupId);
+      const spy = makeTerminateSpy();
+      const recoveryDrain = await createSandboxLeaseActivities(reaperServices(), {
+        terminateBox: spy.fn,
+      }).drainSandboxLease({
+        target: {
+          workspaceId: ids.workspaceId,
+          sandboxGroupId: ids.groupId,
+          instanceId: "verified-recovery-box",
+          leaseEpoch: draining!.leaseEpoch,
+        },
+        timeoutClass: "fast",
+        snapshotTimeoutMs: 60_000,
+        captureTimeoutMs: 120_000,
+        operationId: crypto.randomUUID(),
+      });
+      expect(recoveryDrain).toMatchObject({ status: "terminated" });
+      expect(await readLease(db, ids.workspaceId, ids.groupId)).toMatchObject({
+        archiveGeneration: 3,
+        archiveComplete: true,
+      });
+    }, 180_000);
+  }
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1114,6 +1114,8 @@ it may not detach a rejecting task or install an `unhandledRejection` handler
 that exits the shared worker. The worker's global rejection listener is a
 last-resort observational boundary, while deliberate restart remains an
 OpenGeni drain-and-checkpoint decision.
+Explicit historical recovery uses an exact audited checkpoint receipt; see
+[`run-lifecycle.md`](run-lifecycle.md). It preserves the recorded generation gap.
 
 The worker supplies frozen authority and durable sinks. Runtime must not invent
 tenancy or persistence authority from its in-memory agent context.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1114,8 +1114,7 @@ it may not detach a rejecting task or install an `unhandledRejection` handler
 that exits the shared worker. The worker's global rejection listener is a
 last-resort observational boundary, while deliberate restart remains an
 OpenGeni drain-and-checkpoint decision.
-Explicit historical recovery uses an exact audited checkpoint receipt; see
-[`run-lifecycle.md`](run-lifecycle.md). It preserves the recorded generation gap.
+Audited historical recovery preserves generation gaps; see [`run-lifecycle.md`](run-lifecycle.md).
 
 The worker supplies frozen authority and durable sinks. Runtime must not invent
 tenancy or persistence authority from its in-memory agent context.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1325,6 +1325,21 @@ replacement, a previous revision, or a mixed snapshot. A legacy per-session
 archive can participate only after its archive fields—never provider identity—
 are imported and selected under that same lock.
 
+An operator may explicitly authorize recovery from an older, verified checkpoint
+after the provider is gone. `scripts/operator/historical-checkpoint-recovery.ts`
+accepts `preview` or `authorize` and a private JSON input file. Preview needs
+account/workspace/group IDs. Authorization additionally requires the exact lease
+epoch, workspace and archive generations, selected revision, operation UUID,
+operator subject, reason, and `acceptHistoricalCheckpoint: true`. Authorization
+uses operator-controlled database access; the subject is audit attribution.
+Every attempt in the group must be quiescent and the cold lease must have no holders or
+unsettled mutations. The existing audit store retains that decision and its
+generation gap. Neither generation nor checkpoint artifact provenance is
+rewritten. Existing election, restore verification, and warm publication consume
+the exact receipt; unrelated revisions or newer writes invalidate it. Only a
+subsequent fresh checkpoint makes the archive current. This operation does not
+resume a turn, modify session history, or claim recovery of unavailable writes.
+
 New Modal sessions persist `/workspace` with `snapshot_directory`: the restored
 directory Image layers user files onto the currently selected rig/pack/base
 image instead of replacing the whole machine. Existing serialized sessions keep

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43378,6 +43378,11 @@ function resumeStateWithPreservedArchives(
       : {};
   return {
     ...(resumeState ?? {}),
+    ...(typeof archiveSource?.opengeniHistoricalArchiveRecoveryId === "string"
+      ? {
+          opengeniHistoricalArchiveRecoveryId: archiveSource.opengeniHistoricalArchiveRecoveryId,
+        }
+      : {}),
     ...(resumeState?.backendId === undefined && archiveSource?.backendId !== undefined
       ? { backendId: archiveSource.backendId }
       : {}),
@@ -43414,6 +43419,11 @@ function archiveOnlyResumeState(
         ? current.backendId
         : (row.resume_backend_id ?? row.backend),
     ...(Object.keys(durableSession).length > 0 ? { sessionState: durableSession } : {}),
+    ...(typeof current?.opengeniHistoricalArchiveRecoveryId === "string"
+      ? {
+          opengeniHistoricalArchiveRecoveryId: current.opengeniHistoricalArchiveRecoveryId,
+        }
+      : {}),
     opengeniRecovery: recovery,
   };
 }
@@ -43842,8 +43852,9 @@ async function acquireLeaseOnce(
         if (liveness === "cold") {
           const recovery = recoveryStateFromLeaseRow(row);
           if (
-            (recovery.restore.status === "degraded" && recovery.restore.retryable !== true) ||
-            recovery.restore.status === "unrecoverable"
+            ((recovery.restore.status === "degraded" && recovery.restore.retryable !== true) ||
+              recovery.restore.status === "unrecoverable") &&
+            (await authorizedHistoricalArchiveGeneration(tx, row)) === null
           ) {
             return {
               role: "blocked" as const,
@@ -44050,6 +44061,137 @@ function validatedLegacyNativeSnapshotAdoption(
   return { archiveBase64: value.archiveBase64, descriptor };
 }
 
+/** Operator-only authorization for an exact historical checkpoint. Direct
+ * database access is the authority boundary; subjectId records attribution.
+ * This never resumes a turn or changes the archive/workspace generations. */
+export async function authorizeHistoricalSandboxCheckpointRecovery(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sandboxGroupId: string;
+    expectedEpoch: number;
+    expectedWorkspaceGeneration: number;
+    expectedArchiveGeneration: number;
+    selectedRevision: string;
+    operationId: string;
+    subjectId: string;
+    reason: string;
+    acceptHistoricalCheckpoint: true;
+  },
+): Promise<{ authorized: boolean }> {
+  if (
+    input.acceptHistoricalCheckpoint !== true ||
+    !input.subjectId.trim() ||
+    !input.reason.trim()
+  ) {
+    throw new Error(
+      "Historical checkpoint recovery requires an identified operator and explicit reason",
+    );
+  }
+  return await withRlsContext(db, input, async (tx) => {
+    await lockWorkspaceInferenceControl(tx, input.workspaceId, "update");
+    const rows = await tx.execute<LeaseRow>(sql`select * from sandbox_leases
+      where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId} for update`);
+    const row = rows[0];
+    if (
+      !row ||
+      row.backend !== "modal" ||
+      row.liveness !== "cold" ||
+      row.instance_id !== null ||
+      Number(row.lease_epoch) !== input.expectedEpoch ||
+      Number(row.refcount) !== 0 ||
+      Number(row.workspace_generation) !== input.expectedWorkspaceGeneration ||
+      row.archive_generation === null ||
+      Number(row.archive_generation) !== input.expectedArchiveGeneration ||
+      input.expectedArchiveGeneration >= input.expectedWorkspaceGeneration ||
+      recoveryStateFromLeaseRow(row).archive.current?.revision !== input.selectedRevision
+    )
+      return { authorized: false };
+    const blockers = await tx.execute<{ present: boolean }>(sql`select
+      exists(select 1 from session_turn_attempts attempt join sessions session
+        on session.workspace_id = attempt.workspace_id and session.id = attempt.session_id
+        where session.workspace_id = ${input.workspaceId} and session.sandbox_group_id = ${input.sandboxGroupId}
+          and (attempt.state in ('claimed','running') or attempt.quiesced_at is null))
+      or exists(select 1 from sandbox_lease_holders where lease_id = ${row.id})
+      or exists(select 1 from sandbox_workspace_mutation_admissions where lease_id = ${row.id} and settled_at is null)
+      or exists(select 1 from sandbox_retained_processes where lease_id = ${row.id} and state = 'active') as present`);
+    if (blockers[0]?.present) return { authorized: false };
+    if (
+      row.resume_state?.opengeniHistoricalArchiveRecoveryId === input.operationId &&
+      (await authorizedHistoricalArchiveGeneration(tx, row)) === input.expectedArchiveGeneration
+    )
+      return { authorized: true };
+    const metadata = {
+      version: 1,
+      leaseId: row.id,
+      leaseEpoch: input.expectedEpoch,
+      workspaceGeneration: input.expectedWorkspaceGeneration,
+      archiveGeneration: input.expectedArchiveGeneration,
+      selectedRevision: input.selectedRevision,
+      reason: input.reason,
+      acceptedHistoricalCheckpoint: true,
+    };
+    await tx.insert(schema.auditEvents).values(
+      withLosslessContentWriteVersion(
+        {
+          id: input.operationId,
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          subjectId: input.subjectId,
+          action: "sandbox.historical_checkpoint_recovery.authorized",
+          targetType: "sandbox_group",
+          targetId: input.sandboxGroupId,
+          metadata,
+        },
+        "metadata",
+        "metadataCodecVersion",
+      ),
+    );
+    await tx.execute(sql`update sandbox_leases set resume_state = jsonb_set(coalesce(resume_state, '{}'::jsonb),
+      '{opengeniHistoricalArchiveRecoveryId}', ${JSON.stringify(input.operationId)}::jsonb), updated_at = now()
+      where id = ${row.id}`);
+    return { authorized: true };
+  });
+}
+
+async function authorizedHistoricalArchiveGeneration(
+  db: Database,
+  row: LeaseRow,
+): Promise<number | null> {
+  const operationId = row.resume_state?.opengeniHistoricalArchiveRecoveryId;
+  if (
+    typeof operationId !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(operationId)
+  )
+    return null;
+  const [receipt] = await db
+    .select({ metadata: schema.auditEvents.metadata })
+    .from(schema.auditEvents)
+    .where(
+      and(
+        eq(schema.auditEvents.id, operationId),
+        eq(schema.auditEvents.accountId, row.account_id),
+        eq(schema.auditEvents.workspaceId, row.workspace_id),
+        eq(schema.auditEvents.targetId, row.sandbox_group_id),
+        eq(schema.auditEvents.action, "sandbox.historical_checkpoint_recovery.authorized"),
+      ),
+    );
+  const metadata = receipt?.metadata;
+  const archiveGeneration = row.archive_generation === null ? null : Number(row.archive_generation);
+  return metadata?.version === 1 &&
+    metadata.acceptedHistoricalCheckpoint === true &&
+    metadata.leaseId === row.id &&
+    metadata.leaseEpoch === Number(row.lease_epoch) &&
+    metadata.workspaceGeneration === Number(row.workspace_generation) &&
+    metadata.archiveGeneration === archiveGeneration &&
+    archiveGeneration !== null &&
+    archiveGeneration < Number(row.workspace_generation) &&
+    metadata.selectedRevision === recoveryStateFromLeaseRow(row).archive.current?.revision
+    ? archiveGeneration
+    : null;
+}
+
 /** Records the single cold->warming winner's exact restore attempt. The lease
  * election remains the sole spawner guard; this adds durable selected-revision
  * and progress truth under the same epoch. */
@@ -44166,7 +44308,9 @@ export async function beginSandboxRematerialization(
             importedArchiveGeneration = true;
           }
         }
-        const archiveComplete = hasCompleteWorkspaceArchive(workingRow);
+        const historicalGeneration = await authorizedHistoricalArchiveGeneration(tx, workingRow);
+        const archiveComplete =
+          hasCompleteWorkspaceArchive(workingRow) || historicalGeneration !== null;
         if (
           current.archive.status !== "available" ||
           !current.archive.current ||
@@ -44282,7 +44426,7 @@ export async function beginSandboxRematerialization(
             ((artifact.provenance === "native_capture" &&
               artifact.source_workspace_generation !== null &&
               Number(artifact.source_workspace_generation) ===
-                Number(workingRow.workspace_generation)) ||
+                (historicalGeneration ?? Number(workingRow.workspace_generation))) ||
               (artifact.provenance === "legacy_provider_adopted" &&
                 artifact.source_workspace_generation === null)) &&
             artifact.provider_backend === workingRow.backend &&
@@ -44767,7 +44911,11 @@ export async function commitWarmingToWarm(
             reason: "archive_revision_mismatch" as const,
           };
         }
-        if (rematerialization && !hasCompleteWorkspaceArchive(row)) {
+        if (
+          rematerialization &&
+          !hasCompleteWorkspaceArchive(row) &&
+          (await authorizedHistoricalArchiveGeneration(tx, row)) === null
+        ) {
           return {
             committed: false,
             lease: mapLeaseRow(row),

--- a/scripts/operator/historical-checkpoint-recovery.ts
+++ b/scripts/operator/historical-checkpoint-recovery.ts
@@ -1,0 +1,76 @@
+import { dbSearchPath, getSettings } from "@opengeni/config";
+import {
+  authorizeHistoricalSandboxCheckpointRecovery,
+  createDb,
+  readSandboxLeaseReaperHoldTarget,
+} from "@opengeni/db";
+import { z } from "zod";
+
+const scopeSchema = z.object({
+  accountId: z.uuid(),
+  workspaceId: z.uuid(),
+  sandboxGroupId: z.uuid(),
+});
+const authorizationSchema = scopeSchema.extend({
+  expectedEpoch: z.number().int().nonnegative(),
+  expectedWorkspaceGeneration: z.number().int().nonnegative(),
+  expectedArchiveGeneration: z.number().int().nonnegative(),
+  selectedRevision: z.string().min(1),
+  operationId: z.uuid(),
+  subjectId: z.string().trim().min(1),
+  reason: z.string().trim().min(1).max(2000),
+  acceptHistoricalCheckpoint: z.literal(true),
+});
+
+async function main(): Promise<void> {
+  const [mode, path] = process.argv.slice(2);
+  if ((mode !== "preview" && mode !== "authorize") || !path) {
+    throw new Error(
+      "Usage: bun scripts/operator/historical-checkpoint-recovery.ts preview|authorize <private-input.json>",
+    );
+  }
+  const raw: unknown = await Bun.file(path).json();
+  const scope = scopeSchema.parse(raw);
+  const settings = getSettings();
+  const searchPath = dbSearchPath(settings);
+  const client = createDb(settings.databaseUrl, {
+    ...(searchPath ? { searchPath } : {}),
+    rlsStrategy: settings.rlsStrategy,
+    max: 1,
+  });
+  try {
+    if (mode === "authorize") {
+      const result = await authorizeHistoricalSandboxCheckpointRecovery(
+        client.db,
+        authorizationSchema.parse(raw),
+      );
+      console.log(JSON.stringify(result));
+      if (!result.authorized) process.exitCode = 2;
+      return;
+    }
+    const lease = await readSandboxLeaseReaperHoldTarget(client.db, scope);
+    console.log(
+      JSON.stringify(
+        lease
+          ? {
+              ...scope,
+              expectedEpoch: lease.leaseEpoch,
+              liveness: lease.liveness,
+              expectedWorkspaceGeneration: lease.workspaceGeneration,
+              expectedArchiveGeneration: lease.archiveGeneration,
+              selectedRevision: lease.recovery.archive.current?.revision ?? null,
+              restoreStatus: lease.recovery.restore.status,
+            }
+          : { found: false },
+      ),
+    );
+  } finally {
+    await client.close();
+  }
+}
+
+if (import.meta.main)
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
Cold sandboxes whose provider is gone can retain a verified checkpoint older than their last recorded write. Recovery currently blocks even when an operator explicitly accepts that historical revision.

Add an operator-only preview/authorization command and an exact scoped audit receipt consumed by the existing election and restore lifecycle. The receipt binds lease epoch, group, generations and revision; active attempts and unsettled mutations prevent authorization. Original generations, checkpoint provenance and session history remain unchanged. Only a fresh checkpoint closes the recorded gap.

Validation: 58 real PostgreSQL lifecycle tests, 510 assertions; operator typecheck; independent lifecycle review. Includes tar/native restoration, fresh checkpoint, stale epoch/generation/revision and wrong-group rejection, and native provenance constraints.

Stacked on #2363; retarget to main after that merge. No deployment performed by this PR.

## Summary by Sourcery

Enable explicitly audited recovery from exact historical sandbox checkpoints without rewriting unavailable writes or checkpoint history.

New Features:
- Add an operator-only preview and authorization workflow for recovering cold sandboxes from exact historical checkpoints.

Bug Fixes:
- Allow verified historical checkpoints to pass lease election and restore lifecycle checks when an exact audited authorization is present.

Enhancements:
- Bind recovery authorization to the lease epoch, workspace and archive generations, sandbox group, and selected revision while preserving generation gaps and checkpoint provenance.
- Require quiescent attempts, no active holders, and no unsettled mutations before authorization, with stale or altered receipts rejected by existing lifecycle validation.

Documentation:
- Document the audited historical checkpoint recovery workflow, its safety constraints, and its generation-gap semantics.

Tests:
- Add PostgreSQL lifecycle coverage for tar and native checkpoint recovery, receipt invalidation, provenance enforcement, restore verification, and fresh-checkpoint completion.