### PR TITLE
fix(runtime): preserve yielded Modal setup observers

### DIFF
--- a/.changeset/modal-setup-observer.md
+++ b/.changeset/modal-setup-observer.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Preserve the original Modal SDK observer when setup or readiness commands yield, without colliding with retained command handles or replaying commands.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1514,6 +1514,14 @@ non-retrying middleware factory: Modal 0.9.0 otherwise drops them for streaming
 and retry-disabled calls. Cancelling observation is not process-exit proof;
 the existing token/PGID cleanup fence still owns physical cancellation.
 
+SDK-internal setup/readiness commands still use their original live SDK observer
+and may yield. Their adapter-local aliases are above the admitted command range
+(1–2147483647), so a setup process cannot collide with a retained command. Only
+the same adapter can read those aliases; they cannot be bound as durable commands
+or adopted by another reader. A missing retained alias never falls back to an
+SDK process with a coincident numeric ID. Observation failure remains an error,
+not command replay or exit proof.
+
 For historical commands without that locator, the reaper reports
 `process_observation_unavailable`, retaining the exact process/admission/holder.
 After five probes it records `quarantined_process_observation_unavailable` and

--- a/packages/runtime/src/sandbox/provider-command-session.ts
+++ b/packages/runtime/src/sandbox/provider-command-session.ts
@@ -30,12 +30,13 @@ export type ProviderCommandSession = {
 };
 
 const admission = new AsyncLocalStorage<number>();
+export const MAX_PROVIDER_COMMAND_HANDLE = 2147483647;
 
 /** The alias is allocated by serialized workspace mutation admission, not by
  * an SDK instance or a process-writable counter. It remains route-scoped. */
 export function withProviderCommandHandle<T>(handle: number | undefined, fn: () => T): T {
   if (handle === undefined) return fn();
-  if (!Number.isSafeInteger(handle) || handle <= 0 || handle > 2147483647)
+  if (!Number.isSafeInteger(handle) || handle <= 0 || handle > MAX_PROVIDER_COMMAND_HANDLE)
     throw new Error("Invalid admitted provider command handle");
   return admission.run(handle, fn);
 }

--- a/packages/runtime/src/sandbox/providers/modal-command-session.ts
+++ b/packages/runtime/src/sandbox/providers/modal-command-session.ts
@@ -1,15 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { truncateOutput } from "@openai/agents-core/sandbox/internal";
 import type { ChannelASession } from "../channel-a";
-import { markTypedExecHandleLoss } from "../exec-banner";
 import { ModalProcessObservationUnavailableError } from "../errors";
+import { markTypedExecHandleLoss, parseExecResponseBanner } from "../exec-banner";
 import {
-  admittedProviderCommandHandle,
+  MAX_PROVIDER_COMMAND_HANDLE,
   type ProviderCommandOutput,
   type ProviderCommandPersistence,
   type ProviderCommandSession,
+  admittedProviderCommandHandle,
 } from "../provider-command-session";
-import { ModalCommandControl, type ModalProviderCommand } from "./modal-command-control";
+import type { ModalCommandControl, ModalProviderCommand } from "./modal-command-control";
 
 type Entry = {
   command: ModalProviderCommand;
@@ -37,10 +38,32 @@ export function installModalCommandSession(
 ): void {
   markTypedExecHandleLoss(session);
   const originalExec = session.execCommand?.bind(session);
+  const originalWrite = session.writeStdin?.bind(session);
   const cancelLegacyStart = session.cancelPendingExecCommand?.bind(session);
   const pendingStarts = new Set<AbortController>();
   const entries = new Map<number, Entry>();
+  // Current SDK setup commands are not retained/admitted commands. Give their
+  // live observer handles a disjoint, adapter-local range; never use a missing
+  // retained alias as permission to poll an unrelated SDK process with that id.
+  const setupHandles = new Map<number, number>();
+  let nextSetupHandle = MAX_PROVIDER_COMMAND_HANDLE + 1;
   const receipts = new Map<string, { handle: number; page: ProviderCommandOutput }>();
+
+  const setupPage = (raw: string, handle: number, sdkHandle: number): string => {
+    const banner = parseExecResponseBanner(raw);
+    if (banner.kind === "exited") {
+      setupHandles.delete(handle);
+      return raw;
+    }
+    if (banner.kind !== "running" || banner.sessionId !== sdkHandle)
+      throw new ModalProcessObservationUnavailableError(handle);
+    // The parser validated the unique status in the metadata header, before
+    // command-controlled Output. Replace only that first trusted status line.
+    return raw.replace(
+      /^Process running with session ID \d+(?=\r?$)/mu,
+      `Process running with session ID ${handle}`,
+    );
+  };
 
   const formatPage = (
     handle: number,
@@ -83,11 +106,17 @@ export function installModalCommandSession(
 
   session.execCommand = async (args) => {
     const handle = admittedProviderCommandHandle();
-    // SDK-internal setup/readiness commands have no mutation admission. They
-    // retain their existing foreground path and never publish durable handles.
+    // Setup/readiness may yield too. Retain only its original local observer,
+    // without publishing a durable locator or replaying its command.
     if (handle === undefined) {
       if (!originalExec) throw new Error("Modal command requires mutation admission");
-      return originalExec(args);
+      if (!Number.isSafeInteger(nextSetupHandle)) throw new Error("Modal setup handles exhausted");
+      const setupHandle = nextSetupHandle++;
+      const raw = await originalExec(args);
+      const banner = parseExecResponseBanner(raw);
+      if (banner.kind !== "running") return raw;
+      setupHandles.set(setupHandle, banner.sessionId);
+      return setupPage(raw, setupHandle, banner.sessionId);
     }
     if (entries.has(handle)) throw new Error("Modal command handle is already bound");
     const cancellation = new AbortController();
@@ -106,7 +135,11 @@ export function installModalCommandSession(
       } catch {
         // Start succeeded. A failed/cancelled first observation must still
         // publish the known locator for durable retention and exact cleanup.
-        return formatPage(handle, { command: entry.command, chunks: [], exitCode: null });
+        return formatPage(handle, {
+          command: entry.command,
+          chunks: [],
+          exitCode: null,
+        });
       }
     } finally {
       pendingStarts.delete(cancellation);
@@ -128,7 +161,7 @@ export function installModalCommandSession(
     return entry ? structuredClone(entry.command) : null;
   };
   session.bindProviderCommand = (handle, command, persistence) => {
-    if (!Number.isSafeInteger(handle) || handle <= 0)
+    if (!Number.isSafeInteger(handle) || handle <= 0 || handle > MAX_PROVIDER_COMMAND_HANDLE)
       throw new Error("Invalid retained Modal command handle");
     const existing = entries.get(handle);
     if (existing && !sameExecution(existing.command, command))
@@ -150,6 +183,11 @@ export function installModalCommandSession(
     receipts.delete(result);
   };
   session.writeStdin = async (args) => {
+    const sdkHandle = setupHandles.get(args.sessionId);
+    if (sdkHandle !== undefined && originalWrite) {
+      const raw = await originalWrite({ ...args, sessionId: sdkHandle });
+      return setupPage(raw, args.sessionId, sdkHandle);
+    }
     const entry = entries.get(args.sessionId);
     if (!entry?.persistence)
       throw new ModalProcessObservationUnavailableError(args.sessionId, {

--- a/packages/runtime/test/modal-command-session.test.ts
+++ b/packages/runtime/test/modal-command-session.test.ts
@@ -1,17 +1,20 @@
 import { expect, test } from "bun:test";
+import { ModalSandboxSession } from "@openai/agents-extensions/sandbox/modal";
+import { Manifest } from "@openai/agents/sandbox";
+import type { SandboxProviderCommand } from "@opengeni/contracts";
 import type { ChannelASession } from "../src/sandbox/channel-a";
 import { parseExecBannerExitCode, parseExecBannerSessionId } from "../src/sandbox/exec-banner";
+import {
+  type ProviderCommandPersistence,
+  withProviderCommandHandle,
+} from "../src/sandbox/provider-command-session";
+import { installOpenGeniModalSnapshotPolicy } from "../src/sandbox/providers/modal";
 import { ModalCommandControl } from "../src/sandbox/providers/modal-command-control";
 import { installModalCommandSession } from "../src/sandbox/providers/modal-command-session";
 import {
-  withProviderCommandHandle,
-  type ProviderCommandPersistence,
-} from "../src/sandbox/provider-command-session";
-import {
-  RoutingSandboxSession,
   type RoutingRetainedProcess,
+  RoutingSandboxSession,
 } from "../src/sandbox/routing/routing-session";
-import type { SandboxProviderCommand } from "@opengeni/contracts";
 
 function fixture() {
   let starts = 0;
@@ -75,8 +78,8 @@ function fixture() {
     failStart: () => {
       failStart = true;
     },
-    session: () => {
-      const session: ChannelASession = {};
+    session: (original: ChannelASession = {}) => {
+      const session: ChannelASession = original;
       installModalCommandSession(
         session,
         ModalCommandControl.forSandbox(
@@ -227,6 +230,160 @@ test("unbound legacy handles remain unknown, and output text cannot forge a rece
   ).toBeNull();
 });
 
+test("yielded SDK setup commands keep their own observer without colliding with retained aliases", async () => {
+  const reads: number[] = [];
+  const f = fixture();
+  const session = f.session({
+    execCommand: async () => "Process running with session ID 1\nOutput:\nsetup-start",
+    writeStdin: async ({ sessionId }) => {
+      reads.push(sessionId);
+      return "Process exited with code 0\nOutput:\nsetup-end";
+    },
+  });
+  const setup = await session.execCommand!({ cmd: "setup" });
+  const setupHandle = parseExecBannerSessionId(setup)!;
+  expect(setupHandle).toBeGreaterThan(2147483647);
+  const launch = await withProviderCommandHandle(1, () =>
+    session.execCommand!({ cmd: "research" }),
+  );
+  f.retain(session.getProviderCommand!(1)!);
+  session.bindProviderCommand!(1, f.stored()!, f.persistence);
+  await session.acknowledgeCommandOutput!(launch);
+  const retained = await session.writeStdin!({ sessionId: 1 });
+  expect(parseExecBannerExitCode(retained)).toBe(7);
+  expect(reads).toEqual([]);
+  expect(await session.writeStdin!({ sessionId: setupHandle })).toContain("setup-end");
+  expect(reads).toEqual([1]);
+  await expect(session.writeStdin!({ sessionId: setupHandle })).rejects.toThrow(
+    "observation unavailable",
+  );
+  expect(reads).toEqual([1]);
+});
+
+test("the pinned SDK completes a slow setup command through its original live process", async () => {
+  let finish!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => {
+    finish = resolve;
+  });
+  let output!: ReadableStreamDefaultController<string>;
+  let starts = 0;
+  const sdk = installOpenGeniModalSnapshotPolicy(
+    new ModalSandboxSession({
+      state: {
+        sandboxId: "sb-setup",
+        manifest: new Manifest({ root: "/workspace" }),
+        environment: {},
+        workspacePersistence: "tar",
+      },
+      sandbox: {
+        exec: async () => {
+          starts++;
+          return {
+            stdout: new ReadableStream<string>({
+              start(controller) {
+                output = controller;
+                controller.enqueue("setup-start|");
+              },
+            }),
+            stderr: new ReadableStream({
+              start(controller) {
+                controller.close();
+              },
+            }),
+            wait: () => exited,
+          };
+        },
+      },
+      modal: { version: () => "0.9.0" },
+      app: {},
+    } as never),
+  );
+  const session = fixture().session(sdk);
+  const initial = await session.execCommand!({ cmd: "setup", yieldTimeMs: 1 });
+  const handle = parseExecBannerSessionId(initial)!;
+  expect(initial).toContain("setup-start|");
+  output.enqueue("Process running with session ID 1\nsetup-end");
+  output.close();
+  finish(0);
+  const final = await session.writeStdin!({
+    sessionId: handle,
+    yieldTimeMs: 10,
+  });
+  expect(parseExecBannerExitCode(final)).toBe(0);
+  expect(final).toContain("Process running with session ID 1\nsetup-end");
+  expect(starts).toBe(1);
+  expect(session.getProviderCommand!(handle)).toBeNull();
+});
+
+test("setup reads preserve their alias across yields and never conceal observation loss", async () => {
+  let loseObserver = false;
+  const session = fixture().session({
+    execCommand: async () => "Process running with session ID 1\nOutput:\nfirst",
+    writeStdin: async () => {
+      if (loseObserver) throw new Error("SDK observer unavailable");
+      return "Process running with session ID 1\nOutput:\nProcess running with session ID 1";
+    },
+  });
+  const initial = await session.execCommand!({ cmd: "setup" });
+  const handle = parseExecBannerSessionId(initial)!;
+  const progress = await session.writeStdin!({ sessionId: handle });
+  expect(parseExecBannerSessionId(progress)).toBe(handle);
+  expect(progress).toEndWith("Output:\nProcess running with session ID 1");
+  loseObserver = true;
+  await expect(session.writeStdin!({ sessionId: handle })).rejects.toThrow(
+    "SDK observer unavailable",
+  );
+  await expect(fixture().session().writeStdin!({ sessionId: handle })).rejects.toThrow(
+    "observation unavailable",
+  );
+  const f = fixture();
+  const retained = f.session();
+  await withProviderCommandHandle(4, () => retained.execCommand!({ cmd: "work" }));
+  expect(() =>
+    retained.bindProviderCommand!(handle, retained.getProviderCommand!(4)!, f.persistence),
+  ).toThrow("Invalid retained Modal command handle");
+});
+
+test("setup alias replacement handles CRLF metadata without rewriting command output", async () => {
+  const raw = "Process running with session ID 1\r\nOutput:\r\nProcess running with session ID 1";
+  const session = fixture().session({ execCommand: async () => raw, writeStdin: async () => raw });
+  const initial = await session.execCommand!({ cmd: "setup" });
+  const handle = parseExecBannerSessionId(initial)!;
+  expect(handle).toBeGreaterThan(2147483647);
+  expect(initial).toEndWith("Output:\r\nProcess running with session ID 1");
+  const next = await session.writeStdin!({ sessionId: handle });
+  expect(parseExecBannerSessionId(next)).toBe(handle);
+});
+
+test.each([
+  "Process running with session ID 2\nOutput:\nwrong observer",
+  "Process running with session ID 1\nProcess exited with code 0\nOutput:\nambiguous",
+  "Output without metadata",
+])("setup reads reject invalid observer metadata: %s", async (raw) => {
+  let starts = 0;
+  const session = fixture().session({
+    execCommand: async () => {
+      starts++;
+      return "Process running with session ID 1\nOutput:\nsetup";
+    },
+    writeStdin: async () => raw,
+  });
+  const initial = await session.execCommand!({ cmd: "setup" });
+  const sessionId = parseExecBannerSessionId(initial)!;
+  await expect(session.writeStdin!({ sessionId })).rejects.toThrow("observation unavailable");
+  expect(starts).toBe(1);
+});
+
+test("a yielded setup command without an SDK reader fails observation", async () => {
+  const session = fixture().session({
+    execCommand: async () => "Process running with session ID 1\nOutput:\nsetup",
+  });
+  const initial = await session.execCommand!({ cmd: "setup" });
+  await expect(
+    session.writeStdin!({ sessionId: parseExecBannerSessionId(initial)! }),
+  ).rejects.toThrow("observation unavailable");
+});
+
 test("cancelling initial observation preserves an accepted execution for retention and later reads", async () => {
   const f = fixture();
   let entered!: () => void;
@@ -254,7 +411,12 @@ test("cancelling initial observation preserves an accepted execution for retenti
       }
       yield {
         batchIndex: 1,
-        items: [{ fileDescriptor: request.fileDescriptor, messageBytes: Buffer.from("complete") }],
+        items: [
+          {
+            fileDescriptor: request.fileDescriptor,
+            messageBytes: Buffer.from("complete"),
+          },
+        ],
         exitCode: 7,
       };
     },
@@ -336,7 +498,12 @@ test("routing promotes initial locator, captures both streams, and adopts throug
   const reader = makeProxy();
   reader.adoptRetainedProcess({
     process: { ...process!, providerCommand: f.stored()! },
-    backend: { sandboxId: null, leaseEpoch: 2, providerInstanceId: "sb-test", activeEpoch: 3 },
+    backend: {
+      sandboxId: null,
+      leaseEpoch: 2,
+      providerInstanceId: "sb-test",
+      activeEpoch: 3,
+    },
   });
   await expect(reader.writeStdinForProcessRead({ sessionId: 77 })).rejects.toThrow(
     "output could not be retained",

--- a/packages/runtime/test/modal-setup-observation-live.test.ts
+++ b/packages/runtime/test/modal-setup-observation-live.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import { createSandboxClient } from "../src/sandbox";
+import type { ChannelASession } from "../src/sandbox/channel-a";
+import { parseExecBannerExitCode, parseExecBannerSessionId } from "../src/sandbox/exec-banner";
+
+// Opt-in: creates one isolated provider sandbox and deletes it in finally.
+test.skipIf(process.env.OPENGENI_LIVE_MODAL_SETUP !== "1")(
+  "live Modal SDK setup yields and completes without a retained-command admission",
+  async () => {
+    const client = createSandboxClient(
+      testSettings({
+        sandboxBackend: "modal",
+        modalAppName: "opengeni-setup-observation-test",
+        modalImageRef: process.env.OPENGENI_MODAL_IMAGE_REF ?? "python:3.12-slim",
+        modalTokenId: process.env.OPENGENI_MODAL_TOKEN_ID,
+        modalTokenSecret: process.env.OPENGENI_MODAL_TOKEN_SECRET,
+        modalTimeoutSeconds: 300,
+        modalIdleTimeoutSeconds: 180,
+        modalWorkspacePersistence: "tar",
+      }),
+    ) as {
+      create(): Promise<ChannelASession & { delete(): Promise<void> }>;
+    };
+    const session = await client.create();
+    try {
+      const initial = await session.execCommand!({
+        cmd: "printf 'setup-start|'; sleep 2; printf 'setup-end'; exit 7",
+        yieldTimeMs: 1,
+        maxOutputTokens: 1000,
+      });
+      const handle = parseExecBannerSessionId(initial);
+      expect(handle).toBeGreaterThan(2147483647);
+      const pages = [initial];
+      const deadline = Date.now() + 30_000;
+      while (parseExecBannerSessionId(pages[pages.length - 1]!) !== null && Date.now() < deadline) {
+        pages.push(
+          await session.writeStdin!({
+            sessionId: handle!,
+            chars: "",
+            yieldTimeMs: 1000,
+            maxOutputTokens: 1000,
+          }),
+        );
+      }
+      expect(parseExecBannerExitCode(pages[pages.length - 1]!)).toBe(7);
+      expect(pages.join("\n")).toContain("setup-start|");
+      expect(pages.join("\n")).toContain("setup-end");
+      expect(session.getProviderCommand!(handle!)).toBeNull();
+    } finally {
+      await session.delete();
+    }
+  },
+  180_000,
+);


### PR DESCRIPTION
When an SDK-internal Modal setup/readiness command yields, the retained-command adapter rejects its original SDK handle before inference. Preserve that live observer under an adapter-local alias above the admitted handle range. Retained commands still require protected persistence; missing observers never authorize replay or exit.

Applies the patch supplied in #2361, adds malformed-metadata and missing-reader regression coverage, and includes a runtime patch changeset.

Validation: reproduced the pinned-SDK regression on unpatched main; 41 focused tests pass, with the opt-in live Modal test skipped. Oxlint and all 32 project typechecks pass. Full `bun run check` passed all 32 project typechecks, then hit five archive-rematerialization test failures because the required Docker image `opengeni-sandbox:local` is absent. Stopped the broad run there; remaining tests/builds and live Modal verification are unverified.

Closes #2361.

## Summary by Sourcery

Preserve yielded Modal setup and readiness observers without allowing them to collide with or authorize retained command replay.

Bug Fixes:
- Preserve live Modal SDK observers when setup or readiness commands yield, preventing retained-command handle rejection from breaking subsequent observation.
- Reject malformed or mismatched setup observer metadata instead of replaying commands or treating missing observation as process completion.

Enhancements:
- Separate adapter-local setup observer aliases from the admitted retained-command handle range and keep them inaccessible to other readers or durable retention.

Documentation:
- Document Modal setup observer aliases, isolation, persistence requirements, and observation-failure behavior.

Tests:
- Add regression coverage for yielded setup observers, alias collisions, missing readers, malformed metadata, CRLF output, and pinned SDK behavior.
- Add an opt-in live Modal setup observation test.

Chores:
- Add a runtime patch changeset for preserving Modal setup observers.