### PR TITLE
fix(ci): validate deployment artifacts for every canary image source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1140,7 +1140,9 @@ jobs:
   deployment:
     name: Deployment artifacts
     needs: [automation-admission, plan]
-    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    # Every image-producing source needs the deployment receipt, including a
+    # docs-only main push. Staging validates it before importing these images.
+    if: ${{ !cancelled() && needs.plan.result == 'success' && (needs.plan.outputs.mode != 'docs' || needs.plan.outputs.bake_images == 'true') && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3790,7 +3790,7 @@ describe("workflow contracts", () => {
     );
     expect(release.on.schedule).toBeUndefined();
     expect(ci.jobs.deployment.if).toBe(
-      "${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+      "${{ !cancelled() && needs.plan.result == 'success' && (needs.plan.outputs.mode != 'docs' || needs.plan.outputs.bake_images == 'true') && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
     );
     expect(ci.jobs.images.if).toBe(
       "${{ always() && needs.plan.result == 'success' && needs.plan.outputs.bake_images == 'true' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "path": ".github/workflows/ci.yml",
-      "sha256": "afd23a7746413d42c4c87aca8c8a628ff4bdf1a44a7eed5f10907694882ba68a"
+      "sha256": "9bbb2a039087284319c8b9635376ae62830eb767e5d70051cd5f45eb0b74e4b0"
     },
     {
       "path": ".github/workflows/desktop-e2e.yml",


### PR DESCRIPTION
A documentation-only main push bakes staging images but skips Deployment artifacts. The staging deployment gate requires that successful job, so such a source cannot deploy.

Run deployment validation whenever the plan bakes images, retaining cancellation, plan, and trusted-dispatch guards. Documentation-only PRs still skip it; no deployment gate is weakened.

Validation: 116 release automation and image-workflow contract tests pass (1,488 assertions); independent review passed. Tracks OPE-470.

## Summary by Sourcery

Validate deployment artifacts for every workflow source that bakes images while continuing to skip validation for documentation-only runs without images.

Bug Fixes:
- Run deployment artifact validation for documentation-only sources that also produce images, ensuring those images can pass staging deployment gates.

CI:
- Update the deployment workflow contract and execution graph manifest to cover image-producing documentation-only runs while preserving cancellation, planning, and trusted-dispatch checks.

Tests:
- Update workflow contract expectations for the expanded deployment validation condition.