### PR TITLE
fix(ci): isolate unrelated Chrome feed during Playwright install

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -113,7 +113,8 @@ runs:
           # `|| status=$?` guard the first failing attempt aborts the script,
           # so the retry, the warnings, and the error summary never run.
           status=0
-          timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s" \
+          bash "${GITHUB_ACTION_PATH}/with-google-feed-isolated.sh" /etc/apt/sources.list.d \
+            timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s" \
             bun x playwright install --with-deps ${only_shell} ${PLAYWRIGHT_BROWSERS} || status=$?
           echo "::endgroup::"
           if [ "${status}" -eq 0 ]; then

--- a/.github/actions/playwright-browsers/with-google-feed-isolated.sh
+++ b/.github/actions/playwright-browsers/with-google-feed-isolated.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Playwright downloads its own pinned browsers. Its Ubuntu dependencies do not
+# require the runner's preinstalled Google Chrome APT feed, which can be briefly
+# inconsistent during publication. Keep all remaining feeds and integrity checks.
+set -euo pipefail
+source_dir="$1"
+shift
+backup_dir="$(mktemp -d)"
+declare -a saved=()
+move_file() {
+  if [[ -w "$(dirname "$1")" && -w "$(dirname "$2")" ]]; then
+    mv -- "$1" "$2"
+  else
+    sudo mv -- "$1" "$2"
+  fi
+}
+restore() {
+  local file
+  for file in "${saved[@]}"; do
+    [[ -e "$backup_dir/$file" ]] || continue
+    if [[ -e "$source_dir/$file" ]]; then
+      echo "Refusing to overwrite changed APT source: $source_dir/$file" >&2
+      return 1
+    fi
+    move_file "$backup_dir/$file" "$source_dir/$file" || return 1
+  done
+  rmdir "$backup_dir"
+}
+trap 'status=$?; restore || exit 1; exit "$status"' EXIT
+trap 'exit 143' TERM
+trap 'exit 130' INT
+for source in "$source_dir"/*.list "$source_dir"/*.sources; do
+  [[ -f "$source" && ! -L "$source" ]] || continue
+  active="$(sed '/^[[:space:]]*#/d' "$source")"
+  google='https?://dl\.google\.com/linux/chrome(-stable)?/deb/?'
+  if ! grep -Eq "$google([[:space:]]|$)" <<<"$active"; then continue; fi
+  # Parse repository fields, including non-HTTP transports. Never hide a mixed file.
+  if [[ "$source" == *.list ]]; then
+    urls="$(sed -E '/^[[:space:]]*$/d; s|^[[:space:]]*deb(-src)?[[:space:]]+(\[[^]]*\][[:space:]]+)?([^[:space:]]+).*|\3|' <<<"$active")"
+  else
+    urls="$(awk '
+      /^[[:space:]]*$/ { in_uris=0; next }
+      /^[^[:space:]]/ {
+        in_uris=(tolower($1)=="uris:")
+        if (in_uris) for (i=2; i<=NF; i++) print $i
+        next
+      }
+      in_uris { for (i=1; i<=NF; i++) print $i }
+    ' <<<"$active")"
+  fi
+  if grep -Evq "^$google$" <<<"$urls"; then
+    echo "Cannot isolate Google Chrome feed from mixed APT source: $source" >&2
+    exit 1
+  fi
+  name="$(basename "$source")"
+  saved+=("$name")
+  move_file "$source" "$backup_dir/$name"
+done
+"$@"

--- a/scripts/playwright-apt-feed-isolation.test.ts
+++ b/scripts/playwright-apt-feed-isolation.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(
+	new URL(
+		"../.github/actions/playwright-browsers/with-google-feed-isolated.sh",
+		import.meta.url,
+	),
+);
+
+test("runs normally when no Google feed is installed", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+	try {
+		await Bun.write(
+			join(dir, "ubuntu.sources"),
+			"URIs: https://archive.ubuntu.com/ubuntu\n",
+		);
+		const child = Bun.spawn(["bash", script, dir, "true"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(await child.exited).toBe(0);
+		expect(await Bun.file(join(dir, "ubuntu.sources")).exists()).toBe(true);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test.each([
+	[
+		"list",
+		"deb [arch=amd64] https://dl.google.com/linux/chrome-stable/deb/ stable main\n",
+	],
+	[
+		"sources",
+		"Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\nSuites: stable\nComponents: main\nSigned-By: /usr/share/keyrings/google.gpg\n",
+	],
+])(
+	"isolates %s Google feed and restores exact bytes after command failure",
+	async (extension, contents) => {
+		const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+		const name = `google-chrome.${extension}`;
+		try {
+			await Bun.write(join(dir, name), contents);
+			await Bun.write(
+				join(dir, "ubuntu.sources"),
+				"URIs: https://archive.ubuntu.com/ubuntu\n",
+			);
+			const child = Bun.spawn(
+				[
+					"bash",
+					script,
+					dir,
+					"bash",
+					"-c",
+					'test ! -e "$1/$2" && test -f "$1/ubuntu.sources" || exit 99; exit 7',
+					"check",
+					dir,
+					name,
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			expect(await child.exited).toBe(7);
+			expect(await Bun.file(join(dir, name)).text()).toBe(contents);
+			expect(await Bun.file(join(dir, "ubuntu.sources")).text()).toBe(
+				"URIs: https://archive.ubuntu.com/ubuntu\n",
+			);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test("refuses mixed Google and Ubuntu sources without hiding either feed", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+	const contents =
+		"deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb https://archive.ubuntu.com/ubuntu noble main\n";
+	try {
+		await Bun.write(join(dir, "mixed.list"), contents);
+		const child = Bun.spawn(
+			["bash", script, dir, "touch", join(dir, "command-ran")],
+			{ stdout: "pipe", stderr: "pipe" },
+		);
+		expect(await child.exited).toBe(1);
+		expect(await Bun.file(join(dir, "mixed.list")).text()).toBe(contents);
+		expect(await Bun.file(join(dir, "command-ran")).exists()).toBe(false);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test.each([
+  ["list", "deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb file:/srv/packages stable main\n"],
+  ["sources", "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/ file:/srv/packages\nSuites: stable\n"],
+  ["sources", "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\n ftp://example.org/packages\nSuites: stable\n"],
+])("preserves mixed non-HTTP %s repositories", async (extension, contents) => {
+  const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+  const path = join(dir, `mixed.${extension}`);
+  try {
+    await Bun.write(path, contents);
+    const child = Bun.spawn(["bash", script, dir, "touch", join(dir, "command-ran")], { stdout: "pipe", stderr: "pipe" });
+    expect(await child.exited).toBe(1);
+    expect(await Bun.file(path).text()).toBe(contents);
+    expect(await Bun.file(join(dir, "command-ran")).exists()).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/playwright-apt-feed-isolation.test.ts
+++ b/scripts/playwright-apt-feed-isolation.test.ts
@@ -5,103 +5,103 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const script = fileURLToPath(
-	new URL(
-		"../.github/actions/playwright-browsers/with-google-feed-isolated.sh",
-		import.meta.url,
-	),
+  new URL("../.github/actions/playwright-browsers/with-google-feed-isolated.sh", import.meta.url),
 );
 
 test("runs normally when no Google feed is installed", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
-	try {
-		await Bun.write(
-			join(dir, "ubuntu.sources"),
-			"URIs: https://archive.ubuntu.com/ubuntu\n",
-		);
-		const child = Bun.spawn(["bash", script, dir, "true"], {
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		expect(await child.exited).toBe(0);
-		expect(await Bun.file(join(dir, "ubuntu.sources")).exists()).toBe(true);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
+  const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+  try {
+    await Bun.write(join(dir, "ubuntu.sources"), "URIs: https://archive.ubuntu.com/ubuntu\n");
+    const child = Bun.spawn(["bash", script, dir, "true"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await child.exited).toBe(0);
+    expect(await Bun.file(join(dir, "ubuntu.sources")).exists()).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test.each([
-	[
-		"list",
-		"deb [arch=amd64] https://dl.google.com/linux/chrome-stable/deb/ stable main\n",
-	],
-	[
-		"sources",
-		"Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\nSuites: stable\nComponents: main\nSigned-By: /usr/share/keyrings/google.gpg\n",
-	],
+  ["list", "deb [arch=amd64] https://dl.google.com/linux/chrome-stable/deb/ stable main\n"],
+  [
+    "sources",
+    "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\nSuites: stable\nComponents: main\nSigned-By: /usr/share/keyrings/google.gpg\n",
+  ],
 ])(
-	"isolates %s Google feed and restores exact bytes after command failure",
-	async (extension, contents) => {
-		const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
-		const name = `google-chrome.${extension}`;
-		try {
-			await Bun.write(join(dir, name), contents);
-			await Bun.write(
-				join(dir, "ubuntu.sources"),
-				"URIs: https://archive.ubuntu.com/ubuntu\n",
-			);
-			const child = Bun.spawn(
-				[
-					"bash",
-					script,
-					dir,
-					"bash",
-					"-c",
-					'test ! -e "$1/$2" && test -f "$1/ubuntu.sources" || exit 99; exit 7',
-					"check",
-					dir,
-					name,
-				],
-				{ stdout: "pipe", stderr: "pipe" },
-			);
-			expect(await child.exited).toBe(7);
-			expect(await Bun.file(join(dir, name)).text()).toBe(contents);
-			expect(await Bun.file(join(dir, "ubuntu.sources")).text()).toBe(
-				"URIs: https://archive.ubuntu.com/ubuntu\n",
-			);
-		} finally {
-			await rm(dir, { recursive: true, force: true });
-		}
-	},
+  "isolates %s Google feed and restores exact bytes after command failure",
+  async (extension, contents) => {
+    const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+    const name = `google-chrome.${extension}`;
+    try {
+      await Bun.write(join(dir, name), contents);
+      await Bun.write(join(dir, "ubuntu.sources"), "URIs: https://archive.ubuntu.com/ubuntu\n");
+      const child = Bun.spawn(
+        [
+          "bash",
+          script,
+          dir,
+          "bash",
+          "-c",
+          'test ! -e "$1/$2" && test -f "$1/ubuntu.sources" || exit 99; exit 7',
+          "check",
+          dir,
+          name,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      expect(await child.exited).toBe(7);
+      expect(await Bun.file(join(dir, name)).text()).toBe(contents);
+      expect(await Bun.file(join(dir, "ubuntu.sources")).text()).toBe(
+        "URIs: https://archive.ubuntu.com/ubuntu\n",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
 );
 
 test("refuses mixed Google and Ubuntu sources without hiding either feed", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
-	const contents =
-		"deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb https://archive.ubuntu.com/ubuntu noble main\n";
-	try {
-		await Bun.write(join(dir, "mixed.list"), contents);
-		const child = Bun.spawn(
-			["bash", script, dir, "touch", join(dir, "command-ran")],
-			{ stdout: "pipe", stderr: "pipe" },
-		);
-		expect(await child.exited).toBe(1);
-		expect(await Bun.file(join(dir, "mixed.list")).text()).toBe(contents);
-		expect(await Bun.file(join(dir, "command-ran")).exists()).toBe(false);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
+  const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
+  const contents =
+    "deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb https://archive.ubuntu.com/ubuntu noble main\n";
+  try {
+    await Bun.write(join(dir, "mixed.list"), contents);
+    const child = Bun.spawn(["bash", script, dir, "touch", join(dir, "command-ran")], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await child.exited).toBe(1);
+    expect(await Bun.file(join(dir, "mixed.list")).text()).toBe(contents);
+    expect(await Bun.file(join(dir, "command-ran")).exists()).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test.each([
-  ["list", "deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb file:/srv/packages stable main\n"],
-  ["sources", "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/ file:/srv/packages\nSuites: stable\n"],
-  ["sources", "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\n ftp://example.org/packages\nSuites: stable\n"],
+  [
+    "list",
+    "deb https://dl.google.com/linux/chrome/deb/ stable main\ndeb file:/srv/packages stable main\n",
+  ],
+  [
+    "sources",
+    "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/ file:/srv/packages\nSuites: stable\n",
+  ],
+  [
+    "sources",
+    "Types: deb\nURIs: https://dl.google.com/linux/chrome/deb/\n ftp://example.org/packages\nSuites: stable\n",
+  ],
 ])("preserves mixed non-HTTP %s repositories", async (extension, contents) => {
   const dir = await mkdtemp(join(tmpdir(), "playwright-apt-"));
   const path = join(dir, `mixed.${extension}`);
   try {
     await Bun.write(path, contents);
-    const child = Bun.spawn(["bash", script, dir, "touch", join(dir, "command-ran")], { stdout: "pipe", stderr: "pipe" });
+    const child = Bun.spawn(["bash", script, dir, "touch", join(dir, "command-ran")], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     expect(await child.exited).toBe(1);
     expect(await Bun.file(path).text()).toBe(contents);
     expect(await Bun.file(join(dir, "command-ran")).exists()).toBe(false);

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "path": ".github/workflows/ci.yml",
-      "sha256": "9bbb2a039087284319c8b9635376ae62830eb767e5d70051cd5f45eb0b74e4b0"
+      "sha256": "48306f2de7541ff832408f5456a9a53154d0f7e9ae22c83413a0df0338ccff61"
     },
     {
       "path": ".github/workflows/desktop-e2e.yml",
@@ -92,7 +92,7 @@
   "actions": [
     {
       "path": ".github/actions/playwright-browsers/action.yml",
-      "sha256": "1d1865cf748e6cfa686eb69216057d6aa02037549f4728ae05a63828397942c7"
+      "sha256": "9d45ee63274f0097cc5736496674f03d4fadf0dc4ea0278189a2787e54c1f0b3"
     },
     {
       "path": ".github/actions/public-oci-login/action.yml",

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -215,6 +215,7 @@ describe("workflow timeout contract", () => {
       const proc = Bun.spawn(["bash", "--noprofile", "--norc", "-eo", "pipefail", scriptPath], {
         env: {
           ...process.env,
+          GITHUB_ACTION_PATH: resolve(root, ".github/actions/playwright-browsers"),
           PATH: `${binDir}:${process.env.PATH ?? ""}`,
           PLAYWRIGHT_BROWSERS: "chromium",
           PLAYWRIGHT_ONLY_SHELL: "false",


### PR DESCRIPTION
Google Chrome's APT feed currently returns inconsistent package checksums, blocking Playwright dependency installation across nine CI lanes before tests start. Temporarily isolate Chrome-only source files during the existing bounded installation command and restore their exact contents afterward. Ubuntu sources and signature/hash verification remain enabled; mixed repository files fail closed, including non-HTTP transports.

Validation: 10 installation/timeout tests (70 assertions), 29 workflow graph tests (682 assertions), workflow manifest verification, and independent review passed.

## Summary by Sourcery

Isolate the Google Chrome APT feed during Playwright dependency installation to improve CI reliability without weakening Ubuntu repository validation.

Bug Fixes:
- Prevent intermittent Google Chrome APT feed inconsistencies from blocking Playwright dependency installation in CI.

Enhancements:
- Safely isolate Chrome-only APT sources during installation while preserving other repositories, integrity checks, and original source contents.

CI:
- Integrate bounded Playwright dependency installation with Chrome feed isolation across CI workflows.

Tests:
- Add coverage for source isolation, exact restoration after failures, mixed repositories, and non-HTTP transport handling.