### PR TITLE
fix(runtime): follow restored Modal sandbox for admitted commands

### DIFF
--- a/packages/runtime/src/sandbox/providers/modal-command-control.ts
+++ b/packages/runtime/src/sandbox/providers/modal-command-control.ts
@@ -117,14 +117,14 @@ function decodePage(prior: string, input: Uint8Array[], terminal: boolean) {
 export class ModalCommandControl {
   private constructor(
     private readonly client: ControlPlane,
-    private readonly sandboxId: string,
+    private readonly sandboxIdentity: string | (() => string),
     private readonly root: string,
     private readonly environment: Record<string, string> | (() => Record<string, string>) = {},
   ) {}
 
   static forSandbox(
     client: CommandClient,
-    sandboxId: string,
+    sandboxId: string | (() => string),
     root: string,
     environment: Record<string, string> | (() => Record<string, string>) = {},
   ): ModalCommandControl {
@@ -133,16 +133,24 @@ export class ModalCommandControl {
     return new ModalCommandControl(commandControlPlane(client), sandboxId, root, environment);
   }
 
+  private get sandboxId(): string {
+    return typeof this.sandboxIdentity === "function"
+      ? this.sandboxIdentity()
+      : this.sandboxIdentity;
+  }
+
   async start(args: ChannelAExecArgs, signal?: AbortSignal): Promise<ModalProviderCommand> {
     signal?.throwIfAborted();
     const workdir = posix.resolve(this.root, args.workdir ?? this.root);
     if (workdir !== this.root && !workdir.startsWith(`${this.root.replace(/\/$/u, "")}/`))
       throw new Error("Command workdir is outside the sandbox workspace");
-    const task = await this.client.sandboxGetTaskId(
-      { sandboxId: this.sandboxId },
-      signal ? { signal } : undefined,
-    );
+    // Hydration replaces the SDK sandbox. Freeze its current identity for this
+    // start so an asynchronous replacement cannot relabel the returned locator.
+    const sandboxId = this.sandboxId;
+    const task = await this.client.sandboxGetTaskId({ sandboxId }, signal ? { signal } : undefined);
     if (!task.taskId || task.taskResult) throw new Error("Modal command task is unavailable");
+    if (sandboxId !== this.sandboxId)
+      throw new Error("Modal sandbox changed during command preparation");
     const login = args.shell ? (args.login ?? true) : false;
     let command = [args.shell ?? "/bin/sh", login ? "-lc" : "-c", args.cmd];
     if (args.runAs) {
@@ -194,7 +202,7 @@ export class ModalCommandControl {
     if (!result.execId) throw new Error("Modal command start returned no execution identity");
     return {
       kind: "modal-control-v1",
-      sandboxId: this.sandboxId,
+      sandboxId,
       taskId: task.taskId,
       execId: result.execId,
       ...(args.tty ? { pty: true } : {}),

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -562,7 +562,11 @@ export function installOpenGeniModalSnapshotPolicy<T extends object>(session: T)
           profile: mutable.modal.profile,
           ...(mutable.modal.logger ? { logger: mutable.modal.logger } : {}),
         },
-        mutable.state.sandboxId,
+        () => {
+          const sandboxId = mutable.state?.sandboxId;
+          if (!sandboxId) throw new Error("Modal session sandbox identity is unavailable");
+          return sandboxId;
+        },
         mutable.state.manifest.root,
         () => mutable.state?.environment ?? {},
       ),

--- a/packages/runtime/test/modal-command-control.test.ts
+++ b/packages/runtime/test/modal-command-control.test.ts
@@ -192,10 +192,82 @@ test("start disables ambiguous mutation retries and PTY idle-stdin termination",
   });
 });
 
+test("new starts follow hydration while old locators remain fenced", async () => {
+  let sandboxId = "sb-before";
+  const seen: string[] = [];
+  const control = ModalCommandControl.forSandbox(
+    {
+      version: () => "0.9.0",
+      cpClient: {
+        sandboxGetTaskId: async (request: { sandboxId: string }) => {
+          seen.push(request.sandboxId);
+          return { taskId: `ta-${request.sandboxId}` };
+        },
+        containerExec: async () => ({ execId: "tp-test" }),
+      },
+    } as never,
+    () => sandboxId,
+    "/workspace",
+  );
+  const old = await control.start({ cmd: "pwd" });
+  sandboxId = "sb-after";
+  const restored = await control.start({ cmd: "pwd" });
+  expect(seen).toEqual(["sb-before", "sb-after"]);
+  expect(restored.sandboxId).toBe("sb-after");
+  expect(restored.taskId).toBe("ta-sb-after");
+  await expect(control.read(old, 1)).rejects.toThrow("original sandbox");
+  await expect(control.write(old, "x", 1)).rejects.toThrow("original sandbox");
+});
+
 test("foreign sandbox locators never reach the provider", async () => {
   await expect(controller({}).read({ ...locator(), sandboxId: "sb-other" }, 1)).rejects.toThrow(
     "original sandbox",
   );
+});
+
+test("hydration during task lookup prevents command start", async () => {
+  let sandboxId = "sb-before";
+  let starts = 0;
+  const control = ModalCommandControl.forSandbox(
+    {
+      version: () => "0.9.0",
+      cpClient: {
+        sandboxGetTaskId: async () => {
+          sandboxId = "sb-after";
+          return { taskId: "ta-before" };
+        },
+        containerExec: async () => {
+          starts++;
+          return { execId: "tp-test" };
+        },
+      },
+    } as never,
+    () => sandboxId,
+    "/workspace",
+  );
+  await expect(control.start({ cmd: "pwd" })).rejects.toThrow("changed during command preparation");
+  expect(starts).toBe(0);
+});
+
+test("hydration during command start cannot relabel its original locator", async () => {
+  let sandboxId = "sb-before";
+  const control = ModalCommandControl.forSandbox(
+    {
+      version: () => "0.9.0",
+      cpClient: {
+        sandboxGetTaskId: async () => ({ taskId: "ta-before" }),
+        containerExec: async () => {
+          sandboxId = "sb-after";
+          return { execId: "tp-test" };
+        },
+      },
+    } as never,
+    () => sandboxId,
+    "/workspace",
+  );
+  const started = await control.start({ cmd: "pwd" });
+  expect(started).toMatchObject({ sandboxId: "sb-before", taskId: "ta-before", execId: "tp-test" });
+  await expect(control.read(started, 1)).rejects.toThrow("original sandbox");
 });
 
 test("PTY output keeps merged fidelity despite separate provider read endpoints", async () => {

--- a/packages/runtime/test/modal-restored-command-live.test.ts
+++ b/packages/runtime/test/modal-restored-command-live.test.ts
@@ -13,6 +13,12 @@ type Session = ChannelASession & {
   hydrateWorkspace(archive: Uint8Array): Promise<void>;
 };
 
+async function deleteSnapshots(modal: ModalClient, snapshots: string[]): Promise<void> {
+  const cleanup = await Promise.allSettled(snapshots.map((id) => modal.images.delete(id)));
+  const errors = cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length) throw new AggregateError(errors, "Modal snapshot cleanup failed");
+}
+
 // Real provider proof: setup and admitted commands must both survive hydration.
 // Isolated resources only; delete every sandbox and captured snapshot afterward.
 test.skipIf(process.env.OPENGENI_LIVE_MODAL_SETUP !== "1")(
@@ -95,11 +101,7 @@ test.skipIf(process.env.OPENGENI_LIVE_MODAL_SETUP !== "1")(
         if (session) await session.delete();
       } finally {
         try {
-          const cleanup = await Promise.allSettled(snapshots.map((id) => modal.images.delete(id)));
-          const errors = cleanup.flatMap((result) =>
-            result.status === "rejected" ? [result.reason] : [],
-          );
-          if (errors.length) throw new AggregateError(errors, "Modal snapshot cleanup failed");
+          await deleteSnapshots(modal, snapshots);
         } finally {
           modal.close();
         }

--- a/packages/runtime/test/modal-restored-command-live.test.ts
+++ b/packages/runtime/test/modal-restored-command-live.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { ModalClient } from "modal";
+import { decodeNativeSnapshotRef, type SandboxProviderCommand } from "@opengeni/contracts";
+import { testSettings } from "@opengeni/testing";
+import { createSandboxClient } from "../src/sandbox";
+import type { ChannelASession } from "../src/sandbox/channel-a";
+import { parseExecBannerExitCode, parseExecBannerSessionId } from "../src/sandbox/exec-banner";
+import { withProviderCommandHandle } from "../src/sandbox/provider-command-session";
+
+type Session = ChannelASession & {
+  delete(): Promise<void>;
+  persistWorkspace(options: { requestId: string }): Promise<Uint8Array>;
+  hydrateWorkspace(archive: Uint8Array): Promise<void>;
+};
+
+// Real provider proof: setup and admitted commands must both survive hydration.
+// Isolated resources only; delete every sandbox and captured snapshot afterward.
+test.skipIf(process.env.OPENGENI_LIVE_MODAL_SETUP !== "1")(
+  "two cold restores preserve workspace and both Modal command paths",
+  async () => {
+    const settings = testSettings({
+      sandboxBackend: "modal",
+      modalAppName: "opengeni-restored-command-test",
+      modalEnvironment: process.env.OPENGENI_MODAL_ENVIRONMENT,
+      modalImageRef: process.env.OPENGENI_MODAL_IMAGE_REF ?? "python:3.12-slim",
+      modalTokenId: process.env.OPENGENI_MODAL_TOKEN_ID,
+      modalTokenSecret: process.env.OPENGENI_MODAL_TOKEN_SECRET,
+      modalTimeoutSeconds: 300,
+      modalIdleTimeoutSeconds: 180,
+      modalWorkspacePersistence: "snapshot_filesystem",
+    });
+    const client = createSandboxClient(settings) as { create(): Promise<Session> };
+    const modal = new ModalClient({
+      tokenId: settings.modalTokenId,
+      tokenSecret: settings.modalTokenSecret,
+      environment: settings.modalEnvironment,
+    });
+    let session: Session | undefined;
+    const snapshots: string[] = [];
+    let nextHandle = 100;
+    const complete = async (cmd: string, admitted = false): Promise<string> => {
+      const current = session!;
+      const pages = [
+        await withProviderCommandHandle(admitted ? nextHandle++ : undefined, () =>
+          current.execCommand!({ cmd, yieldTimeMs: 1, maxOutputTokens: 1000 }),
+        ),
+      ];
+      const handle = parseExecBannerSessionId(pages[0]!);
+      expect(handle).not.toBeNull();
+      if (admitted) {
+        expect(handle).toBeLessThanOrEqual(2147483647);
+        let saved = current.getProviderCommand!(handle!)!;
+        expect(saved).not.toBeNull();
+        current.bindProviderCommand!(handle!, saved, {
+          load: async () => saved,
+          acknowledge: async (next: SandboxProviderCommand) => (saved = next),
+          reserveInput: async () => 1,
+        });
+        await current.acknowledgeCommandOutput!(pages[0]!);
+      } else expect(handle).toBeGreaterThan(2147483647);
+      const deadline = Date.now() + 30_000;
+      while (parseExecBannerSessionId(pages.at(-1)!) !== null && Date.now() < deadline) {
+        const page = await current.writeStdin!({
+          sessionId: handle!,
+          chars: "",
+          yieldTimeMs: 1000,
+        });
+        pages.push(page);
+        if (admitted) await current.acknowledgeCommandOutput!(page);
+      }
+      expect(parseExecBannerExitCode(pages.at(-1)!)).toBe(0);
+      return pages.join("\n");
+    };
+    try {
+      session = await client.create();
+      await complete(
+        "mkdir -p /workspace; printf preserved-marker > /workspace/restore-proof; sleep 2",
+      );
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const archive = await session.persistWorkspace({ requestId: crypto.randomUUID() });
+        snapshots.push(decodeNativeSnapshotRef(archive)!.snapshotId);
+        await session.delete();
+        session = undefined;
+        session = await client.create();
+        await session.hydrateWorkspace(archive);
+        expect(await complete("sleep 2; cat /workspace/restore-proof")).toContain(
+          "preserved-marker",
+        );
+        expect(await complete("sleep 2; cat /workspace/restore-proof", true)).toContain(
+          "preserved-marker",
+        );
+      }
+    } finally {
+      try {
+        if (session) await session.delete();
+      } finally {
+        try {
+          const cleanup = await Promise.allSettled(snapshots.map((id) => modal.images.delete(id)));
+          const errors = cleanup.flatMap((result) =>
+            result.status === "rejected" ? [result.reason] : [],
+          );
+          if (errors.length) throw new AggregateError(errors, "Modal snapshot cleanup failed");
+        } finally {
+          modal.close();
+        }
+      }
+    }
+  },
+  180_000,
+);


### PR DESCRIPTION
After native Modal snapshot hydration, the SDK replaces its sandbox, but admitted agent commands still targeted the pre-hydration sandbox ID. Rig setup could succeed while normal shell commands failed with `Modal command task is unavailable`.

Resolve the current sandbox identity for each new command and freeze that identity in its returned locator. Reject an identity change during task lookup; existing command locators remain fenced to their original sandbox.

Validation: reproduced the exact failure against the prior staging build; patched live Modal test passed two cold restores with both yielded setup and admitted commands, preserved workspace markers, and 21 assertions. Focused runtime tests and runtime typecheck pass. Added deterministic hydration race and foreign-locator regressions. Independent review found no production blocker.

## Summary by Sourcery

Keep Modal command execution aligned with restored sandbox identities while fencing existing locators to their originating sandbox.

Bug Fixes:
- Ensure newly started Modal commands use the current sandbox after snapshot hydration while preserving existing command locators’ original sandbox binding.
- Prevent commands from starting when the sandbox identity changes during command preparation.

Enhancements:
- Support dynamic Modal sandbox identity resolution for restored sessions.

Tests:
- Add deterministic regressions covering hydration races, restored command routing, and foreign locator rejection.
- Add an optional live Modal test validating workspace persistence and setup/admitted commands across cold restores.