### PR TITLE
test: make credential heartbeat deadline deterministic

### DIFF
--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -4408,6 +4408,8 @@ describe("Codex credential lease deadline fence", () => {
   });
 
   test("does not accept a successful heartbeat that returns after the prior deadline", async () => {
+    let now = performance.now();
+    const clock = spyOn(performance, "now").mockImplementation(() => now);
     let resolveHeartbeat!: (value: Date | null) => void;
     const heartbeat = spyOn(opengeniDb, "heartbeatCodexCredentialLeaseUntil").mockImplementation(
       () =>
@@ -4430,12 +4432,12 @@ describe("Codex credential lease deadline fence", () => {
       lease.held = true;
       lease.holderId = "holder-1";
       lease.generation = 1;
-      const priorDeadline = performance.now() + 1;
+      const priorDeadline = now + 1_000;
       lease.confirmedUntilMs = priorDeadline;
 
       const renewal = lease.renew("timer");
-      await Promise.resolve();
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      now = priorDeadline + 1;
       resolveHeartbeat(new Date());
       await renewal;
 
@@ -4444,6 +4446,7 @@ describe("Codex credential lease deadline fence", () => {
       expect(lease.confirmedUntilMs).toBe(priorDeadline);
     } finally {
       heartbeat.mockRestore();
+      clock.mockRestore();
     }
   });
 


### PR DESCRIPTION
Main CI can expire the test's one-millisecond credential lease before the mocked heartbeat begins, leaving its resolver undefined. Control the monotonic clock, assert the heartbeat started, then advance past the original deadline before returning success. The test continues to require rejection of that late success; production code is unchanged.

Validation: all217 agent-turn tests pass (823 assertions), formatting check passes, independent review passed.

## Summary by Sourcery

Make the credential heartbeat deadline-fence test deterministic without changing production behavior.

Enhancements:
- Make the credential heartbeat deadline-fence test deterministic by controlling monotonic time and verifying the heartbeat starts before advancing beyond the lease deadline.

Tests:
- Stabilize the late-heartbeat rejection test against CI timing variability while preserving its deadline-fence assertion.