### PR TITLE
fix(db): prevent HTTP 500 disconnecting used organization Codex subscriptions

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22607,6 +22607,17 @@ async function lockOrganizationCodexSubscriptionSources(
   `);
   const workspaceIds = rows.map((row: { workspace_id: string }) => row.workspace_id);
   for (const workspaceId of workspaceIds) {
+    // Credential deletion clears session pins/last-used references through FK
+    // SET NULL, including references in Personal or no-longer-inheriting
+    // workspaces. Fence the complete authorized inventory before any source,
+    // pool, or credential lock; the FK's session writes cannot acquire this
+    // prefix after taking their row locks. Keep the UUID order across both
+    // passes, matching ordinary workspace writers' tenancy -> source order.
+    await scopedDb.execute(
+      sql`select pg_advisory_xact_lock_shared(hashtextextended(${`session-tenancy:${workspaceId}`}, 0))`,
+    );
+  }
+  for (const workspaceId of workspaceIds) {
     // Organization credential mutations can change automatic routing in every
     // inheriting workspace. Acquire all workspace source locks before the
     // organization rotation row, matching normal acquisition's source -> pool

--- a/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
+++ b/packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts
@@ -182,6 +182,129 @@ describe("migration 0381 organization Codex subscription inheritance", () => {
     );
   });
 
+  test("disconnect clears used organization credentials across workspace fences atomically", async () => {
+    if (!shared || !client) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('organization-codex-disconnect') returning id`;
+    const actorSubjectId = `user:${crypto.randomUUID()}`;
+    const workspaceIds: string[] = [];
+    for (const name of ["personal", "shared", "disabled"]) {
+      const [workspace] = await shared.admin<{ id: string }[]>`
+        insert into workspaces (account_id, name) values (${account!.id}, ${name}) returning id`;
+      workspaceIds.push(workspace!.id);
+      await shared.admin`
+        insert into workspace_inference_controls (account_id, workspace_id)
+        values (${account!.id}, ${workspace!.id})`;
+    }
+    await shared.admin`
+      insert into organization_memberships (
+        account_id, subject_id, role, status, personal_workspace_id
+      ) values (${account!.id}, ${actorSubjectId}, 'owner', 'active', ${workspaceIds[0]!})`;
+    const connect = () =>
+      upsertOrganizationCodexSubscriptionCredential(client!.db, {
+        organizationId: account!.id,
+        actorSubjectId,
+        credentialEncrypted: "fixture-not-a-token",
+        chatgptAccountId: crypto.randomUUID(),
+        scopes: null,
+        planType: "pro",
+        isFedramp: false,
+        expiresAt: null,
+        lastRefreshAt: null,
+      });
+    const credential = await connect();
+    const replacement = await connect();
+    const sessionIds: string[] = [];
+    for (const workspaceId of workspaceIds) {
+      const session = await createSession(client.db, {
+        accountId: account!.id,
+        workspaceId,
+        initialMessage: "disconnect fixture",
+        resources: [],
+        tools: [],
+        metadata: {},
+        model: "codex/gpt-5",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sandboxBackend: "none",
+      });
+      sessionIds.push(session.id);
+      await shared.admin`
+        update sessions set codex_pinned_credential_id = ${credential.id},
+          codex_last_credential_id = ${credential.id}, codex_pin_source = 'manual'
+        where id = ${session.id}`;
+    }
+    // Historical references can survive a routing change. The delete must fence
+    // the whole organization inventory, not just currently inheriting sources.
+    await shared.admin.begin(async (tx) => {
+      await tx`set local session_replication_role = replica`;
+      await tx`insert into workspace_codex_subscription_preferences (account_id, workspace_id, mode)
+        values (${account!.id}, ${workspaceIds[2]!}, 'disabled')`;
+    });
+    const before = await shared.admin`
+      select id, updated_at, activity_revision, visibility, owner_subject_id, authority_epoch
+      from sessions where account_id = ${account!.id} order by id`;
+    // A non-administrator cannot acquire deletion authority through the new fences.
+    await expect(
+      disconnectOrganizationCodexAccount(client.db, {
+        organizationId: account!.id,
+        actorSubjectId: `user:${crypto.randomUUID()}`,
+        credentialId: credential.id,
+      }),
+    ).rejects.toThrow();
+    const [otherAccount] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('unrelated-codex-disconnect') returning id`;
+    const [otherCredential] = await shared.admin<{ id: string }[]>`
+      insert into codex_subscription_credentials (
+        account_id, organization_id, authority_scope, credential_encrypted, chatgpt_account_id
+      ) values (${otherAccount!.id}, ${otherAccount!.id}, 'organization',
+        'unrelated-fixture-not-a-token', ${crypto.randomUUID()}) returning id`;
+    expect(
+      await disconnectOrganizationCodexAccount(client.db, {
+        organizationId: account!.id,
+        actorSubjectId,
+        credentialId: otherCredential!.id,
+      }),
+    ).toMatchObject({ removed: false, newActiveCredentialId: credential.id });
+    expect(
+      await disconnectOrganizationCodexAccount(client.db, {
+        organizationId: account!.id,
+        actorSubjectId,
+        credentialId: credential.id,
+      }),
+    ).toMatchObject({ removed: true, newActiveCredentialId: replacement.id });
+    const references = await shared.admin`
+      select id, codex_pinned_credential_id, codex_last_credential_id
+      from sessions where account_id = ${account!.id} order by id`;
+    expect(references).toHaveLength(sessionIds.length);
+    for (const row of references) {
+      expect(row.codex_pinned_credential_id).toBeNull();
+      expect(row.codex_last_credential_id).toBeNull();
+    }
+    const after = await shared.admin`
+      select id, updated_at, activity_revision, visibility, owner_subject_id, authority_epoch
+      from sessions where account_id = ${account!.id} order by id`;
+    expect([...after]).toEqual([...before]);
+    expect(
+      await disconnectOrganizationCodexAccount(client.db, {
+        organizationId: account!.id,
+        actorSubjectId,
+        credentialId: credential.id,
+      }),
+    ).toMatchObject({ removed: false, newActiveCredentialId: replacement.id });
+    expect(
+      await disconnectOrganizationCodexAccount(client.db, {
+        organizationId: account!.id,
+        actorSubjectId,
+        credentialId: replacement.id,
+      }),
+    ).toMatchObject({ removed: true, newActiveCredentialId: null });
+    expect(
+      await shared.admin`select id from codex_subscription_credentials
+      where id = ${otherCredential!.id}`,
+    ).toHaveLength(1);
+  });
+
   test("inherits into shared and Personal workspaces and honors overrides", async () => {
     if (!shared || !app || !client) return;
     const [account] = await shared.admin<{ id: string }[]>`


### PR DESCRIPTION
## Summary

- Acquire all UUID-ordered shared session-tenancy fences for the complete authorized organization Codex workspace inventory before source, pool, or credential locks.
- Preserve organization-administrator authorization, source-change checks, live credential lease guards, active-account replacement, and transactional capacity wakes.
- Add real-database regression coverage for used credential deletion across Personal, shared, and disabled/non-inheriting workspaces, unauthorized/cross-organization deletion, repeat deletion, replacement selection, and unchanged session activity/authority fields.

## Root cause

Deleting an organization Codex credential invokes sessions foreign keys' ON DELETE SET NULL actions for pinned/last-used references. The organization transaction had not acquired the workspaces' session-tenancy fences. PostgreSQL rejected the FK-driven UPDATE with SQLSTATE 55000: `session tenancy mutation requires the workspace fence`, propagated as HTTP 500.

This enters the existing fence protocol without disabling triggers, broadening RLS, or changing credential lifecycle. It covers historical references in workspaces no longer inheriting the pool without reading their session content.

## Verification

- Regression RED on unpatched main c376703d with the exact SQLSTATE 55000 / sessions FK error; GREEN with this patch.
- Real PostgreSQL 17, complete migration chain, exact provisioned non-owner opengeni_app role: 9 organization Codex database tests passed, 93 assertions. No domain/database mocks. A local-only bootstrap replaced Docker container acquisition with a disposable native database connection because this sandbox has no Docker daemon; the checked-in suite uses the standard shared test harness.
- Standard CI/reproduction command: `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/migration-0381-organization-codex-subscription-inheritance.test.ts`.
- `bun run typecheck`: all 32 projects clean.
- `bun scripts/check-workspace-billing-static.ts`: passed.
- Targeted oxlint, oxfmt check, and `git diff --check`: passed.
- Independent review approved the exact two-file diff, SHA-256 `3781b381c4ad3f7de043a50a81b3fb03d3dd8dbdef2d1e630de4b6054df788f2`, with no blockers. The new regression is sequential, not a concurrent lock-scheduling test.

## Scope

Tracked in [OPE-471](https://linear.app/cloudgeni/issue/OPE-471/fix-organization-codex-disconnect-http-500-from-missing-session).

No real subscriptions modified for testing. No schema migration, permissions change, ops change, merge, or deployment. Production logs for the screenshot request were unavailable: this is a reproduced defect on the disconnect path, not request-correlated production log confirmation. Full Docker integration stack and production UI smoke were not run.

## Summary by Sourcery

Prevent organization Codex credential disconnects from failing by fencing all affected workspaces before clearing session references.

Bug Fixes:
- Prevent organization Codex credential deletion from failing with HTTP 500 when sessions in Personal, shared, disabled, or no-longer-inheriting workspaces reference the credential.
- Preserve session state and authorization behavior while clearing deleted credential references and selecting any replacement credential.

Enhancements:
- Extend organization credential deletion locking to cover the complete authorized workspace inventory before related mutations.

Tests:
- Add real-database regression coverage for credential deletion across workspace types, authorization boundaries, repeated deletion, replacement selection, reference cleanup, and unchanged session fields.