### PR TITLE
fix(web): compact sidebar header and account actions

### DIFF
--- a/apps/web/src/components/rail/rail-density.test.tsx
+++ b/apps/web/src/components/rail/rail-density.test.tsx
@@ -50,6 +50,7 @@ window.matchMedia = (query) => {
   Object.defineProperty(media, "matches", { get: () => window.innerHeight < 720 });
   return media;
 };
+const railHeader = await Bun.file(new URL("./rail-header.tsx", import.meta.url)).text();
 const railShell = await Bun.file(new URL("./rail-shell.tsx", import.meta.url)).text();
 
 describe("rail overflow boundaries", () => {
@@ -61,7 +62,7 @@ describe("rail overflow boundaries", () => {
       /data-rail-scroll-viewport\s+className="relative z-0 min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain"/,
     );
     expect(railShell).toMatch(
-      /data-rail-footer\s+className="relative z-10 shrink-0 border-t border-border bg-surface pt-2"/,
+      /data-rail-footer\s+className="relative z-10 shrink-0 border-t border-border bg-surface"/,
     );
   });
 });
@@ -166,9 +167,9 @@ describe("session-first rail density", () => {
         4,
       );
       expect(railShell).toMatch(
-        /id="mobile-nav-panel-workspace"[\s\S]*?<SwitcherBlock \/>[\s\S]*?<WorkspaceShortcutLinks className="px-2" \/>/,
+        /id="mobile-nav-panel-workspace"[\s\S]*?<WorkspaceShortcutLinks className="px-2" \/>/,
       );
-      expect(railShell).toMatch(/\{rail\.isMobile \? null : <SwitcherBlock \/>\}/);
+      expect(railHeader).toMatch(/\{!rail\.collapsed \? <SwitcherBlock inline \/> : null\}/);
     } finally {
       await act(async () => workspace.root.unmount());
       workspace.container.remove();

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -1,6 +1,5 @@
-// Pinned rail footer: the collapse-toggle chevron and the signed-in user menu
-// (account/sign-out, depending on auth mode). Collapsed → just the avatar +
-// a collapse chevron, both with tooltips.
+// Pinned account row with direct settings, feedback, and collapse actions.
+// In the collapsed rail, the same controls stack with accessible labels.
 import {
   ChartColumnIcon,
   ChevronsLeftIcon,
@@ -13,7 +12,7 @@ import {
 import { lazy, Suspense, useState } from "react";
 import { toast } from "sonner";
 
-import { cn } from "@/lib/utils";
+import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { AppearanceMenu } from "@/components/appearance-menu";
 import {
   accountMenuAriaLabel,
@@ -80,39 +79,21 @@ export function RailFooter() {
   });
 
   return (
-    <div className="mt-auto border-t border-border p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+    <div className="mt-auto p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
       {hasWorkspacePermission(context.accessContext, rail.workspaceId, "sessions:create") ? (
-        <>
-          <Suspense fallback={null}>
-            <FeedbackDialog
-              key={rail.workspaceId}
-              client={context.client}
-              workspaceId={rail.workspaceId}
-              open={feedbackOpen}
-              onOpenChange={setFeedbackOpen}
-              onSubmitted={() => toast.success("Thanks for your feedback")}
-            />
-          </Suspense>
-          <button
-            type="button"
-            className={cn(
-              "mb-1 flex h-8 items-center rounded-md text-sm font-medium text-fg-muted outline-none transition-colors pointer-coarse:h-10",
-              "hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/50",
-              rail.collapsed
-                ? "mx-auto w-8 justify-center pointer-coarse:w-10"
-                : "w-full gap-2.5 px-2.5 text-left",
-            )}
-            aria-label="Send feedback"
-            title="Send feedback"
-            onClick={() => setFeedbackOpen(true)}
-          >
-            <FeedbackIcon className="size-4 shrink-0" />
-            {rail.collapsed ? null : <span className="min-w-0 truncate">Send feedback</span>}
-          </button>
-        </>
+        <Suspense fallback={null}>
+          <FeedbackDialog
+            key={rail.workspaceId}
+            client={context.client}
+            workspaceId={rail.workspaceId}
+            open={feedbackOpen}
+            onOpenChange={setFeedbackOpen}
+            onSubmitted={() => toast.success("Thanks for your feedback")}
+          />
+        </Suspense>
       ) : null}
       <div
-        className={rail.collapsed ? "grid justify-items-center gap-1" : "flex items-end gap-1.5"}
+        className={rail.collapsed ? "grid justify-items-center gap-1" : "flex items-center gap-0.5"}
       >
         {browserAccounts ? (
           <div className={rail.collapsed ? undefined : "min-w-0 flex-1"}>
@@ -222,6 +203,25 @@ export function RailFooter() {
           </div>
         )}
 
+        <WorkspaceNav compact />
+        {hasWorkspacePermission(context.accessContext, rail.workspaceId, "sessions:create") ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0 text-fg-muted pointer-coarse:size-10"
+                aria-label="Send feedback"
+                onClick={() => setFeedbackOpen(true)}
+              >
+                <FeedbackIcon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side={rail.collapsed ? "right" : "top"}>Send feedback</TooltipContent>
+          </Tooltip>
+        ) : null}
+
         {!rail.isMobile ? (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -231,7 +231,7 @@ export function RailFooter() {
                 size="icon-sm"
                 aria-label={rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
                 onClick={rail.toggleCollapsed}
-                className="shrink-0 text-fg-subtle hover:text-fg"
+                className="shrink-0 text-fg-subtle hover:text-fg pointer-coarse:size-10"
               >
                 {rail.collapsed ? (
                   <ChevronsRightIcon className="size-4" />

--- a/apps/web/src/components/rail/rail-header.tsx
+++ b/apps/web/src/components/rail/rail-header.tsx
@@ -1,0 +1,44 @@
+import { Link } from "@tanstack/react-router";
+import { XIcon } from "lucide-react";
+import { BrandMark } from "@/components/brand-mark";
+import { useRail } from "@/components/rail/rail-context";
+import { SwitcherBlock } from "@/components/rail/switcher-block";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function RailHeader() {
+  const rail = useRail();
+  return (
+    <div
+      className={cn(
+        "@container flex h-12 shrink-0 items-center gap-2",
+        rail.collapsed ? "justify-center px-2" : "px-3",
+      )}
+    >
+      <Link
+        to="/workspaces/$workspaceId/sessions"
+        params={{ workspaceId: rail.workspaceId }}
+        className="flex shrink-0 items-center gap-2 rounded-md text-[15px] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="OpenGeni home"
+      >
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
+          <BrandMark className="size-4" />
+        </span>
+        {!rail.collapsed ? <span className="hidden @[280px]:inline">OpenGeni</span> : null}
+      </Link>
+      {!rail.collapsed ? <SwitcherBlock inline /> : null}
+      {rail.isMobile ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close navigation"
+          onClick={() => rail.setDrawerOpen(false)}
+          className="ml-auto pointer-coarse:size-11"
+        >
+          <XIcon className="size-4" />
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -6,7 +6,7 @@
 import { findPickerRow, useLastStartedTurnPolicy, useSessionLineage } from "@opengeni/react";
 import type { SessionSummary } from "@opengeni/sdk";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
-import { MenuIcon, MessagesSquareIcon, Settings2Icon, XIcon } from "lucide-react";
+import { MenuIcon, MessagesSquareIcon, Settings2Icon } from "lucide-react";
 
 import { BrandMark } from "@/components/brand-mark";
 import {
@@ -22,6 +22,7 @@ import {
   type RefObject,
 } from "react";
 
+import { RailHeader } from "@/components/rail/rail-header";
 import { RailFooter } from "@/components/rail/rail-footer";
 import { SessionHeader } from "@/components/rail/session-header";
 import {
@@ -38,7 +39,6 @@ import {
   sessionSupportsFleetSwitching,
 } from "@/components/session/sandbox-switcher";
 import { CodexAccountIndicator } from "@/components/session/codex-account-indicator";
-import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -78,39 +78,9 @@ function RailBody() {
         className="relative z-0 min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain"
       >
         <div className="flex min-h-full flex-col">
-          {/* Brand */}
-          <div
-            className={cn(
-              "flex h-10 shrink-0 items-center gap-2",
-              rail.collapsed ? "justify-center px-2" : "px-3",
-            )}
-          >
-            <Link
-              to="/workspaces/$workspaceId/sessions"
-              params={{ workspaceId: rail.workspaceId }}
-              className="flex items-center gap-2 rounded-md text-[15px] font-semibold focus-visible:outline-none"
-              aria-label="OpenGeni home"
-            >
-              <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
-                <BrandMark className="size-4" />
-              </span>
-              {!rail.collapsed ? <span className="truncate">OpenGeni</span> : null}
-            </Link>
-            {rail.isMobile ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Close navigation"
-                onClick={() => rail.setDrawerOpen(false)}
-                className="ml-auto pointer-coarse:size-11"
-              >
-                <XIcon className="size-4" />
-              </Button>
-            ) : null}
-          </div>
+          <RailHeader />
 
-          {rail.isMobile ? null : <SwitcherBlock />}
+          {rail.collapsed ? <SwitcherBlock /> : null}
 
           {rail.isMobile ? (
             <>
@@ -184,8 +154,6 @@ function RailBody() {
                   aria-labelledby="mobile-nav-tab-workspace"
                   className="mt-2 flex shrink-0 flex-col border-t border-border pt-2"
                 >
-                  <SwitcherBlock />
-                  <div className="my-2 border-t border-border" />
                   <WorkspaceShortcutLinks className="px-2" />
                   <div className="my-2 border-t border-border" />
                 </div>
@@ -205,11 +173,7 @@ function RailBody() {
       </div>
       {/* Keep the persistent controls opaque and above the scroll viewport,
           including session-row actions with their own stacking levels. */}
-      <div
-        data-rail-footer
-        className="relative z-10 shrink-0 border-t border-border bg-surface pt-2"
-      >
-        <WorkspaceNav />
+      <div data-rail-footer className="relative z-10 shrink-0 border-t border-border bg-surface">
         <RailFooter />
       </div>
     </div>

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -50,7 +50,7 @@ export function additionalOrganizationCreationAttemptIsCurrent(input: {
 
 export const WORKSPACE_SWITCHER_GRID_CLASS = "grid min-w-0 grid-cols-[minmax(0,1fr)] px-2";
 
-export function SwitcherBlock() {
+export function SwitcherBlock({ inline = false }: { inline?: boolean }) {
   const context = useAppContext();
   const rail = useRail();
   const managedUserId = context.authSession?.user.id ?? null;
@@ -211,7 +211,7 @@ export function SwitcherBlock() {
   }
 
   return (
-    <div className={WORKSPACE_SWITCHER_GRID_CLASS}>
+    <div className={inline ? "ml-auto grid min-w-0 flex-1" : WORKSPACE_SWITCHER_GRID_CLASS}>
       {createOpen ? (
         <Suspense fallback={null}>
           <LazyCreateOrganizationDialog
@@ -231,6 +231,7 @@ export function SwitcherBlock() {
       <WorkspaceSwitcherMenu
         workspaceId={rail.workspaceId}
         collapsed={false}
+        compact={inline}
         align="start"
         onSelect={rail.openWorkspace}
         onCreateOrganization={canCreateOrganization ? () => setCreateOpen(true) : undefined}

--- a/apps/web/src/components/rail/workspace-nav-data.test.ts
+++ b/apps/web/src/components/rail/workspace-nav-data.test.ts
@@ -12,7 +12,9 @@ const workspaceNavSource = await Bun.file(`${import.meta.dir}/workspace-nav.tsx`
 describe("workspace rail destinations", () => {
   test("labels the settings entry without changing its destination", () => {
     expect(workspaceNavSource).toContain('aria-label="Settings"');
-    expect(workspaceNavSource).toContain('title={rail.collapsed ? "Settings" : undefined}');
+    expect(workspaceNavSource).toContain(
+      '<TooltipContent side={rail.collapsed ? "right" : "top"}>Settings</TooltipContent>',
+    );
     expect(workspaceNavSource).toContain('<span className="min-w-0 truncate">Settings</span>');
     expect(workspaceNavSource).toContain('to="/workspaces/$workspaceId/settings"');
     expect(workspaceNavSource).toContain('search={{ section: "general" }}');

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -5,6 +5,7 @@ import { SlidersHorizontalIcon } from "lucide-react";
 
 import { useRail } from "@/components/rail/rail-context";
 import { isWorkspaceConfigPath } from "@/components/rail/workspace-nav-data";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export type {
@@ -19,7 +20,7 @@ export {
   WORKSPACE_CONFIG_GROUPS,
 } from "@/components/rail/workspace-nav-data";
 
-export function WorkspaceNav() {
+export function WorkspaceNav({ compact = false }: { compact?: boolean }) {
   const rail = useRail();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const active = isWorkspaceConfigPath(pathname, rail.workspaceId);
@@ -27,32 +28,43 @@ export function WorkspaceNav() {
   return (
     <nav
       aria-label="Settings"
-      className={cn("grid gap-0.5 px-2", rail.collapsed && "justify-center")}
+      className={cn(
+        "grid shrink-0 gap-0.5",
+        !compact && "px-2",
+        rail.collapsed && "justify-center",
+      )}
     >
-      <Link
-        to="/workspaces/$workspaceId/settings"
-        params={{ workspaceId: rail.workspaceId }}
-        search={{ section: "general" }}
-        aria-current={active ? "page" : undefined}
-        title={rail.collapsed ? "Settings" : undefined}
-        onClick={() => rail.setDrawerOpen(false)}
-        className={cn(
-          "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted outline-none transition-colors pointer-coarse:h-10",
-          "hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/50",
-          active && "bg-surface-2 text-fg",
-          rail.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className={cn(
-            "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand transition-opacity",
-            active ? "opacity-100" : "opacity-0",
-          )}
-        />
-        <SlidersHorizontalIcon className="size-4 shrink-0" />
-        {rail.collapsed ? null : <span className="min-w-0 truncate">Settings</span>}
-      </Link>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to="/workspaces/$workspaceId/settings"
+            params={{ workspaceId: rail.workspaceId }}
+            search={{ section: "general" }}
+            aria-current={active ? "page" : undefined}
+            aria-label="Settings"
+            onClick={() => rail.setDrawerOpen(false)}
+            className={cn(
+              "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted outline-none transition-colors pointer-coarse:h-10",
+              "hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/50",
+              active && "bg-surface-2 text-fg",
+              rail.collapsed || compact
+                ? "w-8 justify-center pointer-coarse:w-10"
+                : "gap-2.5 px-2.5",
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand transition-opacity",
+                active ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <SlidersHorizontalIcon className="size-4 shrink-0" />
+            {rail.collapsed || compact ? null : <span className="min-w-0 truncate">Settings</span>}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side={rail.collapsed ? "right" : "top"}>Settings</TooltipContent>
+      </Tooltip>
     </nav>
   );
 }

--- a/apps/web/src/components/rail/workspace-switcher.tsx
+++ b/apps/web/src/components/rail/workspace-switcher.tsx
@@ -53,6 +53,7 @@ export function WorkspaceSwitcherMenu(props: {
   onSelect: (workspaceId: string) => void;
   onCreateOrganization?: () => void;
   className?: string;
+  compact?: boolean;
 }) {
   const context = useAppContext();
   const activeWorkspace =
@@ -111,6 +112,7 @@ export function WorkspaceSwitcherMenu(props: {
           activeWorkspace={activeWorkspace}
           activeOrganizationLabel={currentOrgLabel}
           personal={activeIsPersonal}
+          compact={props.compact}
           collapsed={props.collapsed}
           className={props.className}
         />
@@ -131,6 +133,7 @@ export function WorkspaceSwitcherMenu(props: {
 }
 
 type WorkspaceSwitcherTriggerProps = {
+  compact?: boolean;
   activeWorkspace: Workspace | null;
   activeOrganizationLabel: string;
   personal: boolean;
@@ -145,6 +148,7 @@ export const WorkspaceSwitcherTrigger = forwardRef<
     activeWorkspace,
     activeOrganizationLabel: organizationLabel,
     personal,
+    compact,
     collapsed,
     className,
     ...buttonProps
@@ -179,6 +183,7 @@ export const WorkspaceSwitcherTrigger = forwardRef<
       ref={ref}
       aria-label={accessibleLabel}
       className={className}
+      compact={compact}
       label={activeWorkspace?.name ?? "Select workspace"}
       icon={workspaceInitial(activeWorkspace)}
       badge={personal ? <PersonalWorkspaceBadge decorative /> : null}

--- a/apps/web/src/components/ui/scope-switcher-trigger.tsx
+++ b/apps/web/src/components/ui/scope-switcher-trigger.tsx
@@ -12,8 +12,9 @@ export const ScopeSwitcherTrigger = forwardRef<
     label: string;
     icon: ReactNode;
     badge?: ReactNode;
+    compact?: boolean;
   }
->(function ScopeSwitcherTrigger({ label, icon, badge, className, ...props }, ref) {
+>(function ScopeSwitcherTrigger({ label, icon, badge, compact = false, className, ...props }, ref) {
   return (
     <button
       {...props}
@@ -21,14 +22,17 @@ export const ScopeSwitcherTrigger = forwardRef<
       type="button"
       className={cn(
         "group flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+        compact && "h-8 gap-1.5 py-0 pointer-coarse:h-11",
         className,
       )}
     >
-      <Avatar size="sm" className="rounded-md">
-        <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
-          {icon}
-        </AvatarFallback>
-      </Avatar>
+      {compact ? null : (
+        <Avatar size="sm" className="rounded-md">
+          <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
+            {icon}
+          </AvatarFallback>
+        </Avatar>
+      )}
       <span className="min-w-0 flex-1 truncate text-sm font-medium" title={label}>
         {label}
       </span>


### PR DESCRIPTION
## Changes
Move the workspace selector beside the sidebar brand and consolidate settings, feedback, and collapse controls into the account row. Narrow sidebars retain the brand icon and prioritize the workspace name; mobile exposes the selector in the drawer header.

Preserves workspace/account menus, feedback permissions, keyboard focus, and the fixed footer. Long emails truncate without displacing actions.

## Validation
- 14 focused rail/switcher tests passed in isolated runs
- Web typecheck, targeted lint, and diff checks passed
- Desktop, narrow, collapsed, and mobile component previews inspected
- Full local stack started and the sessions route verified

## Summary by Sourcery

Reorganize the sidebar header and account actions to make workspace navigation and controls more compact across responsive layouts.

New Features:
- Place the workspace selector alongside the sidebar brand, with compact presentation for constrained layouts and mobile drawer support.
- Consolidate settings, feedback, and sidebar collapse actions into the account row while retaining permission-aware behavior and accessible controls.

Bug Fixes:
- Improve sidebar behavior across desktop, collapsed, narrow, and mobile layouts, including truncation of long account identifiers without displacing actions.

Enhancements:
- Add consistent tooltips and focus-visible treatment for compact sidebar actions and preserve the fixed footer structure.

Tests:
- Update rail density and workspace navigation tests for the revised header, footer, and tooltip layouts.