### PR TITLE
feat(web): connect integrations directly from conversation cards

### DIFF
--- a/.changeset/chat-integration-cards.md
+++ b/.changeset/chat-integration-cards.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": minor
+"@opengeni/sdk": minor
+"@opengeni/contracts": minor
+---
+
+Allow hosts to render inline connection setup for timeline authentication requests. Add an optional safe return path to Fiken OAuth so setup can return to the originating conversation.

--- a/apps/api/src/integrations/fiken.ts
+++ b/apps/api/src/integrations/fiken.ts
@@ -1,3 +1,4 @@
+import { safeReturnPath } from "./oauth-return-path";
 import type { ApiRouteDeps } from "@opengeni/core";
 import type { Settings } from "@opengeni/config";
 import {
@@ -1028,7 +1029,9 @@ export async function startFikenOAuth(
     accountId: input.accountId,
     workspaceId: input.workspaceId,
     subjectId: input.subjectId,
-    returnPath: `/workspaces/${input.workspaceId}/capabilities`,
+    returnPath: safeReturnPath(
+      input.payload.returnPath ?? `/workspaces/${input.workspaceId}/capabilities`,
+    ),
     ...(existing ? { connectionId: existing.id, connectionVersion: existing.version } : {}),
   });
   const authorizationUrl = new URL(FIKEN_AUTHORIZE_URL);

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -1,3 +1,4 @@
+import { safeReturnPath } from "./oauth-return-path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -2083,23 +2084,6 @@ function oauthEndpointUrl(rawUrl: string, settings: Settings, label: string): st
     }
     throw error;
   }
-}
-
-function safeReturnPath(value: string): string {
-  if (!value.startsWith("/") || value.startsWith("//")) {
-    throw new HTTPException(400, {
-      message: "OAuth returnPath must be a relative path",
-    });
-  }
-  const parsed = new URL(value, "https://opengeni.local");
-  // `..` segments can normalize back into a `//host` prefix, which browsers
-  // resolve as a protocol-relative absolute URL. Reject the NORMALIZED path.
-  if (parsed.origin !== "https://opengeni.local" || parsed.pathname.startsWith("//")) {
-    throw new HTTPException(400, {
-      message: "OAuth returnPath must be a relative path",
-    });
-  }
-  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }
 
 async function fetchOAuth(

--- a/apps/api/src/integrations/oauth-return-path.ts
+++ b/apps/api/src/integrations/oauth-return-path.ts
@@ -1,0 +1,18 @@
+import { HTTPException } from "hono/http-exception";
+
+export function safeReturnPath(value: string): string {
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    throw new HTTPException(400, {
+      message: "OAuth returnPath must be a relative path",
+    });
+  }
+  const parsed = new URL(value, "https://opengeni.local");
+  // `..` segments can normalize back into a `//host` prefix, which browsers
+  // resolve as a protocol-relative absolute URL. Reject the NORMALIZED path.
+  if (parsed.origin !== "https://opengeni.local" || parsed.pathname.startsWith("//")) {
+    throw new HTTPException(400, {
+      message: "OAuth returnPath must be a relative path",
+    });
+  }
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}

--- a/apps/api/test/oauth-return-path.test.ts
+++ b/apps/api/test/oauth-return-path.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { safeReturnPath } from "../src/integrations/oauth-return-path";
+test("provider consent can return to the exact conversation", () => {
+  const path = "/workspaces/workspace/sessions/session?capability_auth=api%3Afiken";
+  expect(safeReturnPath(path)).toBe(path);
+});
+for (const value of [
+  "https://other.example/session",
+  "//other.example",
+  "/\\other.example",
+  "/a/..//other.example",
+]) {
+  test(`rejects an off-origin or normalized protocol-relative return: ${value}`, () => {
+    expect(() => safeReturnPath(value)).toThrow("relative path");
+  });
+}

--- a/apps/web/src/components/capabilities/attach-session-capability.test.ts
+++ b/apps/web/src/components/capabilities/attach-session-capability.test.ts
@@ -1,0 +1,56 @@
+import { expect, mock, test } from "bun:test";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type { CapabilityCatalogItem } from "@/types";
+import { attachSessionCapability } from "./attach-session-capability";
+const item = { kind: "mcp", tools: [{ kind: "mcp", id: "new" }] } as CapabilityCatalogItem;
+function harness(mode = "explicit", selectedIds = ["old"], idsTruncated = false) {
+  const updateSessionToolPolicy = mock(
+    async (..._args: Parameters<OpenGeniBrowserClient["updateSessionToolPolicy"]>) => ({}),
+  );
+  const client = {
+    getSession: async () => ({
+      tools: [{ kind: "mcp", id: "old" }],
+      firstPartyMcpTools: ["session_pause"],
+      toolPolicyVersion: 7,
+      toolPolicy: { mode },
+      effectiveToolPolicy: { selectedIds, idsTruncated },
+    }),
+    updateSessionToolPolicy,
+  } as unknown as OpenGeniBrowserClient;
+  return { client, updateSessionToolPolicy };
+}
+test("adding a connection preserves tools and first-party restrictions with CAS", async () => {
+  const h = harness();
+  await attachSessionCapability(h.client, "w", "s", item);
+  expect(h.updateSessionToolPolicy.mock.calls[0]?.[2]).toEqual({
+    mode: "explicit",
+    tools: [
+      { kind: "mcp", id: "old" },
+      { kind: "mcp", id: "new" },
+    ],
+    firstPartyMcpTools: ["session_pause"],
+    expectedVersion: 7,
+  });
+});
+test("a default that already includes the new integration stays a default", async () => {
+  const h = harness("workspace_default", ["old", "new"]);
+  await attachSessionCapability(h.client, "w", "s", item);
+  expect(h.updateSessionToolPolicy).not.toHaveBeenCalled();
+});
+test("a restricted default is preserved when adding just the requested integration", async () => {
+  const h = harness("workspace_default", ["allowed"]);
+  await attachSessionCapability(h.client, "w", "s", item);
+  expect(h.updateSessionToolPolicy.mock.calls[0]?.[2]).toMatchObject({
+    tools: [
+      { kind: "mcp", id: "allowed" },
+      { kind: "mcp", id: "new" },
+    ],
+  });
+});
+test("a truncated default cannot silently drop tools", async () => {
+  const h = harness("workspace_default", ["old"], true);
+  await expect(attachSessionCapability(h.client, "w", "s", item)).rejects.toThrow(
+    "full session tool selection",
+  );
+  expect(h.updateSessionToolPolicy).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/capabilities/attach-session-capability.test.ts
+++ b/apps/web/src/components/capabilities/attach-session-capability.test.ts
@@ -1,7 +1,10 @@
 import { expect, mock, test } from "bun:test";
 import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
 import type { CapabilityCatalogItem } from "@/types";
-import { attachSessionCapability } from "./attach-session-capability";
+import {
+  attachSessionCapability,
+  completeSessionCapabilityOAuth,
+} from "./attach-session-capability";
 const item = { kind: "mcp", tools: [{ kind: "mcp", id: "new" }] } as CapabilityCatalogItem;
 function harness(mode = "explicit", selectedIds = ["old"], idsTruncated = false) {
   const updateSessionToolPolicy = mock(
@@ -51,6 +54,45 @@ test("a truncated default cannot silently drop tools", async () => {
   const h = harness("workspace_default", ["old"], true);
   await expect(attachSessionCapability(h.client, "w", "s", item)).rejects.toThrow(
     "full session tool selection",
+  );
+  expect(h.updateSessionToolPolicy).not.toHaveBeenCalled();
+});
+
+test("native OAuth return attaches freshly enabled tools and first-party names", async () => {
+  const h = harness("explicit", ["old"]);
+  h.client.listCapabilities = async () =>
+    ({
+      installations: [],
+      items: [
+        {
+          ...item,
+          id: "fiken",
+          enabled: true,
+          metadata: { firstPartyMcpTools: ["fiken_list_companies"] },
+        },
+      ],
+    }) as Awaited<ReturnType<OpenGeniBrowserClient["listCapabilities"]>>;
+  await completeSessionCapabilityOAuth(h.client, "w", "s", "fiken");
+  expect(h.updateSessionToolPolicy.mock.calls[0]?.[2]).toMatchObject({
+    tools: [
+      { kind: "mcp", id: "old" },
+      { kind: "mcp", id: "new" },
+    ],
+    firstPartyMcpTools: ["session_pause", "fiken_list_companies"],
+    expectedVersion: 7,
+  });
+});
+test("native OAuth return cannot claim success for an unresolved or disabled integration", async () => {
+  const h = harness();
+  h.client.listCapabilities = async () =>
+    ({ items: [], installations: [] }) as Awaited<
+      ReturnType<OpenGeniBrowserClient["listCapabilities"]>
+    >;
+  await expect(completeSessionCapabilityOAuth(h.client, "w", "s", null)).rejects.toThrow(
+    "identified",
+  );
+  await expect(completeSessionCapabilityOAuth(h.client, "w", "s", "missing")).rejects.toThrow(
+    "verified",
   );
   expect(h.updateSessionToolPolicy).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/capabilities/attach-session-capability.ts
+++ b/apps/web/src/components/capabilities/attach-session-capability.ts
@@ -44,3 +44,23 @@ export async function attachSessionCapability(
     expectedVersion: session.toolPolicyVersion,
   });
 }
+
+/** Native OAuth callbacks have already saved the provider connection. Finish
+ * the separate, version-fenced session tool selection before reporting success. */
+export async function completeSessionCapabilityOAuth(
+  client: OpenGeniBrowserClient,
+  workspaceId: string,
+  sessionId: string,
+  capabilityId: string | null,
+): Promise<void> {
+  if (!capabilityId)
+    throw new Error(
+      "The authorized integration could not be identified. Review its connection card to finish setup.",
+    );
+  const connected = (await client.listCapabilities(workspaceId)).items.find(
+    (item) => item.id === capabilityId,
+  );
+  if (!connected?.enabled)
+    throw new Error("The connection was authorized, but enabling its tools could not be verified.");
+  await attachSessionCapability(client, workspaceId, sessionId, connected);
+}

--- a/apps/web/src/components/capabilities/attach-session-capability.ts
+++ b/apps/web/src/components/capabilities/attach-session-capability.ts
@@ -1,0 +1,46 @@
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type { FirstPartyMcpToolName } from "@opengeni/sdk";
+import type { CapabilityCatalogItem } from "@/types";
+
+/** A connection never resets the human's existing tool selection. Default-mode
+ * sessions discover newly enabled servers at admission; explicit/inherited
+ * policies add only this reviewed capability, with the existing CAS fence. */
+export async function attachSessionCapability(
+  client: OpenGeniBrowserClient,
+  workspaceId: string,
+  sessionId: string,
+  item: CapabilityCatalogItem,
+  stillCurrent: () => boolean = () => true,
+): Promise<void> {
+  if (item.kind === "skill" || item.tools.length === 0) return;
+  if (!stillCurrent()) throw new Error("Connection setup was interrupted.");
+  const session = await client.getSession(workspaceId, sessionId);
+  if (!stillCurrent()) throw new Error("Connection setup was interrupted.");
+  let existing = session.tools;
+  if (session.toolPolicy.mode === "workspace_default") {
+    const policy = session.effectiveToolPolicy;
+    if (!policy || policy.idsTruncated)
+      throw new Error(
+        "Connected, but the full session tool selection could not be read. Review the Tools picker before continuing.",
+      );
+    // A workspace may choose a restricted default instead of all enabled servers.
+    // Preserve that exact selection if this connection needs an explicit addition.
+    existing = policy.selectedIds.map((id) => ({ kind: "mcp" as const, id }));
+  }
+  const additions = item.tools.filter(
+    (tool) => !existing.some((current) => current.kind === tool.kind && current.id === tool.id),
+  );
+  const recommended = Array.isArray(item.metadata?.firstPartyMcpTools)
+    ? (item.metadata.firstPartyMcpTools.filter(
+        (name): name is string => typeof name === "string",
+      ) as FirstPartyMcpToolName[])
+    : [];
+  const firstParty = [...new Set([...session.firstPartyMcpTools, ...recommended])];
+  if (additions.length === 0 && firstParty.length === session.firstPartyMcpTools.length) return;
+  await client.updateSessionToolPolicy(workspaceId, sessionId, {
+    mode: "explicit",
+    tools: [...existing, ...additions],
+    firstPartyMcpTools: firstParty,
+    expectedVersion: session.toolPolicyVersion,
+  });
+}

--- a/apps/web/src/components/capabilities/capability-detail-sheet.test.tsx
+++ b/apps/web/src/components/capabilities/capability-detail-sheet.test.tsx
@@ -556,3 +556,17 @@ describe("social provider integration UI", () => {
     }
   });
 });
+
+test("separate inline connection forms have independent ownership groups", async () => {
+  const r = await render(
+    <>
+      <OwnershipSelector value="workspace" onChange={() => {}} />
+      <OwnershipSelector value="personal" onChange={() => {}} />
+    </>,
+  );
+  const radios = [...r.container.querySelectorAll<HTMLInputElement>('input[type="radio"]')];
+  expect(radios[0]!.name).toBe(radios[1]!.name);
+  expect(radios[2]!.name).toBe(radios[3]!.name);
+  expect(radios[0]!.name).not.toBe(radios[2]!.name);
+  await r.unmount();
+});

--- a/apps/web/src/components/capabilities/capability-detail-sheet.tsx
+++ b/apps/web/src/components/capabilities/capability-detail-sheet.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import {
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -221,6 +222,8 @@ export function CapabilityDetailSheet({
 
 export function DetailBody({
   item,
+  inline = false,
+  onCancel,
   health,
   logoSrc,
   busy,
@@ -231,6 +234,8 @@ export function DetailBody({
   onAction,
 }: {
   item: CapabilityCatalogItem;
+  inline?: boolean;
+  onCancel?: (() => void) | undefined;
   health: ConnectionHealth;
   logoSrc: string | null;
   busy: boolean;
@@ -253,7 +258,8 @@ export function DetailBody({
     [item.id, personalOnly],
   );
 
-  const canDisconnect = item.enabled && item.kind === "mcp" && item.actions.includes("disconnect");
+  const canDisconnect =
+    !inline && item.enabled && item.kind === "mcp" && item.actions.includes("disconnect");
   const keyPageUrl = item.installUrl ?? item.homepageUrl;
   // Repair is driven by the installation's OWN connectionRef.kind, not the catalog
   // plan — on catalog/registry drift an enabled item can carry a live connectionRef
@@ -266,25 +272,59 @@ export function DetailBody({
     plan.mode === "api_key" && plan.fields.length > 0 ? plan.fields : [GENERIC_API_KEY_FIELD];
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      {/* Header */}
-      <SheetHeader className="gap-3 border-b border-border p-5 pr-12">
+    <div
+      className={cn(
+        "flex min-h-0 flex-col",
+        inline
+          ? "[&_form]:flex [&_form]:flex-col [&_form>button]:ml-auto [&_form>button]:w-auto"
+          : "h-full",
+      )}
+    >
+      {inline ? (
         <div className="flex items-start gap-3">
-          <CapabilityLogo src={logoSrc} name={item.name} size="lg" />
+          <CapabilityLogo
+            src={logoSrc}
+            name={item.name}
+            size="lg"
+            fallback={item.kind === "skill" ? <SparklesIcon className="size-5" /> : undefined}
+          />
           <div className="min-w-0 flex-1">
-            <SheetTitle className="truncate text-base">{item.name}</SheetTitle>
-            <SheetDescription className="mt-0.5 text-xs text-fg-subtle">
-              {capabilityItemKindLabel(item)}
-              {capabilityCategoryLabel(item.category)
-                ? ` · ${capabilityCategoryLabel(item.category)}`
-                : ""}
-            </SheetDescription>
+            <h3 className="text-sm font-medium text-fg">{item.name}</h3>
+            {item.providerDomain ? (
+              <p className="mt-0.5 text-xs text-fg-subtle">{item.providerDomain}</p>
+            ) : null}
           </div>
+          <MetaChip>{capabilityItemKindLabel(item)}</MetaChip>
         </div>
-      </SheetHeader>
+      ) : (
+        <SheetHeader className="gap-3 border-b border-border p-5 pr-12">
+          <div className="flex items-start gap-3">
+            <CapabilityLogo
+              src={logoSrc}
+              name={item.name}
+              size="lg"
+              fallback={item.kind === "skill" ? <SparklesIcon className="size-5" /> : undefined}
+            />
+            <div className="min-w-0 flex-1">
+              <SheetTitle className="truncate text-base">{item.name}</SheetTitle>
+              <SheetDescription className="mt-0.5 text-xs text-fg-subtle">
+                {capabilityItemKindLabel(item)}
+                {capabilityCategoryLabel(item.category)
+                  ? ` · ${capabilityCategoryLabel(item.category)}`
+                  : ""}
+              </SheetDescription>
+            </div>
+          </div>
+        </SheetHeader>
+      )}
 
       {/* Scrollable body */}
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5">
+      <div
+        className={cn(
+          "min-h-0 flex-1",
+          inline ? "mt-3 space-y-3" : "space-y-5 overflow-y-auto p-5",
+        )}
+      >
         {item.stale ? (
           <Notice tone="muted">
             No longer listed in the public registry. Existing installations keep working.
@@ -295,7 +335,7 @@ export function DetailBody({
           <p className="text-sm leading-6 text-fg-muted">{item.description}</p>
         ) : null}
 
-        {item.tags.length > 0 ? (
+        {!inline && item.tags.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {item.tags.slice(0, 10).map((tag) => (
               <MetaChip key={tag}>{tag}</MetaChip>
@@ -303,31 +343,40 @@ export function DetailBody({
           </div>
         ) : null}
 
-        <dl className="grid gap-2.5 text-xs">
-          <MetaRow label="Source">{capabilitySourceLabel(item.source)}</MetaRow>
-          {item.homepageUrl ? (
-            <MetaRow label="Homepage">
-              <ExternalMetaLink href={item.homepageUrl} />
-            </MetaRow>
-          ) : null}
-          {item.installUrl && item.installUrl !== item.homepageUrl ? (
-            <MetaRow label="Setup">
-              <ExternalMetaLink href={item.installUrl} />
-            </MetaRow>
-          ) : null}
-          {item.endpointUrl ? (
-            <MetaRow label="Endpoint">
-              <span className="min-w-0 truncate font-mono text-fg-muted">{item.endpointUrl}</span>
-            </MetaRow>
-          ) : null}
-        </dl>
+        {!inline ? (
+          <dl className="grid gap-2.5 text-xs">
+            <MetaRow label="Source">{capabilitySourceLabel(item.source)}</MetaRow>
+            {item.homepageUrl ? (
+              <MetaRow label="Homepage">
+                <ExternalMetaLink href={item.homepageUrl} />
+              </MetaRow>
+            ) : null}
+            {item.installUrl && item.installUrl !== item.homepageUrl ? (
+              <MetaRow label="Setup">
+                <ExternalMetaLink href={item.installUrl} />
+              </MetaRow>
+            ) : null}
+            {item.endpointUrl ? (
+              <MetaRow label="Endpoint">
+                <span className="min-w-0 truncate font-mono text-fg-muted">{item.endpointUrl}</span>
+              </MetaRow>
+            ) : null}
+          </dl>
+        ) : null}
 
         <CuratedSkillProvenanceSection item={item} />
 
         {/* Action — flows directly after the content so a sparse item stays a
             compact top-flowing column, with no dead void before a bottom-pinned
             button. The whole body scrolls only when content actually overflows. */}
-        <div className="space-y-3 border-t border-border pt-5">
+        <div
+          className={cn(
+            "space-y-3",
+            inline
+              ? "[&>button]:ml-auto [&>button]:flex [&>button]:w-auto [&>div>button]:ml-auto [&>div>button]:flex [&>div>button]:w-auto"
+              : "border-t border-border pt-5",
+          )}
+        >
           {errorMessage ? <Notice tone="failed">{errorMessage}</Notice> : null}
 
           {item.surfaceType === "codex_apps" ? (
@@ -348,6 +397,8 @@ export function DetailBody({
               item={item}
               busy={busy}
               canManage={canManageSkills}
+              setupOnly={inline}
+              onCancel={onCancel}
               onAction={onAction}
             />
           ) : plan.mode === "social_oauth" ? (
@@ -359,6 +410,7 @@ export function DetailBody({
               onOwnershipChange={setConnectionOwnership}
               busy={busy}
               canManage={canManageSocial}
+              setupOnly={inline}
               onAction={onAction}
             />
           ) : plan.mode === "fiken_api_token" ? (
@@ -367,6 +419,7 @@ export function DetailBody({
               health={health}
               keyPageUrl={keyPageUrl}
               busy={busy}
+              setupOnly={inline}
               onAction={onAction}
             />
           ) : item.enabled ? (
@@ -394,6 +447,7 @@ export function DetailBody({
                   </Button>
                 ) : reconnecting ? (
                   <CredentialForm
+                    onCancel={onCancel}
                     fields={reconnectFields}
                     itemName={item.name}
                     keyPageUrl={keyPageUrl}
@@ -433,11 +487,11 @@ export function DetailBody({
                   {busy && !reconnect ? <Loader2Icon className="animate-spin" /> : <TrashIcon />}
                   Disconnect
                 </Button>
-              ) : (
+              ) : !inline ? (
                 <p className="text-center text-xs text-fg-subtle">
                   Manage this capability from its dedicated controls.
                 </p>
-              )}
+              ) : null}
             </div>
           ) : plan.mode === "api_key" ? (
             <div className="space-y-3">
@@ -451,6 +505,7 @@ export function DetailBody({
                 <OwnershipSelector value={connectionOwnership} onChange={setConnectionOwnership} />
               )}
               <CredentialForm
+                onCancel={onCancel}
                 fields={plan.fields}
                 itemName={item.name}
                 keyPageUrl={keyPageUrl}
@@ -482,44 +537,48 @@ export function DetailBody({
               ) : (
                 <OwnershipSelector value={connectionOwnership} onChange={setConnectionOwnership} />
               )}
-              <Button
-                type="button"
-                className="w-full"
-                disabled={busy}
-                onClick={() =>
-                  onAction({
-                    type: "oauth",
-                    item,
-                    ownership: connectionOwnership,
-                  })
-                }
-              >
-                {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
-                {connectionOwnership === "workspace"
-                  ? "Connect for workspace"
-                  : "Connect only for me"}
-              </Button>
               <p className="text-center text-xs text-fg-subtle">
                 {connectionOwnership === "workspace"
                   ? `You'll authorize ${item.name} once for this workspace. Provider actions may appear as the account you connect.`
                   : `You'll authorize ${item.name} for your personal use, then return here.`}
               </p>
+              <ConnectionActions onCancel={onCancel} busy={busy}>
+                <Button
+                  type="button"
+                  className="w-full"
+                  disabled={busy}
+                  onClick={() =>
+                    onAction({
+                      type: "oauth",
+                      item,
+                      ownership: connectionOwnership,
+                    })
+                  }
+                >
+                  {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
+                  {connectionOwnership === "workspace"
+                    ? "Connect for workspace"
+                    : "Connect only for me"}
+                </Button>
+              </ConnectionActions>
             </div>
           ) : item.kind === "mcp" ? (
-            <Button
-              type="button"
-              className="w-full"
-              disabled={busy || (item.kind === "mcp" && !item.runtime.available)}
-              title={
-                item.kind === "mcp" && !item.runtime.available
-                  ? (item.runtime.notes ?? undefined)
-                  : undefined
-              }
-              onClick={() => onAction({ type: "enable", item })}
-            >
-              {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
-              Enable
-            </Button>
+            <ConnectionActions onCancel={onCancel} busy={busy}>
+              <Button
+                type="button"
+                className="w-full"
+                disabled={busy || (item.kind === "mcp" && !item.runtime.available)}
+                title={
+                  item.kind === "mcp" && !item.runtime.available
+                    ? (item.runtime.notes ?? undefined)
+                    : undefined
+                }
+                onClick={() => onAction({ type: "enable", item })}
+              >
+                {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
+                Enable
+              </Button>
+            </ConnectionActions>
           ) : (
             <p className="text-center text-xs text-fg-subtle">
               Install or connect this capability from its dedicated controls.
@@ -536,9 +595,13 @@ function SkillControls({
   busy,
   canManage,
   onAction,
+  onCancel,
+  setupOnly = false,
 }: {
   item: CapabilityCatalogItem;
   busy: boolean;
+  onCancel?: (() => void) | undefined;
+  setupOnly?: boolean;
   canManage: boolean;
   onAction: (action: ConnectAction) => void;
 }) {
@@ -552,17 +615,19 @@ function SkillControls({
         </div>
       ) : null}
       {!item.enabled || updateAvailable ? (
-        <Button
-          type="button"
-          className="w-full"
-          disabled={busy || !canManage || !item.runtime.available}
-          onClick={() => onAction({ type: "install_skill", item })}
-        >
-          {busy ? <Loader2Icon className="animate-spin" /> : <SparklesIcon />}
-          {item.enabled ? "Update Skill" : "Install Skill"}
-        </Button>
+        <ConnectionActions onCancel={onCancel} busy={busy}>
+          <Button
+            type="button"
+            className="w-full"
+            disabled={busy || !canManage || !item.runtime.available}
+            onClick={() => onAction({ type: "install_skill", item })}
+          >
+            {busy ? <Loader2Icon className="animate-spin" /> : <SparklesIcon />}
+            {item.enabled ? "Update Skill" : setupOnly ? "Install for workspace" : "Install Skill"}
+          </Button>
+        </ConnectionActions>
       ) : null}
-      {item.enabled ? (
+      {item.enabled && !setupOnly ? (
         <Button
           type="button"
           variant="outline"
@@ -670,6 +735,7 @@ export function SocialConnectorControls({
   busy,
   canManage,
   onAction,
+  setupOnly = false,
 }: {
   item: CapabilityCatalogItem;
   provider: "x" | "reddit";
@@ -677,6 +743,7 @@ export function SocialConnectorControls({
   ownership: ConnectionOwnership;
   onOwnershipChange: (ownership: ConnectionOwnership) => void;
   busy: boolean;
+  setupOnly?: boolean;
   canManage: boolean;
   onAction: (action: ConnectAction) => void;
 }) {
@@ -720,7 +787,7 @@ export function SocialConnectorControls({
                   @{connection.accountHandle} · {socialConnectionStatusLabel(connection.status)}
                 </p>
               </div>
-              {connection.status !== "disabled" ? (
+              {!setupOnly && connection.status !== "disabled" ? (
                 <Button
                   type="button"
                   variant="ghost"
@@ -786,11 +853,13 @@ export function FikenConnectorControls({
   keyPageUrl,
   busy,
   onAction,
+  setupOnly = false,
 }: {
   item: CapabilityCatalogItem;
   health: ConnectionHealth;
   keyPageUrl: string | null;
   busy: boolean;
+  setupOnly?: boolean;
   onAction: (action: ConnectAction) => void;
 }) {
   const [replacing, setReplacing] = useState(false);
@@ -870,22 +939,24 @@ export function FikenConnectorControls({
             Replace credential
           </Button>
         )}
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full text-status-failed hover:bg-status-failed/10 hover:text-status-failed pointer-coarse:min-h-11"
-          disabled={busy}
-          onClick={() =>
-            onAction({
-              type: "fiken_disconnect",
-              item,
-              connectionId: connection.id,
-            })
-          }
-        >
-          {busy ? <Loader2Icon className="animate-spin" /> : <TrashIcon />}
-          Disconnect
-        </Button>
+        {!setupOnly ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full text-status-failed hover:bg-status-failed/10 hover:text-status-failed pointer-coarse:min-h-11"
+            disabled={busy}
+            onClick={() =>
+              onAction({
+                type: "fiken_disconnect",
+                item,
+                connectionId: connection.id,
+              })
+            }
+          >
+            {busy ? <Loader2Icon className="animate-spin" /> : <TrashIcon />}
+            Disconnect
+          </Button>
+        ) : null}
         <p className="text-center text-xs text-fg-subtle">
           Credentials are stored encrypted and used only for this workspace's Fiken tools.
         </p>
@@ -940,10 +1011,12 @@ export function OwnershipSelector({
   value: ConnectionOwnership;
   onChange: (value: ConnectionOwnership) => void;
 }) {
+  const groupName = useId();
   return (
     <fieldset className="space-y-2">
       <legend className="text-xs font-medium text-fg-muted">Who can use this connection?</legend>
       <OwnershipOption
+        groupName={groupName}
         checked={value === "workspace"}
         value="workspace"
         title="Connect for workspace"
@@ -951,6 +1024,7 @@ export function OwnershipSelector({
         onChange={() => onChange("workspace")}
       />
       <OwnershipOption
+        groupName={groupName}
         checked={value === "personal"}
         value="personal"
         title="Connect only for me"
@@ -962,12 +1036,14 @@ export function OwnershipSelector({
 }
 
 function OwnershipOption({
+  groupName,
   checked,
   value,
   title,
   description,
   onChange,
 }: {
+  groupName: string;
   checked: boolean;
   value: ConnectionOwnership;
   title: string;
@@ -983,7 +1059,7 @@ function OwnershipOption({
     >
       <input
         type="radio"
-        name="connection-ownership"
+        name={groupName}
         value={value}
         checked={checked}
         onChange={onChange}
@@ -1075,6 +1151,7 @@ function CredentialForm({
   submitIcon,
   busy,
   onSubmit,
+  onCancel,
 }: {
   fields: { name: string; label: string }[];
   itemName: string;
@@ -1082,8 +1159,10 @@ function CredentialForm({
   submitLabel: string;
   submitIcon: ReactNode;
   busy: boolean;
+  onCancel?: (() => void) | undefined;
   onSubmit: (headers: Record<string, string>) => void;
 }) {
+  const inputId = useId();
   const [headers, setHeaders] = useState<Record<string, string>>({});
   const ready = fields.every((field) => headers[field.name]?.trim());
 
@@ -1097,11 +1176,11 @@ function CredentialForm({
     >
       {fields.map((field) => (
         <div key={field.name} className="space-y-1.5">
-          <Label htmlFor={`cred-${field.name}`} className="text-xs text-fg-muted">
+          <Label htmlFor={`${inputId}-cred-${field.name}`} className="text-xs text-fg-muted">
             {field.label}
           </Label>
           <Input
-            id={`cred-${field.name}`}
+            id={`${inputId}-cred-${field.name}`}
             type="password"
             autoComplete="off"
             value={headers[field.name] ?? ""}
@@ -1130,10 +1209,12 @@ function CredentialForm({
           Stored encrypted and used only to reach {itemName}.
         </p>
       )}
-      <Button type="submit" className="w-full" disabled={busy || !ready}>
-        {busy ? <Loader2Icon className="animate-spin" /> : submitIcon}
-        {submitLabel}
-      </Button>
+      <ConnectionActions onCancel={onCancel} busy={busy}>
+        <Button type="submit" className="w-full" disabled={busy || !ready}>
+          {busy ? <Loader2Icon className="animate-spin" /> : submitIcon}
+          {submitLabel}
+        </Button>
+      </ConnectionActions>
     </form>
   );
 }
@@ -1211,5 +1292,26 @@ function ExternalMetaLink({ href }: { href: string }) {
       <span className="truncate">{label}</span>
       <ExternalLinkIcon className="size-3 shrink-0" />
     </a>
+  );
+}
+
+/** The same action row for inline OAuth review, credentials, and Skills. */
+function ConnectionActions({
+  onCancel,
+  busy,
+  children,
+}: {
+  onCancel?: (() => void) | undefined;
+  busy: boolean;
+  children: ReactNode;
+}) {
+  if (!onCancel) return children;
+  return (
+    <div className="flex items-center justify-end gap-2 [&>button]:w-auto">
+      <Button type="button" size="sm" variant="ghost" disabled={busy} onClick={onCancel}>
+        Cancel
+      </Button>
+      {children}
+    </div>
   );
 }

--- a/apps/web/src/components/capabilities/capability-logo.tsx
+++ b/apps/web/src/components/capabilities/capability-logo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { capabilityMonogram } from "@/lib/capabilities";
 import { cn } from "@/lib/utils";
@@ -23,7 +23,7 @@ export function CapabilityLogo({
   size?: "sm" | "md" | "lg";
   className?: string;
   /** Optional reviewed initials for named products; catalog rows derive them from the name. */
-  fallback?: string;
+  fallback?: ReactNode;
 }) {
   const [failed, setFailed] = useState(false);
   // A new src (e.g. switching the sheet to another item) gets a fresh attempt.

--- a/apps/web/src/components/capabilities/perform-capability-action.test.ts
+++ b/apps/web/src/components/capabilities/perform-capability-action.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, mock, test } from "bun:test";
+import { CapabilityCatalogItem } from "@opengeni/contracts";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type { ConnectionMetadata } from "@/types";
+import { performCapabilityAction } from "./perform-capability-action";
+
+const item = CapabilityCatalogItem.parse({
+  id: "test-key",
+  kind: "mcp",
+  source: "manual",
+  name: "Test",
+  providerDomain: "api.example.com",
+  mcpUrl: "https://api.example.com/mcp",
+  authKind: "api_key",
+  requiredHeaders: ["Authorization"],
+  runtime: { available: true },
+});
+function harness(overrides: Record<string, unknown> = {}) {
+  const createConnection = mock(async () => ({
+    id: "connection",
+    providerDomain: "canonical.example.com",
+  }));
+  const updateConnection = mock(async () => ({
+    id: "existing",
+    providerDomain: "canonical.example.com",
+  }));
+  const enableCapability = mock(
+    async (..._args: Parameters<OpenGeniBrowserClient["enableCapability"]>) => {},
+  );
+  const options = {
+    client: {
+      createConnection,
+      updateConnection,
+      enableCapability,
+      ...overrides,
+    } as unknown as OpenGeniBrowserClient,
+    workspaceId: "workspace",
+    item,
+    connections: [] as ConnectionMetadata[],
+    canManageSkills: true,
+    refresh: mock(async () => {}),
+    onRuntimeChanged: mock(() => {}),
+    onComplete: mock(async () => {}),
+    onSkillRemoval: mock(() => {}),
+    returnPathFor: () => "/workspaces/workspace/sessions/session",
+    redirect: mock(() => {}),
+  };
+  return { options, createConnection, updateConnection, enableCapability };
+}
+const action = {
+  type: "api_key" as const,
+  item,
+  ownership: "workspace" as const,
+  headers: { Authorization: "private-input" },
+};
+
+describe("shared capability connection lifecycle", () => {
+  test("enables using the server's canonical connection, never the form's domain", async () => {
+    const h = harness();
+    await performCapabilityAction(h.options, action);
+    expect(h.enableCapability.mock.calls[0]?.[2]).toMatchObject({
+      connectionRef: { connectionId: "connection", providerDomain: "canonical.example.com" },
+    });
+    expect(h.options.onComplete).toHaveBeenCalledTimes(1);
+  });
+  test("a failed enable never announces completion and a retry reuses the existing credential", async () => {
+    const h = harness();
+    h.enableCapability.mockImplementationOnce(async () => {
+      throw new Error("Enable unavailable");
+    });
+    await expect(performCapabilityAction(h.options, action)).rejects.toThrow("Enable unavailable");
+    expect(h.options.onComplete).not.toHaveBeenCalled();
+    h.options.connections = [
+      {
+        id: "existing",
+        providerDomain: "api.example.com",
+        kind: "api_key",
+        subjectId: null,
+        status: "active",
+      } as ConnectionMetadata,
+    ];
+    await performCapabilityAction(h.options, action);
+    expect(h.createConnection).toHaveBeenCalledTimes(1);
+    expect(h.updateConnection).toHaveBeenCalledTimes(1);
+    expect(h.options.onComplete).toHaveBeenCalledTimes(1);
+  });
+  test("an unreadable connection list cannot create duplicate credentials", async () => {
+    const h = harness();
+    await expect(
+      performCapabilityAction({ ...h.options, connections: null }, action),
+    ).rejects.toThrow("could not be checked");
+    expect(h.createConnection).not.toHaveBeenCalled();
+  });
+  test("a stale credential form cannot silently turn into an unauthenticated enable", async () => {
+    const h = harness();
+    const changed = { ...item, authKind: "none" as const, requiredHeaders: [] };
+    await expect(
+      performCapabilityAction({ ...h.options, item: changed }, action),
+    ).rejects.toThrow();
+    expect(h.enableCapability).not.toHaveBeenCalled();
+  });
+  test("a failed session attachment leaves setup retryable", async () => {
+    const h = harness();
+    h.options.onComplete.mockImplementationOnce(async () => {
+      throw new Error("Tool selection changed");
+    });
+    await expect(performCapabilityAction(h.options, action)).rejects.toThrow(
+      "Tool selection changed",
+    );
+    expect(h.enableCapability).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/capabilities/perform-capability-action.ts
+++ b/apps/web/src/components/capabilities/perform-capability-action.ts
@@ -1,0 +1,330 @@
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type { CapabilityCatalogItem, ConnectionMetadata, SkillUninstallPreview } from "@/types";
+import type { ConnectAction } from "./capability-detail-sheet";
+import {
+  apiKeyConnectionRef,
+  capabilityConnectPlan,
+  connectionToReuseForApiKey,
+  createInputFromCatalogItem,
+} from "@/lib/capabilities";
+import { startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
+import { toast } from "sonner";
+
+/** One connection lifecycle for catalog sheets and conversation cards. The caller
+ * resolves the live item and owns busy/error state; credentials never enter chat. */
+export async function performCapabilityAction(
+  {
+    client,
+    workspaceId,
+    item,
+    registry = false,
+    connections,
+    canManageSkills,
+    refresh,
+    onRuntimeChanged,
+    onComplete,
+    onSkillRemoval,
+    returnPathFor,
+    redirect,
+  }: {
+    client: OpenGeniBrowserClient;
+    workspaceId: string;
+    item: CapabilityCatalogItem;
+    registry?: boolean;
+    connections: ConnectionMetadata[] | null;
+    canManageSkills: boolean;
+    refresh: () => Promise<unknown>;
+    onRuntimeChanged: () => void;
+    onComplete: () => void | Promise<void>;
+    onSkillRemoval: (value: {
+      item: CapabilityCatalogItem;
+      preview: SkillUninstallPreview;
+    }) => void;
+    returnPathFor: (id: string) => string;
+    redirect: (url: string) => void;
+  },
+  action: ConnectAction,
+): Promise<void> {
+  if (action.item !== item) throw new Error("The selected capability changed. Review it again.");
+  async function persistIfRegistry(candidate: CapabilityCatalogItem, fromRegistry: boolean) {
+    return fromRegistry
+      ? client.createCapability(workspaceId, createInputFromCatalogItem(candidate))
+      : candidate;
+  }
+  // The plan is derived from the current catalog/registry item (it carries
+  // authKind/mcpUrl/providerDomain); connect calls use the persisted id.
+  const plan = capabilityConnectPlan(item);
+  if ((action.type === "api_key" || action.type === "reconnect_api_key") && connections === null) {
+    throw new Error(
+      "Existing connections could not be checked. Refresh and retry before saving credentials.",
+    );
+  }
+
+  if (action.type === "install_skill") {
+    if (!canManageSkills) {
+      throw new Error("Workspace administrator permission is required to install Skills.");
+    }
+    const libraryId = metadataString(item.metadata.libraryId);
+    const expectedVersion = metadataString(item.metadata.version);
+    const expectedContentSha256 = metadataString(item.metadata.contentSha256);
+    if (!libraryId || !expectedVersion || !expectedContentSha256) {
+      throw new Error(
+        "This Skill is missing its reviewed library identity. Refresh and try again.",
+      );
+    }
+    const installationVersion = installedSkillVersion(item);
+    const installed = await client.installLibrarySkill(workspaceId, libraryId, {
+      expectedVersion,
+      expectedContentSha256,
+      ...(installationVersion !== null ? { expectedInstallationVersion: installationVersion } : {}),
+    });
+    await refresh();
+    onRuntimeChanged();
+    if (installed.skillReceipt?.outcome === "pending") {
+      throw new Error("This Skill is awaiting review and has not been activated.");
+    }
+    await onComplete();
+    toast.success(item.enabled ? `Updated ${item.name}` : `Installed ${item.name}`, {
+      description:
+        installed.skillReceipt?.outcome === "preserved"
+          ? "Your customized Skill was preserved."
+          : `Pinned to reviewed Skill version ${expectedVersion}.`,
+    });
+    return;
+  }
+
+  if (action.type === "remove_skill") {
+    if (!canManageSkills) {
+      throw new Error("Workspace administrator permission is required to remove Skills.");
+    }
+    const preview = await client.previewSkillUninstall(workspaceId, item.id);
+    if (!preview.installed || preview.installationVersion === null || !preview.directOwner) {
+      throw new Error("This Skill is no longer directly installed. Refresh and try again.");
+    }
+    onSkillRemoval({ item, preview });
+    return;
+  }
+
+  if (action.type === "disconnect") {
+    if (item.kind !== "mcp" || !item.actions.includes("disconnect")) {
+      throw new Error(`${item.name} must be managed through its dedicated controls.`);
+    }
+    await client.disableCapability(workspaceId, item.id);
+    await refresh();
+    onRuntimeChanged();
+    await onComplete();
+    toast.success(`Disabled ${item.name}`);
+    return;
+  }
+
+  if (action.type === "social_oauth" && plan.mode === "social_oauth") {
+    const returnPath = returnPathFor(item.id);
+    const response = await client.startSocialOAuth(workspaceId, {
+      provider: action.provider,
+      ownership: action.ownership,
+      returnPath,
+    });
+    if (!response.authorizationUrl) {
+      throw new Error("The provider did not return an authorization link.");
+    }
+    redirect(response.authorizationUrl);
+    return;
+  }
+
+  if (action.type === "disconnect_social") {
+    await client.disconnectSocialConnection(workspaceId, action.connectionId);
+    await refresh();
+    await onComplete();
+    toast.success(`Disconnected ${item.name}`);
+    return;
+  }
+
+  // First-party Fiken connect / token replacement. The install route
+  // verifies the token against Fiken before storing it, so a bad paste
+  // fails here with a specific message instead of at first tool use.
+  if (action.type === "fiken_api_token") {
+    await client.installFikenConnection(workspaceId, {
+      apiToken: action.apiToken,
+      ...(action.connectionId ? { connectionId: action.connectionId } : {}),
+    });
+    await refresh();
+    onRuntimeChanged();
+    await onComplete();
+    toast.success(`Connected ${item.name}`);
+    return;
+  }
+
+  // Full-page redirect into Fiken's consent screen; the API callback
+  // stores the workspace connection and returns to this page with a
+  // `fiken` query param handled by the return effect below.
+  if (action.type === "fiken_oauth") {
+    const response = await client.startFikenOAuth(workspaceId, {
+      returnPath: returnPathFor(item.id),
+      ...(action.connectionId ? { connectionId: action.connectionId } : {}),
+    });
+    if (!response.authorizationUrl) {
+      throw new Error("Fiken did not return an authorization link.");
+    }
+    redirect(response.authorizationUrl);
+    return;
+  }
+
+  if (action.type === "fiken_disconnect") {
+    await client.deleteConnection(workspaceId, action.connectionId);
+    await refresh();
+    onRuntimeChanged();
+    await onComplete();
+    toast.success(`Disconnected ${item.name}`);
+    return;
+  }
+
+  // Reconnect an already-enabled item whose credential lapsed. When the
+  // connection row survives, OAuth reuses it (pass connectionId) and the
+  // return handler just refreshes; when it was deleted (null id), OAuth
+  // mints a fresh row and the return handler re-enables against it. API-key
+  // reactivates the surviving row in place, or mints + re-enables if gone.
+  if (action.type === "reconnect_oauth") {
+    // Trust the installation's connectionRef.kind (the sheet already chose this
+    // branch from it), not the catalog plan - on drift plan.mode can read
+    // "enable", so fall back to the ref's domain and the item's own MCP URL.
+    const providerDomain =
+      plan.mode === "oauth" ? plan.providerDomain : (item.connectionRef?.providerDomain ?? null);
+    const mcpUrl = plan.mode === "oauth" ? plan.mcpUrl : (item.mcpUrl ?? item.endpointUrl ?? null);
+    const returnPath = returnPathFor(item.id);
+    const response = await startMcpOAuthWithTimeout(client, workspaceId, {
+      ...(mcpUrl ? { mcpUrl } : {}),
+      ...(providerDomain ? { providerDomain } : {}),
+      // Reuse the existing row when it survives; a null id means the row was
+      // deleted, so OAuth mints a fresh connection and the return handler
+      // re-enables against it.
+      ...(action.connectionId ? { connectionId: action.connectionId } : {}),
+      ownership: action.ownership,
+      returnPath,
+    });
+    if (!response.authorizationUrl) {
+      throw new Error("The provider did not return an authorization link.");
+    }
+    redirect(response.authorizationUrl);
+    return;
+  }
+
+  if (action.type === "reconnect_api_key") {
+    if (action.connectionId) {
+      // The existing row went inactive - rewrite its credential and
+      // reactivate it in place; the installation ref already points at it.
+      await client.updateConnection(workspaceId, action.connectionId, {
+        credential: { headers: action.headers },
+        status: "active",
+      });
+    } else {
+      // The row was deleted - mint a fresh connection and re-enable the
+      // installation against it (enable upserts the installation config). Domain
+      // comes from the plan, or the installation's ref when the catalog drifted.
+      const providerDomain =
+        plan.mode === "api_key" ? plan.providerDomain : (item.connectionRef?.providerDomain ?? "");
+      const connection = await client.createConnection(workspaceId, {
+        providerDomain,
+        kind: "api_key",
+        ownership: action.ownership,
+        credential: { headers: action.headers },
+      });
+      await client.enableCapability(workspaceId, item.id, {
+        connectionRef: apiKeyConnectionRef(
+          action.ownership,
+          connection.id,
+          connection.providerDomain,
+        ),
+      });
+    }
+    await refresh();
+    onRuntimeChanged();
+    await onComplete();
+    toast.success(`Reconnected ${item.name}`);
+    return;
+  }
+
+  if (item.kind !== "mcp") {
+    throw new Error(`${item.name} must be installed through its dedicated controls.`);
+  }
+  const persisted = await persistIfRegistry(item, registry);
+
+  if (action.type === "oauth" && plan.mode === "oauth") {
+    const returnPath = returnPathFor(persisted.id);
+    const response = await startMcpOAuthWithTimeout(client, workspaceId, {
+      ...(plan.mcpUrl ? { mcpUrl: plan.mcpUrl } : {}),
+      ...(plan.providerDomain ? { providerDomain: plan.providerDomain } : {}),
+      ownership: action.ownership,
+      returnPath,
+    });
+    if (!response.authorizationUrl) {
+      throw new Error("The provider did not return an authorization link.");
+    }
+    // Full-page redirect into the provider's consent screen; we return to
+    // returnPath and resume in the OAuth-return effect below.
+    redirect(response.authorizationUrl);
+    return;
+  }
+
+  if (action.type === "api_key" && plan.mode === "api_key") {
+    // Reuse only a connection with the selected ownership rather than creating
+    // a duplicate on retry; workspace and personal rows never cross-reuse.
+    const reuseId = connectionToReuseForApiKey(
+      item,
+      connections ?? [],
+      plan.providerDomain,
+      action.ownership,
+    );
+    const connection = reuseId
+      ? await client.updateConnection(workspaceId, reuseId, {
+          credential: { headers: action.headers },
+          status: "active",
+        })
+      : await client.createConnection(workspaceId, {
+          providerDomain: plan.providerDomain,
+          kind: "api_key",
+          ownership: action.ownership,
+          credential: { headers: action.headers },
+        });
+    // Build the enable ref from the connection row the API returns, never the
+    // catalog domain - the API may canonicalize providerDomain, and the row
+    // is the authoritative match the enable path validates against.
+    await client.enableCapability(workspaceId, persisted.id, {
+      connectionRef: apiKeyConnectionRef(
+        action.ownership,
+        connection.id,
+        connection.providerDomain,
+      ),
+    });
+    await refresh();
+    onRuntimeChanged();
+    await onComplete();
+    toast.success(`Connected and enabled ${persisted.name}`);
+    return;
+  }
+
+  // A stale form must not fall through from a credentialed action to enable.
+  if (action.type !== "enable" || plan.mode !== "enable") {
+    throw new Error(
+      "The connection requirements changed. Close this form and review the current setup.",
+    );
+  }
+  // Plain enable (no credentials).
+  await client.enableCapability(workspaceId, persisted.id);
+  await refresh();
+  if (persisted.kind === "mcp") onRuntimeChanged();
+  await onComplete();
+  toast.success(`Enabled ${persisted.name}`);
+}
+
+function metadataString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function installedSkillVersion(item: CapabilityCatalogItem): number | null {
+  const installedSkill = item.metadata.installedSkill;
+  if (!installedSkill || typeof installedSkill !== "object" || Array.isArray(installedSkill)) {
+    return null;
+  }
+  const value = (installedSkill as Record<string, unknown>).installationVersion;
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}

--- a/apps/web/src/components/capabilities/session-auth-recommendation.test.ts
+++ b/apps/web/src/components/capabilities/session-auth-recommendation.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import type { AuthNeededItem } from "@opengeni/react/session";
+import type { CapabilityCatalogItem } from "@/types";
+import { sessionAuthRecommendation } from "./session-auth-recommendation";
+const event = {
+  serverId: "example",
+  connectionId: "connection",
+  authoritySource: null,
+  reason: "token_expired",
+} as unknown as AuthNeededItem;
+const item = {
+  id: "catalog-example",
+  name: "Example",
+  kind: "mcp",
+  source: "manual",
+  runtime: { mcpServerId: "example" },
+  connectionRef: { connectionId: "connection" },
+} as CapabilityCatalogItem;
+test("reconnect resolves the exact runtime integration", () => {
+  expect(sessionAuthRecommendation(event, [item])?.capability?.id).toBe("catalog-example");
+});
+test("host-managed and unavailable authority never use stock connection controls", () => {
+  expect(sessionAuthRecommendation({ ...event, authoritySource: "host" }, [item])).toBeUndefined();
+  expect(
+    sessionAuthRecommendation({ ...event, reason: "personal_authority_unavailable" }, [item]),
+  ).toBeUndefined();
+});
+test("ambiguous accounts are not guessed by provider domain", () => {
+  expect(sessionAuthRecommendation(event, [item, { ...item, id: "other" }])).toBeUndefined();
+});

--- a/apps/web/src/components/capabilities/session-auth-recommendation.ts
+++ b/apps/web/src/components/capabilities/session-auth-recommendation.ts
@@ -1,0 +1,39 @@
+import type { AuthNeededItem } from "@opengeni/react/session";
+import type { CapabilityCatalogItem } from "@/types";
+
+/** Recovery events identify runtime servers/connections, while recommendation
+ * events already carry a catalog id. Never guess among same-domain accounts. */
+export function sessionAuthRecommendation(
+  item: AuthNeededItem,
+  catalog: CapabilityCatalogItem[],
+): AuthNeededItem | undefined {
+  if (
+    item.authoritySource === "host" ||
+    item.reason === "personal_authority_unavailable" ||
+    item.reason === "unsupported_auth" ||
+    item.reason === "resource_scope_unavailable"
+  )
+    return undefined;
+  if (item.capability) return item;
+  const matches = catalog.filter(
+    (candidate) =>
+      (item.serverId !== null &&
+        candidate.runtime.mcpServerId === item.serverId &&
+        item.serverId !== "opengeni") ||
+      (item.connectionId !== null && candidate.connectionRef?.connectionId === item.connectionId),
+  );
+  if (matches.length !== 1) return undefined;
+  const entry = matches[0]!;
+  return {
+    ...item,
+    capability: {
+      id: entry.id,
+      name: entry.name,
+      kind: entry.kind,
+      source: entry.source,
+      action: "connect",
+      rationale: "Reconnect this integration to use its tools in this conversation.",
+      requiredVariables: [],
+    },
+  };
+}

--- a/apps/web/src/components/capabilities/session-capability-card.test.tsx
+++ b/apps/web/src/components/capabilities/session-capability-card.test.tsx
@@ -46,7 +46,6 @@ const context = {
             ? {
                 connectionRef: {
                   subjectScope: "subject",
-                  connectionId: "connection",
                   providerDomain: "api.example.com",
                   kind: "api_key",
                 },

--- a/apps/web/src/components/capabilities/session-capability-card.test.tsx
+++ b/apps/web/src/components/capabilities/session-capability-card.test.tsx
@@ -1,0 +1,176 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+
+import { CapabilityCatalogItem } from "@opengeni/contracts";
+import type { AuthNeededItem } from "@opengeni/react";
+
+const catalogItem = CapabilityCatalogItem.parse({
+  id: "example",
+  kind: "mcp",
+  source: "manual",
+  name: "Example",
+  providerDomain: "api.example.com",
+  mcpUrl: "https://api.example.com/mcp",
+  authKind: "api_key",
+  runtime: { available: true },
+  tools: [{ kind: "mcp", id: "example" }],
+});
+let enabled = false;
+let connections: unknown[] = [];
+const row = {
+  id: "connection",
+  providerDomain: "api.example.com",
+  kind: "api_key",
+  subjectId: null,
+  status: "active",
+};
+const createConnection = mock(async () => {
+  connections.push(row);
+  return row;
+});
+const updateConnection = mock(async () => row);
+const enableCapability = mock(async () => {
+  enabled = true;
+});
+const context = {
+  client: {
+    listCapabilities: async () => ({ items: [{ ...catalogItem, enabled }] }),
+    listConnections: async () => connections,
+    listSocialConnections: async () => [],
+    listSlackInstallationBindings: async () => [],
+    listIntegrationDefinitions: async () => ({ definitions: [] }),
+    listApiIntegrations: async () => ({ integrations: [] }),
+    catalogAssetUrl: (path: string) => path,
+    createConnection,
+    updateConnection,
+    enableCapability,
+    getSession: async () => ({
+      tools: [{ kind: "mcp", id: "example" }],
+      toolPolicy: { mode: "explicit" },
+      firstPartyMcpTools: [],
+      toolPolicyVersion: 1,
+    }),
+  },
+  workspaceCapabilityCatalog: [catalogItem],
+  refreshWorkspaceMcpServers: async () => {},
+  accessContext: { workspaceGrants: [] },
+};
+mock.module("@/context", () => ({ useAppContext: () => context }));
+mock.module("sonner", () => ({ toast: { success: () => {}, error: () => {} } }));
+GlobalRegistrator.register();
+const { createRoot } = await import("react-dom/client");
+const { SessionCapabilityCard } = await import("./session-capability-card");
+const item = {
+  id: "notice",
+  kind: "auth-needed",
+  serverId: "opengeni",
+  providerDomain: "api.example.com",
+  reason: "missing_connection",
+  capability: {
+    id: "example",
+    name: "Example",
+    kind: "mcp",
+    action: "add_credentials",
+    rationale: "Use Example for your report.",
+    requiredVariables: [],
+  },
+} as unknown as AuthNeededItem;
+beforeAll(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+async function render() {
+  enabled = false;
+  connections = [];
+  updateConnection.mockClear();
+  createConnection.mockClear();
+  enableCapability.mockClear();
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () =>
+    root.render(<SessionCapabilityCard item={item} workspaceId="workspace" sessionId="session" />),
+  );
+  return {
+    container,
+    close: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+}
+function button(container: HTMLElement, label: string) {
+  const result = [...container.querySelectorAll("button")].find((node) =>
+    node.textContent?.includes(label),
+  );
+  if (!result) throw new Error(`Missing ${label}: ${container.textContent}`);
+  return result;
+}
+
+describe("conversation connection card", () => {
+  test("opens the actual credential form inline and cancellation writes nothing", async () => {
+    const h = await render();
+    await act(async () => button(h.container, "Connect Example").click());
+    expect(h.container.querySelector('input[type="password"]')).not.toBeNull();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    await act(async () => button(h.container, "Cancel").click());
+    expect(h.container.querySelector("form")).toBeNull();
+    expect(createConnection).not.toHaveBeenCalled();
+    await h.close();
+  });
+  test("credentials go only to the connection API and success follows enable", async () => {
+    const h = await render();
+    await act(async () => button(h.container, "Connect Example").click());
+    const input = h.container.querySelector('input[type="password"]') as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+      setter.call(input, "secret-for-provider-only");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () =>
+      h.container
+        .querySelector("form")!
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    );
+    expect(createConnection).toHaveBeenCalledTimes(1);
+    expect(enableCapability).toHaveBeenCalledTimes(1);
+    expect(h.container.textContent).toContain("Setup complete");
+    expect(h.container.textContent).not.toContain("secret-for-provider-only");
+    await h.close();
+  });
+  test("retry after a partial save reuses the persisted Connection", async () => {
+    const h = await render();
+    enableCapability.mockImplementationOnce(async () => {
+      throw new Error("Enable failed");
+    });
+    await act(async () => button(h.container, "Connect Example").click());
+    const input = h.container.querySelector('input[type="password"]') as HTMLInputElement;
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(
+        input,
+        "fixture-credential",
+      );
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const submit = async () => {
+      await act(async () => {
+        h.container
+          .querySelector("form")!
+          .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      });
+    };
+    await submit();
+    expect(h.container.textContent).toContain("Enable failed");
+    expect(h.container.textContent).not.toContain("Setup complete");
+    await submit();
+    expect(createConnection).toHaveBeenCalledTimes(1);
+    expect(updateConnection).toHaveBeenCalledTimes(1);
+    expect(h.container.textContent).toContain("Setup complete");
+    await h.close();
+  });
+});

--- a/apps/web/src/components/capabilities/session-capability-card.test.tsx
+++ b/apps/web/src/components/capabilities/session-capability-card.test.tsx
@@ -13,9 +13,10 @@ const catalogItem = CapabilityCatalogItem.parse({
   providerDomain: "api.example.com",
   mcpUrl: "https://api.example.com/mcp",
   authKind: "api_key",
-  runtime: { available: true },
+  runtime: { available: true, mcpServerId: "example" },
   tools: [{ kind: "mcp", id: "example" }],
 });
+let personal = false;
 let enabled = false;
 let connections: unknown[] = [];
 const row = {
@@ -33,19 +34,42 @@ const updateConnection = mock(async () => row);
 const enableCapability = mock(async () => {
   enabled = true;
 });
+const issueUserResourceGrant = mock(async (..._args: unknown[]) => ({}));
 const context = {
   client: {
-    listCapabilities: async () => ({ items: [{ ...catalogItem, enabled }] }),
+    listCapabilities: async () => ({
+      items: [
+        {
+          ...catalogItem,
+          enabled,
+          ...(personal
+            ? {
+                connectionRef: {
+                  subjectScope: "subject",
+                  connectionId: "connection",
+                  providerDomain: "api.example.com",
+                  kind: "api_key",
+                },
+              }
+            : {}),
+        },
+      ],
+    }),
     listConnections: async () => connections,
     listSocialConnections: async () => [],
     listSlackInstallationBindings: async () => [],
     listIntegrationDefinitions: async () => ({ definitions: [] }),
     listApiIntegrations: async () => ({ integrations: [] }),
     catalogAssetUrl: (path: string) => path,
+    listUserResourceAuthorities: async () => ({ authorities: [] }),
+    issueUserResourceGrant,
     createConnection,
     updateConnection,
     enableCapability,
     getSession: async () => ({
+      id: "session",
+      workspaceId: "workspace",
+      tenancy: { visibility: "workspace", authorityEpoch: 4 },
       tools: [{ kind: "mcp", id: "example" }],
       toolPolicy: { mode: "explicit" },
       firstPartyMcpTools: [],
@@ -83,9 +107,11 @@ afterAll(() => {
   mock.restore();
   GlobalRegistrator.unregister();
 });
-async function render() {
-  enabled = false;
-  connections = [];
+async function render(personalAccount = false) {
+  personal = personalAccount;
+  enabled = personalAccount;
+  connections = personalAccount ? [{ ...row, subjectId: "owner", authorityId: "authority" }] : [];
+  issueUserResourceGrant.mockClear();
   updateConnection.mockClear();
   createConnection.mockClear();
   enableCapability.mockClear();
@@ -141,6 +167,28 @@ describe("conversation connection card", () => {
     expect(enableCapability).toHaveBeenCalledTimes(1);
     expect(h.container.textContent).toContain("Setup complete");
     expect(h.container.textContent).not.toContain("secret-for-provider-only");
+    await h.close();
+  });
+  test("a personal account requires explicit shared-results consent before completion", async () => {
+    const h = await render(true);
+    await act(async () => button(h.container, "Connect Example").click());
+    const use = button(h.container, "Use in this");
+    expect(use.disabled).toBe(true);
+    expect(issueUserResourceGrant).not.toHaveBeenCalled();
+    expect(h.container.textContent).not.toContain("Setup complete");
+    await act(async () =>
+      (h.container.querySelector('input[type="checkbox"]') as HTMLInputElement).click(),
+    );
+    expect(use.disabled).toBe(false);
+    await act(async () => use.click());
+    expect(issueUserResourceGrant).toHaveBeenCalledTimes(1);
+    expect(issueUserResourceGrant.mock.calls[0]?.[2]).toMatchObject({
+      mode: "session",
+      sessionId: "session",
+      expectedAuthorityEpoch: 4,
+      workspaceSharedAcknowledged: true,
+    });
+    expect(h.container.textContent).toContain("Setup complete");
     await h.close();
   });
   test("retry after a partial save reuses the persisted Connection", async () => {

--- a/apps/web/src/components/capabilities/session-capability-card.tsx
+++ b/apps/web/src/components/capabilities/session-capability-card.tsx
@@ -1,3 +1,4 @@
+import { authorizeSessionPersonalConnection } from "./session-connection-authority";
 import { attachSessionCapability } from "./attach-session-capability";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import type { AuthNeededItem } from "@opengeni/react";
@@ -24,7 +25,11 @@ export function SessionCapabilityCard({
   item,
   workspaceId,
   sessionId,
+  visibility = "workspace",
+  onConfigured,
 }: {
+  visibility?: "private" | "workspace";
+  onConfigured?: (() => Promise<void>) | undefined;
   item: AuthNeededItem;
   workspaceId: string;
   sessionId: string;
@@ -87,7 +92,7 @@ export function SessionCapabilityCard({
               onClick={() => setExpanded(true)}
             >
               {recommendation.kind === "skill" ? <SparklesIcon /> : <PlugIcon />}
-              {complete
+              {complete || catalogItem?.enabled
                 ? "Review"
                 : recommendation.kind === "skill"
                   ? "Review Skill"
@@ -119,6 +124,8 @@ export function SessionCapabilityCard({
         <SessionCapabilitySetup
           key={`${workspaceId}:${sessionId}:${recommendation.id}`}
           capabilityId={recommendation.id}
+          visibility={visibility}
+          onConfigured={onConfigured}
           workspaceId={workspaceId}
           sessionId={sessionId}
           onClose={close}
@@ -134,12 +141,16 @@ export function SessionCapabilityCard({
 
 function SessionCapabilitySetup({
   capabilityId,
+  visibility,
+  onConfigured,
   workspaceId,
   sessionId,
   onClose,
   onComplete,
 }: {
   capabilityId: string;
+  visibility: "private" | "workspace";
+  onConfigured?: (() => Promise<void>) | undefined;
   workspaceId: string;
   sessionId: string;
   onClose: () => void;
@@ -147,6 +158,8 @@ function SessionCapabilitySetup({
 }) {
   const context = useAppContext();
   const catalog = useCapabilitiesCatalog(workspaceId);
+  const [sharedAcknowledged, setSharedAcknowledged] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inFlight = useRef(false);
@@ -199,7 +212,14 @@ function SessionCapabilitySetup({
             if (!current()) return;
             if (!updated?.enabled)
               throw new Error("Setup could not be verified. Refresh and try again.");
+            if (updated.connectionRef?.subjectScope === "subject") {
+              setNotice(
+                "Your account is connected. Choose how to use it in this conversation below.",
+              );
+              return;
+            }
             await attachSessionCapability(context.client, workspaceId, sessionId, updated, current);
+            await onConfigured?.();
             if (current()) onComplete();
           },
           onSkillRemoval: () => {
@@ -237,7 +257,19 @@ function SessionCapabilitySetup({
       scope.current.workspaceId === invocation.workspaceId &&
       scope.current.sessionId === invocation.sessionId;
     try {
+      if (item.connectionRef?.subjectScope === "subject") {
+        await authorizeSessionPersonalConnection(
+          context.client,
+          workspaceId,
+          sessionId,
+          item,
+          visibility,
+          sharedAcknowledged,
+          current,
+        );
+      }
       await attachSessionCapability(context.client, workspaceId, sessionId, item, current);
+      if (current()) await onConfigured?.();
       if (current()) onComplete();
     } catch (failure) {
       if (current())
@@ -297,6 +329,34 @@ function SessionCapabilitySetup({
           onAction={(action) => void act(action)}
         />
       )}
+      {notice ? (
+        <p role="status" className="mt-2 text-xs text-fg-muted">
+          {notice}
+        </p>
+      ) : null}
+      {item?.enabled && item.connectionRef?.subjectScope === "subject" ? (
+        <div className="mt-3 text-xs text-fg-muted">
+          {visibility === "workspace" ? (
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={sharedAcknowledged}
+                onChange={(event) => setSharedAcknowledged(event.target.checked)}
+                disabled={busy}
+                className="mt-0.5 size-4"
+              />
+              <span>
+                Allow this conversation to use my personal account. Results shared here will be
+                visible to other workspace members.
+              </span>
+            </label>
+          ) : (
+            <p>
+              Allow your personal account only in this private conversation and its continuations.
+            </p>
+          )}
+        </div>
+      ) : null}
       <div className="mt-2 flex justify-end gap-2">
         {!ownsActionRow ? (
           <Button size="sm" variant="ghost" disabled={busy} onClick={onClose}>
@@ -304,7 +364,16 @@ function SessionCapabilitySetup({
           </Button>
         ) : null}
         {item?.enabled && health?.state !== "attention" && health?.state !== "unverified" ? (
-          <Button size="sm" disabled={busy} onClick={() => void useConnected()}>
+          <Button
+            size="sm"
+            disabled={
+              busy ||
+              (item.connectionRef?.subjectScope === "subject" &&
+                visibility === "workspace" &&
+                !sharedAcknowledged)
+            }
+            onClick={() => void useConnected()}
+          >
             {busy ? <Loader2Icon className="animate-spin" /> : <CheckIcon />}Use in this
             conversation
           </Button>

--- a/apps/web/src/components/capabilities/session-capability-card.tsx
+++ b/apps/web/src/components/capabilities/session-capability-card.tsx
@@ -1,0 +1,465 @@
+import { attachSessionCapability } from "./attach-session-capability";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import type { AuthNeededItem } from "@opengeni/react";
+import { CheckIcon, Loader2Icon, PlugIcon, SparklesIcon } from "lucide-react";
+import { useAppContext } from "@/context";
+import { Button } from "@/components/ui/button";
+import { Notice } from "@/components/ui/notice";
+import { MetaChip } from "@/components/ui/meta-chip";
+import { CapabilityLogo } from "./capability-logo";
+import { capabilityLogoSource } from "./capability-logo-source";
+import { DetailBody, type ConnectAction } from "./capability-detail-sheet";
+import { performCapabilityAction } from "./perform-capability-action";
+import { useCapabilitiesCatalog } from "./use-capabilities-catalog";
+import { capabilityErrorToast, connectionHealth } from "@/lib/capabilities";
+import { hasWorkspacePermission } from "@/lib/permissions";
+
+const CodexSubscriptionsCard = lazy(async () => ({
+  default: (await import("@/components/codex-connection")).CodexSubscriptionsCard,
+}));
+
+/** Recommendations carry identity and rationale, never connection configuration.
+ * Expand against the current authenticated catalog before rendering any form. */
+export function SessionCapabilityCard({
+  item,
+  workspaceId,
+  sessionId,
+}: {
+  item: AuthNeededItem;
+  workspaceId: string;
+  sessionId: string;
+}) {
+  const context = useAppContext();
+  const recommendation = item.capability!;
+  const [expanded, setExpanded] = useState(false);
+  const [complete, setComplete] = useState(false);
+  const opener = useRef<HTMLButtonElement>(null);
+  const catalogItem = context.workspaceCapabilityCatalog.find(
+    (entry) => entry.id === recommendation.id,
+  );
+  const logo = catalogItem
+    ? capabilityLogoSource(catalogItem, (path) => context.client.catalogAssetUrl(path))
+    : null;
+  const close = () => {
+    setExpanded(false);
+    requestAnimationFrame(() => opener.current?.focus());
+  };
+  return (
+    <section
+      className="rounded-xl border border-border p-4"
+      aria-label={`${recommendation.name} setup`}
+    >
+      {!expanded ? (
+        <>
+          <div className="flex items-start gap-3">
+            <CapabilityLogo
+              src={logo}
+              name={recommendation.name}
+              size="lg"
+              fallback={
+                recommendation.kind === "skill" ? <SparklesIcon className="size-5" /> : undefined
+              }
+            />
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-medium text-fg">{recommendation.name}</h3>
+              <p className="mt-0.5 text-xs text-fg-subtle">{item.providerDomain}</p>
+            </div>
+            <MetaChip>
+              {recommendation.kind === "skill"
+                ? "Skill"
+                : recommendation.kind === "mcp"
+                  ? "MCP server"
+                  : "Integration"}
+            </MetaChip>
+          </div>
+          <p className="mt-3 text-sm leading-6 text-fg-muted">{recommendation.rationale}</p>
+          <div className="mt-3 flex items-center justify-end gap-2">
+            {complete ? (
+              <span role="status" className="mr-auto flex items-center gap-2 text-xs text-fg-muted">
+                <CheckIcon className="size-4" />
+                Setup complete
+              </span>
+            ) : null}
+            <Button
+              ref={opener}
+              size="sm"
+              variant={complete ? "outline" : "default"}
+              onClick={() => setExpanded(true)}
+            >
+              {recommendation.kind === "skill" ? <SparklesIcon /> : <PlugIcon />}
+              {complete
+                ? "Review"
+                : recommendation.kind === "skill"
+                  ? "Review Skill"
+                  : `Connect ${recommendation.name}`}
+            </Button>
+          </div>
+        </>
+      ) : recommendation.id === "api:github-app" ? (
+        <SessionGitHubSetup
+          workspaceId={workspaceId}
+          sessionId={sessionId}
+          onClose={close}
+          onComplete={() => {
+            setComplete(true);
+            close();
+          }}
+        />
+      ) : recommendation.id === "mcp:codex_apps" ? (
+        <SessionCodexAppsSetup
+          workspaceId={workspaceId}
+          sessionId={sessionId}
+          onClose={close}
+          onComplete={() => {
+            setComplete(true);
+            close();
+          }}
+        />
+      ) : (
+        <SessionCapabilitySetup
+          key={`${workspaceId}:${sessionId}:${recommendation.id}`}
+          capabilityId={recommendation.id}
+          workspaceId={workspaceId}
+          sessionId={sessionId}
+          onClose={close}
+          onComplete={() => {
+            setComplete(true);
+            close();
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+function SessionCapabilitySetup({
+  capabilityId,
+  workspaceId,
+  sessionId,
+  onClose,
+  onComplete,
+}: {
+  capabilityId: string;
+  workspaceId: string;
+  sessionId: string;
+  onClose: () => void;
+  onComplete: () => void;
+}) {
+  const context = useAppContext();
+  const catalog = useCapabilitiesCatalog(workspaceId);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
+  const scope = useRef({ client: context.client, workspaceId, sessionId, alive: true });
+  scope.current = { client: context.client, workspaceId, sessionId, alive: true };
+  useEffect(() => {
+    void catalog.refresh();
+    return () => {
+      scope.current.alive = false;
+    };
+    // Catalog refresh is intentionally invoked once per mounted scope.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.client, workspaceId, sessionId]);
+  const item = catalog.items.find((entry) => entry.id === capabilityId);
+  const refreshRuntime = useCallback(() => {
+    void context.refreshWorkspaceMcpServers(workspaceId);
+  }, [context, workspaceId]);
+  async function act(action: ConnectAction) {
+    if (!item || inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
+    setError(null);
+    const invocation = scope.current;
+    const current = () =>
+      scope.current.alive &&
+      scope.current.client === invocation.client &&
+      scope.current.workspaceId === invocation.workspaceId &&
+      scope.current.sessionId === invocation.sessionId;
+    try {
+      await performCapabilityAction(
+        {
+          client: context.client,
+          workspaceId,
+          item,
+          connections: catalog.connectionsLoadFailed ? null : catalog.connections,
+          canManageSkills: hasWorkspacePermission(
+            context.accessContext,
+            workspaceId,
+            "capabilities:manage",
+          ),
+          refresh: catalog.refresh,
+          onRuntimeChanged: () => {
+            if (current()) refreshRuntime();
+          },
+          onComplete: async () => {
+            if (!current()) return;
+            const updated = (await context.client.listCapabilities(workspaceId)).items.find(
+              (entry) => entry.id === item.id,
+            );
+            if (!current()) return;
+            if (!updated?.enabled)
+              throw new Error("Setup could not be verified. Refresh and try again.");
+            await attachSessionCapability(context.client, workspaceId, sessionId, updated, current);
+            if (current()) onComplete();
+          },
+          onSkillRemoval: () => {
+            throw new Error(
+              "Use the workspace Skill controls to review removal and its other owners.",
+            );
+          },
+          returnPathFor: (id) =>
+            `/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}?capability_auth=${encodeURIComponent(id)}`,
+          redirect: (url) => {
+            if (current()) window.location.assign(url);
+          },
+        },
+        action,
+      );
+    } catch (failure) {
+      // A credential may have committed before enabling failed. Reconcile before
+      // offering Retry so it reuses that row instead of minting a duplicate.
+      if (current()) await catalog.refresh();
+      if (current()) setError(capabilityErrorToast(failure, "Couldn't complete setup").description);
+    } finally {
+      inFlight.current = false;
+      if (current()) setBusy(false);
+    }
+  }
+  async function useConnected() {
+    if (!item || inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
+    setError(null);
+    const invocation = scope.current;
+    const current = () =>
+      scope.current.alive &&
+      scope.current.client === invocation.client &&
+      scope.current.workspaceId === invocation.workspaceId &&
+      scope.current.sessionId === invocation.sessionId;
+    try {
+      await attachSessionCapability(context.client, workspaceId, sessionId, item, current);
+      if (current()) onComplete();
+    } catch (failure) {
+      if (current())
+        setError(
+          failure instanceof Error ? failure.message : "Couldn't add this connection. Try again.",
+        );
+    } finally {
+      inFlight.current = false;
+      if (current()) setBusy(false);
+    }
+  }
+  const ownsActionRow =
+    !catalog.loadError && item && !item.enabled && (item.kind === "skill" || item.kind === "mcp");
+  const health = item
+    ? connectionHealth(item, catalog.connections ?? [], catalog.connections !== null)
+    : null;
+  return (
+    <div>
+      {catalog.loading && !item ? (
+        <p role="status" className="flex items-center gap-2 text-sm text-fg-muted">
+          <Loader2Icon className="size-4 animate-spin" />
+          Loading connection details…
+        </p>
+      ) : catalog.loadError || !item ? (
+        <Notice
+          tone="failed"
+          action={
+            <Button size="sm" onClick={() => void catalog.refresh()}>
+              Retry
+            </Button>
+          }
+        >
+          {catalog.loadError
+            ? "Couldn't load the integration catalog."
+            : "This recommendation is no longer in the current catalog."}
+        </Notice>
+      ) : (
+        <DetailBody
+          inline
+          onCancel={ownsActionRow ? onClose : undefined}
+          item={item}
+          health={connectionHealth(item, catalog.connections ?? [], catalog.connections !== null)}
+          logoSrc={capabilityLogoSource(item, (path) => context.client.catalogAssetUrl(path))}
+          busy={busy}
+          errorMessage={error}
+          socialConnections={catalog.socialConnections}
+          canManageSocial={hasWorkspacePermission(
+            context.accessContext,
+            workspaceId,
+            "connections:write",
+          )}
+          canManageSkills={hasWorkspacePermission(
+            context.accessContext,
+            workspaceId,
+            "capabilities:manage",
+          )}
+          onAction={(action) => void act(action)}
+        />
+      )}
+      <div className="mt-2 flex justify-end gap-2">
+        {!ownsActionRow ? (
+          <Button size="sm" variant="ghost" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+        ) : null}
+        {item?.enabled && health?.state !== "attention" && health?.state !== "unverified" ? (
+          <Button size="sm" disabled={busy} onClick={() => void useConnected()}>
+            {busy ? <Loader2Icon className="animate-spin" /> : <CheckIcon />}Use in this
+            conversation
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SessionGitHubSetup({
+  workspaceId,
+  sessionId,
+  onClose,
+  onComplete,
+}: {
+  workspaceId: string;
+  sessionId: string;
+  onClose: () => void;
+  onComplete: () => void;
+}) {
+  const { client } = useAppContext();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const active = useRef(true);
+  const inFlight = useRef(false);
+  useEffect(
+    () => () => {
+      active.current = false;
+    },
+    [],
+  );
+  async function connect() {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const status = await client.getGitHubApp(workspaceId, {
+        returnPath: `/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
+      });
+      if (!active.current) return;
+      if (status.status === "bound") {
+        onComplete();
+        return;
+      }
+      if (!status.linkUrl)
+        throw new Error(
+          status.configured
+            ? "Your account cannot manage this workspace's GitHub connection."
+            : "GitHub is not configured on this deployment.",
+        );
+      window.location.assign(status.linkUrl);
+    } catch (failure) {
+      if (active.current)
+        setError(
+          failure instanceof Error ? failure.message : "Couldn't start GitHub setup. Try again.",
+        );
+    } finally {
+      inFlight.current = false;
+      if (active.current) setBusy(false);
+    }
+  }
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium">Connect GitHub</h3>
+      <p className="text-sm leading-6 text-fg-muted">
+        Choose the account and repositories to share with this workspace on GitHub, then return to
+        this conversation.
+      </p>
+      {error ? <Notice tone="failed">{error}</Notice> : null}
+      <div className="flex justify-end gap-2">
+        <Button size="sm" variant="ghost" disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={busy} onClick={() => void connect()}>
+          {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}Continue to GitHub
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SessionCodexAppsSetup({
+  workspaceId,
+  sessionId,
+  onClose,
+  onComplete,
+}: {
+  workspaceId: string;
+  sessionId: string;
+  onClose: () => void;
+  onComplete: () => void;
+}) {
+  const context = useAppContext();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const inFlight = useRef(false);
+  const active = useRef(true);
+  useEffect(
+    () => () => {
+      active.current = false;
+    },
+    [],
+  );
+  async function useApps() {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const catalog = await context.client.listCapabilities(workspaceId);
+      const item = catalog.items.find((entry) => entry.id === "mcp:codex_apps");
+      if (!active.current) return;
+      if (!item?.enabled || !item.runtime.available)
+        throw new Error("Choose an active subscription for Codex Apps before continuing.");
+      await attachSessionCapability(
+        context.client,
+        workspaceId,
+        sessionId,
+        item,
+        () => active.current,
+      );
+      await context.refreshWorkspaceMcpServers(workspaceId);
+      if (active.current) onComplete();
+    } catch (failure) {
+      if (active.current)
+        setError(
+          failure instanceof Error ? failure.message : "Couldn't enable Apps in this conversation.",
+        );
+    } finally {
+      inFlight.current = false;
+      if (active.current) setBusy(false);
+    }
+  }
+  return (
+    <div>
+      <Suspense fallback={<p role="status">Loading connection controls…</p>}>
+        <CodexSubscriptionsCard
+          workspaceId={workspaceId}
+          canManage={hasWorkspacePermission(
+            context.accessContext,
+            workspaceId,
+            "connections:write",
+          )}
+        />
+      </Suspense>
+      {error ? <Notice tone="failed">{error}</Notice> : null}
+      <div className="mt-2 flex justify-end gap-2">
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={busy} onClick={() => void useApps()}>
+          {busy ? <Loader2Icon className="animate-spin" /> : <CheckIcon />}Use in this conversation
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/capabilities/session-connection-authority.test.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.test.ts
@@ -1,0 +1,145 @@
+import { expect, mock, test } from "bun:test";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type {
+  CapabilityCatalogItem,
+  Session,
+  McpConnectionAuthoritySelection,
+} from "@opengeni/sdk";
+import {
+  authorizeSessionPersonalConnection,
+  sessionConnectionAuthorities,
+} from "./session-connection-authority";
+
+const item = {
+  enabled: true,
+  connectionRef: { subjectScope: "subject", connectionId: "connection" },
+  runtime: { mcpServerId: "example" },
+} as CapabilityCatalogItem;
+const session = {
+  id: "session",
+  workspaceId: "workspace",
+  tenancy: { visibility: "workspace", authorityEpoch: 4 },
+} as Session;
+const grant = {
+  mode: "session",
+  status: "active",
+  action: "connection.use",
+  targetSessionId: "session",
+  targetWorkspaceId: "workspace",
+  authorityEpoch: 4,
+  context: "workspace_shared",
+  delegation: {
+    authorityId: "authority",
+    grantId: "grant",
+  } as McpConnectionAuthoritySelection["userDelegation"],
+};
+function harness(grants: unknown[] = []) {
+  const issueUserResourceGrant = mock(
+    async (..._args: Parameters<OpenGeniBrowserClient["issueUserResourceGrant"]>) => ({}),
+  );
+  const client = {
+    getSession: async () => session,
+    listConnections: async () => [
+      { id: "connection", subjectId: "owner", status: "active", authorityId: "authority" },
+    ],
+    listUserResourceAuthorities: async () => ({
+      authorities: [
+        { resourceId: "connection", authorityId: "authority", status: "active", grants },
+      ],
+    }),
+    issueUserResourceGrant,
+  } as unknown as OpenGeniBrowserClient;
+  return { client, issueUserResourceGrant };
+}
+test("only exact session, visibility, epoch and active grants enter messages", async () => {
+  const h = harness([
+    { ...grant, mode: "always" },
+    { ...grant, targetSessionId: "other" },
+    { ...grant, authorityEpoch: 3 },
+    { ...grant, context: "user_private" },
+    { ...grant, status: "revoked" },
+    { ...grant, expiresAt: "2020-01-01T00:00:00Z" },
+  ]);
+  expect(await sessionConnectionAuthorities(h.client, session, [item])).toEqual([]);
+  const valid = harness([grant]);
+  expect(await sessionConnectionAuthorities(valid.client, session, [item])).toEqual([
+    { serverId: "example", connectionId: "connection", userDelegation: grant.delegation },
+  ]);
+});
+test("personal use requires explicit shared-results acknowledgement", async () => {
+  const h = harness();
+  await expect(
+    authorizeSessionPersonalConnection(
+      h.client,
+      "workspace",
+      "session",
+      item,
+      "workspace",
+      false,
+      () => true,
+    ),
+  ).rejects.toThrow("Acknowledge");
+  expect(h.issueUserResourceGrant).not.toHaveBeenCalled();
+});
+test("visibility changes and navigation prevent granting", async () => {
+  const h = harness();
+  await expect(
+    authorizeSessionPersonalConnection(
+      h.client,
+      "workspace",
+      "session",
+      item,
+      "private",
+      true,
+      () => true,
+    ),
+  ).rejects.toThrow("visibility changed");
+  await expect(
+    authorizeSessionPersonalConnection(
+      h.client,
+      "workspace",
+      "session",
+      item,
+      "workspace",
+      true,
+      () => false,
+    ),
+  ).rejects.toThrow("interrupted");
+  expect(h.issueUserResourceGrant).not.toHaveBeenCalled();
+});
+test("the explicit action issues an epoch-fenced session grant and reuses it on retry", async () => {
+  const h = harness();
+  await authorizeSessionPersonalConnection(
+    h.client,
+    "workspace",
+    "session",
+    item,
+    "workspace",
+    true,
+    () => true,
+  );
+  expect(h.issueUserResourceGrant.mock.calls[0]).toEqual([
+    "workspace",
+    "authority",
+    {
+      scope: "user",
+      resourceKind: "connection",
+      mode: "session",
+      sessionId: "session",
+      expectedAuthorityEpoch: 4,
+      context: "workspace_shared",
+      workspaceSharedAcknowledged: true,
+    },
+  ]);
+  const existing = harness([grant]);
+  await authorizeSessionPersonalConnection(
+    existing.client,
+    "workspace",
+    "session",
+    item,
+    "workspace",
+    true,
+    () => true,
+  );
+  expect(existing.issueUserResourceGrant).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/capabilities/session-connection-authority.test.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.test.ts
@@ -12,7 +12,7 @@ import {
 
 const item = {
   enabled: true,
-  connectionRef: { subjectScope: "subject", connectionId: "connection" },
+  connectionRef: { subjectScope: "subject", providerDomain: "example.com", kind: "api_key" },
   runtime: { mcpServerId: "example" },
 } as CapabilityCatalogItem;
 const session = {
@@ -40,7 +40,14 @@ function harness(grants: unknown[] = []) {
   const client = {
     getSession: async () => session,
     listConnections: async () => [
-      { id: "connection", subjectId: "owner", status: "active", authorityId: "authority" },
+      {
+        id: "connection",
+        subjectId: "owner",
+        status: "active",
+        authorityId: "authority",
+        providerDomain: "example.com",
+        kind: "api_key",
+      },
     ],
     listUserResourceAuthorities: async () => ({
       authorities: [
@@ -51,7 +58,7 @@ function harness(grants: unknown[] = []) {
   } as unknown as OpenGeniBrowserClient;
   return { client, issueUserResourceGrant };
 }
-test("only exact session, visibility, epoch and active grants enter messages", async () => {
+test("private IDs resolve from owner metadata and only exact active session grants enter messages", async () => {
   const h = harness([
     { ...grant, mode: "always" },
     { ...grant, targetSessionId: "other" },
@@ -142,4 +149,29 @@ test("the explicit action issues an epoch-fenced session grant and reuses it on 
     () => true,
   );
   expect(existing.issueUserResourceGrant).not.toHaveBeenCalled();
+});
+
+test("ambiguous personal accounts never issue an arbitrary account grant", async () => {
+  const h = harness();
+  h.client.listConnections = async () =>
+    ["first", "second"].map((id) => ({
+      id,
+      subjectId: "owner",
+      status: "active",
+      authorityId: id,
+      providerDomain: "example.com",
+      kind: "api_key",
+    })) as Awaited<ReturnType<OpenGeniBrowserClient["listConnections"]>>;
+  await expect(
+    authorizeSessionPersonalConnection(
+      h.client,
+      "workspace",
+      "session",
+      item,
+      "workspace",
+      true,
+      () => true,
+    ),
+  ).rejects.toThrow("More than one personal account");
+  expect(h.issueUserResourceGrant).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/capabilities/session-connection-authority.test.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.test.ts
@@ -175,3 +175,18 @@ test("ambiguous personal accounts never issue an arbitrary account grant", async
   ).rejects.toThrow("More than one personal account");
   expect(h.issueUserResourceGrant).not.toHaveBeenCalled();
 });
+
+test("unselected duplicate accounts do not block messages; an exact grant restores its account", async () => {
+  const h = harness();
+  const connections = await h.client.listConnections("workspace");
+  h.client.listConnections = async () => [
+    ...connections,
+    { ...connections[0]!, id: "second", authorityId: "second-authority" },
+  ];
+  expect(await sessionConnectionAuthorities(h.client, session, [item])).toEqual([]);
+  const granted = harness([grant]);
+  granted.client.listConnections = h.client.listConnections;
+  const selections = await sessionConnectionAuthorities(granted.client, session, [item]);
+  expect(selections).toHaveLength(1);
+  expect(selections[0]?.connectionId).toBe("connection");
+});

--- a/apps/web/src/components/capabilities/session-connection-authority.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.ts
@@ -1,0 +1,111 @@
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type {
+  CapabilityCatalogItem,
+  McpConnectionAuthoritySelection,
+  Session,
+  UserResourceAuthoritySummary,
+} from "@opengeni/sdk";
+
+export async function sessionConnectionAuthorities(
+  client: OpenGeniBrowserClient,
+  session: Pick<Session, "id" | "workspaceId" | "tenancy">,
+  items: CapabilityCatalogItem[],
+): Promise<McpConnectionAuthoritySelection[]> {
+  const personal = items.filter(
+    (item) =>
+      item.enabled &&
+      item.connectionRef?.subjectScope === "subject" &&
+      item.connectionRef.connectionId &&
+      item.runtime.mcpServerId,
+  );
+  if (personal.length === 0) return [];
+  if (!session.tenancy) throw new Error("Conversation sharing authority is not available.");
+  const authorityEpoch = session.tenancy.authorityEpoch;
+  const visibility =
+    session.tenancy.visibility === "workspace" ? "workspace_shared" : "user_private";
+  const authorities: UserResourceAuthoritySummary[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.listUserResourceAuthorities(session.workspaceId, {
+      resourceKind: "connection",
+      limit: 100,
+      ...(cursor ? { cursor } : {}),
+    });
+    authorities.push(...page.authorities);
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
+  return personal.flatMap((item) => {
+    const authority = authorities.find(
+      (entry) => entry.resourceId === item.connectionRef!.connectionId && entry.status === "active",
+    );
+    // Only an exact-session grant is adopted here. A standing grant from another
+    // surface never silently opts a personal account into this conversation.
+    const grant = authority?.grants.find(
+      (entry) =>
+        entry.mode === "session" &&
+        entry.status === "active" &&
+        entry.action === "connection.use" &&
+        entry.targetSessionId === session.id &&
+        entry.targetWorkspaceId === session.workspaceId &&
+        entry.authorityEpoch === authorityEpoch &&
+        entry.context === visibility &&
+        (!entry.expiresAt || Date.parse(entry.expiresAt) > Date.now()),
+    );
+    return grant
+      ? [
+          {
+            serverId: item.runtime.mcpServerId!,
+            connectionId: item.connectionRef!.connectionId!,
+            userDelegation: grant.delegation,
+          },
+        ]
+      : [];
+  });
+}
+
+/** Called only by the human's explicit Use-in-this-conversation action. */
+export async function authorizeSessionPersonalConnection(
+  client: OpenGeniBrowserClient,
+  workspaceId: string,
+  sessionId: string,
+  item: CapabilityCatalogItem,
+  reviewedVisibility: "private" | "workspace",
+  sharedOutputAcknowledged: boolean,
+  stillCurrent: () => boolean,
+): Promise<void> {
+  const ref = item.connectionRef;
+  if (ref?.subjectScope !== "subject" || !ref.connectionId || !item.runtime.mcpServerId)
+    throw new Error("The personal connection could not be resolved. Refresh and retry.");
+  const [session, connections] = await Promise.all([
+    client.getSession(workspaceId, sessionId),
+    client.listConnections(workspaceId),
+  ]);
+  if (!stillCurrent()) throw new Error("Connection setup was interrupted.");
+  if (!session.tenancy || session.tenancy.visibility !== reviewedVisibility)
+    throw new Error(
+      "The conversation's visibility changed. Close and review the connection again.",
+    );
+  if (session.tenancy.visibility === "workspace" && !sharedOutputAcknowledged)
+    throw new Error("Acknowledge shared results before using your personal account here.");
+  const connection = connections.find(
+    (entry) =>
+      entry.id === ref.connectionId && entry.subjectId !== null && entry.status === "active",
+  );
+  if (!connection?.authorityId)
+    throw new Error(
+      "This personal connection has no active sharing authority. Reconnect it and try again.",
+    );
+  const existing = await sessionConnectionAuthorities(client, session, [item]);
+  if (!stillCurrent()) throw new Error("Connection setup was interrupted.");
+  if (existing.some((entry) => entry.connectionId === connection.id)) return;
+  await client.issueUserResourceGrant(workspaceId, connection.authorityId, {
+    scope: "user",
+    resourceKind: "connection",
+    mode: "session",
+    sessionId,
+    expectedAuthorityEpoch: session.tenancy.authorityEpoch,
+    context: session.tenancy.visibility === "workspace" ? "workspace_shared" : "user_private",
+    workspaceSharedAcknowledged:
+      session.tenancy.visibility === "workspace" && sharedOutputAcknowledged,
+  });
+}

--- a/apps/web/src/components/capabilities/session-connection-authority.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.ts
@@ -1,24 +1,45 @@
 import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
 import type {
   CapabilityCatalogItem,
+  ConnectionMetadata,
   McpConnectionAuthoritySelection,
   Session,
   UserResourceAuthoritySummary,
 } from "@opengeni/sdk";
 
+import { normalizeProviderDomain } from "@/lib/capabilities";
+
+function personalConnection(item: CapabilityCatalogItem, connections: ConnectionMetadata[]) {
+  const ref = item.connectionRef;
+  if (ref?.subjectScope !== "subject") return undefined;
+  // The shared catalog deliberately omits personal IDs. Resolve only against
+  // the authenticated owner's private metadata, never store that ID in catalog.
+  const matches = connections.filter(
+    (entry) =>
+      entry.subjectId !== null &&
+      entry.status === "active" &&
+      entry.kind === ref.kind &&
+      normalizeProviderDomain(entry.providerDomain) === normalizeProviderDomain(ref.providerDomain),
+  );
+  if (matches.length > 1)
+    throw new Error(
+      "More than one personal account matches this integration. Review its connection settings before continuing.",
+    );
+  return matches[0];
+}
+
 export async function sessionConnectionAuthorities(
   client: OpenGeniBrowserClient,
   session: Pick<Session, "id" | "workspaceId" | "tenancy">,
   items: CapabilityCatalogItem[],
+  knownConnections?: ConnectionMetadata[],
 ): Promise<McpConnectionAuthoritySelection[]> {
   const personal = items.filter(
     (item) =>
-      item.enabled &&
-      item.connectionRef?.subjectScope === "subject" &&
-      item.connectionRef.connectionId &&
-      item.runtime.mcpServerId,
+      item.enabled && item.connectionRef?.subjectScope === "subject" && item.runtime.mcpServerId,
   );
   if (personal.length === 0) return [];
+  const connections = knownConnections ?? (await client.listConnections(session.workspaceId));
   if (!session.tenancy) throw new Error("Conversation sharing authority is not available.");
   const authorityEpoch = session.tenancy.authorityEpoch;
   const visibility =
@@ -35,8 +56,13 @@ export async function sessionConnectionAuthorities(
     cursor = page.nextCursor ?? undefined;
   } while (cursor);
   return personal.flatMap((item) => {
+    const connection = personalConnection(item, connections);
+    if (!connection?.authorityId) return [];
     const authority = authorities.find(
-      (entry) => entry.resourceId === item.connectionRef!.connectionId && entry.status === "active",
+      (entry) =>
+        entry.resourceId === connection.id &&
+        entry.authorityId === connection.authorityId &&
+        entry.status === "active",
     );
     // Only an exact-session grant is adopted here. A standing grant from another
     // surface never silently opts a personal account into this conversation.
@@ -55,7 +81,7 @@ export async function sessionConnectionAuthorities(
       ? [
           {
             serverId: item.runtime.mcpServerId!,
-            connectionId: item.connectionRef!.connectionId!,
+            connectionId: connection.id,
             userDelegation: grant.delegation,
           },
         ]
@@ -74,7 +100,7 @@ export async function authorizeSessionPersonalConnection(
   stillCurrent: () => boolean,
 ): Promise<void> {
   const ref = item.connectionRef;
-  if (ref?.subjectScope !== "subject" || !ref.connectionId || !item.runtime.mcpServerId)
+  if (ref?.subjectScope !== "subject" || !item.runtime.mcpServerId)
     throw new Error("The personal connection could not be resolved. Refresh and retry.");
   const [session, connections] = await Promise.all([
     client.getSession(workspaceId, sessionId),
@@ -87,15 +113,12 @@ export async function authorizeSessionPersonalConnection(
     );
   if (session.tenancy.visibility === "workspace" && !sharedOutputAcknowledged)
     throw new Error("Acknowledge shared results before using your personal account here.");
-  const connection = connections.find(
-    (entry) =>
-      entry.id === ref.connectionId && entry.subjectId !== null && entry.status === "active",
-  );
+  const connection = personalConnection(item, connections);
   if (!connection?.authorityId)
     throw new Error(
       "This personal connection has no active sharing authority. Reconnect it and try again.",
     );
-  const existing = await sessionConnectionAuthorities(client, session, [item]);
+  const existing = await sessionConnectionAuthorities(client, session, [item], connections);
   if (!stillCurrent()) throw new Error("Connection setup was interrupted.");
   if (existing.some((entry) => entry.connectionId === connection.id)) return;
   await client.issueUserResourceGrant(workspaceId, connection.authorityId, {

--- a/apps/web/src/components/capabilities/session-connection-authority.ts
+++ b/apps/web/src/components/capabilities/session-connection-authority.ts
@@ -9,9 +9,9 @@ import type {
 
 import { normalizeProviderDomain } from "@/lib/capabilities";
 
-function personalConnection(item: CapabilityCatalogItem, connections: ConnectionMetadata[]) {
+function personalConnections(item: CapabilityCatalogItem, connections: ConnectionMetadata[]) {
   const ref = item.connectionRef;
-  if (ref?.subjectScope !== "subject") return undefined;
+  if (ref?.subjectScope !== "subject") return [];
   // The shared catalog deliberately omits personal IDs. Resolve only against
   // the authenticated owner's private metadata, never store that ID in catalog.
   const matches = connections.filter(
@@ -21,11 +21,7 @@ function personalConnection(item: CapabilityCatalogItem, connections: Connection
       entry.kind === ref.kind &&
       normalizeProviderDomain(entry.providerDomain) === normalizeProviderDomain(ref.providerDomain),
   );
-  if (matches.length > 1)
-    throw new Error(
-      "More than one personal account matches this integration. Review its connection settings before continuing.",
-    );
-  return matches[0];
+  return matches;
 }
 
 export async function sessionConnectionAuthorities(
@@ -56,32 +52,41 @@ export async function sessionConnectionAuthorities(
     cursor = page.nextCursor ?? undefined;
   } while (cursor);
   return personal.flatMap((item) => {
-    const connection = personalConnection(item, connections);
-    if (!connection?.authorityId) return [];
-    const authority = authorities.find(
-      (entry) =>
-        entry.resourceId === connection.id &&
-        entry.authorityId === connection.authorityId &&
-        entry.status === "active",
-    );
-    // Only an exact-session grant is adopted here. A standing grant from another
-    // surface never silently opts a personal account into this conversation.
-    const grant = authority?.grants.find(
-      (entry) =>
-        entry.mode === "session" &&
-        entry.status === "active" &&
-        entry.action === "connection.use" &&
-        entry.targetSessionId === session.id &&
-        entry.targetWorkspaceId === session.workspaceId &&
-        entry.authorityEpoch === authorityEpoch &&
-        entry.context === visibility &&
-        (!entry.expiresAt || Date.parse(entry.expiresAt) > Date.now()),
-    );
+    // Multiple accounts in the owner's metadata are harmless until this
+    // conversation has authorized them. Restore the exact grant, not a
+    // provider-domain default, and do not block unrelated messages.
+    const matches = personalConnections(item, connections).flatMap((connection) => {
+      if (!connection.authorityId) return [];
+      const authority = authorities.find(
+        (entry) =>
+          entry.resourceId === connection.id &&
+          entry.authorityId === connection.authorityId &&
+          entry.status === "active",
+      );
+      const grant = authority?.grants.find(
+        (entry) =>
+          entry.mode === "session" &&
+          entry.status === "active" &&
+          entry.action === "connection.use" &&
+          entry.targetSessionId === session.id &&
+          entry.targetWorkspaceId === session.workspaceId &&
+          entry.authorityEpoch === authorityEpoch &&
+          entry.context === visibility &&
+          (!entry.expiresAt || Date.parse(entry.expiresAt) > Date.now()),
+      );
+      return grant ? [{ connection, grant }] : [];
+    });
+    if (matches.length > 1)
+      throw new Error(
+        "Multiple personal accounts are authorized for this integration. Review this conversation's connection grants before continuing.",
+      );
+    const match = matches[0];
+    const grant = match?.grant;
     return grant
       ? [
           {
             serverId: item.runtime.mcpServerId!,
-            connectionId: connection.id,
+            connectionId: match!.connection.id,
             userDelegation: grant.delegation,
           },
         ]
@@ -113,7 +118,12 @@ export async function authorizeSessionPersonalConnection(
     );
   if (session.tenancy.visibility === "workspace" && !sharedOutputAcknowledged)
     throw new Error("Acknowledge shared results before using your personal account here.");
-  const connection = personalConnection(item, connections);
+  const matches = personalConnections(item, connections);
+  if (matches.length > 1)
+    throw new Error(
+      "More than one personal account matches this integration. Review its connection settings before continuing.",
+    );
+  const connection = matches[0];
   if (!connection?.authorityId)
     throw new Error(
       "This personal connection has no active sharing authority. Reconnect it and try again.",

--- a/apps/web/src/components/capabilities/use-session-connection-authorities.ts
+++ b/apps/web/src/components/capabilities/use-session-connection-authorities.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
+import type {
+  CapabilityCatalogItem,
+  McpConnectionAuthoritySelection,
+  Session,
+} from "@opengeni/sdk";
+
+export function useSessionConnectionAuthorities(
+  client: OpenGeniBrowserClient,
+  session: Session,
+  catalog: CapabilityCatalogItem[],
+) {
+  const identity = `${session.workspaceId}:${session.id}:${session.tenancy?.visibility}:${session.tenancy?.authorityEpoch}`;
+  const selectedIds =
+    session.effectiveToolPolicy?.selectedIds ?? session.tools.map((tool) => tool.id);
+  const selectedKey = selectedIds.join("\u0000");
+  const scope = useRef({ client, identity, catalog, selectedKey, session });
+  scope.current = { client, identity, catalog, selectedKey, session };
+  const [result, setResult] = useState<{
+    client: OpenGeniBrowserClient;
+    identity: string;
+    catalog: CapabilityCatalogItem[];
+    selectedKey: string;
+    selections: McpConnectionAuthoritySelection[];
+    error: string | null;
+  } | null>(null);
+  const request = useRef(0);
+  const refresh = useCallback(async () => {
+    const invocation = scope.current;
+    const revision = ++request.current;
+    const current = () =>
+      request.current === revision &&
+      scope.current.client === invocation.client &&
+      scope.current.identity === invocation.identity &&
+      scope.current.catalog === invocation.catalog &&
+      scope.current.selectedKey === invocation.selectedKey;
+    try {
+      const selected = new Set(invocation.selectedKey.split("\u0000"));
+      const { sessionConnectionAuthorities } = await import("./session-connection-authority");
+      const selections = await sessionConnectionAuthorities(
+        invocation.client,
+        invocation.session,
+        invocation.catalog.filter(
+          (item) => item.runtime.mcpServerId && selected.has(item.runtime.mcpServerId),
+        ),
+      );
+      if (current()) setResult({ ...invocation, selections, error: null });
+    } catch (failure) {
+      if (current())
+        setResult({
+          ...invocation,
+          selections: [],
+          error:
+            failure instanceof Error
+              ? failure.message
+              : "Personal connection access could not be checked.",
+        });
+    }
+    // The snapshot only depends on session identity/authority and selected tools.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, identity, catalog, selectedKey]);
+  useEffect(() => {
+    const counter = request;
+    void refresh();
+    return () => {
+      counter.current++;
+    };
+  }, [refresh]);
+  const matches =
+    result?.client === client &&
+    result.identity === identity &&
+    result.catalog === catalog &&
+    result.selectedKey === selectedKey;
+  const hasPersonal = catalog.some(
+    (item) =>
+      item.enabled &&
+      item.connectionRef?.subjectScope === "subject" &&
+      item.runtime.mcpServerId &&
+      selectedIds.includes(item.runtime.mcpServerId),
+  );
+  return {
+    selections: matches ? result.selections : [],
+    error: matches ? result.error : null,
+    loading: hasPersonal && !matches,
+    refresh,
+  };
+}

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -1,3 +1,4 @@
+import { performCapabilityAction } from "@/components/capabilities/perform-capability-action";
 import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 // Plugins: the workspace integrations marketplace. A single scrollable
 // page with exactly three sections: Integrations, Connectors, and Bundles.
@@ -895,269 +896,31 @@ function CapabilitiesBody({ workspaceId, initialSection, slackLinkToken }: Capab
   }
 
   async function handleAction(action: ConnectAction) {
-    // Act on the LIVE item (derived from the catalog by id), never the stored
-    // snapshot - a mutation elsewhere may have changed it since the sheet opened.
-    if (!selected || !selectedItem) return;
-    const item = selectedItem;
-    setBusyId(item.id);
+    if (!selected || !selectedItem || busyId !== null) return;
+    setBusyId(selectedItem.id);
     setSheetError(null);
     try {
-      // The plan is derived from the current catalog/registry item (it carries
-      // authKind/mcpUrl/providerDomain); connect calls use the persisted id.
-      const plan = capabilityConnectPlan(item);
-
-      if (action.type === "install_skill") {
-        if (!canManageSkills) {
-          throw new Error("Workspace administrator permission is required to install Skills.");
-        }
-        const libraryId = metadataString(item.metadata.libraryId);
-        const expectedVersion = metadataString(item.metadata.version);
-        const expectedContentSha256 = metadataString(item.metadata.contentSha256);
-        if (!libraryId || !expectedVersion || !expectedContentSha256) {
-          throw new Error(
-            "This Skill is missing its reviewed library identity. Refresh and try again.",
-          );
-        }
-        const installationVersion = installedSkillVersion(item);
-        await client.installLibrarySkill(workspaceId, libraryId, {
-          expectedVersion,
-          expectedContentSha256,
-          ...(installationVersion !== null
-            ? { expectedInstallationVersion: installationVersion }
-            : {}),
-        });
-        await refresh();
-        onRuntimeChanged();
-        toast.success(item.enabled ? `Updated ${item.name}` : `Installed ${item.name}`, {
-          description: `Pinned to reviewed Skill version ${expectedVersion}.`,
-        });
-        setSelected(null);
-        return;
-      }
-
-      if (action.type === "remove_skill") {
-        if (!canManageSkills) {
-          throw new Error("Workspace administrator permission is required to remove Skills.");
-        }
-        const preview = await client.previewSkillUninstall(workspaceId, item.id);
-        if (!preview.installed || preview.installationVersion === null || !preview.directOwner) {
-          throw new Error("This Skill is no longer directly installed. Refresh and try again.");
-        }
-        setSkillRemoval({ item, preview });
-        return;
-      }
-
-      if (action.type === "disconnect") {
-        if (item.kind !== "mcp" || !item.actions.includes("disconnect")) {
-          throw new Error(`${item.name} must be managed through its dedicated controls.`);
-        }
-        await client.disableCapability(workspaceId, item.id);
-        await refresh();
-        onRuntimeChanged();
-        toast.success(`Disabled ${item.name}`);
-        setSelected(null);
-        return;
-      }
-
-      if (action.type === "social_oauth" && plan.mode === "social_oauth") {
-        const returnPath = `${window.location.pathname}?connect_item=${encodeURIComponent(item.id)}`;
-        const response = await client.startSocialOAuth(workspaceId, {
-          provider: action.provider,
-          ownership: action.ownership,
-          returnPath,
-        });
-        if (!response.authorizationUrl) {
-          throw new Error("The provider did not return an authorization link.");
-        }
-        window.location.assign(response.authorizationUrl);
-        return;
-      }
-
-      if (action.type === "disconnect_social") {
-        await client.disconnectSocialConnection(workspaceId, action.connectionId);
-        await refresh();
-        toast.success(`Disconnected ${item.name}`);
-        setSelected(null);
-        return;
-      }
-
-      // First-party Fiken connect / token replacement. The install route
-      // verifies the token against Fiken before storing it, so a bad paste
-      // fails here with a specific message instead of at first tool use.
-      if (action.type === "fiken_api_token") {
-        await client.installFikenConnection(workspaceId, {
-          apiToken: action.apiToken,
-          ...(action.connectionId ? { connectionId: action.connectionId } : {}),
-        });
-        await refresh();
-        onRuntimeChanged();
-        toast.success(`Connected ${item.name}`);
-        setSelected(null);
-        return;
-      }
-
-      // Full-page redirect into Fiken's consent screen; the API callback
-      // stores the workspace connection and returns to this page with a
-      // `fiken` query param handled by the return effect below.
-      if (action.type === "fiken_oauth") {
-        const response = await client.startFikenOAuth(workspaceId, {
-          ...(action.connectionId ? { connectionId: action.connectionId } : {}),
-        });
-        if (!response.authorizationUrl) {
-          throw new Error("Fiken did not return an authorization link.");
-        }
-        window.location.assign(response.authorizationUrl);
-        return;
-      }
-
-      if (action.type === "fiken_disconnect") {
-        await client.deleteConnection(workspaceId, action.connectionId);
-        await refresh();
-        onRuntimeChanged();
-        toast.success(`Disconnected ${item.name}`);
-        setSelected(null);
-        return;
-      }
-
-      // Reconnect an already-enabled item whose credential lapsed. When the
-      // connection row survives, OAuth reuses it (pass connectionId) and the
-      // return handler just refreshes; when it was deleted (null id), OAuth
-      // mints a fresh row and the return handler re-enables against it. API-key
-      // reactivates the surviving row in place, or mints + re-enables if gone.
-      if (action.type === "reconnect_oauth") {
-        // Trust the installation's connectionRef.kind (the sheet already chose this
-        // branch from it), not the catalog plan - on drift plan.mode can read
-        // "enable", so fall back to the ref's domain and the item's own MCP URL.
-        const providerDomain =
-          plan.mode === "oauth"
-            ? plan.providerDomain
-            : (item.connectionRef?.providerDomain ?? null);
-        const mcpUrl =
-          plan.mode === "oauth" ? plan.mcpUrl : (item.mcpUrl ?? item.endpointUrl ?? null);
-        const returnPath = `${window.location.pathname}?connect_item=${encodeURIComponent(item.id)}`;
-        const response = await startMcpOAuthWithTimeout(client, workspaceId, {
-          ...(mcpUrl ? { mcpUrl } : {}),
-          ...(providerDomain ? { providerDomain } : {}),
-          // Reuse the existing row when it survives; a null id means the row was
-          // deleted, so OAuth mints a fresh connection and the return handler
-          // re-enables against it.
-          ...(action.connectionId ? { connectionId: action.connectionId } : {}),
-          ownership: action.ownership,
-          returnPath,
-        });
-        if (!response.authorizationUrl) {
-          throw new Error("The provider did not return an authorization link.");
-        }
-        window.location.assign(response.authorizationUrl);
-        return;
-      }
-
-      if (action.type === "reconnect_api_key") {
-        if (action.connectionId) {
-          // The existing row went inactive - rewrite its credential and
-          // reactivate it in place; the installation ref already points at it.
-          await client.updateConnection(workspaceId, action.connectionId, {
-            credential: { headers: action.headers },
-            status: "active",
-          });
-        } else {
-          // The row was deleted - mint a fresh connection and re-enable the
-          // installation against it (enable upserts the installation config). Domain
-          // comes from the plan, or the installation's ref when the catalog drifted.
-          const providerDomain =
-            plan.mode === "api_key"
-              ? plan.providerDomain
-              : (item.connectionRef?.providerDomain ?? "");
-          const connection = await client.createConnection(workspaceId, {
-            providerDomain,
-            kind: "api_key",
-            ownership: action.ownership,
-            credential: { headers: action.headers },
-          });
-          await client.enableCapability(workspaceId, item.id, {
-            connectionRef: apiKeyConnectionRef(
-              action.ownership,
-              connection.id,
-              connection.providerDomain,
-            ),
-          });
-        }
-        await refresh();
-        onRuntimeChanged();
-        toast.success(`Reconnected ${item.name}`);
-        setSelected(null);
-        return;
-      }
-
-      if (item.kind !== "mcp") {
-        throw new Error(`${item.name} must be installed through its dedicated controls.`);
-      }
-      const persisted = await persistIfRegistry(item, selected.registry);
-
-      if (action.type === "oauth" && plan.mode === "oauth") {
-        const returnPath = `${window.location.pathname}?connect_item=${encodeURIComponent(persisted.id)}`;
-        const response = await startMcpOAuthWithTimeout(client, workspaceId, {
-          ...(plan.mcpUrl ? { mcpUrl: plan.mcpUrl } : {}),
-          ...(plan.providerDomain ? { providerDomain: plan.providerDomain } : {}),
-          ownership: action.ownership,
-          returnPath,
-        });
-        if (!response.authorizationUrl) {
-          throw new Error("The provider did not return an authorization link.");
-        }
-        // Full-page redirect into the provider's consent screen; we return to
-        // returnPath and resume in the OAuth-return effect below.
-        window.location.assign(response.authorizationUrl);
-        return;
-      }
-
-      if (action.type === "api_key" && plan.mode === "api_key") {
-        // Reuse only a connection with the selected ownership rather than creating
-        // a duplicate on retry; workspace and personal rows never cross-reuse.
-        const reuseId = connectionToReuseForApiKey(
-          item,
-          connections ?? [],
-          plan.providerDomain,
-          action.ownership,
-        );
-        const connection = reuseId
-          ? await client.updateConnection(workspaceId, reuseId, {
-              credential: { headers: action.headers },
-              status: "active",
-            })
-          : await client.createConnection(workspaceId, {
-              providerDomain: plan.providerDomain,
-              kind: "api_key",
-              ownership: action.ownership,
-              credential: { headers: action.headers },
-            });
-        // Build the enable ref from the connection row the API returns, never the
-        // catalog domain - the API may canonicalize providerDomain, and the row
-        // is the authoritative match the enable path validates against.
-        await client.enableCapability(workspaceId, persisted.id, {
-          connectionRef: apiKeyConnectionRef(
-            action.ownership,
-            connection.id,
-            connection.providerDomain,
-          ),
-        });
-        await refresh();
-        onRuntimeChanged();
-        toast.success(`Connected and enabled ${persisted.name}`);
-        setSelected(null);
-        return;
-      }
-
-      // Plain enable (no credentials).
-      await client.enableCapability(workspaceId, persisted.id);
-      await refresh();
-      if (persisted.kind === "mcp") onRuntimeChanged();
-      toast.success(`Enabled ${persisted.name}`);
-      setSelected(null);
+      await performCapabilityAction(
+        {
+          client,
+          workspaceId,
+          item: selectedItem,
+          registry: selected.registry,
+          connections: connectionsLoadFailed ? null : connections,
+          canManageSkills,
+          refresh,
+          onRuntimeChanged,
+          onComplete: () => setSelected(null),
+          onSkillRemoval: setSkillRemoval,
+          returnPathFor: (id) =>
+            `${window.location.pathname}?connect_item=${encodeURIComponent(id)}`,
+          redirect: (url) => window.location.assign(url),
+        },
+        action,
+      );
     } catch (error) {
+      await refresh();
       const copy = capabilityErrorToast(error, "Something went wrong");
-      // In-sheet human copy; the raw missing-credentials 422 becomes a prompt to
-      // connect rather than an error string.
       setSheetError(
         isMissingCredentialsError(error)
           ? "This integration needs credentials before it can be enabled."
@@ -2024,17 +1787,4 @@ export function integrationQuickConnect(
   if (chip.tone !== "idle" || footer.kind !== "setup") return undefined;
   if (footer.disabled === true || footer.busy === true) return undefined;
   return footer.onSetup;
-}
-
-function metadataString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function installedSkillVersion(item: CapabilityCatalogItem): number | null {
-  const installedSkill = item.metadata.installedSkill;
-  if (!installedSkill || typeof installedSkill !== "object" || Array.isArray(installedSkill)) {
-    return null;
-  }
-  const value = (installedSkill as Record<string, unknown>).installationVersion;
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,5 +1,9 @@
+import { useSessionConnectionAuthorities } from "@/components/capabilities/use-session-connection-authorities";
 import { sessionAuthRecommendation } from "@/components/capabilities/session-auth-recommendation";
-import { attachSessionCapability } from "@/components/capabilities/attach-session-capability";
+import {
+  attachSessionCapability,
+  completeSessionCapabilityOAuth,
+} from "@/components/capabilities/attach-session-capability";
 import { loadSessionFeedback } from "../lib/session-feedback";
 import { PersonalResourceAttachmentSurface } from "@/components/personal-resource-attachment-surface";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
@@ -651,6 +655,13 @@ export function SessionRoute({
         throw new Error(
           "The connection was authorized, but enabling its tools could not be verified.",
         );
+      if (connected.connectionRef?.subjectScope === "subject") {
+        toast.success(`${item.name} connected`, {
+          description:
+            "Review its connection card to allow your personal account in this conversation.",
+        });
+        return;
+      }
       await attachSessionCapability(capabilityClient, workspaceId, sessionId, connected);
       toast.success(`${item.name} connected`, {
         description: "It is available to new tool calls in this session.",
@@ -679,19 +690,29 @@ export function SessionRoute({
     nativeReturnHandled.current = true;
     window.history.replaceState(null, "", window.location.pathname);
     if (social === "success" || fiken === "connected") {
-      void refreshCapabilityCatalog(workspaceId)
-        .then(() =>
-          toast.success("Connection setup completed", {
-            description: "Send a new message to continue with this connection.",
-          }),
-        )
-        .catch(() => toast.error("Connection authorized, but its status could not be refreshed."));
+      const capabilityId = params.get("capability_auth");
+      void (async () => {
+        await refreshCapabilityCatalog(workspaceId);
+        await completeSessionCapabilityOAuth(
+          capabilityClient,
+          workspaceId,
+          sessionId,
+          capabilityId,
+        );
+        toast.success("Connection setup completed", {
+          description: "It is available to new tool calls in this session.",
+        });
+      })().catch((error) =>
+        toast.error("Connection authorized, but setup needs attention", {
+          description: error instanceof Error ? error.message : String(error),
+        }),
+      );
     } else {
       toast.error("Connection wasn't completed", {
         description: "You can retry from the connection card.",
       });
     }
-  }, [capabilityCatalogReady, refreshCapabilityCatalog, workspaceId]);
+  }, [capabilityCatalogReady, capabilityClient, refreshCapabilityCatalog, workspaceId, sessionId]);
 
   const githubReturnHandled = useRef(false);
   useEffect(() => {
@@ -1419,6 +1440,17 @@ function SessionChatPane(props: {
     () => selectableSessionMcpServers.map((server) => server.id),
     [selectableSessionMcpServers],
   );
+  const connectionAuthorities = useSessionConnectionAuthorities(
+    context.client,
+    props.session,
+    context.workspaceCapabilityCatalog,
+  );
+  const reloadSessionAfterSetup = props.onReloadSession;
+  const refreshConnectionAuthorities = connectionAuthorities.refresh;
+  const afterConnectionSetup = useCallback(async () => {
+    await reloadSessionAfterSetup();
+    await refreshConnectionAuthorities();
+  }, [reloadSessionAfterSetup, refreshConnectionAuthorities]);
   const renderAuthNeeded = useCallback(
     (item: AuthNeededItem) => {
       const recommendation = sessionAuthRecommendation(item, context.workspaceCapabilityCatalog);
@@ -1431,15 +1463,24 @@ function SessionChatPane(props: {
           }
         >
           <SessionCapabilityCard
-            key={`${props.session.id}:${item.id}`}
+            key={`${props.session.id}:${props.session.tenancy?.authorityEpoch}:${item.id}`}
             item={recommendation}
             workspaceId={props.session.workspaceId}
             sessionId={props.session.id}
+            visibility={props.session.tenancy?.visibility ?? "workspace"}
+            onConfigured={afterConnectionSetup}
           />
         </Suspense>
       ) : undefined;
     },
-    [context.workspaceCapabilityCatalog, props.session.id, props.session.workspaceId],
+    [
+      context.workspaceCapabilityCatalog,
+      props.session.id,
+      props.session.workspaceId,
+      props.session.tenancy?.visibility,
+      props.session.tenancy?.authorityEpoch,
+      afterConnectionSetup,
+    ],
   );
   const policyToolIds = useMemo(
     () => sessionPolicyPickerIds(props.session, selectableToolIds, context.workspaceDefaultToolIds),
@@ -1623,18 +1664,25 @@ function SessionChatPane(props: {
       policyValid: composerPolicyValidRef.current,
       variableSetBlocked: variableSetComposerBlocked,
       personalDecision: personalAttachment.requiresDecision,
-      personalLoading: personalAttachment.loading || personalAttachment.refreshing,
+      personalLoading:
+        personalAttachment.loading ||
+        personalAttachment.refreshing ||
+        connectionAuthorities.loading ||
+        connectionAuthorities.error !== null,
     });
   const composer = useComposer(props.session.id, {
     events: props.events,
     sendExtras: () => ({
       resources: [...attachments.readyResources, ...repositories.pendingResources],
-      ...(repositories.pendingResources.some(
-        (resource) =>
-          resource.kind === "repository" && resource.connectionType === "github_personal",
-      ) && context.personalGitHubAuthority
-        ? { connectionAuthorities: [context.personalGitHubAuthority] }
-        : {}),
+      connectionAuthorities: [
+        ...connectionAuthorities.selections,
+        ...(repositories.pendingResources.some(
+          (resource) =>
+            resource.kind === "repository" && resource.connectionType === "github_personal",
+        ) && context.personalGitHubAuthority
+          ? [context.personalGitHubAuthority]
+          : []),
+      ],
       ...(personalAttachment.intent
         ? { personalResourceAttachment: personalAttachment.intent }
         : {}),
@@ -2269,6 +2317,18 @@ function SessionChatPane(props: {
 
       <div ref={composerRegionRef} className="shrink-0 px-4 pb-4 pt-1 sm:px-6">
         <div className="mx-auto w-full max-w-3xl">
+          {connectionAuthorities.error ? (
+            <p role="alert" className="mb-2 text-xs text-fg-muted">
+              Personal connection access could not be checked.{" "}
+              <button
+                type="button"
+                className="text-brand underline"
+                onClick={() => void connectionAuthorities.refresh()}
+              >
+                Retry
+              </button>
+            </p>
+          ) : null}
           <PersonalResourceAttachmentSurface
             controller={personalAttachment}
             disabled={terminal || composer.sending}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,3 +1,5 @@
+import { sessionAuthRecommendation } from "@/components/capabilities/session-auth-recommendation";
+import { attachSessionCapability } from "@/components/capabilities/attach-session-capability";
 import { loadSessionFeedback } from "../lib/session-feedback";
 import { PersonalResourceAttachmentSurface } from "@/components/personal-resource-attachment-surface";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
@@ -147,6 +149,11 @@ import {
 import { useWorkspaceModelCatalog } from "@/lib/use-workspace-model-catalog";
 import type { LineageNode, SessionRealtimeModel } from "@opengeni/sdk";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
+
+const SessionCapabilityCard = lazy(async () => ({
+  default: (await import("@/components/capabilities/session-capability-card"))
+    .SessionCapabilityCard,
+}));
 
 const FAILURE_CONTINUATION_MESSAGE =
   "Continue from the last failure. Check current progress before repeating work.";
@@ -637,6 +644,14 @@ export function SessionRoute({
         connectionRef: oauthConnectionRef(ownership, connectionId, providerDomain),
       });
       await refreshCapabilityCatalog(workspaceId);
+      const connected = (await capabilityClient.listCapabilities(workspaceId)).items.find(
+        (candidate) => candidate.id === item.id,
+      );
+      if (!connected?.enabled)
+        throw new Error(
+          "The connection was authorized, but enabling its tools could not be verified.",
+        );
+      await attachSessionCapability(capabilityClient, workspaceId, sessionId, connected);
       toast.success(`${item.name} connected`, {
         description: "It is available to new tool calls in this session.",
       });
@@ -651,7 +666,32 @@ export function SessionRoute({
     capabilityClient,
     refreshCapabilityCatalog,
     workspaceId,
+    sessionId,
   ]);
+
+  const nativeReturnHandled = useRef(false);
+  useEffect(() => {
+    if (nativeReturnHandled.current || !capabilityCatalogReady) return;
+    const params = new URLSearchParams(window.location.search);
+    const social = params.get("social_oauth");
+    const fiken = params.get("fiken");
+    if (!social && !fiken) return;
+    nativeReturnHandled.current = true;
+    window.history.replaceState(null, "", window.location.pathname);
+    if (social === "success" || fiken === "connected") {
+      void refreshCapabilityCatalog(workspaceId)
+        .then(() =>
+          toast.success("Connection setup completed", {
+            description: "Send a new message to continue with this connection.",
+          }),
+        )
+        .catch(() => toast.error("Connection authorized, but its status could not be refreshed."));
+    } else {
+      toast.error("Connection wasn't completed", {
+        description: "You can retry from the connection card.",
+      });
+    }
+  }, [capabilityCatalogReady, refreshCapabilityCatalog, workspaceId]);
 
   const githubReturnHandled = useRef(false);
   useEffect(() => {
@@ -1379,6 +1419,28 @@ function SessionChatPane(props: {
     () => selectableSessionMcpServers.map((server) => server.id),
     [selectableSessionMcpServers],
   );
+  const renderAuthNeeded = useCallback(
+    (item: AuthNeededItem) => {
+      const recommendation = sessionAuthRecommendation(item, context.workspaceCapabilityCatalog);
+      return recommendation ? (
+        <Suspense
+          fallback={
+            <p role="status" className="text-sm text-fg-muted">
+              Loading connection card…
+            </p>
+          }
+        >
+          <SessionCapabilityCard
+            key={`${props.session.id}:${item.id}`}
+            item={recommendation}
+            workspaceId={props.session.workspaceId}
+            sessionId={props.session.id}
+          />
+        </Suspense>
+      ) : undefined;
+    },
+    [context.workspaceCapabilityCatalog, props.session.id, props.session.workspaceId],
+  );
   const policyToolIds = useMemo(
     () => sessionPolicyPickerIds(props.session, selectableToolIds, context.workspaceDefaultToolIds),
     [context.workspaceDefaultToolIds, props.session, selectableToolIds],
@@ -1414,7 +1476,10 @@ function SessionChatPane(props: {
       }
       return;
     }
-    if (durableToolsHydrated) {
+    if (
+      durableToolsSaving ||
+      (durableToolsHydrated && props.session.toolPolicyVersion <= durableToolPolicyVersion)
+    ) {
       return;
     }
     setDurableToolSelection({
@@ -1426,6 +1491,8 @@ function SessionChatPane(props: {
   }, [
     context.workspaceMcpCatalogReady,
     durableToolsHydrated,
+    durableToolsSaving,
+    durableToolPolicyVersion,
     policyToolIds,
     props.session.id,
     props.session.firstPartyMcpTools,
@@ -2023,6 +2090,7 @@ function SessionChatPane(props: {
               onOpenSession={props.onOpenSession}
               onMemoryClick={props.onMemoryClick}
               onReconnect={props.onReconnect}
+              renderAuthNeeded={renderAuthNeeded}
               resolveProviderLogo={props.resolveProviderLogo}
               loadRetainedScreenshot={loadRetainedScreenshot}
               loadRetainedArtifact={loadRetainedArtifact}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1643,17 +1643,12 @@ Workspace timers: [implementation and rollout](workspace-pause-timers.md).
 
 ### In-conversation connection setup
 
-The stock web session renders catalog recommendations and exact server/Connection
-recovery notices through `SessionCapabilityCard`. Its optional
-`MessageTimeline.renderAuthNeeded` slot leaves host-owned authorization with the
-embedding host. Forms resolve live catalog configuration, share
-`performCapabilityAction` with the Capabilities page, and send credentials only
-to the existing human-authorized Connection API. OAuth returns to the same
-conversation; connection completion never replays an earlier tool call.
-`attachSessionCapability` adds the reviewed tools while preserving the session's
-existing selection and tool-policy CAS. Catalog library Skill installs retain
-their existing workspace scope and exact reviewed version/hash; the card does
-not offer unsupported conversation/personal installation scopes.
-
-
-Personal MCP connections connected from conversation cards are explicitly admitted through an owner-issued, exact-session user-resource grant. Shared conversations require acknowledgement that results are shared. The web composer restores only active grants matching the session visibility and authority epoch and includes their opaque connection-authority selections in new messages; saving credentials or enabling tools alone grants no personal-account use.
+The stock session's `SessionCapabilityCard` uses `MessageTimeline.renderAuthNeeded`;
+embedding hosts retain their authorization. Live catalog forms share
+`performCapabilityAction` with Capabilities and send credentials only to the
+human-authorized Connection API. OAuth returns here without replaying tools.
+`attachSessionCapability` preserves existing tool selection through CAS.
+Library Skills retain workspace scope and reviewed version/hash.
+Personal MCP use requires an owner-issued exact-session grant, with shared-results
+acknowledgement for shared conversations. The composer restores only active grants
+matching visibility and authority epoch; credentials alone grant no use.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1654,3 +1654,6 @@ conversation; connection completion never replays an earlier tool call.
 existing selection and tool-policy CAS. Catalog library Skill installs retain
 their existing workspace scope and exact reviewed version/hash; the card does
 not offer unsupported conversation/personal installation scopes.
+
+
+Personal MCP connections connected from conversation cards are explicitly admitted through an owner-issued, exact-session user-resource grant. Shared conversations require acknowledgement that results are shared. The web composer restores only active grants matching the session visibility and authority epoch and includes their opaque connection-authority selections in new messages; saving credentials or enabling tools alone grants no personal-account use.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1640,3 +1640,17 @@ Agent goal lifecycle exposes `goal_resume` alongside `goal_pause`: any pause rea
 Filtered session page ownership and its maintenance boundary: [session pagination](session-pagination.md).
 
 Workspace timers: [implementation and rollout](workspace-pause-timers.md).
+
+### In-conversation connection setup
+
+The stock web session renders catalog recommendations and exact server/Connection
+recovery notices through `SessionCapabilityCard`. Its optional
+`MessageTimeline.renderAuthNeeded` slot leaves host-owned authorization with the
+embedding host. Forms resolve live catalog configuration, share
+`performCapabilityAction` with the Capabilities page, and send credentials only
+to the existing human-authorized Connection API. OAuth returns to the same
+conversation; connection completion never replays an earlier tool call.
+`attachSessionCapability` adds the reviewed tools while preserving the session's
+existing selection and tool-policy CAS. Catalog library Skill installs retain
+their existing workspace scope and exact reviewed version/hash; the card does
+not offer unsupported conversation/personal installation scopes.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10845,6 +10845,8 @@ export const FikenInstallRequest = z.object({
 export type FikenInstallRequest = z.infer<typeof FikenInstallRequest>;
 
 export const FikenOAuthStartRequest = z.object({
+  /** Same-origin product route to return to after provider consent. */
+  returnPath: z.string().min(1).max(2048).optional(),
   /** Existing Fiken connection to re-authorize in place (reconnect). */
   connectionId: z.string().uuid().optional(),
 });

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -157,6 +157,8 @@ export type MessageTimelineProps = {
    * a Reconnect button without a handler to run it.
    */
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  /** Host-owned inline connection setup. Return undefined to use the default recovery card. */
+  renderAuthNeeded?: ((item: AuthNeededItem) => ReactNode | undefined) | undefined;
   /**
    * Decide which durable authentication notices this timeline presents.
    * Defaults to showing every notice. Embedded hosts can suppress notices for
@@ -407,6 +409,7 @@ export function MessageTimeline({
   onOpenSession,
   onMemoryClick,
   onReconnect,
+  renderAuthNeeded,
   shouldRenderAuthNeeded,
   resolveProviderLogo,
   toolRegistry = defaultToolRegistry,
@@ -910,6 +913,7 @@ export function MessageTimeline({
         onOpenSession,
         onMemoryClick,
         onReconnect,
+        renderAuthNeeded,
         resolveProviderLogo,
         toolRegistry,
         loadRetainedScreenshot,
@@ -925,6 +929,7 @@ export function MessageTimeline({
       onMemoryClick,
       onOpenSession,
       onReconnect,
+      renderAuthNeeded,
       renderMessageActions,
       renderMessageText,
       resolveProviderLogo,
@@ -2309,6 +2314,7 @@ type TimelineGroupBehaviorProps = {
   onOpenSession: MessageTimelineProps["onOpenSession"];
   onMemoryClick: MessageTimelineProps["onMemoryClick"];
   onReconnect: MessageTimelineProps["onReconnect"];
+  renderAuthNeeded: MessageTimelineProps["renderAuthNeeded"];
   resolveProviderLogo: MessageTimelineProps["resolveProviderLogo"];
   toolRegistry: ToolRegistry;
   loadRetainedScreenshot: MessageTimelineProps["loadRetainedScreenshot"];
@@ -2373,6 +2379,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   onOpenSession,
   onMemoryClick,
   onReconnect,
+  renderAuthNeeded,
   resolveProviderLogo,
   toolRegistry,
   loadRetainedScreenshot,
@@ -2393,6 +2400,8 @@ const TimelineGroupView = memo(function TimelineGroupView({
   onOpenSession?: ((sessionId: string) => void) | undefined;
   onMemoryClick?: ((memoryId: string) => void) | undefined;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  /** Host-owned inline connection setup. Return undefined to use the default recovery card. */
+  renderAuthNeeded?: ((item: AuthNeededItem) => ReactNode | undefined) | undefined;
   resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
   toolRegistry: ToolRegistry;
   loadRetainedScreenshot?: RetainedScreenshotLoader | undefined;
@@ -2550,6 +2559,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
               onOpenSession,
               onMemoryClick,
               onReconnect,
+              renderAuthNeeded,
               resolveProviderLogo,
               toolRegistry,
               loadRetainedScreenshot,
@@ -2565,6 +2575,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
               onOpenSession={onOpenSession}
               onMemoryClick={onMemoryClick}
               onReconnect={onReconnect}
+              renderAuthNeeded={renderAuthNeeded}
               resolveProviderLogo={resolveProviderLogo}
               toolRegistry={toolRegistry}
               loadRetainedScreenshot={loadRetainedScreenshot}
@@ -2610,6 +2621,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           renderMessageActions={renderMessageActions}
           renderMessageText={renderMessageText}
           onReconnect={onReconnect}
+          renderAuthNeeded={renderAuthNeeded}
           resolveProviderLogo={resolveProviderLogo}
           onOpenSession={onOpenSession}
           loadVideoArtifactPlayback={loadVideoArtifactPlayback}
@@ -2862,6 +2874,7 @@ export function TimelineRow({
   renderMessageActions,
   renderMessageText,
   onReconnect,
+  renderAuthNeeded,
   resolveProviderLogo,
   onOpenSession,
   loadVideoArtifactPlayback,
@@ -2872,6 +2885,8 @@ export function TimelineRow({
     | ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode)
     | undefined;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  /** Host-owned inline connection setup. Return undefined to use the default recovery card. */
+  renderAuthNeeded?: ((item: AuthNeededItem) => ReactNode | undefined) | undefined;
   resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
   loadVideoArtifactPlayback?: VideoArtifactPlaybackLoader | undefined;
@@ -2915,11 +2930,13 @@ export function TimelineRow({
       return <CompactionRow item={item} />;
     case "auth-needed":
       return (
-        <AuthNeededRow
-          item={item}
-          onReconnect={onReconnect}
-          resolveProviderLogo={resolveProviderLogo}
-        />
+        renderAuthNeeded?.(item) ?? (
+          <AuthNeededRow
+            item={item}
+            onReconnect={onReconnect}
+            resolveProviderLogo={resolveProviderLogo}
+          />
+        )
       );
     default:
       return null;

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -886,6 +886,24 @@ function authNeededItem(overrides: Partial<AuthNeededItem> = {}): AuthNeededItem
 }
 
 describe("TimelineRow — connection recovery", () => {
+  test("lets the authenticated host render setup inline and preserves the fallback", async () => {
+    const row = authNeededItem();
+    const custom = await renderComponent(
+      <TimelineRow
+        item={row}
+        renderAuthNeeded={(value) => <button>Review {value.providerDomain} inline</button>}
+      />,
+    );
+    expect(custom.container.textContent).toContain("Review linear.app inline");
+    expect(custom.container.textContent).not.toContain("This tool call wasn't replayed");
+    await custom.unmount();
+    const fallback = await renderComponent(
+      <TimelineRow item={row} renderAuthNeeded={() => undefined} onReconnect={() => {}} />,
+    );
+    expect(fallback.container.textContent).toContain("Connect Linear");
+    await fallback.unmount();
+  });
+
   test("renders a capability recommendation as ungranted access with one review action", async () => {
     let selected = "";
     const r = await renderComponent(

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -879,6 +879,7 @@ export type FikenInstallRequest = {
 };
 
 export type FikenOAuthStartRequest = {
+  returnPath?: string | undefined;
   /** Existing Fiken connection to re-authorize in place (reconnect). */
   connectionId?: string | undefined;
 };


### PR DESCRIPTION
Connection recommendations in a conversation previously sent API-key and Skill setup to the Capabilities page, while OAuth skipped inline review. The stock session now opens the approved logo/type-tag cards in place, with consistent review, Cancel/Connect actions, password fields, retryable failures, and verified completion. GitHub and Codex Apps use their existing human connection controls; embedding-host authorization keeps its existing boundary.

The conversation and catalog share one connection action handler. A failed enable reconciles the saved Connection before retrying, and successful setup adds only the recommended tools to the session's existing selection using its version fence. OAuth returns to the same conversation, including Fiken's optional validated return path. Native OAuth also resolves the fresh enabled catalog item and attaches its tools before reporting completion. Personal MCP accounts require an explicit session grant, including shared-results acknowledgement in shared conversations; the composer restores only exact-session grants matching the current visibility and authority epoch. Earlier tool calls are never replayed. Reviewed library Skills keep their actual workspace installation scope and pinned version/hash; this change does not invent conversation/personal install scopes that the library API does not support.

Validation: repository-wide typecheck; production web build and unchanged bundle budgets; shared connection UI, timeline renderers, inline credential/cancel/partial-save retry tests, tool-policy preservation and native OAuth completion tests, personal-grant consent/visibility/epoch/retry tests, OAuth return-path rejection tests; actual Chrome desktop and 390px touch viewport checks using the production card components and API fixtures, including failure, retry, success, personal-account consent, and Skill installation.

Implements [OPE-473](https://linear.app/cloudgeni/issue/OPE-473/implement-approved-in-chat-integration-connection-and-skill-cards), based on approved artifact `7c039ec4-f33a-4d06-b549-52ea674ab894` revision 4. No database migration.

## Summary by Sourcery

Enable reviewed integrations and Skills to be connected directly from conversation cards while preserving secure authorization, session tool policy, and retryable completion flows.

New Features:
- Add inline conversation cards for reviewing and completing integration, OAuth, credential, and Skill setup.
- Allow hosts to render custom inline authentication setup in timeline auth-needed messages.
- Support safe OAuth return paths back to the originating conversation, including Fiken.
- Add explicit personal MCP session authorization with shared-results consent and authority validation.

Bug Fixes:
- Prevent duplicate credentials after partial connection failures by reconciling persisted connections before retrying.
- Verify OAuth completion and newly enabled catalog items before reporting setup success.
- Preserve existing session tool selections and first-party restrictions when attaching recommended tools.

Enhancements:
- Share the capability connection lifecycle between the catalog and conversation cards.
- Keep OAuth and connection setup retryable without replaying earlier tool calls.
- Preserve reviewed Skill installation scope, version, and content hash during inline setup.
- Restore only exact-session personal grants matching conversation visibility and authority epoch.
- Use isolated ownership and credential field identifiers for multiple inline forms.

Documentation:
- Document inline connection setup, OAuth return behavior, session tool attachment, Skill provenance, and personal connection grant rules.

Tests:
- Add coverage for inline setup cancellation, credential handling, partial-save retries, OAuth completion, tool-policy preservation, personal-grant consent, and timeline rendering.