### PR TITLE
fix(ci): accept skipped tests for docs image builds

### DIFF
--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -660,7 +660,7 @@ describe("workflow fail-closed contracts", () => {
   });
 
   test("docs main pushes require image evidence but skip unselected tests", () => {
-    const options = {
+    const options: Parameters<typeof requiredResult>[1] = {
       event: "push",
       mode: "docs",
       unit: 0,

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -659,6 +659,46 @@ describe("workflow fail-closed contracts", () => {
     ).toBe(true);
   });
 
+  test("docs main pushes require image evidence but skip unselected tests", () => {
+    const options = {
+      event: "push",
+      mode: "docs",
+      unit: 0,
+      integration: 0,
+      e2e: 0,
+      browser: 0,
+      artifactRuntime: true,
+      build: 0,
+      bakeImages: true,
+    };
+    const results = Object.fromEntries(
+      ["plan", "source-contracts", "artifact-runtime", "deployment", "images"].map((name) => [
+        name,
+        { result: "success" },
+      ]),
+    );
+    for (const name of [
+      "unit-shards",
+      "integration-shards",
+      "e2e-shards",
+      "test-suite",
+      "browser-acceptance",
+      "package-contracts",
+    ]) {
+      results[name] = { result: "skipped" };
+    }
+    expect(requiredResult(results, options)).toBe(true);
+    for (const name of ["source-contracts", "artifact-runtime", "deployment", "images"]) {
+      for (const result of ["failure", "cancelled", "skipped"]) {
+        expect(requiredResult({ ...results, [name]: { result } }, options)).toBe(false);
+      }
+    }
+    expect(requiredResult({ ...results, "test-suite": { result: "failure" } }, options)).toBe(
+      false,
+    );
+    expect(requiredResult(results, { ...options, mode: "focused" })).toBe(false);
+  });
+
   test("CI preserves trusted admission while planning candidate jobs from the exact head", () => {
     const ci = readFileSync(".github/workflows/ci.yml", "utf8");
     const admission = ci.slice(ci.indexOf("  automation-admission:"), ci.indexOf("  plan:"));

--- a/scripts/ci/required-results.jq
+++ b/scripts/ci/required-results.jq
@@ -11,7 +11,7 @@
    .deployment.result == "skipped" and
    .images.result == "skipped"
  else
-   ."test-suite".result == "success" and
+   (if $mode == "docs" then ."test-suite".result == "skipped" else ."test-suite".result == "success" end) and
    (if $browser == 0 then ."browser-acceptance".result == "skipped" else ."browser-acceptance".result == "success" end) and
    .deployment.result == "success" and
    (if $bakeImages then .images.result == "success" else .images.result == "skipped" end)


### PR DESCRIPTION
Docs-only pushes to main build release images but intentionally skip the test-suite job. The aggregate incorrectly required that skipped job to succeed, blocking releases after every selected lane passed. Require skipped tests for docs mode while retaining all selected source, runtime, deployment, and image gates. Validation: 39 impact tests pass, including failures and cancellations of required image-path jobs.

## Summary by Sourcery

Allow docs-mode image builds to accept skipped tests without weakening required CI validation.

Bug Fixes:
- Allow docs-mode main pushes to pass CI when the intentionally unselected test suite is skipped, while still requiring all selected image-path gates to succeed.

Tests:
- Add coverage for successful docs image builds and failures, cancellations, or skips across required gates.