### PR TITLE
fix(release): allow independently recorded merge timestamps

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1946,10 +1946,9 @@ function assertProviderMergeEvent(events, sourceSha, pullIdentity) {
     event.commit_url === repositoryApiUrl(`/commits/${sourceSha}`),
     "provider merge event commit URL changed",
   );
-  invariant(
-    assertTimestamp(event.created_at, "provider merge event timestamp") === pullIdentity.mergedAt,
-    "provider merge event timestamp differs from pull-request merge time",
-  );
+  // GitHub can record the timeline event a second after pull.merged_at.
+  // Bind identity to the exact commit and actor, not independently recorded clocks.
+  assertTimestamp(event.created_at, "provider merge event timestamp");
   assertIdentity(event.actor, pullIdentity.merger, "provider merge actor");
   assertString(event.node_id, "provider merge event node ID");
   const eventId = assertPositiveInteger(event.id, "provider merge event ID");

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2302,6 +2302,7 @@ function approvalFixture(
     reviewedBaseSha?: string;
     discontinuousCompare?: boolean;
     mergeEvent?: Record<string, unknown> | null;
+    mergeEventTimestamp?: string;
     movingMainOverlap?: boolean;
     movingMainSourceExtra?: boolean;
     movingMainTreeTruncated?: "parent" | "source";
@@ -2382,7 +2383,7 @@ function approvalFixture(
             actor: merger,
             commit_id: mergeSha,
             commit_url: `${RELEASE_AUTOMATION_CONTRACT.apiUrl}${prefix}/commits/${mergeSha}`,
-            created_at: "2026-07-23T12:00:00Z",
+            created_at: options.mergeEventTimestamp ?? "2026-07-23T12:00:00Z",
           },
         ];
   let mainReads = 0;
@@ -3265,6 +3266,22 @@ describe("release approval provenance", () => {
         fetchImpl: approvalFixture({ pullState: "open", merged: false }).fetchImpl,
       }),
     ).rejects.toThrow("is not merged");
+  });
+
+  test("accepts independently recorded merge event time but rejects malformed timestamps", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ mergeEventTimestamp: "2026-07-23T12:00:01Z" }).fetchImpl,
+        logger: { log() {} },
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ mergeEventTimestamp: "not-a-timestamp" }).fetchImpl,
+      }),
+    ).rejects.toThrow("provider merge event timestamp");
   });
 
   test("rejects an associated direct fast-forward with matching provider topology", async () => {


### PR DESCRIPTION
GitHub reported PR #2397 merged_at at 08:14:32Z and its matching timeline merge event at 08:14:33Z. Exact timestamp equality rejected the same authenticated merge and blocked candidate publication. Validate both timestamps while binding merge identity to the unique exact commit, actor, and provider event URLs/IDs. Validation: 93 release automation tests pass, including the one-second difference and malformed timestamp rejection.

## Summary by Sourcery

Allow release merge validation to accept independently recorded timestamps without weakening merge identity checks.

Bug Fixes:
- Allow independently recorded pull-request and provider merge-event timestamps while continuing to reject malformed event timestamps.

Enhancements:
- Continue binding merge provenance to the exact commit, actor, and provider event identity rather than requiring clock equality.

Tests:
- Add coverage for valid one-second timestamp differences and malformed merge-event timestamps.