### PR TITLE
fix(web): recover transient bootstrap reads

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1037,8 +1037,9 @@ export async function resetPassword(input: {
   });
 }
 
-export async function fetchClientConfig(): Promise<ClientConfig> {
-  const config = await request<ClientConfig>("/v1/config/client");
+export async function fetchClientConfig(signal?: AbortSignal): Promise<ClientConfig> {
+  const config = await request<ClientConfig>("/v1/config/client", { signal });
+  signal?.throwIfAborted();
   reloadIfStaleApiContract(config);
   reloadIfStaleDeployment(config);
   configureClientAuth(config.auth);

--- a/apps/web/src/bootstrap-error-surface.test.tsx
+++ b/apps/web/src/bootstrap-error-surface.test.tsx
@@ -1,4 +1,5 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from "bun:test";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/contracts";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -20,6 +21,115 @@ afterAll(() => {
 });
 
 describe("bootstrap error surface", () => {
+  test.each([
+    { status: 503, body: "unavailable", attempts: 3, title: "OpenGeni is temporarily unavailable" },
+    { status: 401, body: "unauthorized", attempts: 1, title: "OpenGeni couldn't start" },
+    { status: 403, body: "forbidden", attempts: 1, title: "OpenGeni couldn't start" },
+    { status: 500, body: "invalid configuration", attempts: 1, title: "OpenGeni couldn't start" },
+    { status: 200, body: "not json", attempts: 1, title: "OpenGeni couldn't start" },
+  ])(
+    "stops at the terminal configuration surface: %s",
+    async ({ status, body, attempts, title }) => {
+      jest.useFakeTimers();
+      const originalFetch = globalThis.fetch;
+      let requests = 0;
+      globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+        const path = new URL(String(input), window.location.href).pathname;
+        if (path !== "/v1/config/client") throw new Error(`Unexpected request: ${path}`);
+        requests++;
+        return new Response(body, { status });
+      }) as typeof fetch;
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      try {
+        await act(async () => root.render(<App />));
+        expect(requests).toBe(1);
+        await act(async () => jest.advanceTimersByTime(500));
+        await act(async () => jest.advanceTimersByTime(1_500));
+        expect(container.textContent).toContain(title);
+        expect(container.querySelector("button")?.textContent).toContain("Try again");
+        await act(async () => jest.advanceTimersByTime(60_000));
+        expect(requests).toBe(attempts);
+      } finally {
+        await act(async () => root.unmount());
+        globalThis.fetch = originalFetch;
+        jest.useRealTimers();
+      }
+    },
+  );
+
+  test.each(["config", "access", "network"])(
+    "recovers %s bootstrap without reload",
+    async (stage) => {
+      jest.useFakeTimers();
+      const originalFetch = globalThis.fetch;
+      const counts = new Map<string, number>();
+      let recovered = false;
+      globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+        const path = new URL(String(input), window.location.href).pathname;
+        const count = (counts.get(path) ?? 0) + 1;
+        counts.set(path, count);
+        const failingPath = stage === "access" ? "/v1/access/me" : "/v1/config/client";
+        if (path === failingPath && !recovered) {
+          if (stage === "network") throw new TypeError("Failed to fetch");
+          return new Response("upstream unavailable", { status: 503 });
+        }
+        const payload =
+          path === "/v1/config/client"
+            ? {
+                apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
+                deploymentRevision: "",
+                managedAuthSessionSetMode: "legacy",
+                defaultModel: "gpt-5.6-sol",
+                allowedModels: ["gpt-5.6-sol"],
+                models: [],
+                defaultReasoningEffort: "none",
+                allowedReasoningEfforts: ["none"],
+                mcpServers: [],
+                fileUploads: { enabled: false, maxSizeBytes: 0 },
+                productAccessMode: "local",
+                auth: { mode: "none" },
+                analytics: { consentRequired: true, providers: {} },
+                structuredServices: { fileSystem: false, git: false, terminalEvents: false },
+              }
+            : path === "/v1/access/me"
+              ? {
+                  subjectId: "test-user",
+                  accountGrants: [],
+                  workspaceGrants: [],
+                  defaultWorkspaceId: null,
+                }
+              : path === "/v1/workspaces"
+                ? []
+                : null;
+        if (payload === null) throw new Error(`Unexpected request: ${path}`);
+        return Response.json(payload);
+      }) as typeof fetch;
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      try {
+        await act(async () => {
+          root.render(<App />);
+        });
+        expect(container.textContent).not.toContain("temporarily unavailable");
+        const failingPath = stage === "access" ? "/v1/access/me" : "/v1/config/client";
+        const initialRequests = counts.get(failingPath)!;
+        recovered = true;
+        await act(async () => {
+          jest.advanceTimersByTime(500);
+        });
+        expect(container.textContent).toContain("No workspace access");
+        expect(counts.get(failingPath)).toBe(initialRequests + 1);
+      } finally {
+        await act(async () => root.unmount());
+        globalThis.fetch = originalFetch;
+        jest.useRealTimers();
+      }
+    },
+  );
+
   test("shows maintenance copy without the raw payload and retries in place", async () => {
     const originalFetch = globalThis.fetch;
     let configRequests = 0;

--- a/apps/web/src/bootstrap-error-surface.test.tsx
+++ b/apps/web/src/bootstrap-error-surface.test.tsx
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from "bun:test";
 import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/contracts";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act } from "react";
+import { act, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 let App: typeof import("./App").App;
@@ -21,6 +21,39 @@ afterAll(() => {
 });
 
 describe("bootstrap error surface", () => {
+  test("StrictMode skips config I/O for its discarded effect and aborts the live request on unmount", async () => {
+    const originalFetch = globalThis.fetch;
+    const signals: AbortSignal[] = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const path = new URL(String(input), window.location.href).pathname;
+      if (path !== "/v1/config/client") throw new Error(`Unexpected request: ${path}`);
+      signals.push(init!.signal!);
+      return await new Promise<Response>((_resolve, reject) => {
+        const signal = init!.signal!;
+        if (signal.aborted) reject(signal.reason);
+        else signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    }) as typeof fetch;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          <StrictMode>
+            <App />
+          </StrictMode>,
+        ),
+      );
+      expect(signals).toHaveLength(1);
+      expect(signals[0]!.aborted).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      globalThis.fetch = originalFetch;
+    }
+    expect(signals[0]!.aborted).toBe(true);
+  });
+
   test.each([
     { status: 503, body: "unavailable", attempts: 3, title: "OpenGeni is temporarily unavailable" },
     { status: 401, body: "unauthorized", attempts: 1, title: "OpenGeni couldn't start" },

--- a/apps/web/src/context-principal-transition.test.ts
+++ b/apps/web/src/context-principal-transition.test.ts
@@ -93,10 +93,7 @@ describe("principal transition contract", () => {
   });
 
   test("access bootstrap is synchronously fenced by principal generation", () => {
-    const accessLoad = sourceBetween(
-      "void Promise.all([client.getAccessContext(), client.listWorkspaces(), selfContextPromise])",
-      "const selectedInstalledRepositories",
-    );
+    const accessLoad = sourceBetween("void Promise.all([", "const selectedInstalledRepositories");
     expect(accessLoad).toContain(
       "ownsPrincipalTransition(principalTransitionIdentity.current, acceptedPrincipal)",
     );

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -877,11 +877,16 @@ export function RootRouteComponent() {
     if (isPublicDevHarness) return;
     let cancelled = false;
     const controller = new AbortController();
-    void readBootstrap({
-      context: "client_configuration",
-      request: () => fetchClientConfig(controller.signal),
-      signal: controller.signal,
-    })
+    // Let synchronous effect cleanup (including StrictMode's discarded mount)
+    // cancel before starting I/O. Active requests still abort on real cleanup.
+    void Promise.resolve()
+      .then(() =>
+        readBootstrap({
+          context: "client_configuration",
+          request: () => fetchClientConfig(controller.signal),
+          signal: controller.signal,
+        }),
+      )
       .then((config) => {
         if (cancelled) {
           return;

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -62,6 +62,7 @@ import { Label } from "@/components/ui/label";
 import { Toaster } from "@/components/ui/sonner";
 import type { AnalyticsEventName, AnalyticsProperties } from "@/lib/analytics";
 import { bootstrapErrorPresentation, type BootstrapErrorPresentation } from "@/lib/bootstrap-error";
+import { readBootstrap } from "@/lib/bootstrap-read";
 import { ManagedAuthSessionUnavailableError } from "@/lib/managed-auth-form";
 import { signOutWithAuthoritativeReconciliation } from "@/lib/managed-auth-transition";
 import { unlinkGitHubInstallationWithReconciliation } from "@/lib/github-installation-unlink";
@@ -875,7 +876,12 @@ export function RootRouteComponent() {
   useEffect(() => {
     if (isPublicDevHarness) return;
     let cancelled = false;
-    void fetchClientConfig()
+    const controller = new AbortController();
+    void readBootstrap({
+      context: "client_configuration",
+      request: () => fetchClientConfig(controller.signal),
+      signal: controller.signal,
+    })
       .then((config) => {
         if (cancelled) {
           return;
@@ -899,6 +905,7 @@ export function RootRouteComponent() {
       });
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [configRequestVersion, isPublicDevHarness]);
 
@@ -974,14 +981,29 @@ export function RootRouteComponent() {
     setManagedSelfContext(null);
     setAccessLoading(true);
     setAccessError(null);
+    const controller = new AbortController();
+    // These SDK reads do not accept a caller signal. Fence their late results
+    // and every new attempt without changing the SDK's general retry policy.
+    const readAccess = <T,>(request: () => Promise<T>) =>
+      readBootstrap({
+        context: "workspace_access",
+        request,
+        signal: controller.signal,
+        isCurrent: () =>
+          ownsPrincipalTransition(principalTransitionIdentity.current, acceptedPrincipal),
+      });
     const selfContextPromise = acceptedManagedIdentity
       ? loadCurrentManagedSelfContext({
           identity: acceptedManagedIdentity,
           currentIdentity: () => managedSelfContextIdentityRef.current,
-          request: () => client.listOrganizationMemberships(),
+          request: () => readAccess(() => client.listOrganizationMemberships()),
         })
       : Promise.resolve(null);
-    void Promise.all([client.getAccessContext(), client.listWorkspaces(), selfContextPromise])
+    void Promise.all([
+      readAccess(() => client.getAccessContext()),
+      readAccess(() => client.listWorkspaces()),
+      selfContextPromise,
+    ])
       .then(([context, nextWorkspaces, nextManagedSelfContext]) => {
         if (
           cancelled ||
@@ -1022,6 +1044,7 @@ export function RootRouteComponent() {
           return;
         }
         const presentation = bootstrapErrorPresentation(error, "workspace_access");
+        controller.abort();
         setAccessContext(null);
         setWorkspaces([]);
         setAccessError(presentation);
@@ -1039,6 +1062,7 @@ export function RootRouteComponent() {
       if (managedSelfContextIdentityRef.current === acceptedManagedIdentity) {
         managedSelfContextIdentityRef.current = null;
       }
+      controller.abort();
     };
   }, [
     accessKeyVersion,

--- a/apps/web/src/lib/bootstrap-error.ts
+++ b/apps/web/src/lib/bootstrap-error.ts
@@ -91,6 +91,25 @@ function errorMetadata(error: unknown): ErrorMetadata {
   };
 }
 
+/** Only transient bootstrap reads qualify; presentation copy is not retry authority. */
+export function isTransientBootstrapError(error: unknown, context: BootstrapErrorContext): boolean {
+  const metadata = errorMetadata(error);
+  if (isMaintenanceCode(metadata.code) || bodyIndicatesMaintenance(metadata.body)) return false;
+  if (metadata.status !== null) {
+    return (
+      [0, 502, 503, 504].includes(metadata.status) ||
+      (context === "workspace_access" && metadata.status === 500)
+    );
+  }
+  // Do not retry arbitrary TypeErrors from invalid config or application code.
+  return (
+    error instanceof TypeError &&
+    /^(Failed to fetch|fetch failed|Load failed|NetworkError when attempting to fetch resource\.)$/u.test(
+      error.message,
+    )
+  );
+}
+
 /**
  * Bootstrap failures replace the whole application surface, so they should
  * explain the recovery path without exposing API JSON, proxy HTML, or internal

--- a/apps/web/src/lib/bootstrap-read.test.ts
+++ b/apps/web/src/lib/bootstrap-read.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, expect, jest, test } from "bun:test";
+import { readBootstrap } from "./bootstrap-read";
+
+afterEach(() => jest.useRealTimers());
+const flush = async () => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+test("an already cancelled bootstrap never starts a request", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let calls = 0;
+  const error = await readBootstrap({
+    context: "client_configuration",
+    signal: controller.signal,
+    request: async () => {
+      calls++;
+      return "unused";
+    },
+  }).catch((failure) => failure);
+  expect(error.name).toBe("AbortError");
+  expect(calls).toBe(0);
+});
+
+test("terminal sibling failure cancels pending access retries", async () => {
+  jest.useFakeTimers();
+  const controller = new AbortController();
+  let calls = 0;
+  const permanent = { status: 403 };
+  const pending = readBootstrap({
+    context: "workspace_access",
+    signal: controller.signal,
+    request: async () => {
+      calls++;
+      throw { status: 503 };
+    },
+  });
+  const denied = readBootstrap({
+    context: "workspace_access",
+    signal: controller.signal,
+    request: async () => {
+      throw permanent;
+    },
+  });
+  const result = await Promise.all([pending, denied]).catch((error) => {
+    controller.abort();
+    return error;
+  });
+  expect(result).toBe(permanent);
+  jest.advanceTimersByTime(60_000);
+  await flush();
+  expect(calls).toBe(1);
+});
+
+test.each([500, 502, 503, 504, new TypeError("Failed to fetch")])(
+  "recovers from %s",
+  async (failure) => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const result = readBootstrap({
+      context: "workspace_access",
+      signal: new AbortController().signal,
+      request: async () => {
+        if (++calls === 1) throw typeof failure === "number" ? { status: failure } : failure;
+        return "ready";
+      },
+    });
+    await flush();
+    expect(calls).toBe(1);
+    jest.advanceTimersByTime(499);
+    await flush();
+    expect(calls).toBe(1);
+    jest.advanceTimersByTime(1);
+    expect(await result).toBe("ready");
+    expect(calls).toBe(2);
+  },
+);
+
+test("exhausts exactly three attempts and preserves the last failure", async () => {
+  jest.useFakeTimers();
+  let calls = 0;
+  const error = { status: 503 };
+  const result = readBootstrap({
+    context: "client_configuration",
+    signal: new AbortController().signal,
+    request: async () => {
+      calls++;
+      throw error;
+    },
+  }).catch((failure) => failure);
+  await flush();
+  jest.advanceTimersByTime(500);
+  await flush();
+  expect(calls).toBe(2);
+  jest.advanceTimersByTime(1_500);
+  expect(await result).toBe(error);
+  jest.advanceTimersByTime(60_000);
+  expect(calls).toBe(3);
+});
+
+test.each([
+  { status: 400 },
+  { status: 401 },
+  { status: 403 },
+  { status: 404 },
+  { status: 409 },
+  { status: 500 },
+  { status: 422 },
+  { status: 429 },
+  { status: 501 },
+  { status: 503, body: '{"error":"maintenance"}' },
+  new SyntaxError("Invalid JSON"),
+  new TypeError("Cannot read properties of undefined"),
+  new DOMException("Aborted", "AbortError"),
+  new Error("invalid config"),
+])("does not retry permanent failures: %s", async (error) => {
+  let calls = 0;
+  const result = readBootstrap({
+    context: "client_configuration",
+    signal: new AbortController().signal,
+    request: async () => {
+      calls++;
+      throw error;
+    },
+  }).catch((failure) => failure);
+  expect(await result).toBe(error);
+  expect(calls).toBe(1);
+});
+
+test.each(["abort", "principal"])("%s prevents a scheduled retry", async (transition) => {
+  jest.useFakeTimers();
+  const controller = new AbortController();
+  let current = true;
+  let calls = 0;
+  const result = readBootstrap({
+    context: "workspace_access",
+    signal: controller.signal,
+    isCurrent: () => current,
+    request: async () => {
+      calls++;
+      throw { status: 503 };
+    },
+  }).catch((error) => error);
+  await flush();
+  if (transition === "abort") controller.abort();
+  else current = false;
+  jest.advanceTimersByTime(500);
+  expect((await result).name).toBe("AbortError");
+  expect(calls).toBe(1);
+});
+
+test.each([true, false])("discards stale in-flight success=%s", async (success) => {
+  let current = true;
+  let resolve!: (value: string) => void;
+  let reject!: (error: unknown) => void;
+  const result = readBootstrap({
+    context: "workspace_access",
+    signal: new AbortController().signal,
+    isCurrent: () => current,
+    request: () =>
+      new Promise<string>((yes, no) => {
+        resolve = yes;
+        reject = no;
+      }),
+  }).catch((error) => error);
+  current = false;
+  if (success) resolve("old principal");
+  else reject({ status: 503 });
+  expect((await result).name).toBe("AbortError");
+});

--- a/apps/web/src/lib/bootstrap-read.ts
+++ b/apps/web/src/lib/bootstrap-read.ts
@@ -1,0 +1,46 @@
+import { isTransientBootstrapError, type BootstrapErrorContext } from "./bootstrap-error";
+
+function waitForRetry(delay: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", abort);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, delay);
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+  });
+}
+
+/** Bootstrap GETs only: initial attempt + two retries, never a mutation policy. */
+export async function readBootstrap<T>(input: {
+  request: () => Promise<T>;
+  context: BootstrapErrorContext;
+  signal: AbortSignal;
+  isCurrent?: () => boolean;
+}): Promise<T> {
+  const assertCurrent = () => {
+    input.signal.throwIfAborted();
+    if (input.isCurrent?.() === false) {
+      throw new DOMException("Bootstrap identity changed", "AbortError");
+    }
+  };
+  const delays = [500, 1_500];
+  for (let attempt = 0; ; attempt += 1) {
+    assertCurrent();
+    try {
+      const result = await input.request();
+      assertCurrent();
+      return result;
+    } catch (error) {
+      assertCurrent();
+      const delay = delays[attempt];
+      if (delay === undefined || !isTransientBootstrapError(error, input.context)) throw error;
+      await waitForRetry(delay, input.signal);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Recover transient read-only application bootstrap failures with an initial attempt and two bounded retries. Preserve terminal authentication, maintenance, malformed-response, and permanent failure behavior. Abort retry timers and fence stale principal results without changing general SDK or mutation retry policy.

## Verification

- Red: disabling retries fails the three config/access/network recovery surface regressions.
- Green: 100 tests pass across eight targeted web suites, independently rerun.
- Web typecheck, repository lint, formatting, and diff checks pass.
- Mocked Chromium checks cover recovery and exhaustion at desktop and mobile widths.

## Boundaries

Existing access SDK reads cannot be physically aborted; stale results and future retries are fenced. Model-catalog recovery is outside this patch. No production or full-stack verification is claimed.

## Summary by Sourcery

Recover transient web bootstrap read failures with bounded retries while fencing stale results and preserving terminal error behavior.

New Features:
- Add bounded recovery for transient client-configuration and workspace-access bootstrap read failures.

Bug Fixes:
- Prevent transient bootstrap outages from unnecessarily blocking the application while preserving terminal authentication, maintenance, malformed-response, and permanent failure behavior.
- Prevent stale bootstrap results and pending retries from applying after unmount, cancellation, or principal changes.

Enhancements:
- Abort active configuration requests during cleanup and centralize bootstrap-read cancellation and retry handling without changing general SDK or mutation retry behavior.

Tests:
- Add coverage for retry timing, exhaustion, cancellation, stale results, terminal failures, StrictMode cleanup, and recovery across configuration, access, and network bootstrap paths.