### PR TITLE
fix(worker): clarify actionable goal continuation guidance

### DIFF
--- a/.changeset/actionable-goal-continuation.md
+++ b/.changeset/actionable-goal-continuation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Clarify that goal continuations should continue investigating or addressing unfinished work within the agent's current authority instead of repeating an incomplete-status final. The guidance applies whether or not the input-wait tool is available and preserves the existing completion, waiting, and blocked audits.

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -286,6 +286,8 @@ export function goalContinuationPrompt(
     "Continuation behavior:",
     "- This goal persists across turns. A runtime boundary can end one turn without shrinking the objective; the next continuation resumes the same full objective.",
     "- Keep working until the requested end state is true and verified. Do not end the turn merely because one useful action completed, and do not redefine success around a smaller or easier task.",
+    "- An incomplete-status report is not a substitute for continuing the work. If the remaining problem can be investigated or addressed within your current authority, continue that work in this turn rather than returning another equivalent status-only final.",
+    "- Distinguish unfinished work from a blocker that actually requires human input or external change; use the existing waiting and blocked audits only when their conditions hold.",
     "- Temporary rough edges are acceptable while the work is moving in the right direction. Completion still requires the requested end state to be true and verified.",
     "",
     "Work from evidence:",

--- a/apps/worker/test/goals.test.ts
+++ b/apps/worker/test/goals.test.ts
@@ -57,6 +57,28 @@ describe("goalContinuationPrompt", () => {
     expect(prompt).not.toContain("take the next useful action");
   });
 
+  test.each([true, false])(
+    "distinguishes actionable unfinished work from external blockage (inputWaitAvailable=%s)",
+    (inputWaitAvailable) => {
+      const prompt = goalContinuationPrompt(
+        { text: "Ship the fix" } as Parameters<typeof goalContinuationPrompt>[0],
+        3,
+        null,
+        { inputWaitAvailable },
+      );
+
+      expect(prompt).toContain(
+        "An incomplete-status report is not a substitute for continuing the work",
+      );
+      expect(prompt).toContain(
+        "If the remaining problem can be investigated or addressed within your current authority, continue that work in this turn rather than returning another equivalent status-only final",
+      );
+      expect(prompt).toContain(
+        "Distinguish unfinished work from a blocker that actually requires human input or external change; use the existing waiting and blocked audits only when their conditions hold",
+      );
+    },
+  );
+
   test("teaches wait_for_input only when the tool is in the session's selection", () => {
     const goal = { text: "Ship the fix" } as Parameters<typeof goalContinuationPrompt>[0];
     const withWait = goalContinuationPrompt(goal, 1, null, { inputWaitAvailable: true });


### PR DESCRIPTION
## Summary

Clarify that an incomplete-status report does not replace actionable work within current authority. Distinguish unfinished work from genuine human or external blockers, independently of wait-tool availability.

No runtime non-progress detector, automatic stopping, tool-use quota, goal mutation, or scheduling change.

## Verification

- Red before production change: both new prompt cases fail; nine existing tests pass.
- Green: all 11 prompt tests pass.
- Worker typecheck, repository lint, formatting, and diff checks pass.
- Local durable-goal-wake suite could not initialize because PostgreSQL/Docker was unavailable; its test bodies were not validated locally.

These tests verify prompt delivery, not guaranteed model compliance. No live-model behavioral evaluation or deployment is claimed.

## Summary by Sourcery

Ensure goal continuation guidance distinguishes actionable unfinished work from genuine blockers and directs workers to keep progressing when they retain authority to act.

Bug Fixes:
- Clarify that workers should continue actionable unfinished work instead of returning repeated incomplete-status reports.
- Clarify that waiting or blocked handling applies only when human input or external changes are genuinely required, regardless of wait-tool availability.

Tests:
- Add prompt coverage for actionable unfinished work and genuine external blockage with and without input-wait availability.