### PR TITLE
fix(mcp): expose session goal schema and actionable validation errors

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -378,39 +378,46 @@ function orchestrationFailureCode(tool: OrchestrationToolName, error: HTTPExcept
   return `${tool}_${suffix}`.slice(0, ORCHESTRATION_FAILURE_CODE_MAX_LENGTH);
 }
 
+function sessionCreateValidationFailureResult(error: z4.ZodError) {
+  // Only call with issues from the raw request preflight, never downstream errors.
+  // Paths may contain caller-controlled record keys, and custom issue messages
+  // may contain values. Only publish canonical field names and fixed type labels.
+  const details = error.issues.slice(0, 5).map((issue) => {
+    const [field, goalField] = issue.path;
+    let path =
+      typeof field === "string" && Object.hasOwn(CreateSessionRequest.out.shape, field)
+        ? field
+        : "request";
+    if (
+      field === "goal" &&
+      typeof goalField === "string" &&
+      Object.hasOwn(GoalSpec.shape, goalField)
+    ) {
+      path += `.${goalField}`;
+    }
+    const expected =
+      issue.code === "invalid_type" &&
+      ["string", "number", "boolean", "object", "array", "int"].includes(issue.expected)
+        ? `expected ${issue.expected === "int" ? "integer" : issue.expected}`
+        : "failed schema validation";
+    return `${path} ${expected}`;
+  });
+  const envelope = {
+    error: {
+      code: "session_create_invalid_request",
+      message: boundedOrchestrationFailureMessage(
+        `Invalid session create request: ${details.join("; ") || "request failed schema validation"}${error.issues.length > 5 ? "; additional fields failed validation" : ""}.`,
+      ),
+    },
+  };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }],
+    structuredContent: envelope,
+    isError: true as const,
+  };
+}
+
 function orchestrationFailureEnvelope(tool: OrchestrationToolName, error: unknown) {
-  if (tool === "session_create" && error instanceof z4.ZodError) {
-    // Paths may contain caller-controlled record keys, and custom issue messages
-    // may contain values. Only publish canonical field names and fixed type labels.
-    const details = error.issues.slice(0, 5).map((issue) => {
-      const [field, goalField] = issue.path;
-      let path =
-        typeof field === "string" && Object.hasOwn(CreateSessionRequest.out.shape, field)
-          ? field
-          : "request";
-      if (
-        field === "goal" &&
-        typeof goalField === "string" &&
-        Object.hasOwn(GoalSpec.shape, goalField)
-      ) {
-        path += `.${goalField}`;
-      }
-      const expected =
-        issue.code === "invalid_type" &&
-        ["string", "number", "boolean", "object", "array", "int"].includes(issue.expected)
-          ? `expected ${issue.expected === "int" ? "integer" : issue.expected}`
-          : "failed schema validation";
-      return `${path} ${expected}`;
-    });
-    return {
-      error: {
-        code: "session_create_invalid_request",
-        message: boundedOrchestrationFailureMessage(
-          `Invalid session create request: ${details.join("; ") || "request failed schema validation"}${error.issues.length > 5 ? "; additional fields failed validation" : ""}.`,
-        ),
-      },
-    };
-  }
   if (error instanceof SessionSpawnDeniedError) {
     const denial = sessionSpawnDenialEnvelope(error);
     return {
@@ -5245,22 +5252,28 @@ function registerWorkspaceOrchestrationTools(
             await authorizeFirstPartySession(deps, grant, callerSessionId, "session.child.create");
           }
           const { machineTarget, title, projectId, ...request } = args;
+          const rawRequest = {
+            ...request,
+            ...(projectId !== undefined ? { channelId: projectId } : {}),
+            ...(machineTarget
+              ? {
+                  targetSandboxId: machineTarget.targetSandboxId,
+                  ...(machineTarget.workingDir !== undefined
+                    ? { workingDir: machineTarget.workingDir }
+                    : {}),
+                }
+              : {}),
+          };
+          // Keep authorization above validation and let core parse the original
+          // request. Only this preflight's failures are attributable to input;
+          // arbitrary downstream schema failures retain the private fallback.
+          const validation = CreateSessionRequest.safeParse(rawRequest);
+          if (!validation.success) return sessionCreateValidationFailureResult(validation.error);
           const result = await createSessionForRequestWithOutcome(
             deps,
             grant,
             grant.workspaceId,
-            {
-              ...request,
-              ...(projectId !== undefined ? { channelId: projectId } : {}),
-              ...(machineTarget
-                ? {
-                    targetSandboxId: machineTarget.targetSandboxId,
-                    ...(machineTarget.workingDir !== undefined
-                      ? { workingDir: machineTarget.workingDir }
-                      : {}),
-                  }
-                : {}),
-            },
+            rawRequest,
             undefined,
             title === undefined ? {} : { automaticTitleCandidate: title },
           );

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -15,6 +15,8 @@ import {
 } from "../site-uploads";
 import {
   CreateScheduledTaskRequest,
+  CreateSessionRequest,
+  GoalSpec,
   boundSessionMcpText as capSessionDiscoveryText,
   compactSessionMcpListRow,
   sessionMcpIncludesRelatedWork,
@@ -377,6 +379,38 @@ function orchestrationFailureCode(tool: OrchestrationToolName, error: HTTPExcept
 }
 
 function orchestrationFailureEnvelope(tool: OrchestrationToolName, error: unknown) {
+  if (tool === "session_create" && error instanceof z4.ZodError) {
+    // Paths may contain caller-controlled record keys, and custom issue messages
+    // may contain values. Only publish canonical field names and fixed type labels.
+    const details = error.issues.slice(0, 5).map((issue) => {
+      const [field, goalField] = issue.path;
+      let path =
+        typeof field === "string" && Object.hasOwn(CreateSessionRequest.out.shape, field)
+          ? field
+          : "request";
+      if (
+        field === "goal" &&
+        typeof goalField === "string" &&
+        Object.hasOwn(GoalSpec.shape, goalField)
+      ) {
+        path += `.${goalField}`;
+      }
+      const expected =
+        issue.code === "invalid_type" &&
+        ["string", "number", "boolean", "object", "array", "int"].includes(issue.expected)
+          ? `expected ${issue.expected === "int" ? "integer" : issue.expected}`
+          : "failed schema validation";
+      return `${path} ${expected}`;
+    });
+    return {
+      error: {
+        code: "session_create_invalid_request",
+        message: boundedOrchestrationFailureMessage(
+          `Invalid session create request: ${details.join("; ") || "request failed schema validation"}${error.issues.length > 5 ? "; additional fields failed validation" : ""}.`,
+        ),
+      },
+    };
+  }
   if (error instanceof SessionSpawnDeniedError) {
     const denial = sessionSpawnDenialEnvelope(error);
     return {
@@ -5102,7 +5136,7 @@ function registerWorkspaceOrchestrationTools(
             "Concise semantic title for the child session. Omit only when the delegated goal or initial message already provides a suitable title; OpenGeni derives a sensitive-safe bounded fallback from that text.",
           ),
         instructions: z4.string().min(1).max(SESSION_INSTRUCTIONS_MAX_CHARACTERS).optional(),
-        goal: z4.unknown().optional(),
+        goal: GoalSpec.optional(),
         resources: z4
           .array(z4.unknown())
           .optional()

--- a/apps/api/test/first-party-mcp-tool-policy.test.ts
+++ b/apps/api/test/first-party-mcp-tool-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_FIRST_PARTY_MCP_PERMISSIONS,
   DEFAULT_FIRST_PARTY_MCP_TOOLS,
+  GoalSpec,
   FIRST_PARTY_MCP_TOOL_NAMES,
   FIRST_PARTY_REMOTE_MCP_TOOL_NAMES,
   MAX_SELECTED_VARIABLE_SETS,
@@ -19,6 +20,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { ApiRouteDeps } from "@opengeni/core";
 import { listSessionDiscoverySummaries } from "@opengeni/db";
 import { HTTPException } from "hono/http-exception";
+import * as z4 from "zod/v4";
 import { createAttemptToolEnvironment, generateCodemodeDeclarations } from "@opengeni/codemode";
 import { buildOpenGeniMcpServer } from "../src/mcp/server";
 import { buildFilesMcpServer } from "../src/mcp/files";
@@ -682,6 +684,136 @@ describe("first-party MCP tool visibility policy", () => {
     } finally {
       await Promise.all([client.close(), server.close()]);
     }
+  });
+
+  test("session_create publishes the canonical nested goal input schema", async () => {
+    const server = buildOpenGeniMcpServer(deps(), grant(["sessions:create"], ["session_create"]));
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "session-goal-schema-test", version: "1" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const tool = (await client.listTools()).tools.find(
+        (entry) => entry.name === "session_create",
+      );
+      expect(tool?.inputSchema.properties?.goal).toMatchObject({
+        type: "object",
+        required: ["text"],
+        properties: {
+          text: { type: "string", minLength: 1 },
+          successCriteria: { type: "string", minLength: 1 },
+          rootConstraints: { type: "array", items: { type: "string" } },
+          maxAutoContinuations: { type: "integer" },
+          mutationPolicy: {
+            type: "string",
+            enum: ["review_changes", "preserve_intent", "autonomous_adaptation"],
+          },
+        },
+      });
+      expect(tool?.inputSchema.required).not.toContain("goal");
+      const schema = registeredToolInputSchema(server, "session_create");
+      for (const goal of [
+        { text: "Run checks", successCriteria: "Checks pass" },
+        { objective: "Run checks", successCriteria: ["pass"] },
+        { text: "Run checks", successCriteria: ["pass"] },
+        { text: "Run checks", rootConstraints: [42] },
+        { text: "" },
+        { text: "Run checks", maxAutoContinuations: 0 },
+      ]) {
+        expect(schema.safeParse({ initialMessage: "work", goal }).success).toBe(
+          GoalSpec.safeParse(goal).success,
+        );
+      }
+      const rejected = await client.callTool({
+        name: "session_create",
+        arguments: {
+          initialMessage: "private-draft",
+          goal: { objective: "private-objective", successCriteria: ["private-success"] },
+        },
+      });
+      expect(rejected.isError).toBe(true);
+      expect(JSON.stringify(rejected)).toContain("text");
+      expect(JSON.stringify(rejected)).toContain("successCriteria");
+      expect(JSON.stringify(rejected)).not.toContain("private-");
+    } finally {
+      await Promise.all([client.close(), server.close()]);
+    }
+  });
+
+  test("session_create nested parser failures are actionable without reflecting input", async () => {
+    let databaseTouches = 0;
+    const routeDeps = deps();
+    routeDeps.db = new Proxy(
+      {},
+      {
+        get() {
+          databaseTouches += 1;
+          throw new Error("private-storage-error");
+        },
+      },
+    ) as ApiRouteDeps["db"];
+    // A sessionless grant reaches the pure request parser without live-attempt storage checks.
+    const server = buildOpenGeniMcpServer(routeDeps, {
+      ...grant(["sessions:create"], ["session_create"]),
+      principalKind: "human_session",
+      metadata: { firstPartyMcpTools: ["session_create"] },
+    });
+    const result = await callRegisteredTool(server, "session_create", {
+      initialMessage: "private-draft",
+      goal: { objective: "private-objective", successCriteria: ["private-success"] },
+    });
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: "session_create_invalid_request",
+          message:
+            "Invalid session create request: goal.text expected string; goal.successCriteria expected string.",
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("private-");
+    expect(databaseTouches).toBe(0);
+
+    const unknown = await callRegisteredTool(server, "session_create", {
+      initialMessage: "work",
+      goal: { text: "Run checks", successCriteria: "Checks pass" },
+    });
+    expect(databaseTouches).toBeGreaterThan(0);
+    expect(unknown).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: "session_create_failed",
+          message: "OpenGeni could not complete the request.",
+        },
+      },
+    });
+    expect(JSON.stringify(unknown)).not.toContain("private-");
+
+    routeDeps.db = new Proxy(
+      {},
+      {
+        get() {
+          throw new z4.ZodError(
+            Array.from({ length: 20 }, () => ({
+              code: "custom" as const,
+              path: ["metadata", "private-record-key"],
+              message: "private-custom-message",
+            })),
+          );
+        },
+      },
+    ) as ApiRouteDeps["db"];
+    const bounded = await callRegisteredTool(server, "session_create", { initialMessage: "work" });
+    expect(bounded.structuredContent?.error?.code).toBe("session_create_invalid_request");
+    expect(bounded.structuredContent?.error?.message).toContain(
+      "additional fields failed validation",
+    );
+    expect(JSON.stringify(bounded)).not.toContain("private-");
+    expect(
+      new TextEncoder().encode(bounded.structuredContent?.error?.message).byteLength,
+    ).toBeLessThanOrEqual(1024);
   });
 
   test("model-facing session_create accepts ordered Variable Sets and authorizes attachment before storage", async () => {

--- a/apps/api/test/first-party-mcp-tool-policy.test.ts
+++ b/apps/api/test/first-party-mcp-tool-policy.test.ts
@@ -805,8 +805,31 @@ describe("first-party MCP tool visibility policy", () => {
         },
       },
     ) as ApiRouteDeps["db"];
-    const bounded = await callRegisteredTool(server, "session_create", { initialMessage: "work" });
+    const internal = await callRegisteredTool(server, "session_create", { initialMessage: "work" });
+    expect(internal).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: "session_create_failed",
+          message: "OpenGeni could not complete the request.",
+        },
+      },
+    });
+    expect(JSON.stringify(internal)).not.toContain("private-");
+
+    const bounded = await callRegisteredTool(server, "session_create", {
+      initialMessage: "work",
+      goal: {
+        text: "Run checks",
+        rootConstraints: Array.from({ length: 20 }, () => ({
+          "private-record-key": "private-value",
+        })),
+      },
+    });
     expect(bounded.structuredContent?.error?.code).toBe("session_create_invalid_request");
+    expect(bounded.structuredContent?.error?.message).toContain(
+      "goal.rootConstraints expected string",
+    );
     expect(bounded.structuredContent?.error?.message).toContain(
       "additional fields failed validation",
     );
@@ -814,6 +837,25 @@ describe("first-party MCP tool visibility policy", () => {
     expect(
       new TextEncoder().encode(bounded.structuredContent?.error?.message).byteLength,
     ).toBeLessThanOrEqual(1024);
+
+    routeDeps.db = new Proxy(
+      {},
+      {
+        get() {
+          throw new HTTPException(403, { message: "Attempt is not authorized" });
+        },
+      },
+    ) as ApiRouteDeps["db"];
+    const agentServer = buildOpenGeniMcpServer(
+      routeDeps,
+      grant(["sessions:create"], ["session_create"]),
+    );
+    const unauthorized = await callRegisteredTool(agentServer, "session_create", {
+      initialMessage: "work",
+      goal: { objective: "private-objective" },
+    });
+    expect(unauthorized.structuredContent?.error?.code).toBe("session_create_forbidden");
+    expect(JSON.stringify(unauthorized)).not.toContain("private-");
   });
 
   test("model-facing session_create accepts ordered Variable Sets and authorizes attachment before storage", async () => {


### PR DESCRIPTION
## Summary

Expose the canonical nested GoalSpec in the session_create MCP input schema instead of an opaque value. Validate the raw create request after existing authorization checks and return bounded, value-free field diagnostics for malformed input.

Internal/core/storage validation failures retain the existing private server-error response. No input coercion, authority expansion, or session-creation retry behavior changes.

## Verification

- Red before production changes: emitted-schema and malformed-goal regressions fail.
- Review regression: an internal schema error must not be classified as invalid caller input; demonstrated red before boundary correction.
- Green: 35 tests, 181 assertions, independently rerun across MCP tool policy and session-create error suites.
- API typecheck, targeted lint, formatting, and diff checks pass.
- No real session creation probes or deployment performed; full integration validation is left to CI.

## Summary by Sourcery

Improve session_create MCP schema visibility and safely report actionable validation errors for invalid requests.

New Features:
- Expose the canonical nested GoalSpec schema for the session_create MCP tool.
- Return bounded, actionable validation diagnostics for malformed session creation requests.

Bug Fixes:
- Prevent downstream storage and internal schema failures from being misclassified as caller input errors.
- Avoid reflecting sensitive input values or private validation details in session-create error responses.

Enhancements:
- Preserve authorization ordering and existing private fallback behavior for internal session-creation failures.

Tests:
- Add coverage for published goal schemas, malformed nested goals, bounded diagnostics, internal failures, and authorization behavior.