### PR TITLE
fix(react): recover composer draft sync timeouts

### DIFF
--- a/.changeset/composer-draft-timeout-recovery.md
+++ b/.changeset/composer-draft-timeout-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Retry timed-out composer draft reads with backoff and clear their warning after a successful refresh, including when the draft revision is unchanged. Keep draft-read failures separate from Send, Steer, and control failures, and identify draft sync timeouts in the composer message.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -589,7 +589,10 @@ state remains application-owned; durable draft and session state remain in
   directly in chat and supersedes the current direction. Resume is always an
   explicit control action and never an implicit side effect of Send. Drafts
   autosave with optimistic concurrency, survive failed sends, and reuse one
-  `clientEventId` across retries so the server dedupes. `composer.policy` and
+  `clientEventId` across retries so the server dedupes. Draft reads retry transient
+  failures, including request timeouts, with backoff. Successful refreshes clear
+  draft-read errors without dismissing Send, Steer, or control errors; a draft
+  sync timeout does not mean the agent turn has stopped. `composer.policy` and
   `setModel` / `setReasoningEffort` / `setLatencyMode` expose the exact policy
   owned by that actor/session draft; policy is `null` until hydration completes.
   `sendExtras` (object or function evaluated at send time) is only for

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -677,6 +677,8 @@ export function useComposer(
   const [acceptedControl, setAcceptedControl] = useState<EffectiveSessionControl | null>(null);
   const [resuming, setResuming] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  // Background draft reads recover independently of Send/Steer/control failures.
+  const [draftReadError, setDraftReadError] = useState<Error | null>(null);
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
   const [draftLoading, setDraftLoading] = useState(Boolean(sessionId) && durableDrafts);
   const [draftSaving, setDraftSaving] = useState(false);
@@ -794,6 +796,7 @@ export function useComposer(
     setAcceptedControl(null);
     setResuming(false);
     setError(null);
+    setDraftReadError(null);
     setDraft(null);
     setDraftLoading(Boolean(sessionId) && durableDrafts);
     setDraftSaving(false);
@@ -920,6 +923,7 @@ export function useComposer(
       if (targetKeyRef.current !== targetKey) return;
       if (!sessionId || !durableDrafts) {
         setDraftLoading(false);
+        setDraftReadError(null);
         return;
       }
       let retry = draftReadRetryRef.current;
@@ -993,6 +997,8 @@ export function useComposer(
         if (retry.timer !== null) clearTimeout(retry.timer);
         retry.failures = 0;
         retry.timer = null;
+        // Recovery also counts when the server returns the same draft revision.
+        setDraftReadError(null);
         const currentRevision = draftRef.current?.revision ?? -1;
         // Reconnect and client-generation effects can legitimately ask for the
         // draft again. A same-revision response is not new authority: publishing
@@ -1045,12 +1051,18 @@ export function useComposer(
         }
       } catch (cause) {
         if (
+          !requestAbort.signal.aborted &&
           generation === targetGeneration.current &&
           targetKeyRef.current === targetKey &&
           readTicket === draftReadGeneration.current
         ) {
-          setError(asError(cause));
+          const problem = asError(cause);
+          const timedOut = problem.name === "TimeoutError";
+          setDraftReadError(
+            timedOut ? new Error("Draft sync timed out. Retrying…", { cause }) : problem,
+          );
           if (
+            timedOut ||
             cause instanceof TypeError ||
             (cause && typeof cause === "object" && "retryable" in cause && cause.retryable === true)
           ) {
@@ -2639,6 +2651,7 @@ export function useComposer(
   const clearError = useCallback(() => {
     if (targetKeyRef.current !== targetKey) return;
     setError(null);
+    setDraftReadError(null);
     setDraftConflict(null);
   }, [targetKey]);
   // `valueRef` is the synchronous composer authority. React state exists to
@@ -2706,7 +2719,7 @@ export function useComposer(
     resolveDraftConflict,
     restoredResources: identityMatches ? restoredResources : [],
     removeRestoredResource,
-    error: identityMatches ? error : null,
+    error: identityMatches ? (error ?? draftReadError) : null,
     clearError,
   };
 }

--- a/packages/react/test/composer-draft-recovery.test.tsx
+++ b/packages/react/test/composer-draft-recovery.test.tsx
@@ -1,0 +1,181 @@
+import { expect, test } from "bun:test";
+import {
+  OpenGeniApiError,
+  OpenGeniClient,
+  OPENGENI_API_CONTRACT_HEADER,
+  OPENGENI_API_CONTRACT_REVISION,
+} from "@opengeni/sdk";
+import { useComposer } from "../src/hooks/use-composer";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+import { actRun, flush, registerDom, renderHook } from "./render-hook";
+
+registerDom();
+
+for (const initialLoad of [true, false]) {
+  test(`draft timeout recovers automatically during ${initialLoad ? "initial hydration" : "same-revision refresh"}`, async () => {
+    const base = fakeClient({});
+    const draft = {
+      ...(await base.getComposerDraft(WORKSPACE_ID, SESSION_ID)),
+      text: "Keep this draft",
+      resources: [{ kind: "file" as const, fileId: "44444444-4444-4444-8444-444444444444" }],
+    };
+    let reads = 0;
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        if (reads === (initialLoad ? 1 : 2)) {
+          throw new DOMException("Request timed out", "TimeoutError");
+        }
+        return draft;
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    try {
+      if (!initialLoad) await actRun(() => hook.result.current.reloadDraft());
+      expect(hook.result.current.error?.message).toBe("Draft sync timed out. Retrying…");
+      await flush(1400);
+      expect(reads).toBe(initialLoad ? 2 : 3);
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.value).toBe(draft.text);
+      expect(hook.result.current.restoredResources).toEqual(draft.resources);
+      expect(hook.result.current.policy?.model).toBe(draft.model);
+    } finally {
+      await hook.unmount();
+    }
+  });
+}
+
+test("draft recovery preserves a concurrent control error", async () => {
+  let failRead = true;
+  const base = fakeClient({});
+  const controlError = new Error("Pause was rejected");
+  const client = fakeClient({
+    getComposerDraft: async (...args) => {
+      if (failRead) throw new DOMException("Request timed out", "TimeoutError");
+      return base.getComposerDraft(...args);
+    },
+    pauseSession: async () => {
+      throw controlError;
+    },
+  });
+  const hook = await renderHook(
+    () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+    undefined,
+  );
+  try {
+    await actRun(() => hook.result.current.pause());
+    expect(hook.result.current.error).toBe(controlError);
+    // A further draft failure must not obscure the actionable control failure.
+    await actRun(() => hook.result.current.reloadDraft());
+    expect(hook.result.current.error).toBe(controlError);
+    failRead = false;
+    await actRun(() => hook.result.current.reloadDraft());
+    expect(hook.result.current.draft).not.toBeNull();
+    expect(hook.result.current.error).toBe(controlError);
+    await actRun(() => hook.result.current.clearError());
+    expect(hook.result.current.error).toBeNull();
+  } finally {
+    await hook.unmount();
+  }
+});
+
+test("successful draft refresh clears a previous non-retryable read error", async () => {
+  let reads = 0;
+  const base = fakeClient({});
+  const denied = new OpenGeniApiError(403, "Draft access denied");
+  const client = fakeClient({
+    getComposerDraft: async (...args) => {
+      reads += 1;
+      if (reads === 1) throw denied;
+      return base.getComposerDraft(...args);
+    },
+  });
+  const hook = await renderHook(
+    () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+    undefined,
+  );
+  try {
+    expect(hook.result.current.error).toBe(denied);
+    await flush(1400);
+    expect(reads).toBe(1);
+    await actRun(() => hook.result.current.reloadDraft());
+    expect(hook.result.current.error).toBeNull();
+  } finally {
+    await hook.unmount();
+  }
+});
+
+test("the SDK deadline retries a read without aborting the composer's caller signal", async () => {
+  const draft = await fakeClient({}).getComposerDraft(WORKSPACE_ID, SESSION_ID);
+  let requests = 0;
+  let callerSignal: AbortSignal | undefined;
+  const sdk = new OpenGeniClient({
+    baseUrl: "https://opengeni.invalid",
+    sessionCommandTimeoutMs: 20,
+    fetch: async (_input, init) => {
+      requests += 1;
+      if (requests === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          init!.signal!.addEventListener("abort", () => reject(init!.signal!.reason), {
+            once: true,
+          });
+        });
+      }
+      return new Response(JSON.stringify(draft), {
+        headers: {
+          "content-type": "application/json",
+          [OPENGENI_API_CONTRACT_HEADER]: OPENGENI_API_CONTRACT_REVISION,
+        },
+      });
+    },
+  });
+  const client = fakeClient({
+    getComposerDraft: async (workspaceId, sessionId, options) => {
+      callerSignal = options?.signal;
+      return await sdk.getComposerDraft(workspaceId, sessionId, options);
+    },
+  });
+  const hook = await renderHook(
+    () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+    undefined,
+  );
+  try {
+    await flush(60);
+    expect(hook.result.current.error?.message).toBe("Draft sync timed out. Retrying…");
+    expect(callerSignal?.aborted).toBe(false);
+    await flush(1400);
+    expect(requests).toBe(2);
+    expect(hook.result.current.error).toBeNull();
+  } finally {
+    await hook.unmount();
+  }
+});
+
+test("switching sessions cancels the old draft timeout retry and warning", async () => {
+  const otherSessionId = "33333333-3333-4333-8333-333333333333";
+  const reads: string[] = [];
+  const base = fakeClient({});
+  const client = fakeClient({
+    getComposerDraft: async (workspaceId, sessionId) => {
+      reads.push(sessionId);
+      if (sessionId === SESSION_ID) throw new DOMException("Request timed out", "TimeoutError");
+      return await base.getComposerDraft(workspaceId, sessionId);
+    },
+  });
+  const hook = await renderHook(
+    (sessionId: string) => useComposer(sessionId, { client, workspaceId: WORKSPACE_ID }),
+    SESSION_ID as string,
+  );
+  try {
+    expect(hook.result.current.error).not.toBeNull();
+    await hook.rerender(otherSessionId);
+    await flush(1400);
+    expect(reads).toEqual([SESSION_ID, otherSessionId]);
+    expect(hook.result.current.error).toBeNull();
+  } finally {
+    await hook.unmount();
+  }
+});


### PR DESCRIPTION
## Summary

A background composer draft refresh that exceeded the SDK deadline left “Request timed out” beneath the composer while the agent continued running. The draft loader did not classify `TimeoutError` as retryable, and successful refreshes never cleared the shared error state—even when they returned the same draft revision.

Retry these reads through the existing backoff and show “Draft sync timed out. Retrying…”. Track draft-read errors separately so successful refreshes clear their warning without hiding a failed Send, Steer, or control action. Caller cancellation and session-change fences remain authoritative.

## Testing

- [x] Workspace typecheck: all 33 projects passed (React rerun after correcting a test-only literal type).
- [x] 123 focused hook/recovery tests passed; the expanded six-test recovery suite also passed, including an actual SDK deadline and cancellation on session switch.
- [x] Focused lint, formatting, and `git diff --check`.
- [x] Independent review: no blocking findings.
- [x] SDK, React, React demo, web (including bundle budgets), and Northstar example builds.
- [ ] Full local unit suite: stopped after 2,705 passes and five environment failures in `apps/api/test/rematerialize-archive-ref.test.ts`; Docker could not find `opengeni-sandbox:local` and its attempted pull was denied. These fail during sandbox fixture setup, outside the changed React code. GitHub CI remains in progress with no failures reported at this update.

## Delivery integrity

- [x] Candidate represents a substantive source fix; no base-only refresh.
- [x] Branch started from current `main`; merge-tree compatibility check passed without source mutation.

## Notes

Includes a React patch changeset and documentation. This fixes the reproduced composer recovery defect; the original browser/network delay was not established, and this does not change model timeouts or the separate preview-browser tool failure.
