### PR TITLE
fix(sandbox): spool host workspace archives through object storage

### DIFF
--- a/.changeset/bounded-host-workspace-archives.md
+++ b/.changeset/bounded-host-workspace-archives.md
@@ -1,8 +1,10 @@
 ---
 "@opengeni/runtime": patch
 "@opengeni/storage": patch
+"@opengeni/contracts": patch
+"@opengeni/db": patch
 "@opengeni/worker-bundle": patch
 "@opengeni/api-router": patch
 ---
 
-Spool Linux host-backed workspace archives through capture, object storage, and cold restore instead of materializing whole JSON/base64 payloads. Preserve the existing archive format, integrity verification, configured restore limits, and lease capture/publication fences.
+Spool Linux host-backed workspace archives through capture, object storage, and cold restore instead of materializing whole JSON/base64 payloads. Isolate each upload at a fresh physical locator and verify stored bytes without assuming conditional-PUT support. Preserve legacy locators, archive format, configured restore limits, and lease capture/publication authority; retain candidates after ambiguous publication outcomes.

--- a/.changeset/bounded-host-workspace-archives.md
+++ b/.changeset/bounded-host-workspace-archives.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/storage": patch
+"@opengeni/worker-bundle": patch
+"@opengeni/api-router": patch
+---
+
+Spool Linux host-backed workspace archives through capture, object storage, and cold restore instead of materializing whole JSON/base64 payloads. Preserve the existing archive format, integrity verification, configured restore limits, and lease capture/publication fences.

--- a/apps/api/src/sandbox/rematerialize.ts
+++ b/apps/api/src/sandbox/rematerialize.ts
@@ -32,7 +32,11 @@ import {
   type EstablishedSandboxSession,
   type WorkspaceArchiveDescriptor,
 } from "@opengeni/runtime/sandbox";
-import type { ObjectStorage } from "@opengeni/storage";
+import {
+  downloadWorkspaceArchiveSpool,
+  WorkspaceArchiveStorageError,
+  type ObjectStorage,
+} from "@opengeni/storage";
 
 function hasWorkspaceArchive(envelope: Record<string, unknown> | null): boolean {
   const sessionState =
@@ -72,6 +76,14 @@ async function materializeArchiveObjectRef(
       "archive_base64_invalid",
       "workspace archive object storage is not configured",
     );
+  }
+  const descriptor = parseWorkspaceArchiveDescriptor(sessionState.workspaceArchiveMeta);
+  if (
+    process.platform === "linux" &&
+    descriptor?.version === 1 &&
+    descriptor.workspace.projection === "sdk_local_archive_v1"
+  ) {
+    return envelope;
   }
   return {
     ...envelope,
@@ -209,6 +221,26 @@ export async function establishApiSandboxSpawner(input: {
     established = await establishSandboxSessionFromEnvelope(input.settings, hydrateEnvelope, {
       sessionId: input.sessionId,
       recovery: "create-or-restore",
+      ...(input.objectStorage
+        ? {
+            loadHostWorkspaceArchive: async (ref) => {
+              try {
+                return await downloadWorkspaceArchiveSpool(input.objectStorage!, ref.key, {
+                  bytes: ref.bytes,
+                  sha256: ref.sha256,
+                });
+              } catch (error) {
+                if (error instanceof WorkspaceArchiveStorageError) {
+                  throw new WorkspaceArchiveIntegrityError(error.code, error.message, {
+                    retryable: error.retryable,
+                    cause: error,
+                  });
+                }
+                throw error;
+              }
+            },
+          }
+        : {}),
       backendOverride: input.backend as never,
       environment: input.environment,
       onSandboxCreated: async (created) => {

--- a/apps/api/test/rematerialize-archive-ref.test.ts
+++ b/apps/api/test/rematerialize-archive-ref.test.ts
@@ -103,9 +103,26 @@ function objectStorageFor(
       },
       getFileRange: async () => null,
       async getObjectBytes(key: string) {
+        if (process.platform === "linux") throw new Error("whole-object restore forbidden");
         readCount += 1;
         expect(key).toBe(ref.key);
         return reply === null ? null : { bytes: reply };
+      },
+      async headObject(key: string) {
+        expect(key).toBe(ref.key);
+        // Count the initial object observation, not the final version check.
+        if (readCount === 0) readCount += 1;
+        return reply === null ? null : { ContentLength: reply.length, VersionToken: "fixture-v1" };
+      },
+      async getObjectRange(input) {
+        expect(input.key).toBe(ref.key);
+        expect(input.expectedVersionToken).toBe("fixture-v1");
+        return reply === null
+          ? null
+          : {
+              bytes: reply.subarray(input.start, input.endInclusive + 1),
+              versionToken: "fixture-v1",
+            };
       },
       putObject: async () => undefined,
       deleteObject: async () => undefined,

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -163,9 +163,7 @@ import {
 } from "../opensandbox-kubernetes-inventory";
 import type { ObjectStorage } from "@opengeni/storage";
 import {
-  collectWorkspaceArchiveObjectKeys,
-  deleteUnpublishedWorkspaceArchiveObject,
-  deleteWorkspaceArchiveObjectKeys,
+  persistWorkspaceArchiveCandidate,
   putVersion1TarArchiveOrInline,
 } from "../sandbox-archive-storage";
 
@@ -2742,62 +2740,33 @@ async function terminateDrainableBox(
       if (!archiveMetadata) {
         throw new Error("Sandbox snapshot publication requires a verified archive descriptor");
       }
-      const priorKeys = collectWorkspaceArchiveObjectKeys(
-        (lease.resumeState as Record<string, unknown> | null | undefined) ?? null,
-      );
-      let workspaceArchiveRef:
-        | Awaited<ReturnType<typeof putVersion1TarArchiveOrInline>>["workspaceArchiveRef"]
-        | undefined;
-      try {
-        const published = await putVersion1TarArchiveOrInline({
-          backend: lease.backend,
-          objectStorage,
-          accountId,
-          workspaceId: row.workspaceId,
-          sandboxGroupId: row.sandboxGroupId,
-          archive:
-            typeof archiveBase64 === "object"
-              ? archiveBase64
-              : {
-                  bytes: Buffer.from(archiveBase64, "base64"),
-                  descriptor: archiveMetadata,
-                  base64: archiveBase64,
-                },
-          metrics: archiveMetrics,
-        });
-        workspaceArchiveRef = published.workspaceArchiveRef;
-        result = await persistDrainSnapshot(db, {
-          ...baseInput,
-          workspaceArchiveMeta: archiveMetadata,
-          ...published,
-          ...(checkpointArtifactId ? { checkpointArtifactId } : {}),
-        });
-        if (published.workspaceArchiveRef && objectStorage) {
-          if (!result.wrote) {
-            await deleteUnpublishedWorkspaceArchiveObject(
-              objectStorage,
-              published.workspaceArchiveRef,
-              archiveMetrics,
-            );
-          } else {
-            const afterLease = await readLease(db, row.workspaceId, row.sandboxGroupId);
-            const afterKeys = collectWorkspaceArchiveObjectKeys(
-              (afterLease?.resumeState as Record<string, unknown> | null | undefined) ?? null,
-            );
-            await deleteWorkspaceArchiveObjectKeys(
-              objectStorage,
-              [...priorKeys].filter((key) => !afterKeys.has(key)),
-            ).catch(() => undefined);
-          }
-        }
-      } catch (error) {
-        await deleteUnpublishedWorkspaceArchiveObject(
-          objectStorage,
-          workspaceArchiveRef,
-          archiveMetrics,
-        );
-        throw error;
-      }
+      const published = await putVersion1TarArchiveOrInline({
+        backend: lease.backend,
+        objectStorage,
+        accountId,
+        workspaceId: row.workspaceId,
+        sandboxGroupId: row.sandboxGroupId,
+        archive:
+          typeof archiveBase64 === "object"
+            ? archiveBase64
+            : {
+                bytes: Buffer.from(archiveBase64, "base64"),
+                descriptor: archiveMetadata,
+                base64: archiveBase64,
+              },
+        metrics: archiveMetrics,
+      });
+      result = await persistWorkspaceArchiveCandidate({
+        objectStorage,
+        ...(published.workspaceArchiveRef ? { ref: published.workspaceArchiveRef } : {}),
+        persist: () =>
+          persistDrainSnapshot(db, {
+            ...baseInput,
+            workspaceArchiveMeta: archiveMetadata,
+            ...published,
+            ...(checkpointArtifactId ? { checkpointArtifactId } : {}),
+          }),
+      });
     }
     if (!result.wrote && checkpointArtifactId) {
       await markSandboxCheckpointArtifactDeletePending(db, {

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -82,7 +82,10 @@ import {
   // box is typed as provider loss. Stale capture reconciliation separately uses
   // establishSandboxSessionFromEnvelope in strict resume-only mode so it can
   // reuse the runtime's provider-ready proof without ever cold-restoring.
-  captureVerifiedWorkspaceArchive,
+  captureWorkspaceArchiveForStorage,
+  disposeWorkspaceArchive,
+  type VerifiedWorkspaceArchivePayload,
+  type VerifiedHostWorkspaceArchive,
   cancelSelfhostedOp,
   assertConsistentSandboxProviderIdentity,
   createSandboxClientForBackend,
@@ -210,7 +213,7 @@ type DrainSandboxClient = {
  * aborts the terminate before client.delete()).
  */
 export type PersistArchiveFn = (
-  archiveBase64: string | null,
+  archiveBase64: string | VerifiedHostWorkspaceArchive | null,
   archiveMetadata?: WorkspaceArchiveDescriptor,
   providerSession?: unknown,
   providerBinding?: Awaited<
@@ -247,6 +250,7 @@ export type TerminateBoxFn = (
   providerCaptureRequestId?: string,
   captureDisposition?: DrainCaptureDisposition,
   capturePolicy?: ProviderWorkspaceCapturePolicy | null,
+  diskBackedArchives?: boolean,
 ) => Promise<boolean | ProviderTerminationOutcome>;
 
 export type SweepModalOrphansFn = (
@@ -479,6 +483,7 @@ export function createSandboxLeaseActivities(
       providerCaptureRequestId,
       captureDisposition,
       capturePolicy,
+      diskBackedArchives,
     ) =>
       await terminateProviderBox(
         settings,
@@ -490,6 +495,7 @@ export function createSandboxLeaseActivities(
         providerCaptureRequestId,
         captureDisposition,
         capturePolicy,
+        diskBackedArchives,
       ));
   const sweepModalOrphans: SweepModalOrphansFn =
     options.sweepModalOrphans ?? sweepModalOrphansForConfiguredBackend;
@@ -2675,7 +2681,7 @@ async function terminateDrainableBox(
       ? (lease.recovery.archive.current?.revision ?? null)
       : null;
   const persistArchive: PersistArchiveFn = async (
-    archiveBase64: string | null,
+    archiveBase64: string | VerifiedHostWorkspaceArchive | null,
     archiveMetadata?: WorkspaceArchiveDescriptor,
     _providerSession?: unknown,
     providerBinding?: Awaited<
@@ -2691,6 +2697,7 @@ async function terminateDrainableBox(
     const archiveMetrics = runtimeMetricsHooksForObservability(observability);
     let checkpointArtifactId: string | null = null;
     if (
+      typeof archiveBase64 === "string" &&
       archiveBase64 &&
       archiveMetadata?.version === 2 &&
       (archiveMetadata.provider === "modal_snapshot_filesystem" ||
@@ -2748,11 +2755,14 @@ async function terminateDrainableBox(
           accountId,
           workspaceId: row.workspaceId,
           sandboxGroupId: row.sandboxGroupId,
-          archive: {
-            bytes: Buffer.from(archiveBase64, "base64"),
-            descriptor: archiveMetadata,
-            base64: archiveBase64,
-          },
+          archive:
+            typeof archiveBase64 === "object"
+              ? archiveBase64
+              : {
+                  bytes: Buffer.from(archiveBase64, "base64"),
+                  descriptor: archiveMetadata,
+                  base64: archiveBase64,
+                },
           metrics: archiveMetrics,
         });
         workspaceArchiveRef = published.workspaceArchiveRef;
@@ -2823,6 +2833,7 @@ async function terminateDrainableBox(
         captureClaim?.providerRequestId ?? attempt.operationId,
         captureDisposition,
         capturePolicy,
+        Boolean(objectStorage),
       );
   const terminated = typeof termination === "boolean" ? termination : termination.terminated;
   if (!terminated) {
@@ -2955,6 +2966,7 @@ export async function terminateProviderBox(
   providerCaptureRequestId?: string,
   captureDisposition: DrainCaptureDisposition = "capture_required",
   claimedCapturePolicy?: ProviderWorkspaceCapturePolicy | null,
+  diskBackedArchives = false,
 ): Promise<ProviderTerminationOutcome> {
   const durableBackendId = (lease.resumeBackendId ?? lease.backend) as string;
   const backend = sandboxBackendForSdkBackendId(durableBackendId) ?? durableBackendId;
@@ -3147,7 +3159,7 @@ export async function terminateProviderBox(
   // snapshot must re-throw BEFORE any terminate so files are never lost — the next
   // sweep retries, the provider idle-timeout is the backstop. A NotFound here (the
   // box raced gone between resume and persist) is success: nothing to persist.
-  let verifiedArchive: Awaited<ReturnType<typeof captureVerifiedWorkspaceArchive>> | undefined;
+  let verifiedArchive: VerifiedWorkspaceArchivePayload | undefined;
   const sessionWorkspacePersistence = (
     session as { state?: { workspacePersistence?: unknown } } | undefined
   )?.state?.workspacePersistence;
@@ -3162,10 +3174,15 @@ export async function terminateProviderBox(
       : null;
   try {
     if (captureDisposition !== "archive_published" && session?.persistWorkspace) {
-      const capture = captureVerifiedWorkspaceArchive(session, Date.now(), {
-        requestId: providerCaptureRequestId ?? randomUUID(),
-        strategy: liveCapturePolicy.strategy,
-      });
+      const capture = captureWorkspaceArchiveForStorage(
+        session,
+        Date.now(),
+        {
+          requestId: providerCaptureRequestId ?? randomUUID(),
+          strategy: liveCapturePolicy.strategy,
+        },
+        diskBackedArchives,
+      );
       verifiedArchive = await awaitProviderCaptureWithLatePublication({
         capture,
         timeoutMs: settings.sandboxSnapshotTimeoutMs,
@@ -3179,7 +3196,7 @@ export async function terminateProviderBox(
         publishLate: async (archive) => {
           try {
             const result = await persistArchive(
-              archive.base64,
+              archive.kind === "host_spool" ? archive : archive.base64,
               archive.descriptor,
               session,
               checkpointBinding,
@@ -3197,6 +3214,8 @@ export async function terminateProviderBox(
               ...logIdentity,
               error: error instanceof Error ? error.message : String(error),
             });
+          } finally {
+            await disposeWorkspaceArchive(archive);
           }
         },
         observeLateFailure: (error) => {
@@ -3237,12 +3256,17 @@ export async function terminateProviderBox(
       ...logIdentity,
     });
   } else if (verifiedArchive) {
-    const { wrote } = await persistArchive(
-      verifiedArchive.base64,
-      verifiedArchive.descriptor,
-      session,
-      checkpointBinding,
-    );
+    let wrote: boolean;
+    try {
+      ({ wrote } = await persistArchive(
+        verifiedArchive.kind === "host_spool" ? verifiedArchive : verifiedArchive.base64,
+        verifiedArchive.descriptor,
+        session,
+        checkpointBinding,
+      ));
+    } finally {
+      await disposeWorkspaceArchive(verifiedArchive);
+    }
     if (!wrote) {
       observability.info(
         "sandbox reaper: lease re-armed during persist — leaving box RUNNING (no terminate)",

--- a/apps/worker/src/sandbox-archive-storage.ts
+++ b/apps/worker/src/sandbox-archive-storage.ts
@@ -1,4 +1,5 @@
 import { uploadWorkspaceArchiveSpool, type ObjectStorage } from "@opengeni/storage";
+import { randomUUID } from "node:crypto";
 import type { VerifiedHostWorkspaceArchive } from "@opengeni/runtime/sandbox";
 import {
   parseWorkspaceArchiveObjectRef,
@@ -40,37 +41,83 @@ export async function putTarWorkspaceArchiveObject(input: {
     | { bytes: Uint8Array; descriptor: WorkspaceArchiveDescriptor }
     | VerifiedHostWorkspaceArchive;
 }): Promise<WorkspaceArchiveObjectRef> {
-  if (input.archive.descriptor.version !== 1) {
+  // Snapshot caller-owned metadata before any provider callback can mutate it.
+  const descriptor = structuredClone(input.archive.descriptor);
+  if (descriptor.version !== 1) {
     throw new Error("Object-storage workspace archives are portable tar only");
   }
   const key = workspaceArchiveObjectKey({
     accountId: input.accountId,
     workspaceId: input.workspaceId,
     sandboxGroupId: input.sandboxGroupId,
-    revision: input.archive.descriptor.revision,
+    revision: descriptor.revision,
+    uploadId: randomUUID(),
   });
-  if ("spool" in input.archive) {
+  const archive = input.archive;
+  if ("spool" in archive) {
     if (
-      input.archive.spool.byteSize !== input.archive.descriptor.archiveBytes ||
-      input.archive.spool.sha256 !== input.archive.descriptor.archiveSha256
+      archive.spool.byteSize !== descriptor.archiveBytes ||
+      archive.spool.sha256 !== descriptor.archiveSha256
     ) {
       throw new Error("Workspace archive spool does not match its verified descriptor");
     }
-    await uploadWorkspaceArchiveSpool(input.objectStorage, key, input.archive.spool);
-  } else
-    await input.objectStorage.putObject({
-      key,
-      contentType: "application/x-tar",
-      body: input.archive.bytes,
-      sha256: input.archive.descriptor.archiveSha256,
+  }
+  const source =
+    "spool" in archive
+      ? archive.spool
+      : {
+          path: "",
+          byteSize: archive.bytes.byteLength,
+          sha256: descriptor.archiveSha256,
+          async *open() {
+            for (let offset = 0; offset < archive.bytes.length; offset += 1024 * 1024)
+              yield archive.bytes.subarray(offset, offset + 1024 * 1024);
+          },
+          async dispose() {},
+        };
+  try {
+    await uploadWorkspaceArchiveSpool(input.objectStorage, key, {
+      ...source,
+      byteSize: descriptor.archiveBytes,
+      sha256: descriptor.archiveSha256,
+      open: source.open.bind(source),
     });
+  } catch (error) {
+    // This fresh locator has never been offered to database publication. An
+    // ambiguous provider upload can leave an orphan, never overwrite a retained
+    // archive or justify deleting another attempt's object.
+    await input.objectStorage.deleteObject(key).catch(() => undefined);
+    throw error;
+  }
   return {
     schema: "sandbox_archive_object_v1",
     key,
-    sha256: input.archive.descriptor.archiveSha256,
-    bytes: input.archive.descriptor.archiveBytes,
+    sha256: descriptor.archiveSha256,
+    bytes: descriptor.archiveBytes,
     backend: input.objectStorage.backend,
   };
+}
+
+/** The caller owns a fresh candidate returned by this module. A thrown or lost
+ * database response is UNKNOWN: it may have committed, so never delete on catch.
+ * Only the transaction's exact candidate disposition can authorize cleanup. */
+export async function persistWorkspaceArchiveCandidate<
+  T extends {
+    wrote: boolean;
+    candidateDisposition?: "adopted" | "already_referenced" | "unused";
+  },
+>(input: {
+  objectStorage?: ObjectStorage | null;
+  ref?: WorkspaceArchiveObjectRef;
+  persist: () => Promise<T>;
+}): Promise<T> {
+  const objectStorage = input.objectStorage;
+  const ref = input.ref ? { ...input.ref } : undefined;
+  const result = await input.persist();
+  if (objectStorage && ref && result.candidateDisposition === "unused") {
+    await deleteUnpublishedWorkspaceArchiveObject(objectStorage, ref);
+  }
+  return result;
 }
 
 export async function putVersion1TarArchiveOrInline(input: {

--- a/apps/worker/src/sandbox-archive-storage.ts
+++ b/apps/worker/src/sandbox-archive-storage.ts
@@ -1,4 +1,5 @@
-import type { ObjectStorage } from "@opengeni/storage";
+import { uploadWorkspaceArchiveSpool, type ObjectStorage } from "@opengeni/storage";
+import type { VerifiedHostWorkspaceArchive } from "@opengeni/runtime/sandbox";
 import {
   parseWorkspaceArchiveObjectRef,
   workspaceArchiveObjectKey,
@@ -35,7 +36,9 @@ export async function putTarWorkspaceArchiveObject(input: {
   accountId: string;
   workspaceId: string;
   sandboxGroupId: string;
-  archive: { bytes: Uint8Array; descriptor: WorkspaceArchiveDescriptor };
+  archive:
+    | { bytes: Uint8Array; descriptor: WorkspaceArchiveDescriptor }
+    | VerifiedHostWorkspaceArchive;
 }): Promise<WorkspaceArchiveObjectRef> {
   if (input.archive.descriptor.version !== 1) {
     throw new Error("Object-storage workspace archives are portable tar only");
@@ -46,12 +49,21 @@ export async function putTarWorkspaceArchiveObject(input: {
     sandboxGroupId: input.sandboxGroupId,
     revision: input.archive.descriptor.revision,
   });
-  await input.objectStorage.putObject({
-    key,
-    contentType: "application/x-tar",
-    body: input.archive.bytes,
-    sha256: input.archive.descriptor.archiveSha256,
-  });
+  if ("spool" in input.archive) {
+    if (
+      input.archive.spool.byteSize !== input.archive.descriptor.archiveBytes ||
+      input.archive.spool.sha256 !== input.archive.descriptor.archiveSha256
+    ) {
+      throw new Error("Workspace archive spool does not match its verified descriptor");
+    }
+    await uploadWorkspaceArchiveSpool(input.objectStorage, key, input.archive.spool);
+  } else
+    await input.objectStorage.putObject({
+      key,
+      contentType: "application/x-tar",
+      body: input.archive.bytes,
+      sha256: input.archive.descriptor.archiveSha256,
+    });
   return {
     schema: "sandbox_archive_object_v1",
     key,
@@ -67,11 +79,13 @@ export async function putVersion1TarArchiveOrInline(input: {
   accountId: string;
   workspaceId: string;
   sandboxGroupId: string;
-  archive: {
-    bytes: Uint8Array;
-    descriptor: WorkspaceArchiveDescriptor;
-    base64: string;
-  };
+  archive:
+    | VerifiedHostWorkspaceArchive
+    | {
+        bytes: Uint8Array;
+        descriptor: WorkspaceArchiveDescriptor;
+        base64: string;
+      };
   metrics?: {
     onWorkspaceArchiveObject?: (input: {
       outcome: "put" | "put_failed" | "deleted_unpublished";
@@ -83,12 +97,15 @@ export async function putVersion1TarArchiveOrInline(input: {
   workspaceArchiveRef?: WorkspaceArchiveObjectRef;
 }> {
   if (input.archive.descriptor.version !== 1) {
+    if ("spool" in input.archive) throw new Error("Native snapshots cannot use a portable spool");
     return { workspaceArchive: input.archive.base64 };
   }
   if (input.backend === "opensandbox" && !input.objectStorage) {
     throw new WorkspaceArchiveObjectStorageRequiredError("opensandbox");
   }
   if (!input.objectStorage) {
+    if ("spool" in input.archive)
+      throw new WorkspaceArchiveObjectStorageRequiredError(input.backend);
     return { workspaceArchive: input.archive.base64 };
   }
   try {
@@ -97,7 +114,7 @@ export async function putVersion1TarArchiveOrInline(input: {
       accountId: input.accountId,
       workspaceId: input.workspaceId,
       sandboxGroupId: input.sandboxGroupId,
-      archive: { bytes: input.archive.bytes, descriptor: input.archive.descriptor },
+      archive: input.archive,
     });
     try {
       input.metrics?.onWorkspaceArchiveObject?.({

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -89,9 +89,7 @@ import {
 import type { Observability } from "@opengeni/observability";
 import { parseWorkspaceArchiveObjectRef } from "@opengeni/contracts";
 import {
-  collectWorkspaceArchiveObjectKeys,
-  deleteUnpublishedWorkspaceArchiveObject,
-  deleteWorkspaceArchiveObjectKeys,
+  persistWorkspaceArchiveCandidate,
   putVersion1TarArchiveOrInline,
 } from "./sandbox-archive-storage";
 
@@ -955,9 +953,7 @@ async function persistWarmWorkspaceSnapshot(
     const captureAndPublish = (async (): Promise<boolean> => {
       let archive: VerifiedWorkspaceArchivePayload | undefined;
       let candidate: { id: string } | null = null;
-      let workspaceArchiveRef: Awaited<
-        ReturnType<typeof putVersion1TarArchiveOrInline>
-      >["workspaceArchiveRef"];
+      let publicationAttempted = false;
       try {
         archive = await captureWorkspaceArchiveForStorage(
           session,
@@ -969,10 +965,7 @@ async function persistWarmWorkspaceSnapshot(
           Boolean(services.objectStorage),
         );
         candidate = await registerCandidate(archive);
-        const priorLease = await readLease(db, ids.workspaceId, ids.sandboxGroupId);
-        const priorKeys = collectWorkspaceArchiveObjectKeys(
-          (priorLease?.resumeState as Record<string, unknown> | null | undefined) ?? null,
-        );
+        const archiveDescriptor = archive.descriptor;
         const published = await putVersion1TarArchiveOrInline({
           backend: lease.backend,
           objectStorage: services.objectStorage,
@@ -982,53 +975,36 @@ async function persistWarmWorkspaceSnapshot(
           archive,
           ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
         });
-        workspaceArchiveRef = published.workspaceArchiveRef;
-        const { wrote } = await persistWarmSnapshot(db, {
-          accountId: ids.accountId,
-          workspaceId: ids.workspaceId,
-          sessionId: ids.sessionId,
-          turnId: ids.turnId,
-          attemptId: ids.attemptId,
-          sandboxGroupId: ids.sandboxGroupId,
-          expectedEpoch: leaseEpoch,
-          expectedInstanceId: instanceId,
-          expectedWorkspaceGeneration: claimed.claim.workspaceGeneration,
-          captureId,
-          workspaceArchiveMeta: archive.descriptor,
-          ...published,
-          checkpointArtifactId: candidate?.id ?? null,
-          minIntervalMs: force ? 0 : intervalMs,
-          capturedAtMs,
+        publicationAttempted = true;
+        const { wrote } = await persistWorkspaceArchiveCandidate({
+          ...(services.objectStorage ? { objectStorage: services.objectStorage } : {}),
+          ...(published.workspaceArchiveRef ? { ref: published.workspaceArchiveRef } : {}),
+          persist: () =>
+            persistWarmSnapshot(db, {
+              accountId: ids.accountId,
+              workspaceId: ids.workspaceId,
+              sessionId: ids.sessionId,
+              turnId: ids.turnId,
+              attemptId: ids.attemptId,
+              sandboxGroupId: ids.sandboxGroupId,
+              expectedEpoch: leaseEpoch,
+              expectedInstanceId: instanceId,
+              expectedWorkspaceGeneration: claimed.claim.workspaceGeneration,
+              captureId,
+              workspaceArchiveMeta: archiveDescriptor,
+              ...published,
+              checkpointArtifactId: candidate?.id ?? null,
+              minIntervalMs: force ? 0 : intervalMs,
+              capturedAtMs,
+            }),
         });
-        if (published.workspaceArchiveRef && services.objectStorage) {
-          if (!wrote) {
-            await deleteUnpublishedWorkspaceArchiveObject(
-              services.objectStorage,
-              published.workspaceArchiveRef,
-              services.sandboxMetrics,
-            );
-          } else {
-            const afterLease = await readLease(db, ids.workspaceId, ids.sandboxGroupId);
-            const afterKeys = collectWorkspaceArchiveObjectKeys(
-              (afterLease?.resumeState as Record<string, unknown> | null | undefined) ?? null,
-            );
-            await deleteWorkspaceArchiveObjectKeys(
-              services.objectStorage,
-              [...priorKeys].filter((key) => !afterKeys.has(key)),
-            ).catch(() => undefined);
-          }
-        }
         if (!wrote && candidate) {
           await abandonCandidate(candidate.id, "snapshot_publication_fenced");
         }
         return wrote;
       } catch (error) {
-        await deleteUnpublishedWorkspaceArchiveObject(
-          services.objectStorage,
-          workspaceArchiveRef,
-          services.sandboxMetrics,
-        );
-        if (candidate) await abandonCandidate(candidate.id, "snapshot_capture_failed");
+        if (candidate && !publicationAttempted)
+          await abandonCandidate(candidate.id, "snapshot_capture_failed");
         throw error;
       } finally {
         await disposeWorkspaceArchive(archive).catch(() => {

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -55,7 +55,9 @@ import {
   type LeaseHolderKind,
 } from "@opengeni/db";
 import {
-  captureVerifiedWorkspaceArchive,
+  captureWorkspaceArchiveForStorage,
+  disposeWorkspaceArchive,
+  type VerifiedWorkspaceArchivePayload,
   describeLegacyNativeSnapshotArchive,
   inlineWorkspaceArchiveForRestore,
   MODAL_EXEC_READINESS_TIMEOUT_MS,
@@ -79,7 +81,11 @@ import {
   type RuntimeMetricsHooks,
   type WorkspaceArchiveDescriptor,
 } from "@opengeni/runtime";
-import type { ObjectStorage } from "@opengeni/storage";
+import {
+  downloadWorkspaceArchiveSpool,
+  WorkspaceArchiveStorageError,
+  type ObjectStorage,
+} from "@opengeni/storage";
 import type { Observability } from "@opengeni/observability";
 import { parseWorkspaceArchiveObjectRef } from "@opengeni/contracts";
 import {
@@ -582,6 +588,14 @@ async function materializeSpawnEnvelopeArchive(
       "workspace archive object storage is not configured",
     );
   }
+  const descriptor = parseWorkspaceArchiveDescriptor(sessionState.workspaceArchiveMeta);
+  if (
+    process.platform === "linux" &&
+    descriptor?.version === 1 &&
+    descriptor.workspace.projection === "sdk_local_archive_v1"
+  ) {
+    return envelope;
+  }
   return {
     ...record,
     sessionState: await inlineWorkspaceArchiveForRestore(sessionState, (key) =>
@@ -898,9 +912,10 @@ async function persistWarmWorkspaceSnapshot(
     // first (the bounded-wait race Bugbot flagged).
     const capturedAtMs = Date.now();
     const registerCandidate = async (
-      archive: Awaited<ReturnType<typeof captureVerifiedWorkspaceArchive>>,
+      archive: VerifiedWorkspaceArchivePayload,
     ): Promise<{ id: string } | null> => {
       if (
+        archive.kind === "host_spool" ||
         archive.descriptor.version !== 2 ||
         (archive.descriptor.provider !== "modal_snapshot_filesystem" &&
           archive.descriptor.provider !== "modal_snapshot_directory")
@@ -938,15 +953,21 @@ async function persistWarmWorkspaceSnapshot(
     // turn signal resolves first. Its finally block is the only normal release
     // of the exact admission gate; a late callback cannot release a successor.
     const captureAndPublish = (async (): Promise<boolean> => {
+      let archive: VerifiedWorkspaceArchivePayload | undefined;
       let candidate: { id: string } | null = null;
       let workspaceArchiveRef: Awaited<
         ReturnType<typeof putVersion1TarArchiveOrInline>
       >["workspaceArchiveRef"];
       try {
-        const archive = await captureVerifiedWorkspaceArchive(session, capturedAtMs, {
-          requestId: claimed.claim.providerRequestId,
-          strategy: capturePolicy.strategy,
-        });
+        archive = await captureWorkspaceArchiveForStorage(
+          session,
+          capturedAtMs,
+          {
+            requestId: claimed.claim.providerRequestId,
+            strategy: capturePolicy.strategy,
+          },
+          Boolean(services.objectStorage),
+        );
         candidate = await registerCandidate(archive);
         const priorLease = await readLease(db, ids.workspaceId, ids.sandboxGroupId);
         const priorKeys = collectWorkspaceArchiveObjectKeys(
@@ -958,11 +979,7 @@ async function persistWarmWorkspaceSnapshot(
           accountId: ids.accountId,
           workspaceId: ids.workspaceId,
           sandboxGroupId: ids.sandboxGroupId,
-          archive: {
-            bytes: archive.bytes,
-            descriptor: archive.descriptor,
-            base64: archive.base64,
-          },
+          archive,
           ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
         });
         workspaceArchiveRef = published.workspaceArchiveRef;
@@ -1014,6 +1031,9 @@ async function persistWarmWorkspaceSnapshot(
         if (candidate) await abandonCandidate(candidate.id, "snapshot_capture_failed");
         throw error;
       } finally {
+        await disposeWorkspaceArchive(archive).catch(() => {
+          console.warn("workspace archive spool cleanup failed");
+        });
         await releaseWorkspaceArchiveCapture(db, {
           accountId: ids.accountId,
           workspaceId: ids.workspaceId,
@@ -1504,6 +1524,26 @@ export async function resumeBoxForTurn(
       const established = await establishSandboxSessionFromEnvelope(settings, hydrateEnvelope, {
         sessionId: ids.sessionId,
         recovery: "create-or-restore",
+        ...(services.objectStorage
+          ? {
+              loadHostWorkspaceArchive: async (ref) => {
+                try {
+                  return await downloadWorkspaceArchiveSpool(services.objectStorage!, ref.key, {
+                    bytes: ref.bytes,
+                    sha256: ref.sha256,
+                  });
+                } catch (error) {
+                  if (error instanceof WorkspaceArchiveStorageError) {
+                    throw new WorkspaceArchiveIntegrityError(error.code, error.message, {
+                      retryable: error.retryable,
+                      cause: error,
+                    });
+                  }
+                  throw error;
+                }
+              },
+            }
+          : {}),
         backendOverride: ids.backend as never,
         ...(ids.environment ? { environment: ids.environment } : {}),
         ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),

--- a/apps/worker/test/reaper-terminate-roundtrip.test.ts
+++ b/apps/worker/test/reaper-terminate-roundtrip.test.ts
@@ -17,7 +17,7 @@
 // this test does not mock @opengeni/runtime globally and poison unrelated tests.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { testSettings } from "@opengeni/testing";
@@ -78,6 +78,88 @@ const observability = {
 } as never;
 
 describe("reaper terminate envelope→resume round-trip preserves sandboxId", () => {
+  test.skipIf(process.platform !== "linux").each([false, true])(
+    "disk-backed drain owns its spool through publication (failure=%s)",
+    async (failPublication) => {
+      const root = mkdtempSync(join(tmpdir(), "opengeni-spool-drain-"));
+      writeFileSync(join(root, "retained.txt"), "retained workspace");
+      let deleted = false;
+      let spoolPath: string | undefined;
+      const client = {
+        backendId: "docker",
+        async deserializeSessionState(state: Record<string, unknown>) {
+          return { ...state };
+        },
+        async resume(state: Record<string, unknown>) {
+          return {
+            state,
+            persistWorkspace: async () => {
+              throw new Error("whole archive capture forbidden");
+            },
+            delete: async () => {
+              deleted = true;
+            },
+          };
+        },
+      };
+      try {
+        const operation = terminateProviderBox(
+          testSettings({ sandboxBackend: "docker", sandboxOwnershipEnabled: true }),
+          {
+            sandboxGroupId: "spool-drain",
+            leaseEpoch: 4,
+            backend: "docker",
+            instanceId: "docker-spool",
+            resumeBackendId: "docker",
+            resumeState: {
+              backendId: "docker",
+              sessionState: {
+                providerState: {
+                  containerId: "docker-spool",
+                  workspaceRootPath: root,
+                  workspaceRootOwned: true,
+                },
+              },
+            },
+          } as never,
+          observability,
+          async (archive) => {
+            if (!archive || typeof archive === "string")
+              throw new Error("expected disk-backed archive");
+            spoolPath = archive.spool.path;
+            expect(existsSync(spoolPath)).toBe(true);
+            expect(deleted).toBe(false);
+            const payload = JSON.parse(readFileSync(spoolPath, "utf8"));
+            expect(payload.files).toEqual([
+              { path: "retained.txt", data: Buffer.from("retained workspace").toString("base64") },
+            ]);
+            if (failPublication) throw new Error("synthetic publication failure");
+            return { wrote: true };
+          },
+          (() => client) as never,
+          undefined,
+          "stable-provider-request",
+          "capture_required",
+          undefined,
+          true,
+        );
+        if (failPublication)
+          await expect(operation).rejects.toThrow("synthetic publication failure");
+        else
+          expect(await operation).toEqual({
+            terminated: true,
+            providerMissingBeforeCapture: false,
+          });
+        expect(deleted).toBe(!failPublication);
+        expect(spoolPath).toBeDefined();
+        expect(existsSync(spoolPath!)).toBe(false);
+        expect(readFileSync(join(root, "retained.txt"), "utf8")).toBe("retained workspace");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   test("normalizes the SDK local ID and cold-commits an unavailable process-local workspace", async () => {
     const clientBuilds: string[] = [];
     const localClient = {

--- a/apps/worker/test/sandbox-archive-storage.test.ts
+++ b/apps/worker/test/sandbox-archive-storage.test.ts
@@ -30,6 +30,70 @@ function fakeStorage() {
 }
 
 describe("workspace archive object storage", () => {
+  test("publishes disk-backed archive bytes without materializing inline payloads", async () => {
+    const bytes = new TextEncoder().encode("synthetic portable archive");
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    let uploaded = false;
+    const storage = {
+      backend: "s3-compatible",
+      async headObject() {
+        return null;
+      },
+      async getObjectRange() {
+        return null;
+      },
+      async putObjectStreamIfAbsent(input: { chunks: AsyncIterable<Uint8Array> }) {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of input.chunks) chunks.push(chunk);
+        expect(Buffer.concat(chunks)).toEqual(Buffer.from(bytes));
+        uploaded = true;
+        return true;
+      },
+    } as unknown as ObjectStorage;
+    const archive = {
+      kind: "host_spool",
+      spool: {
+        path: "/unused-synthetic-spool",
+        byteSize: bytes.length,
+        sha256,
+        async *open() {
+          yield bytes;
+        },
+        async dispose() {},
+      },
+      descriptor: {
+        version: 1,
+        revision: `wa1:1900000000000:${sha256}`,
+        archiveSha256: sha256,
+        archiveBytes: bytes.length,
+        capturedAt: "2030-03-17T17:46:40.000Z",
+        workspace: {
+          algorithm: "sha256",
+          sha256,
+          entryCount: 1,
+          fileCount: 1,
+          totalFileBytes: bytes.length,
+        },
+      },
+      get bytes(): Uint8Array {
+        throw new Error("whole archive bytes must not be requested");
+      },
+      get base64(): string {
+        throw new Error("whole archive base64 must not be requested");
+      },
+    };
+    const result = await putVersion1TarArchiveOrInline({
+      backend: "local",
+      objectStorage: storage,
+      accountId: "11111111-1111-4111-8111-111111111111",
+      workspaceId: "22222222-2222-4222-8222-222222222222",
+      sandboxGroupId: "33333333-3333-4333-8333-333333333333",
+      archive: archive as Parameters<typeof putVersion1TarArchiveOrInline>[0]["archive"],
+    });
+    expect(uploaded).toBe(true);
+    expect(result.workspaceArchive).toBeUndefined();
+    expect(result.workspaceArchiveRef?.sha256).toBe(sha256);
+  });
   test("writes a tar object, collects current/prev keys, and deletes displaced keys", async () => {
     const { objects, storage } = fakeStorage();
     const accountId = "11111111-1111-4111-8111-111111111111";

--- a/apps/worker/test/sandbox-archive-storage.test.ts
+++ b/apps/worker/test/sandbox-archive-storage.test.ts
@@ -4,10 +4,10 @@ import { workspaceArchiveObjectKey } from "@opengeni/contracts";
 import type { ObjectStorage } from "@opengeni/storage";
 import {
   collectWorkspaceArchiveObjectKeys,
-  deleteUnpublishedWorkspaceArchiveObject,
   deleteWorkspaceArchiveObjectKeys,
   putTarWorkspaceArchiveObject,
   putVersion1TarArchiveOrInline,
+  persistWorkspaceArchiveCandidate,
   WorkspaceArchiveObjectStorageRequiredError,
 } from "../src/sandbox-archive-storage";
 
@@ -17,6 +17,32 @@ function fakeStorage() {
     backend: "s3-compatible" as const,
     async putObject(input: { key: string; body: Uint8Array }) {
       objects.set(input.key, input.body);
+    },
+    async putObjectStream(input: { key: string; chunks: AsyncIterable<Uint8Array> }) {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of input.chunks) chunks.push(chunk);
+      objects.set(input.key, Buffer.concat(chunks));
+    },
+    async headObject(key: string) {
+      const bytes = objects.get(key);
+      return bytes
+        ? {
+            ContentLength: bytes.length,
+            VersionToken: createHash("sha256").update(bytes).digest("hex"),
+          }
+        : null;
+    },
+    async getObjectRange(input: {
+      key: string;
+      start: number;
+      endInclusive: number;
+      expectedVersionToken: string;
+    }) {
+      const bytes = objects.get(input.key);
+      if (!bytes) return null;
+      const token = createHash("sha256").update(bytes).digest("hex");
+      if (token !== input.expectedVersionToken) return null;
+      return { bytes: bytes.subarray(input.start, input.endInclusive + 1), versionToken: token };
     },
     async getObjectBytes(key: string) {
       const bytes = objects.get(key);
@@ -37,17 +63,17 @@ describe("workspace archive object storage", () => {
     const storage = {
       backend: "s3-compatible",
       async headObject() {
-        return null;
+        expect(uploaded).toBe(true);
+        return { ContentLength: bytes.length, VersionToken: sha256 };
       },
-      async getObjectRange() {
-        return null;
+      async getObjectRange(input: { start: number; endInclusive: number }) {
+        return { bytes: bytes.subarray(input.start, input.endInclusive + 1), versionToken: sha256 };
       },
-      async putObjectStreamIfAbsent(input: { chunks: AsyncIterable<Uint8Array> }) {
+      async putObjectStream(input: { chunks: AsyncIterable<Uint8Array> }) {
         const chunks: Uint8Array[] = [];
         for await (const chunk of input.chunks) chunks.push(chunk);
         expect(Buffer.concat(chunks)).toEqual(Buffer.from(bytes));
         uploaded = true;
-        return true;
       },
     } as unknown as ObjectStorage;
     const archive = {
@@ -125,16 +151,24 @@ describe("workspace archive object storage", () => {
     });
     expect(ref).toEqual({
       schema: "sandbox_archive_object_v1",
-      key: workspaceArchiveObjectKey({
-        accountId,
-        workspaceId,
-        sandboxGroupId,
-        revision: descriptor.revision,
-      }),
+      key: expect.stringMatching(/\.[0-9a-f-]{36}\.tar$/),
       sha256,
       bytes: bytes.length,
       backend: "s3-compatible",
     });
+    expect(objects.get(ref.key)).toEqual(bytes);
+    const concurrent = await Promise.all(
+      [1, 2].map(() =>
+        putTarWorkspaceArchiveObject({
+          objectStorage: storage,
+          accountId,
+          workspaceId,
+          sandboxGroupId,
+          archive: { bytes, descriptor },
+        }),
+      ),
+    );
+    expect(new Set([ref.key, ...concurrent.map((value) => value.key)]).size).toBe(3);
     expect(objects.get(ref.key)).toEqual(bytes);
 
     const keys = collectWorkspaceArchiveObjectKeys({
@@ -196,7 +230,7 @@ describe("workspace archive object storage", () => {
     expect(inlined.workspaceArchive?.length).toBeGreaterThan(0);
   });
 
-  test("deletes an unpublished object after persist throws", async () => {
+  test("retains an ambiguously committed candidate and deletes only a definitively unused candidate", async () => {
     const { objects, storage } = fakeStorage();
     const bytes = new TextEncoder().encode("orphan-tar");
     const sha256 = createHash("sha256").update(bytes).digest("hex");
@@ -225,7 +259,41 @@ describe("workspace archive object storage", () => {
     });
     expect(published.workspaceArchive).toBeUndefined();
     expect(objects.has(published.workspaceArchiveRef!.key)).toBe(true);
-    await deleteUnpublishedWorkspaceArchiveObject(storage, published.workspaceArchiveRef);
-    expect(objects.has(published.workspaceArchiveRef!.key)).toBe(false);
+    let committedKey: string | undefined;
+    await expect(
+      persistWorkspaceArchiveCandidate({
+        objectStorage: storage,
+        ref: published.workspaceArchiveRef,
+        persist: async () => {
+          committedKey = published.workspaceArchiveRef!.key;
+          throw new Error("commit succeeded but acknowledgement was lost");
+        },
+      }),
+    ).rejects.toThrow("acknowledgement was lost");
+    expect(objects.has(committedKey!)).toBe(true);
+    await persistWorkspaceArchiveCandidate({
+      objectStorage: storage,
+      ref: published.workspaceArchiveRef,
+      persist: async () => ({
+        wrote: true,
+        candidateDisposition: "already_referenced" as const,
+      }),
+    });
+    expect(objects.has(committedKey!)).toBe(true);
+    // A separate candidate, not the committed one, is rejected by the database.
+    const unused = await putTarWorkspaceArchiveObject({
+      objectStorage: storage,
+      accountId: "11111111-1111-4111-8111-111111111111",
+      workspaceId: "22222222-2222-4222-8222-222222222222",
+      sandboxGroupId: "33333333-3333-4333-8333-333333333333",
+      archive: { bytes, descriptor },
+    });
+    await persistWorkspaceArchiveCandidate({
+      objectStorage: storage,
+      ref: unused,
+      persist: async () => ({ wrote: true, candidateDisposition: "unused" as const }),
+    });
+    expect(objects.has(unused.key)).toBe(false);
+    expect(objects.has(committedKey!)).toBe(true);
   });
 });

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -1324,6 +1324,152 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     expect((await readLease(db, ids.workspaceId, ids.groupId))?.liveness).toBe("cold");
   }, 60_000);
 
+  for (const backend of ["local", "docker"] as const) {
+    test(`(1b-recovery-host) ${backend} capture failure preserves admission fencing and exact successor lineage through publication`, async () => {
+      if (!available) return;
+      const ids = await freshWorkspace();
+      const instanceId = `box-${backend}-capture-failure`;
+      const epoch = 15;
+      await insertLease(ids, {
+        liveness: "draining",
+        leaseEpoch: epoch,
+        expiresInMs: -1_000,
+        instanceId,
+        backend,
+        resumeBackendId: backend,
+        resumeState: {
+          backendId: backend,
+          sessionState: {
+            providerState:
+              backend === "local" ? { workspaceRootPath: instanceId } : { containerId: instanceId },
+          },
+        },
+      });
+      const target = {
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+        instanceId,
+        leaseEpoch: epoch,
+      };
+      const input = {
+        target,
+        timeoutClass: "fast" as const,
+        snapshotTimeoutMs: 60_000,
+        captureTimeoutMs: 120_000,
+      };
+      let providerLive = true;
+      let captureCalls = 0;
+      let stopCalls = 0;
+      let providerRequestId: string | undefined;
+      let priorCaptureId: string | undefined;
+      let successorCaptureId: string | undefined;
+      const assertAdmissionFenced = async () => {
+        const arrival = await acquireLease(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sandboxGroupId: ids.groupId,
+          kind: "viewer",
+          holderId: `viewer-${backend}-during-capture`,
+          backend,
+          leaseTtlMs: 60_000,
+        });
+        expect(arrival).toMatchObject({ role: "fenced", reason: "capture_in_progress" });
+      };
+      const terminateBox: TerminateBoxFn = async (
+        _settings,
+        lease,
+        _observability,
+        persistArchive,
+        requestId,
+        disposition,
+      ) => {
+        expect(providerLive).toBe(true);
+        expect(lease.instanceId).toBe(instanceId);
+        expect(lease.leaseEpoch).toBe(epoch);
+        const current = await readLease(db, ids.workspaceId, ids.groupId);
+        expect(current?.liveness).toBe("draining");
+        await assertAdmissionFenced();
+        if (captureCalls === 0) {
+          expect(disposition).toBe("capture_required");
+          providerRequestId = requestId;
+          priorCaptureId = current?.archiveCapture?.id;
+          expect(priorCaptureId).toBeTruthy();
+          expect(current?.archiveCapture).toMatchObject({
+            providerRequestId: requestId,
+            takeoverSafe: true,
+            providerReplaySafe: false,
+          });
+          captureCalls += 1;
+          throw new Error("synthetic host capture failed before publication");
+        }
+        expect(requestId).toBe(providerRequestId);
+        expect(current?.archiveCapture?.providerRequestId).toBe(providerRequestId);
+        if (captureCalls === 1) {
+          expect(disposition).toBe("capture_required");
+          successorCaptureId = current?.archiveCapture?.id;
+          expect(successorCaptureId).toBeTruthy();
+          expect(successorCaptureId).not.toBe(priorCaptureId);
+          captureCalls += 1;
+          const archive = Buffer.from(`${backend} verified successor archive`).toString("base64");
+          expect(
+            (await persistArchive(archive, archiveDescriptor(archive, Date.now()))).wrote,
+          ).toBe(true);
+          const published = await readLease(db, ids.workspaceId, ids.groupId);
+          expect(published?.archiveCapture?.publishedAt).toBeTruthy();
+          expect(published?.archiveComplete).toBe(true);
+          await assertAdmissionFenced();
+          // Publication succeeded but teardown did not. Its durable claim must
+          // survive this interruption, too; never manually remove the fence.
+          throw new Error("synthetic interruption after verified publication");
+        }
+        expect(disposition).toBe("archive_published");
+        expect(current?.archiveCapture?.id).toBe(successorCaptureId);
+        expect(current?.archiveCapture?.publishedAt).toBeTruthy();
+        stopCalls += 1;
+        providerLive = false;
+        return { terminated: true, providerMissingBeforeCapture: false };
+      };
+      const { drainSandboxLease } = createSandboxLeaseActivities(reaperServices(), {
+        terminateBox,
+        probeDrainableProvider: async () => {
+          throw new Error("readiness is not capture settlement proof");
+        },
+      });
+      await expect(
+        drainSandboxLease({ ...input, operationId: crypto.randomUUID() }),
+      ).rejects.toThrow("synthetic host capture failed before publication");
+      const failed = await readLease(db, ids.workspaceId, ids.groupId);
+      expect(failed).toMatchObject({
+        liveness: "draining",
+        instanceId,
+        leaseEpoch: epoch,
+        archiveComplete: false,
+        archiveCapture: { id: priorCaptureId, providerRequestId, publishedAt: null },
+      });
+      expect(providerLive).toBe(true);
+      expect(stopCalls).toBe(0);
+      await assertAdmissionFenced();
+
+      await expect(
+        drainSandboxLease({ ...input, operationId: crypto.randomUUID() }),
+      ).rejects.toThrow("synthetic interruption after verified publication");
+      expect(providerLive).toBe(true);
+      expect(stopCalls).toBe(0);
+      await assertAdmissionFenced();
+      expect(await drainSandboxLease({ ...input, operationId: crypto.randomUUID() })).toEqual({
+        status: "terminated",
+      });
+      expect(captureCalls).toBe(2);
+      expect(stopCalls).toBe(1);
+      expect(providerLive).toBe(false);
+      expect(await readLease(db, ids.workspaceId, ids.groupId)).toMatchObject({
+        liveness: "cold",
+        archiveCapture: null,
+        archiveComplete: true,
+      });
+    }, 60_000);
+  }
+
   test("(1b-recovery-directory) Modal directory capture waits for predecessor cleanup before retry", async () => {
     if (!available) return;
     const ids = await freshWorkspace();

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -1122,7 +1122,12 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     const workspaceId = "22222222-2222-4222-8222-222222222222";
     const sandboxGroupId = "33333333-3333-4333-8333-333333333333";
     const archive = Buffer.from("left-bytes").toString("base64");
-    const meta = archiveDescriptor(archive, 1_900_000_000_000);
+    // Keep the locator and descriptor valid together so this exercises the
+    // independent inline-byte comparison, not descriptor/ref validation.
+    const meta = archiveDescriptor(
+      Buffer.from("right-bytes").toString("base64"),
+      1_900_000_000_000,
+    );
     await expect(
       persistWarmSnapshotRaw(db, {
         accountId,
@@ -1145,7 +1150,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
             sandboxGroupId,
             revision: meta.revision,
           }),
-          sha256: "0".repeat(64),
+          sha256: meta.archiveSha256,
           bytes: meta.archiveBytes,
           backend: "s3-compatible",
         },

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -1274,6 +1274,12 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       async getObjectBytes() {
         return null;
       },
+      async headObject() {
+        return null;
+      },
+      async getObjectRange() {
+        return null;
+      },
       async deleteObject() {
         return;
       },
@@ -1347,8 +1353,28 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
           return;
         },
         async getObjectBytes(key: string) {
+          if (process.platform === "linux") throw new Error("whole-object restore forbidden");
           const bytes = objects.get(key);
           return bytes ? { bytes } : null;
+        },
+        async headObject(key: string) {
+          const bytes = objects.get(key);
+          return bytes ? { ContentLength: bytes.length, VersionToken: "fixture-v1" } : null;
+        },
+        async getObjectRange(input: {
+          key: string;
+          start: number;
+          endInclusive: number;
+          expectedVersionToken: string;
+        }) {
+          expect(input.expectedVersionToken).toBe("fixture-v1");
+          const bytes = objects.get(input.key);
+          return bytes
+            ? {
+                bytes: bytes.subarray(input.start, input.endInclusive + 1),
+                versionToken: "fixture-v1",
+              }
+            : null;
         },
         async deleteObject() {
           return;

--- a/apps/worker/test/workspace-archive-spool-roundtrip.test.ts
+++ b/apps/worker/test/workspace-archive-spool-roundtrip.test.ts
@@ -59,10 +59,7 @@ test.skipIf(process.platform !== "linux")(
     }, 100);
     const storage = {
       backend: "s3-compatible",
-      async putObjectStreamIfAbsent(input: {
-        chunks: AsyncIterable<Uint8Array>;
-        byteSize: number;
-      }) {
+      async putObjectStream(input: { chunks: AsyncIterable<Uint8Array>; byteSize: number }) {
         const handle = await open(objectPath, "wx");
         try {
           for await (const bytes of input.chunks) {
@@ -78,7 +75,6 @@ test.skipIf(process.platform !== "linux")(
           await handle.close();
         }
         expect(storedBytes).toBe(input.byteSize);
-        return true;
       },
       async headObject() {
         return { ContentLength: (await stat(objectPath)).size, VersionToken: "fixture-version-1" };

--- a/apps/worker/test/workspace-archive-spool-roundtrip.test.ts
+++ b/apps/worker/test/workspace-archive-spool-roundtrip.test.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, open, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  captureWorkspaceArchiveForStorage,
+  disposeWorkspaceArchive,
+  establishSandboxSessionFromEnvelope,
+  terminateManagedSandboxSession,
+} from "@opengeni/runtime/sandbox";
+import { downloadWorkspaceArchiveSpool, type ObjectStorage } from "@opengeni/storage";
+import { testSettings } from "@opengeni/testing";
+import { putVersion1TarArchiveOrInline } from "../src/sandbox-archive-storage";
+
+const large = process.env.OPENGENI_TEST_LARGE_WORKSPACE_ARCHIVE === "1";
+
+test.skipIf(process.platform !== "linux")(
+  "disk-backed capture, object publication, cold restore, and verification retain every byte",
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), "opengeni-archive-roundtrip-"));
+    const objectPath = join(root, "stored-object");
+    const settings = testSettings({ sandboxBackend: "local" });
+    const created = await establishSandboxSessionFromEnvelope(settings, null, {
+      sessionId: "archive-spool-source",
+      recovery: "create-or-restore",
+      backendOverride: "local",
+      environment: {},
+    });
+    const sourceRoot = (created.session as { state: { workspaceRootPath: string } }).state
+      .workspaceRootPath;
+    let restored: Awaited<ReturnType<typeof establishSandboxSessionFromEnvelope>> | undefined;
+    let archive: Awaited<ReturnType<typeof captureWorkspaceArchiveForStorage>> | undefined;
+    const memberBytes = large ? 512 * 1024 * 1024 : 512 * 1024;
+    const chunk = Buffer.alloc(64 * 1024, 0x5a);
+    const expectedHash = createHash("sha256");
+    let storedBytes = 0;
+    const memoryStart = process.memoryUsage();
+    let peakRss = memoryStart.rss;
+    let peakHeap = memoryStart.heapUsed;
+    let peakHeapCapacity = memoryStart.heapTotal;
+    let phase = "fixture";
+    const phasePeaks = new Map<
+      string,
+      { rss: number; heapUsed: number; external: number; arrayBuffers: number }
+    >();
+    const sample = setInterval(() => {
+      const usage = process.memoryUsage();
+      peakRss = Math.max(peakRss, usage.rss);
+      peakHeap = Math.max(peakHeap, usage.heapUsed);
+      peakHeapCapacity = Math.max(peakHeapCapacity, usage.heapTotal);
+      const prior = phasePeaks.get(phase);
+      phasePeaks.set(phase, {
+        rss: Math.max(prior?.rss ?? 0, usage.rss),
+        heapUsed: Math.max(prior?.heapUsed ?? 0, usage.heapUsed),
+        external: Math.max(prior?.external ?? 0, usage.external),
+        arrayBuffers: Math.max(prior?.arrayBuffers ?? 0, usage.arrayBuffers),
+      });
+    }, 100);
+    const storage = {
+      backend: "s3-compatible",
+      async putObjectStreamIfAbsent(input: {
+        chunks: AsyncIterable<Uint8Array>;
+        byteSize: number;
+      }) {
+        const handle = await open(objectPath, "wx");
+        try {
+          for await (const bytes of input.chunks) {
+            let offset = 0;
+            while (offset < bytes.length) {
+              const result = await handle.write(bytes, offset, bytes.length - offset);
+              if (!result.bytesWritten) throw new Error("fixture write made no progress");
+              offset += result.bytesWritten;
+              storedBytes += result.bytesWritten;
+            }
+          }
+        } finally {
+          await handle.close();
+        }
+        expect(storedBytes).toBe(input.byteSize);
+        return true;
+      },
+      async headObject() {
+        return { ContentLength: (await stat(objectPath)).size, VersionToken: "fixture-version-1" };
+      },
+      async getObjectRange(input: {
+        start: number;
+        endInclusive: number;
+        expectedVersionToken: string;
+      }) {
+        expect(input.expectedVersionToken).toBe("fixture-version-1");
+        const bytes = Buffer.alloc(input.endInclusive - input.start + 1);
+        const handle = await open(objectPath, "r");
+        try {
+          let offset = 0;
+          while (offset < bytes.length) {
+            const result = await handle.read(
+              bytes,
+              offset,
+              bytes.length - offset,
+              input.start + offset,
+            );
+            if (!result.bytesRead) throw new Error("fixture range truncated");
+            offset += result.bytesRead;
+          }
+        } finally {
+          await handle.close();
+        }
+        return { bytes, versionToken: "fixture-version-1" };
+      },
+      async getObjectBytes(): Promise<never> {
+        throw new Error("whole-object download forbidden");
+      },
+      async putObject(): Promise<never> {
+        throw new Error("whole-object upload forbidden");
+      },
+    } as unknown as ObjectStorage;
+    try {
+      for (let member = 0; member < 3; member += 1) {
+        const handle = await open(join(sourceRoot, `member-${member}.bin`), "wx");
+        try {
+          for (let offset = 0; offset < memberBytes; offset += chunk.length) {
+            let written = 0;
+            while (written < chunk.length) {
+              const result = await handle.write(chunk, written, chunk.length - written);
+              if (!result.bytesWritten) throw new Error("fixture write made no progress");
+              written += result.bytesWritten;
+            }
+            if (member === 0) expectedHash.update(chunk);
+          }
+        } finally {
+          await handle.close();
+        }
+      }
+      await writeFile(join(sourceRoot, "note.txt"), "Retain all source files.\n");
+      phase = "capture";
+      archive = await captureWorkspaceArchiveForStorage(
+        created.session,
+        1_900_000_000_000,
+        { requestId: "11111111-1111-4111-8111-111111111111" },
+        true,
+      );
+      expect(archive.kind).toBe("host_spool");
+      expect("base64" in archive).toBe(false);
+      expect("bytes" in archive).toBe(false);
+      phase = "upload";
+      const published = await putVersion1TarArchiveOrInline({
+        backend: "local",
+        objectStorage: storage,
+        accountId: "11111111-1111-4111-8111-111111111111",
+        workspaceId: "22222222-2222-4222-8222-222222222222",
+        sandboxGroupId: "33333333-3333-4333-8333-333333333333",
+        archive,
+      });
+      expect(published.workspaceArchive).toBeUndefined();
+      phase = "restore";
+      restored = await establishSandboxSessionFromEnvelope(
+        settings,
+        {
+          backendId: "local",
+          sessionState: { ...published, workspaceArchiveMeta: archive.descriptor },
+        },
+        {
+          sessionId: "archive-spool-restored",
+          recovery: "create-or-restore",
+          backendOverride: "local",
+          environment: {},
+          loadHostWorkspaceArchive: (ref) =>
+            downloadWorkspaceArchiveSpool(storage, ref.key, {
+              bytes: ref.bytes,
+              sha256: ref.sha256,
+            }),
+        },
+      );
+      expect(restored.origin).toBe("restored");
+      const destination = (restored.session as { state: { workspaceRootPath: string } }).state
+        .workspaceRootPath;
+      phase = "test-verification";
+      const expectedDigest = expectedHash.digest("hex");
+      for (let member = 0; member < 3; member += 1) {
+        const handle = await open(join(destination, `member-${member}.bin`), "r");
+        const digest = createHash("sha256");
+        try {
+          expect((await handle.stat()).size).toBe(memberBytes);
+          for await (const bytes of handle.readableWebStream())
+            digest.update(new Uint8Array(bytes));
+        } finally {
+          await handle.close().catch(() => undefined);
+        }
+        expect(digest.digest("hex")).toBe(expectedDigest);
+      }
+      expect(await readFile(join(destination, "note.txt"), "utf8")).toBe(
+        "Retain all source files.\n",
+      );
+      if (large) {
+        console.info("large archive roundtrip memory", {
+          sourceBytes: 3 * memberBytes,
+          storedBytes,
+          peakRss,
+          peakHeap,
+          peakHeapCapacity,
+          rssGrowth: peakRss - memoryStart.rss,
+          phasePeaks: Object.fromEntries(phasePeaks),
+        });
+        // Bun's heapUsed includes external payload allocations awaiting GC and
+        // can exceed both heapTotal and RSS. Do not force GC or reuse chunks
+        // whose consumers may retain them merely to reduce that counter.
+        // Keep the raw capture budget (which caught codec allocation churn),
+        // and bound VM heap capacity plus total resident memory end-to-end.
+        expect(phasePeaks.get("capture")!.heapUsed - memoryStart.heapUsed).toBeLessThan(
+          256 * 1024 * 1024,
+        );
+        expect(peakHeapCapacity - memoryStart.heapTotal).toBeLessThan(256 * 1024 * 1024);
+        expect(peakRss - memoryStart.rss).toBeLessThan(768 * 1024 * 1024);
+      }
+    } finally {
+      clearInterval(sample);
+      await disposeWorkspaceArchive(archive);
+      if (restored)
+        await terminateManagedSandboxSession(
+          restored.client,
+          restored.sessionState,
+          restored.session,
+        );
+      await terminateManagedSandboxSession(created.client, created.sessionState, created.session);
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+  large ? 1_800_000 : 30_000,
+);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -451,28 +451,7 @@ probes remain immediate.
 
 Rotation recovery: [lifecycle](run-lifecycle.md).
 
-Linux host-backed Local/Docker captures with object storage retain the SDK v1
-JSON archive format but spool payload bytes to private disk files. Capture and
-restore fingerprint the persistent projection in bounded chunks; publication
-uses create-only streaming uploads, and restoration downloads version-pinned
-ranges and validates the complete archive before changing the destination.
-The canonical codec is `packages/runtime/src/sandbox/host-archive-spool.ts`;
-bounded object transport is `packages/storage/src/workspace-archive-spool.ts`.
-Warm capture, lease drain, worker cold restore, and API rematerialization share
-this path. Metadata indexes still scale with member count, and temporary disk
-space must hold the archive. Missing streaming/range storage capabilities fail
-explicitly. Non-Linux hosts, inline archives without object storage, and remote
-provider archive protocols retain their existing compatibility paths; this is
-not a bounded-memory guarantee for those paths. Existing archive limits and
-capture/publication ownership fences remain authoritative and unchanged.
-The streaming reader supports canonical SDK-produced v1 archives; it rejects
-malformed/noncanonical base64 and duplicate logical entries rather than adopting
-the SDK reader's permissive base64 decoding. Hydration requires an exclusively
-owned destination with trusted ancestors (the unpublished newly created
-sandbox). Descriptor-relative access prevents symlink redirection but cannot
-prevent an external actor from moving an already-open directory elsewhere.
-Restoration is validated before mutation, not transactional against subsequent
-disk I/O failures or concurrent writers.
+Archive capture/restore: [storage](workspace-archive-storage.md).
 
 Lease liveness, provider existence, route attachment, archive availability,
 workspace readiness, and operation availability are separate facts. A warm row

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -451,6 +451,29 @@ probes remain immediate.
 
 Rotation recovery: [lifecycle](run-lifecycle.md).
 
+Linux host-backed Local/Docker captures with object storage retain the SDK v1
+JSON archive format but spool payload bytes to private disk files. Capture and
+restore fingerprint the persistent projection in bounded chunks; publication
+uses create-only streaming uploads, and restoration downloads version-pinned
+ranges and validates the complete archive before changing the destination.
+The canonical codec is `packages/runtime/src/sandbox/host-archive-spool.ts`;
+bounded object transport is `packages/storage/src/workspace-archive-spool.ts`.
+Warm capture, lease drain, worker cold restore, and API rematerialization share
+this path. Metadata indexes still scale with member count, and temporary disk
+space must hold the archive. Missing streaming/range storage capabilities fail
+explicitly. Non-Linux hosts, inline archives without object storage, and remote
+provider archive protocols retain their existing compatibility paths; this is
+not a bounded-memory guarantee for those paths. Existing archive limits and
+capture/publication ownership fences remain authoritative and unchanged.
+The streaming reader supports canonical SDK-produced v1 archives; it rejects
+malformed/noncanonical base64 and duplicate logical entries rather than adopting
+the SDK reader's permissive base64 decoding. Hydration requires an exclusively
+owned destination with trusted ancestors (the unpublished newly created
+sandbox). Descriptor-relative access prevents symlink redirection but cannot
+prevent an external actor from moving an already-open directory elsewhere.
+Restoration is validated before mutation, not transactional against subsequent
+disk I/O failures or concurrent writers.
+
 Lease liveness, provider existence, route attachment, archive availability,
 workspace readiness, and operation availability are separate facts. A warm row
 or selected pointer alone is not proof that a command can run.

--- a/docs/workspace-archive-storage.md
+++ b/docs/workspace-archive-storage.md
@@ -1,0 +1,38 @@
+# Workspace archive storage
+
+Linux host-backed Local/Docker captures with object storage retain the SDK v1
+JSON archive format but spool payload bytes to private disk files. Capture and
+restore fingerprint the persistent projection in bounded chunks; publication
+uses create-only streaming uploads, and restoration downloads version-pinned
+ranges and validates the complete archive before changing the destination.
+
+The canonical codec is `packages/runtime/src/sandbox/host-archive-spool.ts`;
+bounded object transport is `packages/storage/src/workspace-archive-spool.ts`.
+Warm capture, lease drain, worker cold restore, and API rematerialization share
+this path. Metadata indexes still scale with member count, and temporary disk
+space must hold the archive. Missing streaming/range storage capabilities fail
+explicitly. Non-Linux hosts, inline archives without object storage, and remote
+provider archive protocols retain their existing compatibility paths; this is
+not a bounded-memory guarantee for those paths. Existing archive limits and
+capture/publication ownership fences remain authoritative and unchanged.
+
+The streaming reader supports canonical SDK-produced v1 archives; it rejects
+malformed/noncanonical base64 and duplicate logical entries rather than adopting
+the SDK reader's permissive base64 decoding. Hydration requires an exclusively
+owned destination with trusted ancestors (the unpublished newly created
+sandbox). Descriptor-relative access prevents symlink redirection but cannot
+prevent an external actor from moving an already-open directory elsewhere.
+Restoration is validated before mutation, not transactional against subsequent
+disk I/O failures or concurrent writers.
+
+The opt-in synthetic acceptance test exercises capture, object publication,
+cold restore, and final file hashes with three 512 MiB files:
+
+```sh
+OPENGENI_TEST_LARGE_WORKSPACE_ARCHIVE=1 bun test apps/worker/test/workspace-archive-spool-roundtrip.test.ts
+```
+
+It records phase-level memory measurements, checks capture's raw heap growth,
+and bounds VM heap capacity and total resident memory end-to-end. It does not
+force garbage collection. Streaming chunks retain independent ownership so
+downstream consumers cannot observe a reused buffer changing beneath them.

--- a/docs/workspace-archive-storage.md
+++ b/docs/workspace-archive-storage.md
@@ -3,8 +3,10 @@
 Linux host-backed Local/Docker captures with object storage retain the SDK v1
 JSON archive format but spool payload bytes to private disk files. Capture and
 restore fingerprint the persistent projection in bounded chunks; publication
-uses create-only streaming uploads, and restoration downloads version-pinned
-ranges and validates the complete archive before changing the destination.
+allocates a fresh physical object key for every upload, validates the outgoing
+stream, and reads back every stored byte through version-pinned ranges before
+publishing a locator. Restoration validates the complete archive before changing
+the destination. This does not rely on conditional PUT support.
 
 The canonical codec is `packages/runtime/src/sandbox/host-archive-spool.ts`;
 bounded object transport is `packages/storage/src/workspace-archive-spool.ts`.
@@ -15,6 +17,26 @@ explicitly. Non-Linux hosts, inline archives without object storage, and remote
 provider archive protocols retain their existing compatibility paths; this is
 not a bounded-memory guarantee for those paths. Existing archive limits and
 capture/publication ownership fences remain authoritative and unchanged.
+
+The logical revision stays unchanged; physical locators append a random upload
+UUID before `.tar`. Application-owned unique keys isolate simultaneous attempts
+and malformed producers from existing checkpoints. This is not provider-enforced
+immutability against arbitrary holders of storage credentials. A candidate is
+publishable only after complete stream and stored-content verification.
+Database publication binds the exact locator to its account, workspace, group,
+revision, digest, and size. An exception or lost acknowledgement is an unknown
+publication outcome, never permission to delete the candidate. Cleanup follows
+transaction-derived ownership outcomes, not a separate before/after lease read.
+Only a definitively unused fresh candidate is deleted automatically here.
+Superseded locators and unknown publication outcomes are retained until a durable
+retirement/garbage-collection mechanism can prove they cannot be reattached.
+Storage retention can therefore grow; this correction does not introduce an
+age-based deletion policy or a resource cap.
+
+New readers accept both legacy unsuffixed and new suffixed locators. Old readers
+reject suffixed locators: deploy compatible API/worker readers before enabling
+new writers, and retain suffix-aware readers on rollback. Existing objects are
+not renamed or rewritten. Restore always follows the stored exact key.
 
 The streaming reader supports canonical SDK-produced v1 archives; it rejects
 malformed/noncanonical base64 and duplicate logical entries rather than adopting

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -180,7 +180,9 @@ export {
   encodeNativeSnapshotRef,
   omitInlineWorkspaceArchiveWhenObjectRefPresent,
   parseWorkspaceArchiveDescriptor,
+  parseWorkspaceArchiveObjectKey,
   parseWorkspaceArchiveObjectRef,
+  validateWorkspaceArchiveObjectRef,
   workspaceArchiveObjectKey,
   workspaceArchivePayloadPresent,
   type NativeSnapshotDescriptor,
@@ -189,6 +191,7 @@ export {
   type TarWorkspaceArchiveDescriptor,
   type WorkspaceArchiveDescriptor,
   type WorkspaceArchiveObjectRef,
+  type WorkspaceArchiveObjectKey,
   type WorkspaceTreeFingerprint,
 } from "./sandbox-snapshots";
 

--- a/packages/contracts/src/sandbox-snapshots.ts
+++ b/packages/contracts/src/sandbox-snapshots.ts
@@ -64,8 +64,35 @@ export type WorkspaceArchiveObjectRef = {
   backend: string;
 };
 
+// Keep legacy scope/key spelling readable. New physical upload identities must
+// be a complete RFC UUID (including version and variant), never arbitrary text.
+const UPLOAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const OBJECT_KEY =
-  /^sandbox-archives\/v1\/[0-9a-f-]{36}\/[0-9a-f-]{36}\/[0-9a-f-]{36}\/wa1:[0-9]{13}:[0-9a-f]{64}\.tar$/i;
+  /^sandbox-archives\/v1\/([0-9a-f-]{36})\/([0-9a-f-]{36})\/([0-9a-f-]{36})\/(wa1:[0-9]{13}:[0-9a-f]{64})(?:\.([0-9a-f-]+))?\.tar$/i;
+
+export type WorkspaceArchiveObjectKey = {
+  accountId: string;
+  workspaceId: string;
+  sandboxGroupId: string;
+  revision: string;
+  uploadId: string | null;
+};
+
+export function parseWorkspaceArchiveObjectKey(value: unknown): WorkspaceArchiveObjectKey | null {
+  if (typeof value !== "string") return null;
+  const match = OBJECT_KEY.exec(value);
+  // JS $ may match before a final newline; a locator must match in full.
+  if (!match || match[0] !== value || (match[5] !== undefined && !UPLOAD_ID.test(match[5]))) {
+    return null;
+  }
+  return {
+    accountId: match[1]!,
+    workspaceId: match[2]!,
+    sandboxGroupId: match[3]!,
+    revision: match[4]!,
+    uploadId: match[5] ?? null,
+  };
+}
 
 export function parseWorkspaceArchiveObjectRef(value: unknown): WorkspaceArchiveObjectRef | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -73,7 +100,7 @@ export function parseWorkspaceArchiveObjectRef(value: unknown): WorkspaceArchive
   if (
     candidate.schema !== WORKSPACE_ARCHIVE_OBJECT_REF_SCHEMA ||
     typeof candidate.key !== "string" ||
-    !OBJECT_KEY.test(candidate.key) ||
+    !parseWorkspaceArchiveObjectKey(candidate.key) ||
     typeof candidate.sha256 !== "string" ||
     !SHA256.test(candidate.sha256) ||
     !nonnegativeInteger(candidate.bytes) ||
@@ -98,8 +125,45 @@ export function workspaceArchiveObjectKey(input: {
   workspaceId: string;
   sandboxGroupId: string;
   revision: string;
+  /** New upload invocations supply a fresh randomUUID; omission is legacy-only. */
+  uploadId?: string;
 }): string {
-  return `sandbox-archives/v1/${input.accountId}/${input.workspaceId}/${input.sandboxGroupId}/${input.revision}.tar`;
+  if (
+    input.uploadId !== undefined &&
+    (!UPLOAD_ID.test(input.uploadId) || input.uploadId.length !== 36)
+  ) {
+    throw new Error("Invalid workspace archive upload UUID");
+  }
+  return `sandbox-archives/v1/${input.accountId}/${input.workspaceId}/${input.sandboxGroupId}/${input.revision}${input.uploadId === undefined ? "" : `.${input.uploadId}`}.tar`;
+}
+
+/** Bind a stored locator to its publication/restore scope and verified tar
+ * descriptor. A logical revision never substitutes for the exact physical key. */
+export function validateWorkspaceArchiveObjectRef(
+  value: unknown,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sandboxGroupId: string;
+    descriptor: WorkspaceArchiveDescriptor;
+  },
+): WorkspaceArchiveObjectRef | null {
+  const ref = parseWorkspaceArchiveObjectRef(value);
+  const key = ref && parseWorkspaceArchiveObjectKey(ref.key);
+  const descriptor = parseWorkspaceArchiveDescriptor(input.descriptor);
+  if (
+    !ref ||
+    !key ||
+    descriptor?.version !== 1 ||
+    key.accountId.toLowerCase() !== input.accountId.toLowerCase() ||
+    key.workspaceId.toLowerCase() !== input.workspaceId.toLowerCase() ||
+    key.sandboxGroupId.toLowerCase() !== input.sandboxGroupId.toLowerCase() ||
+    key.revision !== descriptor.revision ||
+    ref.sha256 !== descriptor.archiveSha256 ||
+    ref.bytes !== descriptor.archiveBytes
+  )
+    return null;
+  return ref;
 }
 
 export function workspaceArchivePayloadPresent(

--- a/packages/contracts/test/sandbox-snapshots.test.ts
+++ b/packages/contracts/test/sandbox-snapshots.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import * as snapshots from "../src/sandbox-snapshots";
 import {
   omitInlineWorkspaceArchiveWhenObjectRefPresent,
   parseWorkspaceArchiveObjectRef,
@@ -17,6 +18,118 @@ const ref = {
   bytes: 12,
   backend: "s3-compatible",
 };
+
+const scope = {
+  accountId: "11111111-1111-4111-8111-111111111111",
+  workspaceId: "22222222-2222-4222-8222-222222222222",
+  sandboxGroupId: "33333333-3333-4333-8333-333333333333",
+};
+const descriptor = {
+  version: 1 as const,
+  revision: `wa1:1900000000000:${"a".repeat(64)}`,
+  archiveSha256: ref.sha256,
+  archiveBytes: ref.bytes,
+  capturedAt: new Date(1900000000000).toISOString(),
+  workspace: {
+    algorithm: "sha256" as const,
+    sha256: ref.sha256,
+    entryCount: 1,
+    fileCount: 1,
+    totalFileBytes: 12,
+  },
+};
+const uploadId = "44444444-4444-4444-8444-444444444444";
+
+describe("workspace archive physical locator", () => {
+  test("keeps the legacy key and separates fresh upload identity from logical revision", () => {
+    const input = { ...scope, revision: descriptor.revision };
+    expect(workspaceArchiveObjectKey(input)).toBe(ref.key);
+    expect(workspaceArchiveObjectKey({ ...input, uploadId })).toBe(
+      ref.key.replace(/\.tar$/, `.${uploadId}.tar`),
+    );
+    for (const id of [undefined, uploadId]) {
+      const key = workspaceArchiveObjectKey({ ...input, ...(id ? { uploadId: id } : {}) });
+      expect(snapshots.parseWorkspaceArchiveObjectKey(key)).toEqual({
+        ...input,
+        uploadId: id ?? null,
+      });
+      expect(parseWorkspaceArchiveObjectRef({ ...ref, key })).toEqual({ ...ref, key });
+    }
+  });
+
+  test("rejects malformed UUID suffixes and path extensions", () => {
+    for (const suffix of [
+      "garbage",
+      "../other",
+      "44444444444444448444444444444444",
+      "44444444-4444-0444-8444-444444444444",
+      "44444444-4444-4444-7444-444444444444",
+      `${uploadId}.extra`,
+    ]) {
+      const key = ref.key.replace(/\.tar$/, `.${suffix}.tar`);
+      expect(parseWorkspaceArchiveObjectRef({ ...ref, key })).toBeNull();
+      expect(() =>
+        workspaceArchiveObjectKey({ ...scope, revision: descriptor.revision, uploadId: suffix }),
+      ).toThrow();
+    }
+    expect(snapshots.parseWorkspaceArchiveObjectKey(`${ref.key}/child`)).toBeNull();
+    expect(snapshots.parseWorkspaceArchiveObjectKey(`${ref.key}\n`)).toBeNull();
+  });
+
+  test("binds legacy and unique refs to scope, revision, descriptor hash and size", () => {
+    for (const id of [undefined, uploadId]) {
+      const candidate = {
+        ...ref,
+        key: workspaceArchiveObjectKey({
+          ...scope,
+          revision: descriptor.revision,
+          ...(id ? { uploadId: id } : {}),
+        }),
+      };
+      expect(
+        snapshots.validateWorkspaceArchiveObjectRef(candidate, { ...scope, descriptor }),
+      ).toEqual(candidate);
+      for (const field of ["accountId", "workspaceId", "sandboxGroupId"] as const) {
+        expect(
+          snapshots.validateWorkspaceArchiveObjectRef(candidate, {
+            ...scope,
+            [field]: uploadId,
+            descriptor,
+          }),
+        ).toBeNull();
+      }
+      expect(
+        snapshots.validateWorkspaceArchiveObjectRef(
+          { ...candidate, sha256: "b".repeat(64) },
+          { ...scope, descriptor },
+        ),
+      ).toBeNull();
+      expect(
+        snapshots.validateWorkspaceArchiveObjectRef(
+          { ...candidate, bytes: 13 },
+          { ...scope, descriptor },
+        ),
+      ).toBeNull();
+      const otherCapture = {
+        ...descriptor,
+        revision: descriptor.revision.replace("1900000000000", "1900000000001"),
+        capturedAt: new Date(1900000000001).toISOString(),
+      };
+      expect(
+        snapshots.validateWorkspaceArchiveObjectRef(candidate, {
+          ...scope,
+          descriptor: otherCapture,
+        }),
+      ).toBeNull();
+      expect(
+        snapshots.validateWorkspaceArchiveObjectRef(candidate, {
+          ...scope,
+          descriptor: { ...descriptor, archiveBytes: 0 },
+        }),
+      ).toBeNull();
+    }
+  });
+});
 
 describe("omitInlineWorkspaceArchiveWhenObjectRefPresent", () => {
   test("strips hydrate inlines beside a durable object ref", () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -272,6 +272,7 @@ import {
   SANDBOX_PROVIDER_INSTANCE_ID_FIELDS_BY_BACKEND,
   parseWorkspaceArchiveDescriptor,
   parseWorkspaceArchiveObjectRef,
+  validateWorkspaceArchiveObjectRef,
   workspaceArchivePayloadPresent,
   omitInlineWorkspaceArchiveWhenObjectRefPresent,
   type WorkspaceArchiveObjectRef,
@@ -53448,13 +53449,30 @@ export async function adoptLegacyModalCheckpointArtifact(
 }
 
 function publishedWorkspaceArchiveFields(input: {
+  accountId: string;
+  workspaceId: string;
+  sandboxGroupId: string;
+  workspaceArchiveMeta: SandboxArchiveRevision;
   workspaceArchive?: string | null;
   workspaceArchiveRef?: WorkspaceArchiveObjectRef | null;
 }): {
   workspaceArchive?: string;
   workspaceArchiveRef?: WorkspaceArchiveObjectRef;
 } {
-  const ref = parseWorkspaceArchiveObjectRef(input.workspaceArchiveRef) ?? undefined;
+  const ref =
+    input.workspaceArchiveRef == null
+      ? undefined
+      : (validateWorkspaceArchiveObjectRef(input.workspaceArchiveRef, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sandboxGroupId: input.sandboxGroupId,
+          descriptor: input.workspaceArchiveMeta,
+        }) ?? undefined);
+  if (input.workspaceArchiveRef != null && !ref) {
+    throw new Error(
+      "Invalid workspace archive object ref: publication scope or descriptor mismatch",
+    );
+  }
   const inline =
     typeof input.workspaceArchive === "string" && input.workspaceArchive.length > 0
       ? input.workspaceArchive
@@ -53473,6 +53491,30 @@ function publishedWorkspaceArchiveFields(input: {
     throw new Error("workspace archive publication requires inline bytes or an object ref");
   }
   return { workspaceArchive: inline };
+}
+
+/** Object-candidate outcome from the publication transaction, independent of
+ * lifecycle `wrote`. Absent for inline/provider receipts and pure CAS checks.
+ * `unused` is NOT a retirement receipt: only the owner of a fresh candidate with
+ * no other publication in flight may use it for immediate cleanup. Exceptions
+ * give no disposition (commit may have happened). Legacy/shared keys and evicted
+ * refs need durable no-reattachment evidence before deletion. */
+export type WorkspaceArchiveCandidateDisposition = "adopted" | "already_referenced" | "unused";
+
+function workspaceArchiveCandidateFields(
+  candidate: WorkspaceArchiveObjectRef | undefined,
+  lockedResumeState: Record<string, unknown> | null | undefined,
+): { candidateDisposition?: WorkspaceArchiveCandidateDisposition } {
+  if (!candidate) return {};
+  const sessionState = lockedResumeState?.sessionState as Record<string, unknown> | undefined;
+  const referenced = [
+    sessionState?.workspaceArchiveRef,
+    sessionState?.workspaceArchivePrevRef,
+  ].some((value) => {
+    const ref = parseWorkspaceArchiveObjectRef(value);
+    return ref?.key === candidate.key && ref.backend === candidate.backend;
+  });
+  return { candidateDisposition: referenced ? "already_referenced" : "unused" };
 }
 
 export async function persistDrainSnapshot(
@@ -53511,12 +53553,14 @@ export async function persistDrainSnapshot(
 ): Promise<{
   wrote: boolean;
   archiveRevision: string | null;
+  candidateDisposition?: WorkspaceArchiveCandidateDisposition;
 }> {
   const workspaceArchiveMeta =
     input.workspaceArchive === null ? null : parseArchiveRevision(input.workspaceArchiveMeta);
   if (input.workspaceArchive !== null && !workspaceArchiveMeta) {
     throw new Error("Invalid verified workspace archive descriptor");
   }
+  const published = input.workspaceArchive === null ? null : publishedWorkspaceArchiveFields(input);
   if (
     workspaceArchiveMeta?.version === 2 &&
     (workspaceArchiveMeta.provider === "modal_snapshot_filesystem" ||
@@ -53575,10 +53619,15 @@ export async function persistDrainSnapshot(
         for update
       `);
       const row = guard[0];
+      const candidateFields = workspaceArchiveCandidateFields(
+        published?.workspaceArchiveRef,
+        row?.resume_state,
+      );
       if (!row) {
         return {
           wrote: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       const sourceLeaseMatches =
@@ -53624,7 +53673,7 @@ export async function persistDrainSnapshot(
         lateReceipt.providerRequestId === input.providerRequestId &&
         !row.unsettled_mutation;
       if (!activePublication && !coldLatePublication) {
-        return { wrote: false, archiveRevision: null };
+        return { wrote: false, archiveRevision: null, ...candidateFields };
       }
       const priorArchive = row.prior_archive ?? null;
       const priorArchivePrev = row.prior_archive_prev ?? null;
@@ -53642,7 +53691,7 @@ export async function persistDrainSnapshot(
           archiveRevision: null,
         };
       }
-      const published = publishedWorkspaceArchiveFields(input);
+      if (!published) throw new Error("Missing workspace archive publication fields");
       const priorMeta = parseArchiveRevision(priorSessionState?.workspaceArchiveMeta);
       if (activePublication && row.archive_capture_published_at !== null) {
         // A predecessor and its successor may receive the same provider result.
@@ -53668,7 +53717,7 @@ export async function persistDrainSnapshot(
               )
           `);
         }
-        return { wrote: true, archiveRevision: priorMeta.revision };
+        return { wrote: true, archiveRevision: priorMeta.revision, ...candidateFields };
       }
       const rotation = rotateWorkspaceArchives({
         resumeState: row.resume_state,
@@ -53729,11 +53778,13 @@ export async function persistDrainSnapshot(
         return {
           wrote: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       return {
         wrote: true,
         archiveRevision: workspaceArchiveMeta?.revision ?? null,
+        ...(published.workspaceArchiveRef ? { candidateDisposition: "adopted" as const } : {}),
       };
     },
   );
@@ -54132,6 +54183,7 @@ export async function persistWarmSnapshot(
   throttled: boolean;
   superseded: boolean;
   archiveRevision: string | null;
+  candidateDisposition?: WorkspaceArchiveCandidateDisposition;
 }> {
   const capturedAtMs = input.capturedAtMs ?? Date.now();
   const workspaceArchiveMeta = parseArchiveRevision(input.workspaceArchiveMeta);
@@ -54201,6 +54253,26 @@ export async function persistWarmSnapshot(
             (attempt.outcome === "completed" ||
               attempt.outcome === "failed" ||
               attempt.outcome === "requires_action"));
+      // Even a replay rejected by the attempt/epoch/capture guards may name
+      // a committed current or previous object. Inspect those slots under the
+      // same lease lock as publication, after the canonical workspace lock.
+      // This conveys no retirement or no-future-reattachment authority.
+      const candidateLease = published.workspaceArchiveRef
+        ? await scopedDb.execute<{ resume_state: Record<string, unknown> | null }>(sql`
+            select jsonb_build_object('sessionState', jsonb_build_object(
+              'workspaceArchiveRef', resume_state #> '{sessionState,workspaceArchiveRef}',
+              'workspaceArchivePrevRef', resume_state #> '{sessionState,workspaceArchivePrevRef}'
+            )) as resume_state
+            from sandbox_leases
+            where workspace_id = ${input.workspaceId}
+              and sandbox_group_id = ${input.sandboxGroupId}
+            for update
+          `)
+        : [];
+      const candidateFields = workspaceArchiveCandidateFields(
+        published.workspaceArchiveRef,
+        candidateLease[0]?.resume_state,
+      );
       if (
         !attempt ||
         attempt.accountId !== input.accountId ||
@@ -54213,6 +54285,7 @@ export async function persistWarmSnapshot(
           throttled: false,
           superseded: true,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       const guard = await scopedDb.execute<{
@@ -54270,6 +54343,7 @@ export async function persistWarmSnapshot(
           throttled: false,
           superseded: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       const priorArchive = guard[0]!.prior_archive ?? null;
@@ -54290,6 +54364,7 @@ export async function persistWarmSnapshot(
           throttled: false,
           superseded: true,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       if (
@@ -54302,6 +54377,7 @@ export async function persistWarmSnapshot(
           throttled: true,
           superseded: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       const rotation = rotateWorkspaceArchives({
@@ -54323,6 +54399,7 @@ export async function persistWarmSnapshot(
           throttled: false,
           superseded: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       const livenessGuard: "warm" | "draining" = rowLiveness;
@@ -54355,6 +54432,7 @@ export async function persistWarmSnapshot(
           throttled: false,
           superseded: false,
           archiveRevision: null,
+          ...candidateFields,
         };
       }
       return {
@@ -54362,6 +54440,7 @@ export async function persistWarmSnapshot(
         throttled: false,
         superseded: false,
         archiveRevision: workspaceArchiveMeta.revision,
+        ...(published.workspaceArchiveRef ? { candidateDisposition: "adopted" as const } : {}),
       };
     },
   );

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -3,6 +3,7 @@ import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/te
 import { createHash } from "node:crypto";
 import { sql } from "drizzle-orm";
 import postgres from "postgres";
+import { workspaceArchiveObjectKey, type WorkspaceArchiveObjectRef } from "@opengeni/contracts";
 import {
   acquireLease,
   acquireSandboxLeaseReaperHold,
@@ -29,6 +30,7 @@ import {
   claimSandboxCheckpointArtifactsForGc,
   claimSandboxSharedPreparation,
   persistDrainSnapshot as persistDrainSnapshotRaw,
+  persistWarmSnapshot,
   readLease,
   readSandboxSharedPreparation,
   readWorkspaceArchiveCapturePreflight,
@@ -101,6 +103,26 @@ function archiveDescriptor(archive: string, capturedAtMs: number) {
       fileCount: 1,
       totalFileBytes: bytes.length,
     },
+  };
+}
+
+function archiveObjectRef(
+  scope: { accountId: string; workspaceId: string; groupId: string },
+  descriptor: ReturnType<typeof archiveDescriptor>,
+  uploadId?: string,
+): WorkspaceArchiveObjectRef {
+  return {
+    schema: "sandbox_archive_object_v1",
+    // Construct explicitly so red tests exercise publication before the new
+    // optional uploadId generator is implemented.
+    key: workspaceArchiveObjectKey({
+      ...scope,
+      sandboxGroupId: scope.groupId,
+      revision: descriptor.revision,
+    }).replace(/\.tar$/, `${uploadId ? `.${uploadId}` : ""}.tar`),
+    sha256: descriptor.archiveSha256,
+    bytes: descriptor.archiveBytes,
+    backend: "s3-compatible",
   };
 }
 
@@ -413,6 +435,253 @@ async function seedLiveCanonicalAttempt(input: {
   });
   return { turnId, attemptId, holderId: `turn-attempt:${attemptId}` };
 }
+
+describe("archive object publication binding and disposition", () => {
+  async function fixture(liveness: "warm" | "draining") {
+    const ids = await freshWorkspace();
+    const sessionId = crypto.randomUUID();
+    const attempt = await seedLiveCanonicalAttempt({ ...ids, sessionId });
+    const scope = {
+      accountId: ids.accountId,
+      workspaceId: ids.workspaceId,
+      sandboxGroupId: ids.groupId,
+    };
+    await acquireLease(db, {
+      ...scope,
+      kind: "turn",
+      holderId: attempt.holderId,
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    const instanceId = "archive-publication-fixture";
+    await commitWarmingToWarm(db, {
+      ...scope,
+      expectedEpoch: 0,
+      instanceId,
+      resumeBackendId: "modal",
+      resumeState: { backendId: "modal", sessionState: {} },
+      leaseTtlMs: 45_000,
+    });
+    if (liveness === "draining") {
+      await releaseLeaseHolder(db, {
+        ...scope,
+        kind: "turn",
+        holderId: attempt.holderId,
+        idleGraceMs: 0,
+      });
+    }
+    const source = (await readLease(db, ids.workspaceId, ids.groupId))!;
+    const captureId = crypto.randomUUID();
+    const claim = await claimWorkspaceArchiveCapture(db, {
+      ...scope,
+      captureId,
+      expectedEpoch: source.leaseEpoch,
+      expectedInstanceId: instanceId,
+      liveness,
+      captureTimeoutMs: 60_000,
+      minIntervalMs: 0,
+      ...(liveness === "warm" ? { warmAttempt: { sessionId, ...attempt } } : {}),
+    });
+    if (claim.status !== "claimed") throw new Error(`archive fixture capture: ${claim.status}`);
+    const descriptor = archiveDescriptor(
+      Buffer.from("archive candidate bytes").toString("base64"),
+      1_900_000_000_000,
+    );
+    const input = {
+      ...scope,
+      sessionId,
+      ...attempt,
+      expectedLeaseId: source.id,
+      expectedEpoch: source.leaseEpoch,
+      expectedInstanceId: instanceId,
+      expectedWorkspaceGeneration: 0,
+      captureId,
+      providerRequestId: claim.claim.providerRequestId,
+      workspaceArchiveMeta: descriptor,
+      minIntervalMs: 0,
+      capturedAtMs: Date.parse(descriptor.capturedAt),
+    };
+    const publish = (ref: WorkspaceArchiveObjectRef, overrides = {}) =>
+      liveness === "warm"
+        ? persistWarmSnapshot(db, { ...input, workspaceArchiveRef: ref, ...overrides })
+        : persistDrainSnapshotRaw(db, { ...input, workspaceArchiveRef: ref, ...overrides });
+    return { ids, scope, source, input, descriptor, publish };
+  }
+
+  for (const liveness of ["warm", "draining"] as const) {
+    for (const mismatch of [
+      "accountId",
+      "workspaceId",
+      "groupId",
+      "revision",
+      "sha256",
+      "bytes",
+      "malformed",
+    ] as const) {
+      test(`${liveness} rejects archive ref ${mismatch} mismatch before publication`, async () => {
+        if (!available) return;
+        const f = await fixture(liveness);
+        const ref = archiveObjectRef(f.ids, f.descriptor);
+        if (mismatch === "accountId" || mismatch === "workspaceId" || mismatch === "groupId") {
+          ref.key = archiveObjectRef(
+            { ...f.ids, [mismatch]: crypto.randomUUID() },
+            f.descriptor,
+          ).key;
+        } else if (mismatch === "revision") {
+          ref.key = ref.key.replace("1900000000000", "1900000000001");
+        } else if (mismatch === "sha256") ref.sha256 = "b".repeat(64);
+        else if (mismatch === "bytes") ref.bytes += 1;
+        else ref.key = "malformed";
+        const before = await readLease(db, f.ids.workspaceId, f.ids.groupId);
+        // A malformed supplied ref must not silently fall back to valid inline bytes.
+        await expect(
+          f.publish(
+            ref,
+            mismatch === "malformed"
+              ? { workspaceArchive: Buffer.from("archive candidate bytes").toString("base64") }
+              : {},
+          ),
+        ).rejects.toThrow();
+        expect((await readLease(db, f.ids.workspaceId, f.ids.groupId))?.resumeState).toEqual(
+          before?.resumeState,
+        );
+      }, 60_000);
+    }
+
+    test(`${liveness} commits a unique candidate and identifies exact-ref replay without readback inference`, async () => {
+      if (!available) return;
+      const f = await fixture(liveness);
+      const ref = archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID());
+      const first = await f.publish(ref);
+      expect(first).toMatchObject({
+        wrote: true,
+        archiveRevision: f.descriptor.revision,
+        candidateDisposition: "adopted",
+      });
+      // Simulate a lost acknowledgement: retry the exact submitted ref.
+      expect(await f.publish(ref)).toMatchObject({
+        wrote: liveness === "draining",
+        candidateDisposition: "already_referenced",
+      });
+      const otherRef = archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID());
+      expect(await f.publish(otherRef)).toMatchObject({
+        wrote: liveness === "draining",
+        candidateDisposition: "unused",
+      });
+      const lease = await readLease(db, f.ids.workspaceId, f.ids.groupId);
+      expect(lease?.resumeState?.sessionState).toMatchObject({ workspaceArchiveRef: ref });
+      expect(lease?.resumeState?.sessionState).not.toHaveProperty("workspaceArchive");
+    }, 60_000);
+  }
+
+  test("cold-late unique candidate adopts once, exact replay stays referenced and a distinct replay is unused", async () => {
+    if (!available) return;
+    const f = await fixture("draining");
+    expect(
+      await confirmDrainCold(db, {
+        ...f.scope,
+        expectedEpoch: f.source.leaseEpoch,
+        expectedCaptureId: f.input.captureId,
+        providerMissingBeforeCapture: true,
+      }),
+    ).toMatchObject({ wentCold: true });
+    const ref = archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID());
+    for (const overrides of [
+      { expectedLeaseId: crypto.randomUUID() },
+      { expectedEpoch: f.source.leaseEpoch + 1 },
+      { expectedWorkspaceGeneration: 1 },
+      { expectedInstanceId: "different-instance" },
+      { providerRequestId: crypto.randomUUID() },
+    ]) {
+      expect(await f.publish(ref, overrides)).toMatchObject({
+        wrote: false,
+        candidateDisposition: "unused",
+      });
+    }
+    expect(await f.publish(ref)).toMatchObject({ wrote: true, candidateDisposition: "adopted" });
+    expect(await f.publish(ref)).toMatchObject({
+      wrote: false,
+      candidateDisposition: "already_referenced",
+    });
+    expect(
+      await f.publish(archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID())),
+    ).toMatchObject({ wrote: false, candidateDisposition: "unused" });
+    const lease = await readLease(db, f.ids.workspaceId, f.ids.groupId);
+    expect(lease?.recovery.lateArchiveCapture).toBeUndefined();
+    expect(lease?.resumeState?.sessionState).toMatchObject({ workspaceArchiveRef: ref });
+  }, 60_000);
+
+  test("concurrent duplicate drain uploads publish one physical candidate without changing wrote", async () => {
+    if (!available) return;
+    const f = await fixture("draining");
+    const candidates = [
+      archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID()),
+      archiveObjectRef(f.ids, f.descriptor, crypto.randomUUID()),
+    ];
+    const outcomes = await Promise.all(candidates.map((ref) => f.publish(ref)));
+    expect(outcomes.map((result) => result.wrote)).toEqual([true, true]);
+    expect(outcomes.map((result) => result.candidateDisposition).sort()).toEqual([
+      "adopted",
+      "unused",
+    ]);
+    const winner =
+      candidates[outcomes.findIndex((result) => result.candidateDisposition === "adopted")];
+    expect(
+      (await readLease(db, f.ids.workspaceId, f.ids.groupId))?.resumeState?.sessionState,
+    ).toMatchObject({ workspaceArchiveRef: winner });
+  }, 60_000);
+
+  test("warm rotation preserves a legacy previous ref and replay recognizes it after capture fencing", async () => {
+    if (!available) return;
+    const f = await fixture("warm");
+    const legacy = archiveObjectRef(f.ids, f.descriptor);
+    expect(await f.publish(legacy)).toMatchObject({ wrote: true, candidateDisposition: "adopted" });
+    const captureId = crypto.randomUUID();
+    expect(
+      await claimWorkspaceArchiveCapture(db, {
+        ...f.scope,
+        captureId,
+        expectedEpoch: f.source.leaseEpoch,
+        expectedInstanceId: f.input.expectedInstanceId,
+        liveness: "warm",
+        captureTimeoutMs: 60_000,
+        minIntervalMs: 0,
+        warmAttempt: {
+          sessionId: f.input.sessionId,
+          turnId: f.input.turnId,
+          attemptId: f.input.attemptId,
+          holderId: f.input.holderId,
+        },
+      }),
+    ).toMatchObject({ status: "claimed" });
+    const descriptor = archiveDescriptor(
+      Buffer.from("newer archive bytes").toString("base64"),
+      1_900_000_000_001,
+    );
+    const unique = archiveObjectRef(f.ids, descriptor, crypto.randomUUID());
+    expect(
+      await f.publish(unique, {
+        captureId,
+        workspaceArchiveMeta: descriptor,
+        capturedAtMs: Date.parse(descriptor.capturedAt),
+      }),
+    ).toMatchObject({ wrote: true, candidateDisposition: "adopted" });
+    expect(
+      (await readLease(db, f.ids.workspaceId, f.ids.groupId))?.resumeState?.sessionState,
+    ).toMatchObject({ workspaceArchiveRef: unique, workspaceArchivePrevRef: legacy });
+    expect(await f.publish(legacy)).toMatchObject({
+      wrote: false,
+      candidateDisposition: "already_referenced",
+    });
+    // A wrong/closed attempt still cannot turn a referenced ref into cleanup
+    // authority just because the lifecycle write is rejected before its guard.
+    expect(await f.publish(legacy, { attemptId: crypto.randomUUID() })).toMatchObject({
+      wrote: false,
+      superseded: true,
+      candidateDisposition: "already_referenced",
+    });
+  }, 60_000);
+});
 
 describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
   test("(0-delete) workspace deletion atomically refuses live leases and returns durable schedule cleanup ids", async () => {

--- a/packages/runtime/src/sandbox/archive-spool.ts
+++ b/packages/runtime/src/sandbox/archive-spool.ts
@@ -1,0 +1,16 @@
+import type { TarWorkspaceArchiveDescriptor } from "@opengeni/contracts";
+
+/** Process-owned, reopenable archive bytes. Never persisted as a local path. */
+export type WorkspaceArchiveSpool = {
+  path: string;
+  byteSize: number;
+  sha256: string;
+  open: () => AsyncIterable<Uint8Array>;
+  dispose: () => Promise<void>;
+};
+
+export type VerifiedHostWorkspaceArchive = {
+  kind: "host_spool";
+  spool: WorkspaceArchiveSpool;
+  descriptor: TarWorkspaceArchiveDescriptor;
+};

--- a/packages/runtime/src/sandbox/host-archive-spool.ts
+++ b/packages/runtime/src/sandbox/host-archive-spool.ts
@@ -1,0 +1,1040 @@
+import { createHash, type Hash } from "node:crypto";
+import { constants, type BigIntStats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  realpath,
+  rm,
+  rmdir,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import type { WorkspaceTreeFingerprint } from "@opengeni/contracts";
+import type { WorkspaceArchiveSpool } from "./archive-spool";
+import { WorkspaceArchiveIntegrityError } from "./workspace-archive";
+
+const CHUNK_BYTES = 64 * 1024;
+// Filesystem representability, not an archive resource quota. Check component
+// UTF-8 bytes before clearing a destination, not after open/mkdir fails.
+const HOST_FILENAME_BYTES = 255;
+const PROJECTION = "sdk_local_archive_v1" as const;
+const READ = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+const READ_DIRECTORY = READ | constants.O_DIRECTORY;
+const CREATE = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW;
+
+/** Matches SDK 0.14.3 resolveSandboxArchiveLimits: absent/null means unlimited;
+ * an explicit object fills undefined fields with SDK defaults, null disables a field.
+ * chunkBytes controls buffering, never the amount of input accepted. */
+export type HostWorkspaceArchiveOptions = {
+  chunkBytes?: number;
+  archiveLimits?: {
+    maxInputBytes?: number | null;
+    maxExtractedBytes?: number | null;
+    maxMembers?: number | null;
+  } | null;
+};
+
+function invalid(message: string): never {
+  throw new WorkspaceArchiveIntegrityError("archive_hydration_failed", message);
+}
+
+function changed(cause?: unknown): never {
+  throw new WorkspaceArchiveIntegrityError(
+    "workspace_changed_during_capture",
+    "host workspace changed during archive observation",
+    { retryable: true, cause },
+  );
+}
+
+function captureError(error: unknown): never {
+  if (error instanceof WorkspaceArchiveIntegrityError) throw error;
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  if (code === "ENOENT" || code === "ELOOP" || code === "ENOTDIR") return changed(error);
+  // Disk exhaustion, permission failures and other operational errors are not
+  // evidence of a changing tree and must not become a retryable race diagnosis.
+  throw error;
+}
+
+function chunkSize(options: HostWorkspaceArchiveOptions): number {
+  const size = options.chunkBytes ?? CHUNK_BYTES;
+  if (!Number.isSafeInteger(size) || size < 1 || size > CHUNK_BYTES) {
+    throw new RangeError(`chunkBytes must be between 1 and ${CHUNK_BYTES}`);
+  }
+  return size;
+}
+
+function limitsFor(options: HostWorkspaceArchiveOptions) {
+  if (options.archiveLimits == null) return null;
+  const defaults = {
+    maxInputBytes: 1024 ** 3,
+    maxExtractedBytes: 4 * 1024 ** 3,
+    maxMembers: 100_000,
+  };
+  const limits = { ...defaults, ...options.archiveLimits };
+  for (const key of Object.keys(defaults) as Array<keyof typeof defaults>) {
+    if (limits[key] === undefined) limits[key] = defaults[key];
+    const value = limits[key];
+    if (value != null && (!Number.isSafeInteger(value) || value < 1)) {
+      throw new RangeError(`archiveLimits.${key} must be at least 1`);
+    }
+  }
+  return limits;
+}
+
+function checkLimit(actual: number, limit: number | null | undefined, label: string) {
+  if (!Number.isSafeInteger(actual)) invalid(`${label} exceeds the supported integer range`);
+  if (limit != null && actual > limit)
+    invalid(`workspace archive ${label} exceeds configured limit`);
+}
+
+function sameEntry(a: BigIntStats, b: BigIntStats) {
+  return a.dev === b.dev && a.ino === b.ino && a.mode === b.mode;
+}
+
+function sameVersion(a: BigIntStats, b: BigIntStats) {
+  return sameEntry(a, b) && a.size === b.size && a.mtimeNs === b.mtimeNs && a.ctimeNs === b.ctimeNs;
+}
+
+function fdPath(handle: FileHandle, name?: string) {
+  return name === undefined ? `/proc/self/fd/${handle.fd}` : `/proc/self/fd/${handle.fd}/${name}`;
+}
+
+/** Node has no openat API. Linux's descriptor namespace supplies the same pinned
+ * parent resolution; O_NOFOLLOW applies to the child, never an untrusted ancestor.
+ * Do not replace this with lstat(path) followed by open(path): that races. */
+async function openRoot(root: string, create = false): Promise<FileHandle> {
+  if (process.platform !== "linux")
+    invalid("host archive codec requires Linux descriptor-relative filesystem access");
+  if (!isAbsolute(root)) invalid("host workspace root must be absolute");
+  const absolute = resolve(root);
+  if (create && absolute === sep) invalid("cannot restore into the filesystem root");
+  let current = await open(sep, READ_DIRECTORY);
+  try {
+    for (const segment of absolute.split(sep).filter(Boolean)) {
+      if (create) {
+        await mkdir(fdPath(current, segment), { mode: 0o777 }).catch(
+          (error: NodeJS.ErrnoException) => {
+            if (error.code !== "EEXIST") throw error;
+          },
+        );
+      }
+      const next = await open(fdPath(current, segment), READ_DIRECTORY);
+      await current.close();
+      current = next;
+    }
+    return current;
+  } catch (error) {
+    await current.close();
+    throw error;
+  }
+}
+
+type TreeIndex = {
+  directories: Map<string, BigIntStats>;
+  files: Map<string, BigIntStats>;
+};
+
+const compare = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+async function inventory(root: FileHandle, excludedPaths: readonly string[]): Promise<TreeIndex> {
+  const tree: TreeIndex = { directories: new Map(), files: new Map() };
+  const walk = async (handle: FileHandle, logical: string) => {
+    const before = await handle.stat({ bigint: true });
+    tree.directories.set(logical, before);
+    const names = await readdir(fdPath(handle));
+    for (const name of names) {
+      const path = logical ? `${logical}/${name}` : name;
+      if (
+        excludedPaths.some(
+          (excluded) => excluded === "" || path === excluded || path.startsWith(`${excluded}/`),
+        )
+      )
+        continue;
+      const stats = await lstat(fdPath(handle, name), { bigint: true });
+      if (stats.isDirectory()) {
+        const child = await open(fdPath(handle, name), READ_DIRECTORY);
+        try {
+          if (!sameVersion(stats, await child.stat({ bigint: true }))) changed();
+          await walk(child, path);
+          if (!sameVersion(stats, await lstat(fdPath(handle, name), { bigint: true }))) changed();
+        } finally {
+          await child.close();
+        }
+      } else if (stats.isFile()) {
+        tree.files.set(path, stats);
+      }
+      // Exactly the SDK projection: symlinks, FIFOs, sockets and devices are skipped.
+    }
+    if (!sameVersion(before, await handle.stat({ bigint: true }))) changed();
+  };
+  await walk(root, "");
+  return tree;
+}
+
+async function openDirectory(root: FileHandle, logical: string, tree?: TreeIndex, create = false) {
+  let current = await open(fdPath(root), READ_DIRECTORY & ~constants.O_NOFOLLOW);
+  try {
+    if (tree && !sameVersion(tree.directories.get("")!, await current.stat({ bigint: true })))
+      changed();
+    let path = "";
+    for (const segment of logical.split("/").filter(Boolean)) {
+      path = path ? `${path}/${segment}` : segment;
+      if (create) {
+        await mkdir(fdPath(current, segment), { mode: 0o777 }).catch(
+          (error: NodeJS.ErrnoException) => {
+            if (error.code !== "EEXIST") throw error;
+          },
+        );
+      }
+      const next = await open(fdPath(current, segment), READ_DIRECTORY);
+      await current.close();
+      current = next;
+      if (tree) {
+        const expected = tree.directories.get(path);
+        if (!expected || !sameVersion(expected, await current.stat({ bigint: true }))) changed();
+      }
+    }
+    return current;
+  } catch (error) {
+    await current.close();
+    throw error;
+  }
+}
+
+function parentAndName(path: string): [string, string] {
+  const slash = path.lastIndexOf("/");
+  return slash < 0 ? ["", path] : [path.slice(0, slash), path.slice(slash + 1)];
+}
+
+async function readTreeFile(
+  root: FileHandle,
+  tree: TreeIndex,
+  path: string,
+  consume: (bytes: Buffer) => void | Promise<void>,
+) {
+  const [parent, name] = parentAndName(path);
+  const directory = await openDirectory(root, parent, tree);
+  try {
+    const expected = tree.files.get(path)!;
+    const handle = await open(fdPath(directory, name), READ);
+    try {
+      if (!sameVersion(expected, await handle.stat({ bigint: true }))) changed();
+      const size = Number(expected.size);
+      checkLimit(size, null, "file size");
+      const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+      let offset = 0;
+      while (offset < size) {
+        const { bytesRead } = await handle.read(
+          buffer,
+          0,
+          Math.min(buffer.length, size - offset),
+          offset,
+        );
+        if (bytesRead === 0) changed();
+        await consume(buffer.subarray(0, bytesRead));
+        offset += bytesRead;
+      }
+      if (
+        !sameVersion(expected, await handle.stat({ bigint: true })) ||
+        !sameVersion(expected, await lstat(fdPath(directory, name), { bigint: true }))
+      )
+        changed();
+    } finally {
+      await handle.close();
+    }
+  } finally {
+    await directory.close();
+  }
+}
+
+function frame(hash: Hash, label: string, value: string) {
+  hash
+    .update(label)
+    .update("\0")
+    .update(String(Buffer.byteLength(value)))
+    .update("\0")
+    .update(value)
+    .update("\0");
+}
+
+function projection(directories: readonly string[]) {
+  const hash = createHash("sha256");
+  frame(hash, "projection", PROJECTION);
+  for (const path of [...directories].sort(compare)) frame(hash, "dir", path);
+  return hash;
+}
+
+function fingerprint(
+  hash: Hash,
+  directories: number,
+  files: number,
+  totalFileBytes: number,
+): WorkspaceTreeFingerprint {
+  checkLimit(totalFileBytes, null, "extracted size");
+  return {
+    algorithm: "sha256",
+    sha256: hash.digest("hex"),
+    entryCount: directories + files,
+    fileCount: files,
+    totalFileBytes,
+    projection: PROJECTION,
+  };
+}
+
+async function verifyInventory(rootPath: string, root: FileHandle, tree: TreeIndex) {
+  const fresh = await openRoot(rootPath);
+  try {
+    if (!sameVersion(tree.directories.get("")!, await fresh.stat({ bigint: true }))) changed();
+  } finally {
+    await fresh.close();
+  }
+  for (const path of tree.directories.keys()) {
+    const handle = await openDirectory(root, path, tree);
+    await handle.close();
+  }
+  for (const [path, expected] of tree.files) {
+    const [parent, name] = parentAndName(path);
+    const handle = await openDirectory(root, parent, tree);
+    try {
+      if (!sameVersion(expected, await lstat(fdPath(handle, name), { bigint: true }))) changed();
+    } finally {
+      await handle.close();
+    }
+  }
+}
+
+async function hashTree(rootPath: string, root: FileHandle, tree: TreeIndex) {
+  const directories = [...tree.directories.keys()].filter(Boolean);
+  const hash = projection(directories);
+  let total = 0;
+  for (const path of [...tree.files.keys()].sort(compare)) {
+    const size = Number(tree.files.get(path)!.size);
+    frame(hash, "file", path);
+    frame(hash, "bytes", String(size));
+    await readTreeFile(root, tree, path, (bytes) => {
+      hash.update(bytes);
+    });
+    total += size;
+  }
+  await verifyInventory(rootPath, root, tree);
+  return fingerprint(hash, directories.length, tree.files.size, total);
+}
+
+export async function fingerprintHostWorkspace(
+  root: string,
+  excludedPaths: readonly string[],
+): Promise<WorkspaceTreeFingerprint> {
+  const handle = await openRoot(root);
+  try {
+    return await hashTree(root, handle, await inventory(handle, excludedPaths));
+  } catch (error) {
+    return captureError(error);
+  } finally {
+    await handle.close();
+  }
+}
+
+function within(root: string, candidate: string) {
+  const path = relative(root, candidate);
+  return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith(`..${sep}`));
+}
+
+async function privateTemporaryDirectory(root: string) {
+  // Resolve the actual location before creating anything: TMPDIR can itself be a
+  // symlink or live inside the source workspace. Never add spool files to it.
+  const actualRoot = await realpath(root).catch(() => resolve(root));
+  for (const candidate of [tmpdir(), "/var/tmp", "/tmp"]) {
+    const base = await realpath(candidate).catch(() => null);
+    if (!base || within(actualRoot, base) || within("/dev/shm", base)) continue;
+    return await mkdtemp(join(base, "opengeni-host-archive-"));
+  }
+  invalid("no private disk temporary directory exists outside the workspace");
+}
+
+async function writeAll(handle: FileHandle, bytes: Uint8Array) {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const { bytesWritten } = await handle.write(bytes, offset, bytes.byteLength - offset);
+    if (!bytesWritten) throw new Error("archive spool write made no progress");
+    offset += bytesWritten;
+  }
+}
+
+class ArchiveWriter {
+  readonly hash = createHash("sha256");
+  byteSize = 0;
+  constructor(readonly handle: FileHandle) {}
+  async write(input: string | Uint8Array) {
+    const bytes = typeof input === "string" ? Buffer.from(input) : input;
+    for (let offset = 0; offset < bytes.length; offset += CHUNK_BYTES) {
+      const chunk = bytes.subarray(offset, offset + CHUNK_BYTES);
+      await writeAll(this.handle, chunk);
+      this.hash.update(chunk);
+      this.byteSize += chunk.length;
+      checkLimit(this.byteSize, null, "input size");
+    }
+  }
+}
+
+/** Native base64 conversion remains bounded to a chunk; both binary backing
+ * stores are reused. In particular, never Buffer.concat the carry with every
+ * source chunk or Buffer.from every encoded string: external-memory GC can lag
+ * far behind those allocations even though no individual buffer is large. */
+class Base64Encoder {
+  private readonly input = Buffer.allocUnsafe(CHUNK_BYTES + 2);
+  private readonly output = Buffer.allocUnsafe(Math.ceil((CHUNK_BYTES + 2) / 3) * 4);
+  private carry = 0;
+  constructor(private readonly writer: ArchiveWriter) {}
+  async write(bytes: Buffer) {
+    bytes.copy(this.input, this.carry);
+    const available = this.carry + bytes.length;
+    const length = available - (available % 3);
+    if (length) await this.encode(length);
+    this.carry = available - length;
+    this.input.copy(this.input, 0, length, available);
+  }
+  private async encode(length: number) {
+    const written = this.output.write(this.input.subarray(0, length).toString("base64"), "ascii");
+    await this.writer.write(this.output.subarray(0, written));
+  }
+  async finish() {
+    if (this.carry) await this.encode(this.carry);
+  }
+}
+
+function ownedSpool(
+  directory: string,
+  path: string,
+  byteSize: number,
+  sha256: string,
+): WorkspaceArchiveSpool {
+  let disposal: Promise<void> | undefined;
+  return {
+    path,
+    byteSize,
+    sha256,
+    async *open() {
+      if (disposal) throw new Error("archive spool has been disposed");
+      const handle = await open(path, READ);
+      try {
+        const before = await handle.stat({ bigint: true });
+        if (!before.isFile() || Number(before.size) !== byteSize) invalid("archive spool changed");
+        let position = 0;
+        while (position < byteSize) {
+          const buffer = Buffer.allocUnsafe(Math.min(CHUNK_BYTES, byteSize - position));
+          const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+          if (!bytesRead) invalid("archive spool was truncated");
+          position += bytesRead;
+          yield buffer.subarray(0, bytesRead);
+        }
+        if (!sameVersion(before, await handle.stat({ bigint: true })))
+          invalid("archive spool changed while reading");
+      } finally {
+        await handle.close();
+      }
+    },
+    dispose() {
+      return (disposal ??= rm(directory, { recursive: true, force: true }));
+    },
+  };
+}
+
+export async function captureHostWorkspaceArchive(
+  root: string,
+  excludedPaths: readonly string[],
+): Promise<{ spool: WorkspaceArchiveSpool; workspace: WorkspaceTreeFingerprint }> {
+  const handle = await openRoot(root);
+  let temporary: string | undefined;
+  try {
+    const tree = await inventory(handle, excludedPaths);
+    const before = await hashTree(root, handle, tree);
+    temporary = await privateTemporaryDirectory(root);
+    const path = join(temporary, "archive.json");
+    const file = await open(path, CREATE, 0o600);
+    const writer = new ArchiveWriter(file);
+    const directories = [...tree.directories.keys()].filter(Boolean).sort(compare);
+    const hash = projection(directories);
+    let total = 0;
+    try {
+      await writer.write('{"version":1,"directories":[');
+      for (let index = 0; index < directories.length; index++) {
+        await writer.write(`${index ? "," : ""}${JSON.stringify(directories[index])}`);
+      }
+      await writer.write('],"files":[');
+      let first = true;
+      for (const logical of [...tree.files.keys()].sort(compare)) {
+        const size = Number(tree.files.get(logical)!.size);
+        frame(hash, "file", logical);
+        frame(hash, "bytes", String(size));
+        await writer.write(`${first ? "" : ","}{"path":${JSON.stringify(logical)},"data":"`);
+        first = false;
+        const encoder = new Base64Encoder(writer);
+        await readTreeFile(handle, tree, logical, async (bytes) => {
+          hash.update(bytes);
+          await encoder.write(bytes);
+        });
+        await encoder.finish();
+        await writer.write('"}');
+        total += size;
+      }
+      await writer.write("]}");
+    } finally {
+      await file.close();
+    }
+    const archived = fingerprint(hash, directories.length, tree.files.size, total);
+    // Prove equivalence of the serialized bytes themselves, not just of the
+    // source chunks passed to the base64 encoder.
+    const encoded = await open(path, READ);
+    const payloadPath = join(temporary, "capture-payload");
+    let decoded: WorkspaceTreeFingerprint;
+    try {
+      const payload = await open(
+        payloadPath,
+        constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+        0o600,
+      );
+      try {
+        decoded = await fingerprintArchiveIndex(await indexArchive(encoded, payload, {}), payload);
+      } finally {
+        await payload.close();
+      }
+    } finally {
+      await encoded.close();
+    }
+    await unlink(payloadPath);
+    await verifyInventory(root, handle, tree);
+    const after = await hashTree(root, handle, await inventory(handle, excludedPaths));
+    if (
+      before.sha256 !== archived.sha256 ||
+      after.sha256 !== archived.sha256 ||
+      decoded.sha256 !== archived.sha256
+    )
+      changed();
+    const spool = ownedSpool(temporary, path, writer.byteSize, writer.hash.digest("hex"));
+    temporary = undefined;
+    return { spool, workspace: archived };
+  } catch (error) {
+    return captureError(error);
+  } finally {
+    try {
+      await handle.close();
+    } finally {
+      if (temporary) await rm(temporary, { recursive: true, force: true });
+    }
+  }
+}
+
+/** Byte-oriented JSON lexer. Only metadata strings are accumulated. String
+ * payloads are decoded in bounded runs, including JSON escapes and split UTF-8. */
+class JsonReader {
+  private readonly buffer: Buffer;
+  private cursor = 0;
+  private available = 0;
+  private position = 0;
+  constructor(
+    private readonly handle: FileHandle,
+    size: number,
+  ) {
+    this.buffer = Buffer.allocUnsafe(size);
+  }
+  private async fill() {
+    if (this.cursor < this.available) return true;
+    const { bytesRead } = await this.handle.read(this.buffer, 0, this.buffer.length, this.position);
+    this.position += bytesRead;
+    this.cursor = 0;
+    this.available = bytesRead;
+    return bytesRead !== 0;
+  }
+  async peek(): Promise<number> {
+    return (await this.fill()) ? this.buffer[this.cursor]! : -1;
+  }
+  async byte(): Promise<number> {
+    const byte = await this.peek();
+    if (byte === -1) invalid("truncated workspace archive JSON");
+    this.cursor++;
+    return byte;
+  }
+  async whitespace() {
+    while (true) {
+      const byte = await this.peek();
+      if (byte !== 32 && byte !== 9 && byte !== 10 && byte !== 13) return;
+      this.cursor++;
+    }
+  }
+  async expect(character: string) {
+    await this.whitespace();
+    if ((await this.byte()) !== character.charCodeAt(0))
+      invalid(`expected ${character} in workspace archive JSON`);
+  }
+  async string(consume?: Base64Decoder): Promise<string> {
+    await this.expect('"');
+    const parts: string[] = [];
+    const decoder = consume
+      ? undefined
+      : new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+    const emit = async (text: string) => {
+      if (!text) return;
+      if (consume) await consume.write(text);
+      else parts.push(text);
+    };
+    while (await this.fill()) {
+      const start = this.cursor;
+      while (this.cursor < this.available) {
+        const byte = this.buffer[this.cursor]!;
+        if (byte === 34 || byte === 92 || byte < 32) break;
+        this.cursor++;
+      }
+      if (this.cursor > start) {
+        const bytes = this.buffer.subarray(start, this.cursor);
+        // Base64's alphabet is ASCII. Its decoder validates these bytes directly,
+        // so payload runs never become UTF-8/base64 strings or fresh buffers.
+        if (consume) await consume.write(bytes);
+        else await emit(decoder!.decode(bytes, { stream: true }));
+      }
+      if (this.cursor === this.available) continue;
+      if (decoder) await emit(decoder.decode());
+      const special = await this.byte();
+      if (special === 34) return parts.join("");
+      if (special !== 92) invalid("unescaped control character in workspace archive JSON");
+      const escape = String.fromCharCode(await this.byte());
+      if (escape === "u") {
+        let digits = "";
+        for (let index = 0; index < 4; index++) digits += String.fromCharCode(await this.byte());
+        if (!/^[0-9a-fA-F]{4}$/.test(digits)) invalid("invalid JSON Unicode escape");
+        await emit(String.fromCharCode(Number.parseInt(digits, 16)));
+      } else {
+        const escapes: Record<string, string> = {
+          '"': '"',
+          "\\": "\\",
+          "/": "/",
+          b: "\b",
+          f: "\f",
+          n: "\n",
+          r: "\r",
+          t: "\t",
+        };
+        if (!Object.hasOwn(escapes, escape)) invalid("invalid JSON escape");
+        await emit(escapes[escape]!);
+      }
+    }
+    invalid("unterminated workspace archive JSON string");
+  }
+  async array(item: () => Promise<void>) {
+    await this.expect("[");
+    await this.whitespace();
+    if ((await this.peek()) === 93) {
+      await this.byte();
+      return;
+    }
+    while (true) {
+      await item();
+      await this.whitespace();
+      const separator = await this.byte();
+      if (separator === 93) return;
+      if (separator !== 44) invalid("invalid workspace archive JSON array");
+    }
+  }
+  async object(field: (key: string) => Promise<void>) {
+    await this.expect("{");
+    const keys = new Set<string>();
+    await this.whitespace();
+    if ((await this.peek()) === 125) {
+      await this.byte();
+      return keys;
+    }
+    while (true) {
+      const key = await this.string();
+      if (keys.has(key)) invalid("duplicate workspace archive JSON property");
+      keys.add(key);
+      await this.expect(":");
+      await field(key);
+      await this.whitespace();
+      const separator = await this.byte();
+      if (separator === 125) return keys;
+      if (separator !== 44) invalid("invalid workspace archive JSON object");
+    }
+  }
+  async version() {
+    await this.whitespace();
+    // Recognize the exact numeric value 1 without accumulating a potentially
+    // archive-sized number token (1, 1.0, 0.1e1, 100e-2, etc.).
+    let digits = 0;
+    let integerDigits = 0;
+    let significant = -1;
+    let valid = true;
+    const isDigit = (byte: number) => byte >= 48 && byte <= 57;
+    const mantissaDigit = (byte: number) => {
+      if (byte !== 48) {
+        if (byte !== 49 || significant !== -1) valid = false;
+        if (significant === -1) significant = digits;
+      }
+      digits++;
+    };
+    if ((await this.peek()) === 45) {
+      valid = false;
+      await this.byte();
+    }
+    const first = await this.byte();
+    if (!isDigit(first)) invalid("invalid workspace archive version number");
+    mantissaDigit(first);
+    integerDigits++;
+    if (first !== 48) {
+      while (isDigit(await this.peek())) {
+        mantissaDigit(await this.byte());
+        integerDigits++;
+      }
+    } else if (isDigit(await this.peek())) invalid("invalid leading zero in archive version");
+    if ((await this.peek()) === 46) {
+      await this.byte();
+      if (!isDigit(await this.peek())) invalid("invalid archive version fraction");
+      while (isDigit(await this.peek())) mantissaDigit(await this.byte());
+    }
+    let exponent = 0;
+    let sign = 1;
+    if ((await this.peek()) === 101 || (await this.peek()) === 69) {
+      await this.byte();
+      if ((await this.peek()) === 45 || (await this.peek()) === 43) {
+        if ((await this.byte()) === 45) sign = -1;
+      }
+      if (!isDigit(await this.peek())) invalid("invalid archive version exponent");
+      while (isDigit(await this.peek())) {
+        // Saturation is arithmetic only: every byte is still read/validated.
+        exponent = Math.min(Number.MAX_SAFE_INTEGER, exponent * 10 + (await this.byte()) - 48);
+      }
+    }
+    if (!valid || significant === -1 || integerDigits - significant - 1 + sign * exponent !== 0)
+      invalid("unsupported workspace archive version");
+  }
+}
+
+class Base64Decoder {
+  private readonly output = Buffer.allocUnsafe(CHUNK_BYTES);
+  private outputLength = 0;
+  private bits = 0;
+  private digits = 0;
+  /** 1 requires the second '=', 2 forbids any further data. */
+  private padding = 0;
+  byteSize = 0;
+  constructor(private readonly consume: (bytes: Buffer) => Promise<void>) {}
+  private async flush() {
+    if (!this.outputLength) return;
+    await this.consume(this.output.subarray(0, this.outputLength));
+    this.byteSize += this.outputLength;
+    this.outputLength = 0;
+  }
+  async write(input: string | Uint8Array) {
+    for (let index = 0; index < input.length; index++) {
+      const code = typeof input === "string" ? input.charCodeAt(index) : input[index]!;
+      if (this.padding === 2) invalid("data follows workspace archive base64 padding");
+      if (this.padding === 1) {
+        if (code !== 61) invalid("missing workspace archive base64 padding");
+        this.padding = 2;
+        continue;
+      }
+      // Any complete quartet emits at most three bytes. Await the sink before
+      // reusing storage; there are no asynchronous operations per input byte.
+      if (this.outputLength > this.output.length - 3) await this.flush();
+      if (code === 61) {
+        if (this.digits === 2) {
+          if (this.bits & 15) invalid("noncanonical workspace archive base64 unused bits");
+          this.output[this.outputLength++] = this.bits >>> 4;
+          this.padding = 1;
+        } else if (this.digits === 3) {
+          if (this.bits & 3) invalid("noncanonical workspace archive base64 unused bits");
+          this.output[this.outputLength++] = this.bits >>> 10;
+          this.output[this.outputLength++] = (this.bits >>> 2) & 255;
+          this.padding = 2;
+        } else invalid("invalid workspace archive base64 padding");
+        this.digits = 0;
+        continue;
+      }
+      const value =
+        code >= 65 && code <= 90
+          ? code - 65
+          : code >= 97 && code <= 122
+            ? code - 71
+            : code >= 48 && code <= 57
+              ? code + 4
+              : code === 43
+                ? 62
+                : code === 47
+                  ? 63
+                  : -1;
+      if (value < 0) invalid("invalid workspace archive base64 alphabet");
+      this.bits = (this.bits << 6) | value;
+      if (++this.digits === 4) {
+        this.output[this.outputLength++] = this.bits >>> 16;
+        this.output[this.outputLength++] = (this.bits >>> 8) & 255;
+        this.output[this.outputLength++] = this.bits & 255;
+        this.bits = 0;
+        this.digits = 0;
+      }
+    }
+  }
+  async finish() {
+    if (this.digits || this.padding === 1) invalid("truncated workspace archive base64");
+    await this.flush();
+  }
+}
+
+type FileSpan = { path: string; offset: number; byteSize: number };
+type ArchiveIndex = { directories: string[]; files: FileSpan[] };
+
+async function fingerprintArchiveIndex(index: ArchiveIndex, payload: FileHandle) {
+  const hash = projection(index.directories);
+  let total = 0;
+  const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+  for (const file of [...index.files].sort((a, b) => compare(a.path, b.path))) {
+    frame(hash, "file", file.path);
+    frame(hash, "bytes", String(file.byteSize));
+    let copied = 0;
+    while (copied < file.byteSize) {
+      const { bytesRead } = await payload.read(
+        buffer,
+        0,
+        Math.min(buffer.length, file.byteSize - copied),
+        file.offset + copied,
+      );
+      if (!bytesRead) invalid("validated workspace payload was truncated");
+      hash.update(buffer.subarray(0, bytesRead));
+      copied += bytesRead;
+    }
+    total += file.byteSize;
+  }
+  return fingerprint(hash, index.directories.length, index.files.length, total);
+}
+
+function validatePath(path: string) {
+  if (
+    !path ||
+    path.includes("\0") ||
+    Buffer.from(path).toString("utf8") !== path ||
+    path
+      .split("/")
+      .some(
+        (part) =>
+          !part ||
+          part === "." ||
+          part === ".." ||
+          Buffer.byteLength(part, "utf8") > HOST_FILENAME_BYTES,
+      )
+  )
+    invalid("unsafe workspace archive path");
+}
+
+async function indexArchive(
+  input: FileHandle,
+  payload: FileHandle,
+  options: HostWorkspaceArchiveOptions,
+): Promise<ArchiveIndex> {
+  const reader = new JsonReader(input, chunkSize(options));
+  const limits = limitsFor(options);
+  const directories: string[] = [];
+  const files: FileSpan[] = [];
+  let extracted = 0;
+  let members = 0;
+  const member = () => {
+    checkLimit(++members, limits?.maxMembers, "member count");
+  };
+  const keys = await reader.object(async (key) => {
+    if (key === "version") return await reader.version();
+    if (key === "directories") {
+      return await reader.array(async () => {
+        const path = await reader.string();
+        validatePath(path);
+        directories.push(path);
+        member();
+      });
+    }
+    if (key === "files") {
+      return await reader.array(async () => {
+        let path: string | undefined;
+        const offset = extracted;
+        const decoder = new Base64Decoder(async (bytes) => {
+          extracted += bytes.length;
+          checkLimit(extracted, limits?.maxExtractedBytes, "extracted size");
+          await writeAll(payload, bytes);
+        });
+        const fields = await reader.object(async (field) => {
+          if (field === "path") {
+            path = await reader.string();
+            validatePath(path);
+          } else if (field === "data") {
+            await reader.string(decoder);
+            await decoder.finish();
+          } else invalid("unknown workspace archive file property");
+        });
+        if (path === undefined || !fields.has("data"))
+          invalid("workspace archive file is missing path or data");
+        files.push({ path, offset, byteSize: decoder.byteSize });
+        member();
+      });
+    }
+    invalid("unknown workspace archive property");
+  });
+  if (!keys.has("version") || !keys.has("directories") || !keys.has("files"))
+    invalid("workspace archive is missing required properties");
+  await reader.whitespace();
+  if ((await reader.peek()) !== -1) invalid("trailing data in workspace archive JSON");
+  const paths = new Map<string, "file" | "directory">();
+  for (const [path, kind] of [
+    ...directories.map((directory) => [directory, "directory"] as const),
+    ...files.map((file) => [file.path, "file"] as const),
+  ]) {
+    if (paths.has(path)) invalid("duplicate workspace archive path");
+    paths.set(path, kind);
+  }
+  for (const path of paths.keys()) {
+    let parent = parentAndName(path)[0];
+    while (parent) {
+      if (paths.get(parent) === "file") invalid("workspace archive file is also an ancestor");
+      parent = parentAndName(parent)[0];
+    }
+  }
+  return { directories, files };
+}
+
+/** Removes directory entries through pinned parents. unlink never follows a
+ * symlink; rmdir never follows a replacement symlink. No recursive rm uses an
+ * attacker-controlled pathname. */
+async function clearDirectory(handle: FileHandle) {
+  for (const name of await readdir(fdPath(handle))) {
+    const path = fdPath(handle, name);
+    const stats = await lstat(path, { bigint: true });
+    if (stats.isDirectory()) {
+      const child = await open(path, READ_DIRECTORY);
+      try {
+        if (!sameEntry(stats, await child.stat({ bigint: true })))
+          invalid("restore destination directory changed");
+        await clearDirectory(child);
+        if (!sameEntry(stats, await lstat(path, { bigint: true })))
+          invalid("restore destination directory changed");
+        await rmdir(path);
+      } finally {
+        await child.close();
+      }
+    } else {
+      await unlink(path);
+    }
+  }
+}
+
+async function copySpan(payload: FileHandle, output: FileHandle, span: FileSpan) {
+  const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+  let copied = 0;
+  while (copied < span.byteSize) {
+    const { bytesRead } = await payload.read(
+      buffer,
+      0,
+      Math.min(buffer.length, span.byteSize - copied),
+      span.offset + copied,
+    );
+    if (!bytesRead) invalid("validated workspace payload was truncated");
+    await writeAll(output, buffer.subarray(0, bytesRead));
+    copied += bytesRead;
+  }
+}
+
+export async function restoreHostWorkspaceArchive(
+  root: string,
+  spool: WorkspaceArchiveSpool,
+  options: HostWorkspaceArchiveOptions = {},
+): Promise<void> {
+  // A provider callback can mutate the caller's spool/options objects. The
+  // selected expectation must remain the one supplied before any asynchronous
+  // work, not a replacement advertised while bytes are being produced.
+  const { byteSize: expectedByteSize, sha256: expectedSha256 } = spool;
+  const readChunks = spool.open.bind(spool);
+  const processingChunkBytes = chunkSize(options);
+  const limits = limitsFor(options);
+  checkLimit(expectedByteSize, limits?.maxInputBytes, "input size");
+  if (expectedByteSize < 0 || !/^[0-9a-f]{64}$/.test(expectedSha256))
+    invalid("invalid workspace archive spool metadata");
+  const temporary = await privateTemporaryDirectory(root);
+  const handles: FileHandle[] = [];
+  try {
+    const input = await open(
+      join(temporary, "input.json"),
+      constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    handles.push(input);
+    const writer = new ArchiveWriter(input);
+    // Read the untrusted source exactly once. All later work uses this private
+    // copy, so a changing/reopenable provider cannot switch bytes after validation.
+    for await (const bytes of readChunks()) {
+      if (!(bytes instanceof Uint8Array)) invalid("invalid workspace archive stream chunk");
+      checkLimit(writer.byteSize + bytes.length, limits?.maxInputBytes, "input size");
+      if (writer.byteSize + bytes.length > expectedByteSize)
+        invalid("workspace archive size mismatch");
+      await writer.write(bytes);
+    }
+    if (writer.byteSize !== expectedByteSize || writer.hash.digest("hex") !== expectedSha256)
+      invalid("workspace archive SHA-256/size mismatch");
+    const payload = await open(
+      join(temporary, "payload"),
+      constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    handles.push(payload);
+    const archive = await indexArchive(input, payload, {
+      chunkBytes: processingChunkBytes,
+      archiveLimits: limits,
+    });
+    // Nothing above creates, clears or truncates anything under root.
+    const destination = await openRoot(root, true);
+    handles.push(destination);
+    const destinationIdentity = await destination.stat({ bigint: true });
+    await clearDirectory(destination);
+    for (const path of archive.directories) {
+      const directory = await openDirectory(destination, path, undefined, true);
+      await directory.close();
+    }
+    for (const span of archive.files) {
+      const [parent, name] = parentAndName(span.path);
+      const directory = await openDirectory(destination, parent, undefined, true);
+      try {
+        const output = await open(fdPath(directory, name), CREATE, 0o666);
+        try {
+          const identity = await output.stat({ bigint: true });
+          await copySpan(payload, output, span);
+          const freshParent = await openDirectory(destination, parent);
+          try {
+            if (
+              !sameEntry(
+                await directory.stat({ bigint: true }),
+                await freshParent.stat({ bigint: true }),
+              ) ||
+              !sameEntry(identity, await lstat(fdPath(freshParent, name), { bigint: true }))
+            )
+              invalid("restore destination file changed");
+          } finally {
+            await freshParent.close();
+          }
+        } finally {
+          await output.close();
+        }
+      } finally {
+        await directory.close();
+      }
+    }
+    const fresh = await openRoot(root);
+    try {
+      if (!sameEntry(destinationIdentity, await fresh.stat({ bigint: true })))
+        invalid("restore destination root changed");
+    } finally {
+      await fresh.close();
+    }
+  } finally {
+    try {
+      await Promise.all(handles.map((handle) => handle.close()));
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -24,6 +24,15 @@ export type {
 
 import type { Settings } from "@opengeni/config";
 import { collectSandboxEnvironment, parseExposedPorts } from "@opengeni/config";
+export type { WorkspaceArchiveSpool, VerifiedHostWorkspaceArchive } from "./archive-spool";
+import type { WorkspaceArchiveSpool } from "./archive-spool";
+import { restoreHostWorkspaceArchive } from "./host-archive-spool";
+export {
+  captureWorkspaceArchiveForStorage,
+  disposeWorkspaceArchive,
+  type VerifiedWorkspaceArchivePayload,
+} from "./workspace-archive";
+
 import {
   BROWSER_CONTROL_PORT,
   DESKTOP_STREAM_PORT,
@@ -31,6 +40,9 @@ import {
   TERMINAL_STREAM_PORT,
   omitInlineWorkspaceArchiveWhenObjectRefPresent,
   parseWorkspaceArchiveObjectRef,
+  parseWorkspaceArchiveDescriptor,
+  type WorkspaceArchiveObjectRef,
+  type TarWorkspaceArchiveDescriptor,
   type SandboxBackend,
   type SandboxProviderContinuityRecovery,
 } from "@opengeni/contracts";
@@ -1676,9 +1688,16 @@ async function terminateCreatedSandbox(
 }
 
 type ModalNativeWorkspacePersistence = "snapshot_filesystem" | "snapshot_directory";
+type RestoreWorkspaceArchive =
+  | VerifiedWorkspaceArchive
+  | {
+      kind: "host_spool";
+      descriptor: TarWorkspaceArchiveDescriptor;
+      ref: WorkspaceArchiveObjectRef;
+    };
 
 function modalWorkspacePersistenceForRestore(
-  archive: VerifiedWorkspaceArchive | null,
+  archive: RestoreWorkspaceArchive | null,
 ): ModalNativeWorkspacePersistence | null {
   if (archive?.kind !== "provider_snapshot") return null;
   const snapshot = archive.nativeSnapshot;
@@ -1707,7 +1726,7 @@ function modalWorkspacePersistenceForRestore(
 function settingsForWorkspaceArchiveRestore(
   backend: SandboxBackend,
   settings: Settings,
-  archive: VerifiedWorkspaceArchive | null,
+  archive: RestoreWorkspaceArchive | null,
 ): Settings {
   if (backend !== "modal") return settings;
   const workspacePersistence = modalWorkspacePersistenceForRestore(archive);
@@ -1735,6 +1754,7 @@ export async function establishSandboxSessionFromEnvelope(
   opts: {
     sessionId: string;
     recovery: "create-or-restore" | "resume-only";
+    loadHostWorkspaceArchive?: (ref: WorkspaceArchiveObjectRef) => Promise<WorkspaceArchiveSpool>;
     backendOverride?: SandboxBackend;
     environment?: Record<string, string>;
     onSandboxCreated?: SandboxCreatedCallback;
@@ -1817,6 +1837,7 @@ export async function establishSandboxSessionFromEnvelope(
     envelopeSessionState && typeof envelopeSessionState === "object"
       ? (envelopeSessionState as {
           workspaceArchive?: unknown;
+          workspaceArchiveRef?: unknown;
           workspaceArchiveMeta?: unknown;
         })
       : undefined;
@@ -1838,220 +1859,217 @@ export async function establishSandboxSessionFromEnvelope(
     // Parse/verify lazily: a warm resume-by-id does not consume its retained
     // archive, so a legacy live box remains resumable. Creation/restoration is
     // the boundary that requires complete durable metadata.
-    const workspaceArchive: VerifiedWorkspaceArchive | null = readVerifiedWorkspaceArchive(
+    let workspaceArchive: RestoreWorkspaceArchive | null = readVerifiedWorkspaceArchive(
       workspaceArchiveBase64,
       workspaceArchiveMetadata,
     );
-    // The selected native artifact is the durable authority for its restore
-    // protocol. The process setting governs new sandboxes only: a mode rollout
-    // must not make an older, verified Modal snapshot impossible to hydrate.
-    const restoreSettings = settingsForWorkspaceArchiveRestore(backend, settings, workspaceArchive);
-    const restoreClient =
-      restoreSettings === settings
-        ? client
-        : ((opts.clientFactory
-            ? opts.clientFactory(backend, restoreSettings, environment)
-            : createSandboxClientForBackend(
-                backend,
-                restoreSettings,
-                environment,
-                opts.metrics,
-              )) as ResumeCapableClient | undefined);
-    if (!restoreClient?.create) {
-      throw new SandboxConfigError(
-        backend,
-        `Sandbox backend "${backend}" does not support fresh archive restoration`,
+    const objectRef = parseWorkspaceArchiveObjectRef(archiveState?.workspaceArchiveRef);
+    const objectDescriptor = parseWorkspaceArchiveDescriptor(workspaceArchiveMetadata);
+    if (
+      process.platform === "linux" &&
+      objectRef &&
+      objectDescriptor?.version === 1 &&
+      objectDescriptor.workspace.projection === "sdk_local_archive_v1" &&
+      opts.loadHostWorkspaceArchive
+    ) {
+      if (
+        (backend !== "local" && backend !== "docker") ||
+        objectRef.sha256 !== objectDescriptor.archiveSha256 ||
+        objectRef.bytes !== objectDescriptor.archiveBytes
+      ) {
+        throw new WorkspaceArchiveIntegrityError(
+          "archive_metadata_invalid",
+          "Host archive object reference does not match its provider and descriptor",
+        );
+      }
+      workspaceArchive = { kind: "host_spool", descriptor: objectDescriptor, ref: objectRef };
+    }
+    if (objectRef && !workspaceArchive) {
+      throw new WorkspaceArchiveIntegrityError(
+        "archive_hydration_failed",
+        "Selected workspace archive object has no supported restore loader",
       );
     }
-    let createdClient = restoreClient;
-    const createStarted = Date.now();
-    let restored: Awaited<ReturnType<NonNullable<typeof restoreClient.create>>>;
+    let hostSpool: WorkspaceArchiveSpool | undefined;
     try {
-      restored = await restoreClient.create({ manifest: createManifest });
-      recordSandboxCreateMetric(
-        opts.metrics,
-        restoreClient.backendId,
-        createImageSource,
-        "completed",
-        createStarted,
-      );
-    } catch (error) {
-      recordSandboxCreateMetric(
-        opts.metrics,
-        restoreClient.backendId,
-        createImageSource,
-        "failed",
-        createStarted,
-      );
-      recordSandboxProviderApiThrottleMetric(
-        opts.metrics,
-        restoreClient.backendId,
-        "create",
-        error,
-      );
-      if (
-        createImageSource !== "provider_immutable" ||
-        backend !== "modal" ||
-        !isProviderSandboxNotFoundError(restoreClient.backendId, error)
-      ) {
-        throw error;
+      // Preserve the pre-create integrity boundary used by inline archives.
+      // A missing/corrupt object must not create a provider just to delete it.
+      if (workspaceArchive?.kind === "host_spool") {
+        hostSpool = await opts.loadHostWorkspaceArchive!(workspaceArchive.ref);
+        if (
+          hostSpool.sha256 !== workspaceArchive.descriptor.archiveSha256 ||
+          hostSpool.byteSize !== workspaceArchive.descriptor.archiveBytes
+        ) {
+          throw new WorkspaceArchiveIntegrityError(
+            "archive_hash_mismatch",
+            "Downloaded workspace archive does not match its descriptor",
+          );
+        }
       }
-      const fallbackBaseSettings =
-        opts.logicalFallbackSettings ??
-        (settings.modalImageRef ? { ...settings, modalImageId: undefined } : null);
-      if (!fallbackBaseSettings) {
-        // An ID-only logical base is supported. Without the exact pre-selection
-        // settings, clearing the optimized ID would silently boot Modal's
-        // default image, so fail closed instead of changing the rig base.
-        throw error;
-      }
-      const fallbackSettings = settingsForWorkspaceArchiveRestore(
+      // The selected native artifact is the durable authority for its restore
+      // protocol. The process setting governs new sandboxes only: a mode rollout
+      // must not make an older, verified Modal snapshot impossible to hydrate.
+      const restoreSettings = settingsForWorkspaceArchiveRestore(
         backend,
-        fallbackBaseSettings,
+        settings,
         workspaceArchive,
       );
-      await ensureModalRegistryImage(fallbackSettings);
-      const fallbackClient = (
-        opts.clientFactory
-          ? opts.clientFactory(backend, fallbackSettings, environment)
-          : createSandboxClientForBackend(backend, fallbackSettings, environment, opts.metrics)
-      ) as ResumeCapableClient | undefined;
-      if (!fallbackClient?.create) {
+      const restoreClient =
+        restoreSettings === settings
+          ? client
+          : ((opts.clientFactory
+              ? opts.clientFactory(backend, restoreSettings, environment)
+              : createSandboxClientForBackend(
+                  backend,
+                  restoreSettings,
+                  environment,
+                  opts.metrics,
+                )) as ResumeCapableClient | undefined);
+      if (!restoreClient?.create) {
         throw new SandboxConfigError(
           backend,
-          "Modal logical-image fallback does not support fresh creation",
+          `Sandbox backend "${backend}" does not support fresh archive restoration`,
         );
       }
-      const fallbackStarted = Date.now();
+      let createdClient = restoreClient;
+      const createStarted = Date.now();
+      let restored: Awaited<ReturnType<NonNullable<typeof restoreClient.create>>>;
       try {
-        restored = await fallbackClient.create({ manifest: createManifest });
+        restored = await restoreClient.create({ manifest: createManifest });
         recordSandboxCreateMetric(
           opts.metrics,
-          fallbackClient.backendId,
-          "logical",
+          restoreClient.backendId,
+          createImageSource,
           "completed",
-          fallbackStarted,
+          createStarted,
         );
-        createdClient = fallbackClient;
-      } catch (fallbackError) {
+      } catch (error) {
         recordSandboxCreateMetric(
           opts.metrics,
-          fallbackClient.backendId,
-          "logical",
+          restoreClient.backendId,
+          createImageSource,
           "failed",
-          fallbackStarted,
+          createStarted,
         );
         recordSandboxProviderApiThrottleMetric(
           opts.metrics,
-          fallbackClient.backendId,
+          restoreClient.backendId,
           "create",
-          fallbackError,
+          error,
         );
-        throw fallbackError;
-      }
-    }
-    let restoredState = (restored as { state?: unknown }).state;
-    const restoredInstanceId = readInstanceId(backend, restored);
-    if (!restoredInstanceId) {
-      await terminateCreatedSandbox(createdClient, restored, restoredState);
-      throw new SandboxConfigError(
-        backend,
-        `Sandbox backend "${backend}" created a handle without its declared provider identity`,
-      );
-    }
-    let established: EstablishedSandboxSession = {
-      client: createdClient,
-      session: restored,
-      sessionState: restoredState ?? resumeFallbackState,
-      instanceId: restoredInstanceId,
-      backendId: createdClient.backendId,
-    };
-    if (opts.onSandboxCreated) {
-      try {
-        await opts.onSandboxCreated(established);
-      } catch (createCallbackError) {
-        await terminateCreatedSandbox(createdClient, restored, restoredState);
-        throw createCallbackError;
-      }
-    }
-    let hydrationApplied = false;
-    if (workspaceArchive) {
-      const hydrate = (restored as { hydrateWorkspace?: (data: Uint8Array) => Promise<void> })
-        .hydrateWorkspace;
-      if (typeof hydrate !== "function") {
-        await terminateCreatedSandbox(createdClient, restored, restoredState);
-        throw new WorkspaceArchiveIntegrityError(
-          "archive_hydration_failed",
-          `sandbox backend ${createdClient.backendId} cannot hydrate selected archive revision ${workspaceArchive.descriptor.revision}`,
-        );
-      }
-      try {
-        // hydrateWorkspace may internally replace the underlying box.
-        await hydrate.call(restored, workspaceArchive.bytes);
-      } catch (error) {
-        await terminateCreatedSandbox(
-          createdClient,
-          restored,
-          (restored as { state?: unknown }).state,
-        );
-        if (error instanceof WorkspaceArchiveIntegrityError) throw error;
-        throw new WorkspaceArchiveIntegrityError(
-          "archive_hydration_failed",
-          `failed to hydrate selected workspace archive revision ${workspaceArchive.descriptor.revision}`,
-          { retryable: true, cause: error },
-        );
-      }
-      // hydrateWorkspace may replace the provider box (Modal's native snapshot
-      // restore does this). Attribute the newly-active identity immediately,
-      // before restore-state marking, fingerprint verification, or any caller
-      // can publish the box warm. The callback is the durable lease/tagging
-      // boundary; if it cannot persist the replacement, the caller fails closed
-      // and this exact replacement is terminated below.
-      const hydratedState = (restored as { state?: unknown }).state;
-      const hydratedInstanceId = readInstanceId(backend, restored);
-      if (!hydratedInstanceId) {
-        await terminateCreatedSandbox(createdClient, restored, hydratedState);
-        throw new SandboxConfigError(
-          backend,
-          `Sandbox backend "${backend}" hydrated a handle without its declared provider identity`,
-        );
-      }
-      if (hydratedInstanceId !== established.instanceId) {
-        established = {
-          client: createdClient,
-          session: restored,
-          sessionState: hydratedState ?? resumeFallbackState,
-          instanceId: hydratedInstanceId,
-          backendId: createdClient.backendId,
-        };
-        if (opts.onSandboxCreated) {
-          try {
-            await opts.onSandboxCreated(established);
-          } catch (createCallbackError) {
-            await terminateCreatedSandbox(createdClient, restored, hydratedState);
-            throw createCallbackError;
-          }
-        }
-      }
-      if (opts.onWorkspaceRestoreVerifying) {
-        try {
-          await opts.onWorkspaceRestoreVerifying(workspaceArchive.descriptor);
-        } catch (error) {
-          await terminateCreatedSandbox(
-            createdClient,
-            restored,
-            (restored as { state?: unknown }).state,
-          );
+        if (
+          createImageSource !== "provider_immutable" ||
+          backend !== "modal" ||
+          !isProviderSandboxNotFoundError(restoreClient.backendId, error)
+        ) {
           throw error;
         }
-      }
-      // Native provider snapshots are restored by their exact opaque receipt.
-      // OpenGeni verifies receipt identity/hash before hydration, but it must not
-      // impose a tar/inode equivalence contract on the provider's filesystem
-      // image. Tar archives remain content-verified after hydration.
-      if (workspaceArchive.kind === "tar") {
+        const fallbackBaseSettings =
+          opts.logicalFallbackSettings ??
+          (settings.modalImageRef ? { ...settings, modalImageId: undefined } : null);
+        if (!fallbackBaseSettings) {
+          // An ID-only logical base is supported. Without the exact pre-selection
+          // settings, clearing the optimized ID would silently boot Modal's
+          // default image, so fail closed instead of changing the rig base.
+          throw error;
+        }
+        const fallbackSettings = settingsForWorkspaceArchiveRestore(
+          backend,
+          fallbackBaseSettings,
+          workspaceArchive,
+        );
+        await ensureModalRegistryImage(fallbackSettings);
+        const fallbackClient = (
+          opts.clientFactory
+            ? opts.clientFactory(backend, fallbackSettings, environment)
+            : createSandboxClientForBackend(backend, fallbackSettings, environment, opts.metrics)
+        ) as ResumeCapableClient | undefined;
+        if (!fallbackClient?.create) {
+          throw new SandboxConfigError(
+            backend,
+            "Modal logical-image fallback does not support fresh creation",
+          );
+        }
+        const fallbackStarted = Date.now();
         try {
-          await verifyRestoredWorkspace(restored, workspaceArchive.descriptor);
+          restored = await fallbackClient.create({ manifest: createManifest });
+          recordSandboxCreateMetric(
+            opts.metrics,
+            fallbackClient.backendId,
+            "logical",
+            "completed",
+            fallbackStarted,
+          );
+          createdClient = fallbackClient;
+        } catch (fallbackError) {
+          recordSandboxCreateMetric(
+            opts.metrics,
+            fallbackClient.backendId,
+            "logical",
+            "failed",
+            fallbackStarted,
+          );
+          recordSandboxProviderApiThrottleMetric(
+            opts.metrics,
+            fallbackClient.backendId,
+            "create",
+            fallbackError,
+          );
+          throw fallbackError;
+        }
+      }
+      let restoredState = (restored as { state?: unknown }).state;
+      const restoredInstanceId = readInstanceId(backend, restored);
+      if (!restoredInstanceId) {
+        await terminateCreatedSandbox(createdClient, restored, restoredState);
+        throw new SandboxConfigError(
+          backend,
+          `Sandbox backend "${backend}" created a handle without its declared provider identity`,
+        );
+      }
+      let established: EstablishedSandboxSession = {
+        client: createdClient,
+        session: restored,
+        sessionState: restoredState ?? resumeFallbackState,
+        instanceId: restoredInstanceId,
+        backendId: createdClient.backendId,
+      };
+      if (opts.onSandboxCreated) {
+        try {
+          await opts.onSandboxCreated(established);
+        } catch (createCallbackError) {
+          await terminateCreatedSandbox(createdClient, restored, restoredState);
+          throw createCallbackError;
+        }
+      }
+      let hydrationApplied = false;
+      if (workspaceArchive) {
+        const hydrate = (restored as { hydrateWorkspace?: (data: Uint8Array) => Promise<void> })
+          .hydrateWorkspace;
+        if (workspaceArchive.kind !== "host_spool" && typeof hydrate !== "function") {
+          await terminateCreatedSandbox(createdClient, restored, restoredState);
+          throw new WorkspaceArchiveIntegrityError(
+            "archive_hydration_failed",
+            `sandbox backend ${createdClient.backendId} cannot hydrate selected archive revision ${workspaceArchive.descriptor.revision}`,
+          );
+        }
+        try {
+          // hydrateWorkspace may internally replace the underlying box.
+          if (workspaceArchive.kind === "host_spool") {
+            // This is the exact newly-created, unpublished destination. The lease
+            // restore fence must exclude admitted writers until verification ends;
+            // descriptor-relative filesystem access alone is not writer isolation.
+            const root = (restored as { state?: { workspaceRootPath?: unknown } }).state
+              ?.workspaceRootPath;
+            if (typeof root !== "string")
+              throw new WorkspaceArchiveIntegrityError(
+                "archive_hydration_failed",
+                "Host archive restore has no exact workspace root",
+              );
+            await restoreHostWorkspaceArchive(root, hostSpool!, {
+              archiveLimits: Reflect.get(restored as object, "archiveLimits"),
+            });
+          } else await hydrate!.call(restored, workspaceArchive.bytes);
         } catch (error) {
           await terminateCreatedSandbox(
             createdClient,
@@ -2060,35 +2078,106 @@ export async function establishSandboxSessionFromEnvelope(
           );
           if (error instanceof WorkspaceArchiveIntegrityError) throw error;
           throw new WorkspaceArchiveIntegrityError(
-            "workspace_fingerprint_unavailable",
-            `failed to verify selected workspace archive revision ${workspaceArchive.descriptor.revision}`,
-            { retryable: true },
+            "archive_hydration_failed",
+            `failed to hydrate selected workspace archive revision ${workspaceArchive.descriptor.revision}`,
+            { retryable: true, cause: error },
           );
         }
+        // hydrateWorkspace may replace the provider box (Modal's native snapshot
+        // restore does this). Attribute the newly-active identity immediately,
+        // before restore-state marking, fingerprint verification, or any caller
+        // can publish the box warm. The callback is the durable lease/tagging
+        // boundary; if it cannot persist the replacement, the caller fails closed
+        // and this exact replacement is terminated below.
+        const hydratedState = (restored as { state?: unknown }).state;
+        const hydratedInstanceId = readInstanceId(backend, restored);
+        if (!hydratedInstanceId) {
+          await terminateCreatedSandbox(createdClient, restored, hydratedState);
+          throw new SandboxConfigError(
+            backend,
+            `Sandbox backend "${backend}" hydrated a handle without its declared provider identity`,
+          );
+        }
+        if (hydratedInstanceId !== established.instanceId) {
+          established = {
+            client: createdClient,
+            session: restored,
+            sessionState: hydratedState ?? resumeFallbackState,
+            instanceId: hydratedInstanceId,
+            backendId: createdClient.backendId,
+          };
+          if (opts.onSandboxCreated) {
+            try {
+              await opts.onSandboxCreated(established);
+            } catch (createCallbackError) {
+              await terminateCreatedSandbox(createdClient, restored, hydratedState);
+              throw createCallbackError;
+            }
+          }
+        }
+        if (opts.onWorkspaceRestoreVerifying) {
+          try {
+            await opts.onWorkspaceRestoreVerifying(workspaceArchive.descriptor);
+          } catch (error) {
+            await terminateCreatedSandbox(
+              createdClient,
+              restored,
+              (restored as { state?: unknown }).state,
+            );
+            throw error;
+          }
+        }
+        // Native provider snapshots are restored by their exact opaque receipt.
+        // OpenGeni verifies receipt identity/hash before hydration, but it must not
+        // impose a tar/inode equivalence contract on the provider's filesystem
+        // image. Tar archives remain content-verified after hydration.
+        if (workspaceArchive.kind === "tar" || workspaceArchive.kind === "host_spool") {
+          try {
+            await verifyRestoredWorkspace(restored, workspaceArchive.descriptor);
+          } catch (error) {
+            await terminateCreatedSandbox(
+              createdClient,
+              restored,
+              (restored as { state?: unknown }).state,
+            );
+            if (error instanceof WorkspaceArchiveIntegrityError) throw error;
+            throw new WorkspaceArchiveIntegrityError(
+              "workspace_fingerprint_unavailable",
+              `failed to verify selected workspace archive revision ${workspaceArchive.descriptor.revision}`,
+              { retryable: true },
+            );
+          }
+        }
+        hydrationApplied = true;
+        console.info(
+          `[sandbox] cold-restore applied ${workspaceArchive.kind === "provider_snapshot" ? "native snapshot receipt" : "verified tar archive"} revision ${workspaceArchive.descriptor.revision}`,
+        );
       }
-      hydrationApplied = true;
-      console.info(
-        `[sandbox] cold-restore applied ${workspaceArchive.kind === "provider_snapshot" ? "native snapshot receipt" : "verified tar archive"} revision ${workspaceArchive.descriptor.revision}`,
-      );
+      restoredState = (restored as { state?: unknown }).state;
+      const finalInstanceId = readInstanceId(backend, restored);
+      if (!finalInstanceId) {
+        await terminateCreatedSandbox(createdClient, restored, restoredState);
+        throw new SandboxConfigError(
+          backend,
+          `Sandbox backend "${backend}" returned a handle without its declared provider identity`,
+        );
+      }
+      return {
+        client: createdClient,
+        session: restored,
+        sessionState: restoredState ?? resumeFallbackState,
+        instanceId: finalInstanceId,
+        backendId: createdClient.backendId,
+        origin: hydrationApplied ? ("restored" as const) : ("created" as const),
+        ...(workspaceArchive ? { restoredArchive: workspaceArchive.descriptor } : {}),
+      };
+    } finally {
+      await hostSpool?.dispose().catch(() => {
+        // Cleanup must not discard a successfully established provider handle
+        // or replace the authoritative restore failure with a filesystem error.
+        console.warn("workspace archive download spool cleanup failed");
+      });
     }
-    restoredState = (restored as { state?: unknown }).state;
-    const finalInstanceId = readInstanceId(backend, restored);
-    if (!finalInstanceId) {
-      await terminateCreatedSandbox(createdClient, restored, restoredState);
-      throw new SandboxConfigError(
-        backend,
-        `Sandbox backend "${backend}" returned a handle without its declared provider identity`,
-      );
-    }
-    return {
-      client: createdClient,
-      session: restored,
-      sessionState: restoredState ?? resumeFallbackState,
-      instanceId: finalInstanceId,
-      backendId: createdClient.backendId,
-      origin: hydrationApplied ? ("restored" as const) : ("created" as const),
-      ...(workspaceArchive ? { restoredArchive: workspaceArchive.descriptor } : {}),
-    };
   };
 
   // Does the envelope carry a RESUMABLE box id (warm reattach), or only a

--- a/packages/runtime/src/sandbox/workspace-archive.ts
+++ b/packages/runtime/src/sandbox/workspace-archive.ts
@@ -14,6 +14,8 @@ import {
   type WorkspaceTreeFingerprint,
 } from "@opengeni/contracts";
 import { withSandboxProviderCapture } from "./provider-operation-gate";
+import type { VerifiedHostWorkspaceArchive } from "./archive-spool";
+import { captureHostWorkspaceArchive, fingerprintHostWorkspace } from "./host-archive-spool";
 
 export {
   WORKSPACE_ARCHIVE_DESCRIPTOR_VERSION,
@@ -35,6 +37,55 @@ export type VerifiedWorkspaceArchive = {
   kind: "tar" | "provider_snapshot";
   nativeSnapshot?: NativeSnapshotRef;
 };
+
+export type VerifiedWorkspaceArchivePayload =
+  | VerifiedWorkspaceArchive
+  | VerifiedHostWorkspaceArchive;
+
+/** Host-backed portable archives can go directly to object storage without an
+ * intermediate whole-document string or buffer. Existing inline/provider APIs
+ * retain their compatibility path when disk-backed publication is unavailable. */
+export async function captureWorkspaceArchiveForStorage(
+  session: unknown,
+  capturedAtMs: number,
+  options: WorkspaceArchiveCaptureOptions,
+  objectStorageAvailable: boolean,
+): Promise<VerifiedWorkspaceArchivePayload> {
+  const target = session as WorkspaceSession;
+  const root = hostBackedWorkspaceRoot(target);
+  if (
+    process.platform !== "linux" ||
+    !root ||
+    !objectStorageAvailable ||
+    options.strategy === "portable_tar"
+  ) {
+    return await captureVerifiedWorkspaceArchive(session, capturedAtMs, options);
+  }
+  return await withSandboxProviderCapture(session, async () => {
+    const { spool, workspace } = await captureHostWorkspaceArchive(
+      root,
+      workspaceFingerprintExcludes(target),
+    );
+    return {
+      kind: "host_spool" as const,
+      spool,
+      descriptor: {
+        version: 1 as const,
+        revision: `wa1:${String(capturedAtMs).padStart(13, "0")}:${spool.sha256}`,
+        archiveSha256: spool.sha256,
+        archiveBytes: spool.byteSize,
+        capturedAt: new Date(capturedAtMs).toISOString(),
+        workspace,
+      },
+    };
+  });
+}
+
+export async function disposeWorkspaceArchive(
+  archive: VerifiedWorkspaceArchivePayload | undefined,
+): Promise<void> {
+  if (archive?.kind === "host_spool") await archive.spool.dispose();
+}
 
 export type WorkspaceArchiveIntegrityCode =
   | "archive_metadata_missing"
@@ -789,7 +840,9 @@ export async function verifyRestoredWorkspace(
               "selected host-backed workspace archive was restored by a non-host-backed provider",
             );
           }
-          return fingerprintHostBackedWorkspace(root, workspaceFingerprintExcludes(target));
+          return process.platform === "linux"
+            ? fingerprintHostWorkspace(root, workspaceFingerprintExcludes(target))
+            : fingerprintHostBackedWorkspace(root, workspaceFingerprintExcludes(target));
         })()
       : await fingerprintRemoteWorkspace(target);
   if (!fingerprintsEqual(actual, descriptor.workspace)) {

--- a/packages/runtime/test/host-archive-spool.test.ts
+++ b/packages/runtime/test/host-archive-spool.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import * as filesystem from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { WorkspaceArchiveSpool } from "../src/sandbox/archive-spool";
+import {
+  captureHostWorkspaceArchive,
+  fingerprintHostWorkspace,
+  restoreHostWorkspaceArchive,
+} from "../src/sandbox/host-archive-spool";
+
+const roots: string[] = [];
+const spools: WorkspaceArchiveSpool[] = [];
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "host-archive-codec-test-"));
+  roots.push(root);
+  return root;
+}
+afterEach(async () => {
+  await Promise.all(spools.splice(0).map((spool) => spool.dispose()));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function input(text: string | Uint8Array, chunkBytes = 7): WorkspaceArchiveSpool {
+  const bytes = typeof text === "string" ? Buffer.from(text) : Buffer.from(text);
+  return {
+    path: "unused-input-path",
+    byteSize: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    async *open() {
+      for (let offset = 0; offset < bytes.length; offset += chunkBytes) {
+        yield bytes.subarray(offset, offset + chunkBytes);
+      }
+    },
+    async dispose() {},
+  };
+}
+
+function reference(directories: string[], files: Array<{ path: string; data: string }>) {
+  const hash = createHash("sha256");
+  const frame = (label: string, value: string) =>
+    hash.update(`${label}\0${Buffer.byteLength(value)}\0${value}\0`);
+  frame("projection", "sdk_local_archive_v1");
+  for (const path of [...directories].sort()) frame("dir", path);
+  let totalFileBytes = 0;
+  for (const file of [...files].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))) {
+    const content = Buffer.from(file.data, "base64");
+    frame("file", file.path);
+    frame("bytes", String(content.length));
+    hash.update(content);
+    totalFileBytes += content.length;
+  }
+  return {
+    algorithm: "sha256",
+    sha256: hash.digest("hex"),
+    entryCount: directories.length + files.length,
+    fileCount: files.length,
+    totalFileBytes,
+    projection: "sdk_local_archive_v1",
+  };
+}
+
+describe("disk-backed SDK v1 host archive codec", () => {
+  test("capture encoding and validation do not allocate new payload backing stores per chunk", async () => {
+    const source = await fixture();
+    await writeFile(join(source, "file"), Buffer.alloc(2 * 1024 * 1024 + 1, 251));
+    const originalFrom = Buffer.from;
+    const originalConcat = Buffer.concat;
+    let payloadCopies = 0;
+    const fromHook = spyOn(Buffer, "from").mockImplementation((...args) => {
+      const result = Reflect.apply(originalFrom, Buffer, args) as Buffer;
+      if (result.length >= 32 * 1024) payloadCopies++;
+      return result;
+    });
+    const concatHook = spyOn(Buffer, "concat").mockImplementation((...args) => {
+      const result = Reflect.apply(originalConcat, Buffer, args) as Buffer;
+      if (result.length >= 32 * 1024) payloadCopies++;
+      return result;
+    });
+    try {
+      const captured = await captureHostWorkspaceArchive(source, []);
+      spools.push(captured.spool);
+      expect(payloadCopies).toBe(0);
+    } finally {
+      fromHook.mockRestore();
+      concatHook.mockRestore();
+    }
+  });
+
+  test("capture has exact framed fingerprint, bounded chunks, and idempotent disposal", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "empty"));
+    await mkdir(join(root, "目录"));
+    await writeFile(join(root, "目录", "🙂.txt"), "hello\0æ🙂");
+    await writeFile(join(root, "zero"), "");
+    await writeFile(join(root, "binary"), Buffer.alloc(196_613, 251));
+    await writeFile(join(root, "excluded"), "secret fixture");
+    await symlink("binary", join(root, "link"));
+    const captured = await captureHostWorkspaceArchive(root, ["excluded"]);
+    spools.push(captured.spool);
+    const parts: Buffer[] = [];
+    for await (const part of captured.spool.open()) {
+      expect(part.length).toBeLessThanOrEqual(65_536);
+      parts.push(Buffer.from(part));
+    }
+    const bytes = Buffer.concat(parts);
+    const archive = JSON.parse(bytes.toString());
+    expect(archive.version).toBe(1);
+    expect(archive.files.map((file: { path: string }) => file.path)).not.toContain("link");
+    expect(captured.workspace).toEqual(reference(archive.directories, archive.files));
+    expect(await fingerprintHostWorkspace(root, ["excluded"])).toEqual(captured.workspace);
+    expect(captured.spool.byteSize).toBe(bytes.length);
+    expect(captured.spool.sha256).toBe(createHash("sha256").update(bytes).digest("hex"));
+    const destination = await fixture();
+    await restoreHostWorkspaceArchive(destination, captured.spool);
+    expect(await fingerprintHostWorkspace(destination, [])).toEqual(captured.workspace);
+    await captured.spool.dispose();
+    await captured.spool.dispose();
+    await expect(readFile(captured.spool.path)).rejects.toThrow();
+  });
+
+  test("legacy JSON, escaped base64, reordered fields, and every small byte boundary", async () => {
+    const text =
+      '{ "files": [{"data":"AAE\\u002f\\/w==","path":"目录/🙂"}, {"path":"empty","data":""}], "directories": ["目录"], "version":1.0 }';
+    for (let chunkBytes = 1; chunkBytes <= 17; chunkBytes++) {
+      const destination = await fixture();
+      await restoreHostWorkspaceArchive(destination, input(text, chunkBytes), { chunkBytes });
+      expect(await readFile(join(destination, "目录", "🙂"))).toEqual(
+        Buffer.from("AAE//w==", "base64"),
+      );
+      expect(await readFile(join(destination, "empty"))).toHaveLength(0);
+    }
+  });
+
+  test("reusable decoder agrees with native base64 across every byte value and padding remainder", async () => {
+    const files = Array.from({ length: 258 }, (_, size) => ({
+      path: `file-${size}`,
+      data: Buffer.from(
+        Array.from({ length: size }, (_byte, index) => (size * 31 + index * 17) & 255),
+      ).toString("base64"),
+    }));
+    const archive = input(JSON.stringify({ version: 1, directories: [], files }));
+    for (const chunkBytes of [7, 65_536]) {
+      const destination = await fixture();
+      await restoreHostWorkspaceArchive(destination, archive, { chunkBytes });
+      for (const file of files) {
+        expect(await readFile(join(destination, file.path))).toEqual(
+          Buffer.from(file.data, "base64"),
+        );
+      }
+      expect(await fingerprintHostWorkspace(destination, [])).toEqual(reference([], files));
+    }
+  });
+
+  test("malformed document/path/content/hash never changes the destination", async () => {
+    const destination = await fixture();
+    await writeFile(join(destination, "keep"), "unchanged");
+    const bad = [
+      '{"version":1,"directories":[],"files":[]} trailing',
+      '{"version":1,"directories":[],"files":[],"version":1}',
+      '{"version":2,"directories":[],"files":[]}',
+      '{"version":1,"directories":[],"files":[],}',
+      '{"version":1,"directories":["../outside"],"files":[]}',
+      '{"version":1,"directories":["/absolute"],"files":[]}',
+      '{"version":1,"directories":["a//b"],"files":[]}',
+      '{"version":1,"directories":["a\\u0000b"],"files":[]}',
+      '{"version":1,"directories":["a\\ud800"],"files":[]}',
+      '{"version":1,"directories":["a"],"files":[{"path":"a","data":""}]}',
+      '{"version":1,"directories":["a/b"],"files":[{"path":"a","data":""}]}',
+      ...["YQ", "YR==", "YQ===", "YQ==AAAA", "!!!!", "Y Q==", "é"].map((data) =>
+        JSON.stringify({ version: 1, directories: [], files: [{ path: "file", data }] }),
+      ),
+      '{"version":1,"directories":[],"files":[{"path":"file","data":"YQ=="}',
+    ];
+    for (const text of bad) {
+      await expect(
+        restoreHostWorkspaceArchive(destination, input(text), { chunkBytes: 3 }),
+      ).rejects.toThrow();
+      expect(await readdir(destination)).toEqual(["keep"]);
+      expect(await readFile(join(destination, "keep"), "utf8")).toBe("unchanged");
+    }
+    const valid = input('{"version":1,"directories":[],"files":[]}');
+    await expect(
+      restoreHostWorkspaceArchive(destination, { ...valid, sha256: "0".repeat(64) }),
+    ).rejects.toThrow();
+    await expect(
+      restoreHostWorkspaceArchive(destination, { ...valid, byteSize: valid.byteSize + 1 }),
+    ).rejects.toThrow();
+    expect(await readFile(join(destination, "keep"), "utf8")).toBe("unchanged");
+  });
+
+  test("unrepresentable filename components are rejected before destination mutation", async () => {
+    const destination = await fixture();
+    await writeFile(join(destination, "keep"), "unchanged");
+    for (const component of ["x".repeat(256), "é".repeat(128), "🙂".repeat(64)]) {
+      for (const directory of [false, true]) {
+        const archive = input(
+          JSON.stringify({
+            version: 1,
+            directories: directory ? [component] : [],
+            files: directory ? [] : [{ path: `nested/${component}`, data: "YQ==" }],
+          }),
+        );
+        await expect(restoreHostWorkspaceArchive(destination, archive)).rejects.toThrow();
+        expect(await readdir(destination)).toEqual(["keep"]);
+        expect(await readFile(join(destination, "keep"), "utf8")).toBe("unchanged");
+      }
+    }
+  });
+
+  test("restore pins hash and size expectations before calling the spool producer", async () => {
+    const destination = await fixture();
+    await writeFile(join(destination, "keep"), "unchanged");
+    const original = input(
+      JSON.stringify({ version: 1, directories: [], files: [{ path: "file", data: "YQ==" }] }),
+    );
+    for (const data of ["Yg==", "YWJjZA=="]) {
+      const replacement = input(
+        JSON.stringify({ version: 1, directories: [], files: [{ path: "file", data }] }),
+      );
+      const malicious: WorkspaceArchiveSpool = {
+        ...original,
+        async *open() {
+          malicious.byteSize = replacement.byteSize;
+          malicious.sha256 = replacement.sha256;
+          yield* replacement.open();
+        },
+      };
+      await expect(restoreHostWorkspaceArchive(destination, malicious)).rejects.toThrow();
+      expect(await readdir(destination)).toEqual(["keep"]);
+      expect(await readFile(join(destination, "keep"), "utf8")).toBe("unchanged");
+    }
+  });
+
+  test("representable 255-byte ASCII and Unicode filename components remain readable", async () => {
+    const destination = await fixture();
+    for (const path of ["x".repeat(255), `${"é".repeat(127)}x`, `${"🙂".repeat(63)}abc`]) {
+      expect(Buffer.byteLength(path)).toBe(255);
+      await restoreHostWorkspaceArchive(
+        destination,
+        input(
+          JSON.stringify({
+            version: 1,
+            directories: [],
+            files: [{ path, data: "YQ==" }],
+          }),
+        ),
+      );
+      expect(await readFile(join(destination, path), "utf8")).toBe("a");
+    }
+  });
+
+  test("the producer cannot change the selected archive limits during restore", async () => {
+    const destination = await fixture();
+    await writeFile(join(destination, "keep"), "unchanged");
+    const archive = input(
+      JSON.stringify({ version: 1, directories: [], files: [{ path: "file", data: "YWI=" }] }),
+    );
+    const options = { archiveLimits: { maxExtractedBytes: 1 as number | null } };
+    await expect(
+      restoreHostWorkspaceArchive(
+        destination,
+        {
+          ...archive,
+          async *open() {
+            options.archiveLimits.maxExtractedBytes = null;
+            yield* archive.open();
+          },
+        },
+        options,
+      ),
+    ).rejects.toThrow();
+    expect(await readFile(join(destination, "keep"), "utf8")).toBe("unchanged");
+  });
+
+  test("symlink roots/ancestors cannot redirect capture or restore; child symlinks are removed, not followed", async () => {
+    const outer = await fixture();
+    const outside = await fixture();
+    await writeFile(join(outside, "keep"), "safe");
+    await symlink(outside, join(outer, "link"));
+    const empty = input('{"version":1,"directories":[],"files":[]}');
+    await expect(fingerprintHostWorkspace(join(outer, "link"), [])).rejects.toThrow();
+    await expect(restoreHostWorkspaceArchive(join(outer, "link"), empty)).rejects.toThrow();
+    await expect(restoreHostWorkspaceArchive(join(outer, "link", "new"), empty)).rejects.toThrow();
+    await restoreHostWorkspaceArchive(outer, empty);
+    expect(await readdir(outer)).toEqual([]);
+    expect(await readFile(join(outside, "keep"), "utf8")).toBe("safe");
+  });
+
+  test("optional SDK limits remain opt-in and reject before destination mutation", async () => {
+    const destination = await fixture();
+    await writeFile(join(destination, "keep"), "safe");
+    const archive = input(
+      JSON.stringify({ version: 1, directories: [], files: [{ path: "file", data: "YWI=" }] }),
+    );
+    await expect(
+      restoreHostWorkspaceArchive(destination, archive, {
+        archiveLimits: { maxExtractedBytes: 1 },
+      }),
+    ).rejects.toThrow();
+    expect(await readFile(join(destination, "keep"), "utf8")).toBe("safe");
+    await restoreHostWorkspaceArchive(destination, archive, { archiveLimits: null });
+    expect(await readFile(join(destination, "file"), "utf8")).toBe("ab");
+  });
+
+  test("SDK 0.14.x producer and consumer interoperate in both directions", async () => {
+    const sdk = await import(
+      new URL(
+        "./sandbox/sandboxes/shared/localSnapshots.mjs",
+        import.meta.resolve("@openai/agents-core"),
+      ).href
+    );
+    const source = await fixture();
+    await mkdir(join(source, "directory"));
+    await writeFile(join(source, "directory", "file"), Buffer.from([0, 1, 2, 253, 254, 255]));
+    const destination = await fixture();
+    await restoreHostWorkspaceArchive(
+      destination,
+      input(await sdk.createWorkspaceArchive(source, new Set())),
+    );
+    expect(await fingerprintHostWorkspace(destination, [])).toEqual(
+      await fingerprintHostWorkspace(source, []),
+    );
+    const captured = await captureHostWorkspaceArchive(source, []);
+    spools.push(captured.spool);
+    await sdk.restoreWorkspaceArchive(await readFile(captured.spool.path), destination);
+    expect(await fingerprintHostWorkspace(destination, [])).toEqual(captured.workspace);
+  });
+
+  test("same-size file mutation during capture read is detected and private spool is cleaned", async () => {
+    const source = await fixture();
+    const temporaryBase = await fixture();
+    await writeFile(join(source, "file"), "initial");
+    const previousTemp = process.env.TMPDIR;
+    process.env.TMPDIR = temporaryBase;
+    const originalOpen = filesystem.open;
+    let reads = 0;
+    const hook = spyOn(filesystem, "open").mockImplementation(async (...args) => {
+      const handle = await originalOpen(...args);
+      if ((await realpath(String(args[0])).catch(() => "")) === join(source, "file")) {
+        const originalRead = handle.read;
+        Object.defineProperty(handle, "read", {
+          value: async (...readArgs: Parameters<typeof originalRead>) => {
+            const result = await Reflect.apply(originalRead, handle, readArgs);
+            if (++reads === 2) await writeFile(join(source, "file"), "mutated");
+            return result;
+          },
+        });
+      }
+      return handle;
+    });
+    try {
+      await expect(captureHostWorkspaceArchive(source, [])).rejects.toMatchObject({
+        code: "workspace_changed_during_capture",
+      });
+      expect(reads).toBe(2);
+      expect(await readdir(temporaryBase)).toEqual([]);
+    } finally {
+      hook.mockRestore();
+      if (previousTemp === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = previousTemp;
+    }
+  });
+
+  test("directory replacement between lstat and open cannot capture a symlink target", async () => {
+    const source = await fixture();
+    const outside = await fixture();
+    await mkdir(join(source, "directory"));
+    await writeFile(join(outside, "secret"), "outside fixture");
+    const originalOpen = filesystem.open;
+    let swapped = false;
+    const hook = spyOn(filesystem, "open").mockImplementation(async (...args) => {
+      if (!swapped && /^\/proc\/self\/fd\/\d+\/directory$/.test(String(args[0]))) {
+        swapped = true;
+        await rename(join(source, "directory"), join(source, "old-directory"));
+        await symlink(outside, join(source, "directory"));
+      }
+      return originalOpen(...args);
+    });
+    try {
+      await expect(captureHostWorkspaceArchive(source, [])).rejects.toThrow();
+      expect(swapped).toBe(true);
+      expect(await readFile(join(outside, "secret"), "utf8")).toBe("outside fixture");
+    } finally {
+      hook.mockRestore();
+    }
+  });
+
+  test("destination parent swap cannot redirect the exclusive file write", async () => {
+    const destination = await fixture();
+    const outside = await fixture();
+    await writeFile(join(outside, "file"), "outside fixture");
+    const archive = input(
+      JSON.stringify({
+        version: 1,
+        directories: ["directory"],
+        files: [{ path: "directory/file", data: "YQ==" }],
+      }),
+    );
+    const originalOpen = filesystem.open;
+    let swapped = false;
+    const hook = spyOn(filesystem, "open").mockImplementation(async (...args) => {
+      if (!swapped && /^\/proc\/self\/fd\/\d+\/file$/.test(String(args[0]))) {
+        swapped = true;
+        await rename(join(destination, "directory"), join(destination, "old-directory"));
+        await symlink(outside, join(destination, "directory"));
+      }
+      return originalOpen(...args);
+    });
+    try {
+      await expect(restoreHostWorkspaceArchive(destination, archive)).rejects.toThrow();
+      expect(swapped).toBe(true);
+      expect(await readFile(join(outside, "file"), "utf8")).toBe("outside fixture");
+    } finally {
+      hook.mockRestore();
+    }
+  });
+
+  test("numeric version and UTF-8 validation do not depend on buffer boundaries", async () => {
+    const destination = await fixture();
+    for (const version of ["1", "1.0000", "0.001e3", "100e-2", "1E+000"]) {
+      await restoreHostWorkspaceArchive(
+        destination,
+        input(`{"version":${version},"directories":[],"files":[]}`),
+        { chunkBytes: 1 },
+      );
+    }
+    await writeFile(join(destination, "keep"), "safe");
+    for (const version of [
+      "01",
+      "+1",
+      "1.",
+      "1e",
+      "1e+",
+      "-1",
+      "1e100000000000000000000",
+      "1.01",
+    ]) {
+      await expect(
+        restoreHostWorkspaceArchive(
+          destination,
+          input(`{"version":${version},"directories":[],"files":[]}`),
+          { chunkBytes: 1 },
+        ),
+      ).rejects.toThrow();
+    }
+    const invalidUtf8 = Buffer.concat([
+      Buffer.from('{"version":1,"directories":["'),
+      Buffer.from([0xc0, 0xaf]),
+      Buffer.from('"],"files":[]}'),
+    ]);
+    await expect(
+      restoreHostWorkspaceArchive(destination, input(invalidUtf8), { chunkBytes: 1 }),
+    ).rejects.toThrow();
+    expect(await readFile(join(destination, "keep"), "utf8")).toBe("safe");
+  });
+
+  test("short filesystem reads preserve every base64 remainder and empty/excluded projections", async () => {
+    const source = await fixture();
+    for (let size = 0; size <= 19; size++) {
+      await writeFile(
+        join(source, `file-${size}`),
+        Buffer.from(Array.from({ length: size }, (_, index) => index * 13)),
+      );
+    }
+    const originalOpen = filesystem.open;
+    const hook = spyOn(filesystem, "open").mockImplementation(async (...args) => {
+      const handle = await originalOpen(...args);
+      if ((await realpath(String(args[0])).catch(() => "")).startsWith(`${source}/file-`)) {
+        const originalRead = handle.read;
+        Object.defineProperty(handle, "read", {
+          value: async (buffer: Buffer, offset: number, length: number, position: number) =>
+            Reflect.apply(originalRead, handle, [buffer, offset, Math.min(length, 5), position]),
+        });
+      }
+      return handle;
+    });
+    try {
+      const captured = await captureHostWorkspaceArchive(source, []);
+      spools.push(captured.spool);
+      const archive = JSON.parse(await readFile(captured.spool.path, "utf8"));
+      for (const file of archive.files)
+        expect(Buffer.from(file.data, "base64")).toEqual(await readFile(join(source, file.path)));
+      expect(captured.workspace).toEqual(reference(archive.directories, archive.files));
+    } finally {
+      hook.mockRestore();
+    }
+    const empty = await captureHostWorkspaceArchive(source, [""]);
+    spools.push(empty.spool);
+    expect(empty.workspace).toEqual(reference([], []));
+    expect(JSON.parse(await readFile(empty.spool.path, "utf8"))).toEqual({
+      version: 1,
+      directories: [],
+      files: [],
+    });
+    expect((await filesystem.stat(empty.spool.path)).mode & 0o777).toBe(0o600);
+    expect((await filesystem.stat(join(empty.spool.path, ".."))).mode & 0o777).toBe(0o700);
+  });
+
+  test("failed source streams clean their private copy without creating a destination", async () => {
+    const outer = await fixture();
+    const temporaryBase = await fixture();
+    const destination = join(outer, "missing");
+    const previousTemp = process.env.TMPDIR;
+    process.env.TMPDIR = temporaryBase;
+    const archive = input('{"version":1,"directories":[],"files":[]}');
+    try {
+      await expect(
+        restoreHostWorkspaceArchive(destination, {
+          ...archive,
+          async *open() {
+            yield Buffer.from("{");
+            throw new Error("fixture source failed");
+          },
+        }),
+      ).rejects.toThrow("fixture source failed");
+      expect(await readdir(temporaryBase)).toEqual([]);
+      expect(await readdir(outer)).toEqual([]);
+    } finally {
+      if (previousTemp === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = previousTemp;
+    }
+  });
+});

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -44,6 +44,12 @@ export type ObjectHead = {
   VersionToken?: string;
 };
 
+export {
+  uploadWorkspaceArchiveSpool,
+  downloadWorkspaceArchiveSpool,
+  WorkspaceArchiveStorageError,
+} from "./workspace-archive-spool";
+
 export type ObjectStorage = {
   bucket: string;
   backend: "s3-compatible" | "aws-s3" | "azure-blob" | "gcs";

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -108,6 +108,19 @@ export type ObjectStorage = {
     body: Uint8Array;
     sha256?: string | null;
   }) => Promise<void>;
+  /**
+   * Unconditional authenticated upload from a bounded byte stream. May overwrite
+   * an existing key; this is NOT an atomic create-only operation. Callers needing
+   * write isolation must supply a fresh unique key and verify stored content.
+   */
+  putObjectStream?: (args: {
+    key: string;
+    contentType: string;
+    chunks: AsyncIterable<Uint8Array>;
+    byteSize: number;
+    sha256?: string;
+    signal?: AbortSignal;
+  }) => Promise<void>;
   /** Atomic create-only raw PUT. Returns false when the key already exists. */
   putObjectIfAbsent?: (args: {
     key: string;
@@ -258,6 +271,52 @@ function createS3CompatibleObjectStorage(settings: Settings): ObjectStorage | nu
       } catch (error) {
         if (isS3VersionMismatch(error)) return false;
         throw error;
+      }
+    },
+    async putObjectStream(args) {
+      const body = Readable.from(args.chunks, {
+        objectMode: false,
+        highWaterMark: INTERNAL_STREAM_BUFFER_BYTES,
+      });
+      // A producer error can leave the HTTP request waiting for its advertised
+      // ContentLength. Abort this request explicitly; never abort the caller's
+      // controller or rely on provider timeouts to settle the failed upload.
+      const request = new AbortController();
+      let producerFailed = false;
+      let producerError: unknown;
+      const onBodyError = (error: unknown) => {
+        producerFailed = true;
+        producerError = error;
+        request.abort(error);
+      };
+      const onCallerAbort = () => request.abort(args.signal?.reason);
+      body.once("error", onBodyError);
+      // Keep an error listener through asynchronous destruction, then release it.
+      const detachBodyError = () => body.off("error", onBodyError);
+      body.once("close", detachBodyError);
+      args.signal?.addEventListener("abort", onCallerAbort, { once: true });
+      if (args.signal?.aborted) onCallerAbort();
+      try {
+        await requestClient.send(
+          new PutObjectCommand({
+            Bucket: settings.objectStorageBucket,
+            Key: args.key,
+            ContentType: args.contentType,
+            ContentLength: args.byteSize,
+            Body: body,
+            Metadata: args.sha256 ? { sha256: args.sha256 } : undefined,
+          }),
+          { abortSignal: request.signal },
+        );
+        if (producerFailed) throw producerError;
+      } catch (error) {
+        // The SDK commonly rejects with AbortError after our producer abort;
+        // preserve the original integrity/source failure for its caller.
+        if (producerFailed) throw producerError;
+        throw error;
+      } finally {
+        args.signal?.removeEventListener("abort", onCallerAbort);
+        body.destroy();
       }
     },
     async putObjectStreamIfAbsent(args) {
@@ -522,6 +581,23 @@ function createGcsObjectStorage(settings: Settings): ObjectStorage {
         throw error;
       }
     },
+    async putObjectStream(args) {
+      const destination = bucket.file(args.key).createWriteStream({
+        resumable: false,
+        contentType: args.contentType,
+        highWaterMark: INTERNAL_STREAM_BUFFER_BYTES,
+        ...(args.sha256 ? { metadata: { metadata: { sha256: args.sha256 } } } : {}),
+      });
+      const source = Readable.from(args.chunks, {
+        objectMode: false,
+        highWaterMark: INTERNAL_STREAM_BUFFER_BYTES,
+      });
+      if (args.signal) {
+        await pipeline(source, destination, { signal: args.signal });
+      } else {
+        await pipeline(source, destination);
+      }
+    },
     async putObjectStreamIfAbsent(args) {
       const destination = bucket.file(args.key).createWriteStream({
         resumable: false,
@@ -713,6 +789,27 @@ function createAzureBlobObjectStorage(settings: Settings): ObjectStorage | null 
       } catch (error) {
         if (isAzureVersionMismatch(error)) return false;
         throw error;
+      }
+    },
+    async putObjectStream(args) {
+      const blobClient = requestContainerClient.getBlockBlobClient(args.key);
+      const source = Readable.from(args.chunks, {
+        objectMode: false,
+        highWaterMark: INTERNAL_STREAM_BUFFER_BYTES,
+      });
+      try {
+        await blobClient.uploadStream(
+          source,
+          INTERNAL_STREAM_BUFFER_BYTES,
+          INTERNAL_STREAM_CONCURRENCY,
+          {
+            blobHTTPHeaders: { blobContentType: args.contentType },
+            ...(args.sha256 ? { metadata: { sha256: args.sha256 } } : {}),
+            ...(args.signal ? { abortSignal: args.signal } : {}),
+          },
+        );
+      } finally {
+        source.destroy();
       }
     },
     async putObjectStreamIfAbsent(args) {

--- a/packages/storage/src/workspace-archive-spool.ts
+++ b/packages/storage/src/workspace-archive-spool.ts
@@ -32,23 +32,28 @@ export class WorkspaceArchiveStorageError extends Error {
   }
 }
 
-/** Creates at the caller's deterministic key; never owns/disposes the input spool. */
+/**
+ * Uploads at a caller-owned fresh unique key and independently verifies readback.
+ * Unconditional PUT may overwrite: callers must never reuse published keys.
+ * Never owns/disposes the input spool or deletes a failed/unpublished object.
+ */
 export async function uploadWorkspaceArchiveSpool(
   storage: ObjectStorage,
   key: string,
   spool: WorkspaceArchiveSpool,
 ): Promise<void> {
   requireBoundedReads(storage);
-  if (!storage.putObjectStreamIfAbsent) {
+  if (!storage.putObjectStream) {
     throw new WorkspaceArchiveStorageError(
       "archive_hydration_failed",
-      "Workspace archive storage unsupported: streaming create-only upload required",
+      "Workspace archive storage unsupported: unconditional streaming upload required",
       false,
     );
   }
   const expected = { bytes: spool.byteSize, sha256: spool.sha256 };
   validateExpected(expected);
   let validated = false;
+  let streamFailed = false;
   let streamFailure: unknown;
   const chunks = (async function* () {
     const digest = createHash("sha256");
@@ -75,35 +80,42 @@ export async function uploadWorkspaceArchiveSpool(
       }
       validated = true;
     } catch (error) {
+      streamFailed = true;
       streamFailure = error;
       throw error;
     }
   })();
-  let created: boolean;
   try {
-    created = await storage.putObjectStreamIfAbsent({
+    await storage.putObjectStream({
       key,
       contentType: "application/x-tar",
       chunks,
       byteSize: expected.bytes,
       sha256: expected.sha256,
     });
-    if (created && !validated) {
-      if (streamFailure) throw streamFailure;
+    if (!validated) {
+      if (streamFailed) throw streamFailure;
       throw new WorkspaceArchiveStorageError(
         "archive_hydration_failed",
         "Workspace archive upload provider did not completely consume and validate the stream",
         false,
       );
     }
+    // A successful PUT and SHA metadata are not proof of stored content.
+    await verifyRanges(storage, key, expected);
+  } catch (error) {
+    const failure = streamFailed ? streamFailure : error;
+    if (failure instanceof WorkspaceArchiveStorageError) throw failure;
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive upload or readback failed",
+      true,
+      { cause: failure },
+    );
   } finally {
-    // Providers may reject an existing key without consuming the input, or
-    // terminate early. Close any opened file iterator without owning the spool.
+    // Close an early-terminated provider's iterator without owning the spool.
     await chunks.return(undefined);
   }
-  // A collision is not success until the actual pinned bytes match. Metadata
-  // may have been written by a different/untrusted uploader.
-  if (!created) await verifyRanges(storage, key, expected);
 }
 
 /** Caller owns the returned private spool and must dispose it after use. */
@@ -229,12 +241,25 @@ async function verifyRanges(
       endInclusive: bytes + length - 1,
       expectedVersionToken: version,
     });
-    if (!result)
+    if (!result) {
+      // Adapters also return null for failed If-Match/generation reads. Do not
+      // classify replacement as permanent loss or retry without a version pin.
+      const current = await storage.headObject!(key);
+      if (!current) {
+        throw new WorkspaceArchiveStorageError(
+          "archive_base64_invalid",
+          "Workspace archive object is missing during range read",
+          false,
+        );
+      }
       throw new WorkspaceArchiveStorageError(
-        "archive_base64_invalid",
-        "Workspace archive object is missing during range read",
-        false,
+        "archive_hydration_failed",
+        current.VersionToken !== version
+          ? "Workspace archive object version changed"
+          : "Workspace archive pinned range is temporarily unavailable",
+        true,
       );
+    }
     if (result.versionToken !== version)
       throw new WorkspaceArchiveStorageError(
         "archive_hydration_failed",

--- a/packages/storage/src/workspace-archive-spool.ts
+++ b/packages/storage/src/workspace-archive-spool.ts
@@ -1,0 +1,283 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { chmod, mkdtemp, open, rm, type FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ObjectStorage } from "./index";
+import { DEFAULT_BOUNDED_OBJECT_CHUNK_BYTES } from "./bounded-object-read";
+
+/** Structural runtime-compatible contract; storage must not depend on runtime. */
+export type WorkspaceArchiveSpool = {
+  path: string;
+  byteSize: number;
+  sha256: string;
+  open: () => AsyncIterable<Uint8Array>;
+  dispose: () => Promise<void>;
+};
+
+// Transfer granularity, not an archive size limit.
+const CHUNK_BYTES = DEFAULT_BOUNDED_OBJECT_CHUNK_BYTES;
+type ExpectedArchive = { bytes: number; sha256: string };
+
+/** Restore classification shared with runtime without importing runtime. */
+export class WorkspaceArchiveStorageError extends Error {
+  constructor(
+    readonly code: "archive_base64_invalid" | "archive_hash_mismatch" | "archive_hydration_failed",
+    message: string,
+    readonly retryable: boolean,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "WorkspaceArchiveStorageError";
+  }
+}
+
+/** Creates at the caller's deterministic key; never owns/disposes the input spool. */
+export async function uploadWorkspaceArchiveSpool(
+  storage: ObjectStorage,
+  key: string,
+  spool: WorkspaceArchiveSpool,
+): Promise<void> {
+  requireBoundedReads(storage);
+  if (!storage.putObjectStreamIfAbsent) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive storage unsupported: streaming create-only upload required",
+      false,
+    );
+  }
+  const expected = { bytes: spool.byteSize, sha256: spool.sha256 };
+  validateExpected(expected);
+  let validated = false;
+  let streamFailure: unknown;
+  const chunks = (async function* () {
+    const digest = createHash("sha256");
+    let bytes = 0;
+    try {
+      for await (const chunk of spool.open()) {
+        if (!(chunk instanceof Uint8Array) || chunk.byteLength > expected.bytes - bytes) {
+          throw new WorkspaceArchiveStorageError(
+            "archive_hash_mismatch",
+            "Workspace archive upload stream has invalid size",
+            false,
+          );
+        }
+        bytes += chunk.byteLength;
+        digest.update(chunk);
+        yield chunk;
+      }
+      if (bytes !== expected.bytes || digest.digest("hex") !== expected.sha256) {
+        throw new WorkspaceArchiveStorageError(
+          "archive_hash_mismatch",
+          "Workspace archive upload stream digest or size mismatch",
+          false,
+        );
+      }
+      validated = true;
+    } catch (error) {
+      streamFailure = error;
+      throw error;
+    }
+  })();
+  let created: boolean;
+  try {
+    created = await storage.putObjectStreamIfAbsent({
+      key,
+      contentType: "application/x-tar",
+      chunks,
+      byteSize: expected.bytes,
+      sha256: expected.sha256,
+    });
+    if (created && !validated) {
+      if (streamFailure) throw streamFailure;
+      throw new WorkspaceArchiveStorageError(
+        "archive_hydration_failed",
+        "Workspace archive upload provider did not completely consume and validate the stream",
+        false,
+      );
+    }
+  } finally {
+    // Providers may reject an existing key without consuming the input, or
+    // terminate early. Close any opened file iterator without owning the spool.
+    await chunks.return(undefined);
+  }
+  // A collision is not success until the actual pinned bytes match. Metadata
+  // may have been written by a different/untrusted uploader.
+  if (!created) await verifyRanges(storage, key, expected);
+}
+
+/** Caller owns the returned private spool and must dispose it after use. */
+export async function downloadWorkspaceArchiveSpool(
+  storage: ObjectStorage,
+  key: string,
+  inputExpected: ExpectedArchive,
+): Promise<WorkspaceArchiveSpool> {
+  const expected = { bytes: inputExpected.bytes, sha256: inputExpected.sha256 };
+  requireBoundedReads(storage);
+  validateExpected(expected);
+  const directory = await mkdtemp(join(tmpdir(), "opengeni-workspace-archive-"));
+  const path = join(directory, "archive.tar");
+  let handle: FileHandle | undefined;
+  try {
+    await chmod(directory, 0o700);
+    handle = await open(path, "wx", 0o600);
+    await verifyRanges(storage, key, expected, async (chunk) => {
+      let offset = 0;
+      while (offset < chunk.byteLength) {
+        const { bytesWritten } = await handle!.write(chunk, offset, chunk.byteLength - offset);
+        if (bytesWritten <= 0)
+          throw new WorkspaceArchiveStorageError(
+            "archive_hydration_failed",
+            "Workspace archive spool write made no progress",
+            true,
+          );
+        offset += bytesWritten;
+      }
+    });
+    await handle.close();
+    handle = undefined;
+    let disposed = false;
+    return {
+      path,
+      byteSize: expected.bytes,
+      sha256: expected.sha256,
+      async *open() {
+        if (disposed) throw new Error("Workspace archive spool is disposed");
+        const stream = createReadStream(path, { highWaterMark: CHUNK_BYTES });
+        try {
+          for await (const chunk of stream) yield chunk as Uint8Array;
+        } finally {
+          stream.destroy();
+        }
+      },
+      async dispose() {
+        disposed = true;
+        await rm(directory, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(directory, { recursive: true, force: true });
+    if (error instanceof WorkspaceArchiveStorageError) throw error;
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive download failed",
+      true,
+      { cause: error },
+    );
+  }
+}
+
+function requireBoundedReads(storage: ObjectStorage): void {
+  if (!storage.headObject || !storage.getObjectRange) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive storage unsupported: versioned head/range reads required",
+      false,
+    );
+  }
+}
+
+function validateExpected(expected: ExpectedArchive): void {
+  if (
+    !Number.isSafeInteger(expected.bytes) ||
+    expected.bytes < 0 ||
+    !/^[0-9a-f]{64}$/u.test(expected.sha256)
+  ) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive expected size or SHA-256 is invalid",
+      false,
+    );
+  }
+}
+
+async function verifyRanges(
+  storage: ObjectStorage,
+  key: string,
+  expected: ExpectedArchive,
+  consume?: (bytes: Uint8Array) => Promise<void>,
+): Promise<void> {
+  const head = await storage.headObject!(key);
+  if (!head)
+    throw new WorkspaceArchiveStorageError(
+      "archive_base64_invalid",
+      "Workspace archive object is missing",
+      false,
+    );
+  if (head.ContentLength !== expected.bytes)
+    throw new WorkspaceArchiveStorageError(
+      "archive_hash_mismatch",
+      "Workspace archive object size mismatch",
+      false,
+    );
+  const version = head.VersionToken;
+  if (typeof version !== "string" || version.length === 0 || version.length > 2048) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive storage unsupported: valid object version token required",
+      false,
+    );
+  }
+  const digest = createHash("sha256");
+  let bytes = 0;
+  while (bytes < expected.bytes) {
+    const length = Math.min(CHUNK_BYTES, expected.bytes - bytes);
+    const result = await storage.getObjectRange!({
+      key,
+      start: bytes,
+      endInclusive: bytes + length - 1,
+      expectedVersionToken: version,
+    });
+    if (!result)
+      throw new WorkspaceArchiveStorageError(
+        "archive_base64_invalid",
+        "Workspace archive object is missing during range read",
+        false,
+      );
+    if (result.versionToken !== version)
+      throw new WorkspaceArchiveStorageError(
+        "archive_hydration_failed",
+        "Workspace archive object version changed",
+        true,
+      );
+    if (!(result.bytes instanceof Uint8Array) || result.bytes.byteLength !== length) {
+      throw new WorkspaceArchiveStorageError(
+        "archive_hash_mismatch",
+        "Workspace archive object range is truncated or has invalid size",
+        false,
+      );
+    }
+    digest.update(result.bytes);
+    await consume?.(result.bytes);
+    bytes += result.bytes.byteLength;
+  }
+  const finalHead = await storage.headObject!(key);
+  if (!finalHead)
+    throw new WorkspaceArchiveStorageError(
+      "archive_base64_invalid",
+      "Workspace archive object is missing after range read",
+      false,
+    );
+  if (finalHead.VersionToken !== version) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hydration_failed",
+      "Workspace archive object version changed",
+      true,
+    );
+  }
+  if (finalHead.ContentLength !== expected.bytes) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hash_mismatch",
+      "Workspace archive object size changed",
+      false,
+    );
+  }
+  if (bytes !== expected.bytes || digest.digest("hex") !== expected.sha256) {
+    throw new WorkspaceArchiveStorageError(
+      "archive_hash_mismatch",
+      "Workspace archive object digest or size mismatch",
+      false,
+    );
+  }
+}

--- a/packages/storage/test/object-storage-stream.test.ts
+++ b/packages/storage/test/object-storage-stream.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { getEventListeners } from "node:events";
+import {
+  S3Client,
+  PutObjectCommand,
+  HeadObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+import { BlockBlobClient } from "@azure/storage-blob";
+import { File } from "@google-cloud/storage";
+import { getSettings } from "@opengeni/config";
+import {
+  createObjectStorage,
+  downloadWorkspaceArchiveSpool,
+  uploadWorkspaceArchiveSpool,
+  WorkspaceArchiveStorageError,
+} from "../src/index";
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+const signal = new AbortController().signal;
+const input = () => ({
+  key: "archives/unique-invocation.tar",
+  contentType: "application/x-tar",
+  byteSize: bytes.length,
+  sha256: "test-digest",
+  signal,
+  chunks: (async function* () {
+    yield bytes.subarray(0, 2);
+    yield bytes.subarray(2);
+  })(),
+});
+
+function storage(backend: "s3-compatible" | "aws-s3" | "gcs" | "azure-blob") {
+  return createObjectStorage({
+    ...getSettings(),
+    objectStorageBackend: backend,
+    objectStorageBucket: "test-bucket",
+    objectStorageEndpoint: "http://127.0.0.1:1",
+    objectStorageInternalEndpoint: undefined,
+    objectStorageAccessKeyId: "synthetic-test",
+    objectStorageSecretAccessKey: "synthetic-test",
+    objectStorageGcsProjectId: "synthetic-project",
+    objectStorageGcsKeyFilename: undefined,
+    objectStorageGcsCredentialsJson: undefined,
+    objectStorageAzureConnectionString: undefined,
+    objectStorageAzureAccountName: "synthetic",
+    objectStorageAzureAccountKey: Buffer.from("synthetic-key").toString("base64"),
+  })!;
+}
+
+async function consume(chunks: AsyncIterable<Uint8Array>) {
+  const collected: number[] = [];
+  for await (const chunk of chunks) collected.push(...chunk);
+  expect(collected).toEqual([...bytes]);
+}
+
+describe("unconditional streaming object storage (SDK stubs, no providers)", () => {
+  for (const mode of ["direct", "spool"] as const) {
+    test(`S3 ${mode} producer errors abort the owning request and preserve the original failure`, async () => {
+      const original = new WorkspaceArchiveStorageError(
+        "archive_hash_mismatch",
+        "synthetic producer mismatch",
+        false,
+      );
+      const caller = new AbortController();
+      const before = getEventListeners(caller.signal, "abort").length;
+      let requestSignal: AbortSignal | undefined;
+      let requestBody: Readable | undefined;
+      let rejectRequest: ((error: unknown) => void) | undefined;
+      let observeError!: (error: Error) => void;
+      const producerError = new Promise<Error>((resolve) => {
+        observeError = resolve;
+      });
+      const send = spyOn(S3Client.prototype, "send").mockImplementation(
+        (command, options) =>
+          new Promise((_resolve, reject) => {
+            rejectRequest = reject;
+            requestSignal = (options as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            requestBody = (command as PutObjectCommand).input.Body as Readable;
+            // Reproduce the SDK path: body errors alone do not settle send().
+            requestSignal?.addEventListener(
+              "abort",
+              () => reject(new Error("SDK request aborted")),
+              { once: true },
+            );
+            requestBody.once("error", observeError);
+            requestBody.resume();
+          }),
+      );
+      const adapter = storage("s3-compatible");
+      const pending = (
+        mode === "direct"
+          ? adapter.putObjectStream!({
+              ...input(),
+              signal: caller.signal,
+              chunks: (async function* () {
+                yield bytes;
+                throw original;
+              })(),
+            })
+          : uploadWorkspaceArchiveSpool(adapter, input().key, {
+              path: "unused",
+              byteSize: bytes.length,
+              sha256: "a".repeat(64),
+              async *open() {
+                yield bytes;
+              },
+              async dispose() {
+                throw new Error("caller-owned spool");
+              },
+            })
+      ).catch((error: unknown) => error);
+      try {
+        const emitted = await producerError;
+        expect(requestSignal?.aborted).toBe(true);
+        expect(await pending).toBe(emitted);
+        expect(emitted).toMatchObject({ code: "archive_hash_mismatch", retryable: false });
+        if (mode === "direct") expect(emitted).toBe(original);
+        expect(caller.signal.aborted).toBe(false);
+        expect(requestBody?.destroyed).toBe(true);
+        expect(getEventListeners(caller.signal, "abort").length).toBe(before);
+      } finally {
+        // Also settle the deliberately broken pre-fix stub after a red assertion.
+        rejectRequest?.(original);
+        await pending;
+        send.mockRestore();
+      }
+    });
+  }
+
+  for (const alreadyAborted of [false, true]) {
+    test(`S3 forwards caller cancellation and removes its listener (pre-aborted=${alreadyAborted})`, async () => {
+      const caller = new AbortController();
+      const reason = new Error("caller cancellation");
+      if (alreadyAborted) caller.abort(reason);
+      let requestBody: Readable | undefined;
+      let requestSignal: AbortSignal | undefined;
+      const before = getEventListeners(caller.signal, "abort").length;
+      const send = spyOn(S3Client.prototype, "send").mockImplementation(
+        (command, options) =>
+          new Promise((_resolve, reject) => {
+            requestBody = (command as PutObjectCommand).input.Body as Readable;
+            requestSignal = (options as { abortSignal: AbortSignal }).abortSignal;
+            if (requestSignal.aborted) reject(reason);
+            else requestSignal.addEventListener("abort", () => reject(reason), { once: true });
+          }),
+      );
+      try {
+        const pending = storage("s3-compatible").putObjectStream!({
+          ...input(),
+          signal: caller.signal,
+        });
+        caller.abort(reason);
+        await expect(pending).rejects.toBe(reason);
+        expect(requestSignal?.aborted).toBe(true);
+        expect(requestSignal).not.toBe(caller.signal);
+        expect(requestBody?.destroyed).toBe(true);
+        expect(getEventListeners(caller.signal, "abort").length).toBe(before);
+      } finally {
+        send.mockRestore();
+      }
+    });
+  }
+
+  test("S3 successful upload detaches caller cancellation", async () => {
+    const caller = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    let requestBody: Readable | undefined;
+    const before = getEventListeners(caller.signal, "abort").length;
+    const send = spyOn(S3Client.prototype, "send").mockImplementation(async (command, options) => {
+      requestSignal = (options as { abortSignal: AbortSignal }).abortSignal;
+      requestBody = (command as PutObjectCommand).input.Body as Readable;
+      await consume(requestBody);
+      return {};
+    });
+    try {
+      await storage("s3-compatible").putObjectStream!({ ...input(), signal: caller.signal });
+      expect(getEventListeners(caller.signal, "abort").length).toBe(before);
+      caller.abort(new Error("later cancellation"));
+      expect(requestSignal?.aborted).toBe(false);
+      expect(requestBody?.destroyed).toBe(true);
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  test("S3 adapter's failed If-Match range is classified as replacement after a fresh HEAD", async () => {
+    const commands: string[] = [];
+    let heads = 0;
+    const send = spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      commands.push(command.constructor.name);
+      if (command instanceof HeadObjectCommand) {
+        return { ContentLength: bytes.length, ETag: ++heads === 1 ? "v1" : "v2" };
+      }
+      expect(command).toBeInstanceOf(GetObjectCommand);
+      expect((command as GetObjectCommand).input.IfMatch).toBe("v1");
+      expect((command as GetObjectCommand).input.Range).toBe("bytes=0-3");
+      throw { $metadata: { httpStatusCode: 412 } };
+    });
+    try {
+      await expect(
+        downloadWorkspaceArchiveSpool(storage("s3-compatible"), input().key, {
+          bytes: bytes.length,
+          sha256: "a".repeat(64),
+        }),
+      ).rejects.toMatchObject({
+        code: "archive_hydration_failed",
+        retryable: true,
+        message: "Workspace archive object version changed",
+      });
+      expect(commands).toEqual(["HeadObjectCommand", "GetObjectCommand", "HeadObjectCommand"]);
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  for (const backend of ["s3-compatible", "aws-s3"] as const) {
+    test(`${backend} streams with explicit length and no create-only condition`, async () => {
+      const conditions: (string | undefined)[] = [];
+      const send = spyOn(S3Client.prototype, "send").mockImplementation(
+        async (command, options) => {
+          expect(command).toBeInstanceOf(PutObjectCommand);
+          const put = (command as PutObjectCommand).input;
+          expect(put.Key).toBe(input().key);
+          expect(put.ContentType).toBe(input().contentType);
+          expect(put.ContentLength).toBe(bytes.length);
+          expect(put.Metadata).toEqual({ sha256: "test-digest" });
+          expect((options as { abortSignal: AbortSignal }).abortSignal).toBeInstanceOf(AbortSignal);
+          expect((options as { abortSignal: AbortSignal }).abortSignal.aborted).toBe(false);
+          if (put.IfNoneMatch) expect(options).toEqual({ abortSignal: signal });
+          conditions.push(put.IfNoneMatch);
+          await consume(put.Body as Readable);
+          return {};
+        },
+      );
+      try {
+        const adapter = storage(backend);
+        await expect(adapter.putObjectStream!(input())).resolves.toBeUndefined();
+        await expect(adapter.putObjectStreamIfAbsent!(input())).resolves.toBe(true);
+        expect(conditions).toEqual([undefined, "*"]);
+      } finally {
+        send.mockRestore();
+      }
+    });
+  }
+
+  test("Azure streams with bounded buffers and preserves the separate IfAbsent condition", async () => {
+    const conditions: unknown[] = [];
+    const upload = spyOn(BlockBlobClient.prototype, "uploadStream").mockImplementation(
+      async (stream, size, concurrency, options) => {
+        expect(size).toBe(1024 * 1024);
+        expect(concurrency).toBe(2);
+        expect(options?.blobHTTPHeaders).toEqual({ blobContentType: "application/x-tar" });
+        expect(options?.metadata).toEqual({ sha256: "test-digest" });
+        expect(options?.abortSignal).toBe(signal);
+        conditions.push(options?.conditions);
+        await consume(stream as Readable);
+        return {};
+      },
+    );
+    try {
+      const adapter = storage("azure-blob");
+      await expect(adapter.putObjectStream!(input())).resolves.toBeUndefined();
+      await expect(adapter.putObjectStreamIfAbsent!(input())).resolves.toBe(true);
+      expect(conditions).toEqual([undefined, { ifNoneMatch: "*" }]);
+    } finally {
+      upload.mockRestore();
+    }
+  });
+
+  test("GCS pipelines bounded streams without generation preconditions on unconditional PUT", async () => {
+    const conditions: unknown[] = [];
+    const received: number[][] = [];
+    const write = spyOn(File.prototype, "createWriteStream").mockImplementation((options) => {
+      expect(options?.resumable).toBe(false);
+      expect(options?.highWaterMark).toBe(1024 * 1024);
+      expect(options?.contentType).toBe("application/x-tar");
+      expect(options?.metadata).toEqual({ metadata: { sha256: "test-digest" } });
+      conditions.push(options?.preconditionOpts);
+      const output: number[] = [];
+      received.push(output);
+      return new Writable({
+        write(chunk, _encoding, done) {
+          output.push(...chunk);
+          done();
+        },
+      });
+    });
+    try {
+      const adapter = storage("gcs");
+      await expect(adapter.putObjectStream!(input())).resolves.toBeUndefined();
+      await expect(adapter.putObjectStreamIfAbsent!(input())).resolves.toBe(true);
+      expect(conditions).toEqual([undefined, { ifGenerationMatch: 0 }]);
+      expect(received).toEqual([[...bytes], [...bytes]]);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  for (const backend of ["s3-compatible", "azure-blob", "gcs"] as const) {
+    test(`${backend} propagates failed writes rather than treating them as collisions`, async () => {
+      const failure = Object.assign(new Error("synthetic precondition failure"), {
+        code: 412,
+        statusCode: 412,
+        $metadata: { httpStatusCode: 412 },
+      });
+      const send = spyOn(S3Client.prototype, "send").mockRejectedValue(failure);
+      const upload = spyOn(BlockBlobClient.prototype, "uploadStream").mockRejectedValue(failure);
+      const write = spyOn(File.prototype, "createWriteStream").mockImplementation(
+        () =>
+          new Writable({
+            write(_chunk, _encoding, done) {
+              done(failure);
+            },
+          }),
+      );
+      try {
+        await expect(storage(backend).putObjectStream!(input())).rejects.toBe(failure);
+      } finally {
+        send.mockRestore();
+        upload.mockRestore();
+        write.mockRestore();
+      }
+    });
+  }
+});

--- a/packages/storage/test/workspace-archive-spool.test.ts
+++ b/packages/storage/test/workspace-archive-spool.test.ts
@@ -27,7 +27,13 @@ function fixture(bytes = payload) {
       ranges.push(input);
       return { bytes: bytes.slice(input.start, input.endInclusive + 1), versionToken: "v1" };
     },
-    putObjectStreamIfAbsent: async () => false,
+    putObjectStream: async ({ chunks }: { chunks: AsyncIterable<Uint8Array> }) => {
+      for await (const _ of chunks) {
+      }
+    },
+    putObjectStreamIfAbsent: async () => {
+      throw new Error("create-only upload forbidden");
+    },
     getObjectBytes: async () => {
       throw new Error("whole-body read forbidden");
     },
@@ -93,7 +99,7 @@ describe("workspace archive spool storage", () => {
 
   test("streams new uploads at the supplied key without taking spool ownership", async () => {
     const { storage, ranges } = fixture();
-    storage.putObjectStreamIfAbsent = async (input) => {
+    storage.putObjectStream = async (input) => {
       expect(input.key).toBe(key);
       expect(input.byteSize).toBe(expected.bytes);
       expect(input.sha256).toBe(expected.sha256);
@@ -101,13 +107,12 @@ describe("workspace archive spool storage", () => {
       const digest = createHash("sha256");
       for await (const chunk of input.chunks) digest.update(chunk);
       expect(digest.digest("hex")).toBe(expected.sha256);
-      return true;
     };
     await uploadWorkspaceArchiveSpool(storage, key, source());
-    expect(ranges.length).toBe(0);
+    expect(ranges.length).toBe(3);
   });
 
-  test("verifies existing bytes, not forged SHA metadata", async () => {
+  test("always verifies successfully stored bytes, not forged SHA metadata", async () => {
     const { storage, ranges } = fixture();
     await uploadWorkspaceArchiveSpool(storage, key, source());
     expect(ranges.length).toBe(3);
@@ -116,6 +121,60 @@ describe("workspace archive spool storage", () => {
       "digest",
     );
   });
+
+  test("rejects a successful write that produces no object", async () => {
+    const { storage } = fixture();
+    storage.headObject = async () => null;
+    await expect(uploadWorkspaceArchiveSpool(storage, key, source())).rejects.toMatchObject({
+      code: "archive_base64_invalid",
+      retryable: false,
+    });
+  });
+
+  for (const stage of ["upload", "readback"] as const) {
+    test(`classifies ${stage} provider errors without full-body fallback`, async () => {
+      const { storage, ranges } = fixture();
+      const failure = new Error("synthetic provider error");
+      if (stage === "upload")
+        storage.putObjectStream = async () => {
+          throw failure;
+        };
+      else
+        storage.getObjectRange = async () => {
+          throw failure;
+        };
+      await expect(uploadWorkspaceArchiveSpool(storage, key, source())).rejects.toMatchObject({
+        code: "archive_hydration_failed",
+        retryable: true,
+        cause: failure,
+      });
+      expect(ranges).toEqual([]);
+    });
+  }
+
+  for (const after of ["missing", "replaced", "same"] as const) {
+    test(`rechecks HEAD after a null pinned range (${after})`, async () => {
+      const { storage, ranges } = fixture();
+      const head = storage.headObject!;
+      let heads = 0;
+      storage.headObject = async (objectKey) => {
+        const result = await head(objectKey);
+        if (++heads === 1) return result;
+        return after === "missing"
+          ? null
+          : after === "replaced"
+            ? { ...result, VersionToken: "v2" }
+            : result;
+      };
+      storage.getObjectRange = async () => null;
+      await expect(downloadWorkspaceArchiveSpool(storage, key, expected)).rejects.toMatchObject({
+        code: after === "missing" ? "archive_base64_invalid" : "archive_hydration_failed",
+        retryable: after !== "missing",
+      });
+      expect(heads).toBe(2);
+      expect(ranges).toEqual([]);
+    });
+  }
 
   test("rejects a same-length disk spool alteration before fresh upload", async () => {
     const original = new Uint8Array([1, 2, 3]);
@@ -126,10 +185,9 @@ describe("workspace archive spool storage", () => {
     });
     try {
       await writeFile(spool.path, new Uint8Array([3, 2, 1]));
-      storage.putObjectStreamIfAbsent = async ({ chunks }) => {
+      storage.putObjectStream = async ({ chunks }) => {
         for await (const _ of chunks) {
         }
-        return true;
       };
       await expect(uploadWorkspaceArchiveSpool(storage, key, spool)).rejects.toMatchObject({
         code: "archive_hash_mismatch",
@@ -138,6 +196,29 @@ describe("workspace archive spool storage", () => {
     } finally {
       await spool.dispose();
     }
+  });
+
+  test("preserves producer integrity errors when a provider reports only its consequent abort", async () => {
+    const { storage } = fixture();
+    const spool = source();
+    spool.open = async function* () {
+      yield new Uint8Array(payload.length);
+    };
+    let producerFailure: unknown;
+    storage.putObjectStream = async ({ chunks }) => {
+      try {
+        for await (const _ of chunks) {
+        }
+      } catch (error) {
+        producerFailure = error;
+        throw new DOMException("request aborted", "AbortError");
+      }
+    };
+    const failure = await uploadWorkspaceArchiveSpool(storage, key, spool).catch(
+      (error: unknown) => error,
+    );
+    expect(failure).toBe(producerFailure);
+    expect(failure).toMatchObject({ code: "archive_hash_mismatch", retryable: false });
   });
 
   for (const consumption of ["none", "partial", "swallowed-mismatch", "short", "long"] as const) {
@@ -155,13 +236,13 @@ describe("workspace archive spool storage", () => {
           );
         };
       }
-      storage.putObjectStreamIfAbsent = async ({ chunks }) => {
-        if (consumption === "none") return true;
+      storage.putObjectStream = async ({ chunks }) => {
+        if (consumption === "none") return;
         if (consumption === "partial") {
           for await (const _ of chunks) {
             break;
           }
-          return true;
+          return;
         }
         try {
           for await (const _ of chunks) {
@@ -169,7 +250,6 @@ describe("workspace archive spool storage", () => {
         } catch {
           /* Simulate a provider swallowing producer failure. */
         }
-        return true;
       };
       await expect(uploadWorkspaceArchiveSpool(storage, key, spool)).rejects.toBeInstanceOf(
         WorkspaceArchiveStorageError,
@@ -236,6 +316,7 @@ describe("workspace archive spool storage", () => {
       storage.headObject = async () => {
         const value = await head(key);
         if (failure === "missing") return null;
+        if (failure === "range-missing" && ++heads > 1) return null;
         if (failure === "size") return { ...value, ContentLength: 1 };
         if (failure === "token") return { ...value, VersionToken: "" };
         if (failure === "final-drift" && ++heads > 1) return { ...value, VersionToken: "v2" };
@@ -287,7 +368,7 @@ describe("workspace archive spool storage", () => {
   });
 
   test("fails explicitly without bounded primitives, before uploading", async () => {
-    for (const primitive of ["headObject", "getObjectRange", "putObjectStreamIfAbsent"] as const) {
+    for (const primitive of ["headObject", "getObjectRange", "putObjectStream"] as const) {
       const { storage } = fixture();
       delete storage[primitive];
       await expect(uploadWorkspaceArchiveSpool(storage, key, source())).rejects.toThrow(
@@ -297,7 +378,7 @@ describe("workspace archive spool storage", () => {
         code: "archive_hydration_failed",
         retryable: false,
       });
-      if (primitive !== "putObjectStreamIfAbsent") {
+      if (primitive !== "putObjectStream") {
         await expect(downloadWorkspaceArchiveSpool(storage, key, expected)).rejects.toThrow(
           "unsupported",
         );

--- a/packages/storage/test/workspace-archive-spool.test.ts
+++ b/packages/storage/test/workspace-archive-spool.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readdir, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname } from "node:path";
+import type { ObjectStorage } from "../src/index";
+import {
+  downloadWorkspaceArchiveSpool,
+  uploadWorkspaceArchiveSpool,
+  WorkspaceArchiveStorageError,
+} from "../src/workspace-archive-spool";
+
+const hash = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+const payload = new Uint8Array(2 * 1024 * 1024 + 17).fill(37);
+const expected = { bytes: payload.length, sha256: hash(payload) };
+const key = "archives/deterministic-key.tar";
+
+function fixture(bytes = payload) {
+  const ranges: Parameters<NonNullable<ObjectStorage["getObjectRange"]>>[0][] = [];
+  const storage = {
+    headObject: async () => ({
+      ContentLength: bytes.length,
+      VersionToken: "v1",
+      Metadata: { sha256: expected.sha256 },
+    }),
+    getObjectRange: async (input: Parameters<NonNullable<ObjectStorage["getObjectRange"]>>[0]) => {
+      ranges.push(input);
+      return { bytes: bytes.slice(input.start, input.endInclusive + 1), versionToken: "v1" };
+    },
+    putObjectStreamIfAbsent: async () => false,
+    getObjectBytes: async () => {
+      throw new Error("whole-body read forbidden");
+    },
+    putObject: async () => {
+      throw new Error("whole-body write forbidden");
+    },
+  } as unknown as ObjectStorage;
+  return { storage, ranges };
+}
+
+const source = () => ({
+  path: "unused",
+  byteSize: expected.bytes,
+  sha256: expected.sha256,
+  async *open() {
+    yield payload.subarray(0, 100);
+    yield payload.subarray(100);
+  },
+  async dispose() {
+    throw new Error("upload must not dispose caller spool");
+  },
+});
+
+describe("workspace archive spool storage", () => {
+  test("downloads exact bounded pinned ranges to a private reopenable disposable file", async () => {
+    const { storage, ranges } = fixture();
+    const spool = await downloadWorkspaceArchiveSpool(storage, key, expected);
+    const path = spool.path;
+    try {
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+      expect((await stat(dirname(path))).mode & 0o777).toBe(0o700);
+      expect(spool.byteSize).toBe(expected.bytes);
+      expect(spool.sha256).toBe(expected.sha256);
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const digest = createHash("sha256");
+        for await (const chunk of spool.open()) {
+          expect(chunk.length).toBeLessThanOrEqual(1024 * 1024);
+          digest.update(chunk);
+        }
+        expect(digest.digest("hex")).toBe(expected.sha256);
+      }
+      expect(ranges.length).toBe(3);
+      expect(
+        ranges.every((range) => range.key === key && range.expectedVersionToken === "v1"),
+      ).toBe(true);
+      expect(ranges.map((range) => [range.start, range.endInclusive])).toEqual([
+        [0, 1048575],
+        [1048576, 2097151],
+        [2097152, 2097168],
+      ]);
+    } finally {
+      await spool.dispose();
+    }
+    await spool.dispose();
+    expect(await stat(dirname(path)).catch(() => null)).toBeNull();
+    await expect(
+      (async () => {
+        for await (const _ of spool.open()) {
+        }
+      })(),
+    ).rejects.toThrow("disposed");
+  });
+
+  test("streams new uploads at the supplied key without taking spool ownership", async () => {
+    const { storage, ranges } = fixture();
+    storage.putObjectStreamIfAbsent = async (input) => {
+      expect(input.key).toBe(key);
+      expect(input.byteSize).toBe(expected.bytes);
+      expect(input.sha256).toBe(expected.sha256);
+      expect(input.contentType).toBe("application/x-tar");
+      const digest = createHash("sha256");
+      for await (const chunk of input.chunks) digest.update(chunk);
+      expect(digest.digest("hex")).toBe(expected.sha256);
+      return true;
+    };
+    await uploadWorkspaceArchiveSpool(storage, key, source());
+    expect(ranges.length).toBe(0);
+  });
+
+  test("verifies existing bytes, not forged SHA metadata", async () => {
+    const { storage, ranges } = fixture();
+    await uploadWorkspaceArchiveSpool(storage, key, source());
+    expect(ranges.length).toBe(3);
+    const corrupt = fixture(new Uint8Array(payload.length));
+    await expect(uploadWorkspaceArchiveSpool(corrupt.storage, key, source())).rejects.toThrow(
+      "digest",
+    );
+  });
+
+  test("rejects a same-length disk spool alteration before fresh upload", async () => {
+    const original = new Uint8Array([1, 2, 3]);
+    const { storage } = fixture(original);
+    const spool = await downloadWorkspaceArchiveSpool(storage, key, {
+      bytes: original.length,
+      sha256: hash(original),
+    });
+    try {
+      await writeFile(spool.path, new Uint8Array([3, 2, 1]));
+      storage.putObjectStreamIfAbsent = async ({ chunks }) => {
+        for await (const _ of chunks) {
+        }
+        return true;
+      };
+      await expect(uploadWorkspaceArchiveSpool(storage, key, spool)).rejects.toMatchObject({
+        code: "archive_hash_mismatch",
+        retryable: false,
+      });
+    } finally {
+      await spool.dispose();
+    }
+  });
+
+  for (const consumption of ["none", "partial", "swallowed-mismatch", "short", "long"] as const) {
+    test(`rejects fresh upload with ${consumption} stream consumption`, async () => {
+      const { storage } = fixture();
+      const spool = source();
+      if (["swallowed-mismatch", "short", "long"].includes(consumption)) {
+        spool.open = async function* () {
+          yield new Uint8Array(
+            consumption === "short"
+              ? 1
+              : consumption === "long"
+                ? payload.length + 1
+                : payload.length,
+          );
+        };
+      }
+      storage.putObjectStreamIfAbsent = async ({ chunks }) => {
+        if (consumption === "none") return true;
+        if (consumption === "partial") {
+          for await (const _ of chunks) {
+            break;
+          }
+          return true;
+        }
+        try {
+          for await (const _ of chunks) {
+          }
+        } catch {
+          /* Simulate a provider swallowing producer failure. */
+        }
+        return true;
+      };
+      await expect(uploadWorkspaceArchiveSpool(storage, key, spool)).rejects.toBeInstanceOf(
+        WorkspaceArchiveStorageError,
+      );
+    });
+  }
+
+  test("snapshots expected download metadata before provider callbacks can mutate it", async () => {
+    const original = new Uint8Array([1, 2, 3]);
+    const corrupt = new Uint8Array([3, 2, 1]);
+    const mutable = { bytes: original.length, sha256: hash(original) };
+    const { storage } = fixture(corrupt);
+    const head = storage.headObject!;
+    storage.headObject = async (objectKey) => {
+      mutable.sha256 = hash(corrupt);
+      return head(objectKey);
+    };
+    const result = await downloadWorkspaceArchiveSpool(storage, key, mutable).catch(
+      (error: unknown) => error,
+    );
+    if (result && typeof result === "object" && "dispose" in result)
+      await (result as { dispose(): Promise<void> }).dispose();
+    expect(result).toMatchObject({ code: "archive_hash_mismatch", retryable: false });
+  });
+
+  test("snapshots expected download metadata before its first await", async () => {
+    const original = new Uint8Array([1, 2, 3]);
+    const mutable = { bytes: original.length, sha256: hash(original) };
+    const { storage } = fixture(original);
+    const pending = downloadWorkspaceArchiveSpool(storage, key, mutable);
+    mutable.bytes = 0;
+    mutable.sha256 = hash(new Uint8Array());
+    const spool = await pending;
+    try {
+      expect(spool.byteSize).toBe(original.length);
+      expect(spool.sha256).toBe(hash(original));
+    } finally {
+      await spool.dispose();
+    }
+  });
+
+  for (const failure of [
+    "missing",
+    "size",
+    "truncated",
+    "oversized",
+    "drift",
+    "final-drift",
+    "final-missing",
+    "final-size",
+    "range-missing",
+    "provider",
+    "digest",
+    "token",
+  ] as const) {
+    test(`rejects ${failure} and cleans partial spools`, async () => {
+      const before = (await readdir(tmpdir())).filter((name) =>
+        name.startsWith("opengeni-workspace-archive-"),
+      );
+      const { storage } = fixture();
+      const head = storage.headObject!;
+      const range = storage.getObjectRange!;
+      let heads = 0;
+      storage.headObject = async () => {
+        const value = await head(key);
+        if (failure === "missing") return null;
+        if (failure === "size") return { ...value, ContentLength: 1 };
+        if (failure === "token") return { ...value, VersionToken: "" };
+        if (failure === "final-drift" && ++heads > 1) return { ...value, VersionToken: "v2" };
+        if (failure === "final-missing" && ++heads > 1) return null;
+        if (failure === "final-size" && ++heads > 1) return { ...value, ContentLength: 1 };
+        return value;
+      };
+      storage.getObjectRange = async (input) => {
+        if (failure === "range-missing") return null;
+        if (failure === "provider") throw new Error("provider failure");
+        const value = (await range(input))!;
+        if (failure === "truncated") value.bytes = value.bytes.slice(1);
+        if (failure === "oversized") value.bytes = new Uint8Array(value.bytes.length + 1);
+        if (failure === "drift") value.versionToken = "v2";
+        if (failure === "digest") value.bytes[0] ^= 1;
+        return value;
+      };
+      const error = await downloadWorkspaceArchiveSpool(storage, key, expected).catch(
+        (failureCause: unknown) => failureCause,
+      );
+      expect(error).toBeInstanceOf(WorkspaceArchiveStorageError);
+      const missing = ["missing", "range-missing", "final-missing"].includes(failure);
+      const retryable = ["drift", "final-drift", "provider"].includes(failure);
+      expect(error).toMatchObject({
+        code: missing
+          ? "archive_base64_invalid"
+          : retryable || failure === "token"
+            ? "archive_hydration_failed"
+            : "archive_hash_mismatch",
+        retryable,
+      });
+      expect(
+        (await readdir(tmpdir())).filter((name) => name.startsWith("opengeni-workspace-archive-")),
+      ).toEqual(before);
+    });
+  }
+
+  test("supports empty objects and validates their digest", async () => {
+    const { storage, ranges } = fixture(new Uint8Array());
+    const spool = await downloadWorkspaceArchiveSpool(storage, key, {
+      bytes: 0,
+      sha256: hash(new Uint8Array()),
+    });
+    await spool.dispose();
+    expect(ranges).toEqual([]);
+    await expect(
+      downloadWorkspaceArchiveSpool(storage, key, { bytes: 0, sha256: expected.sha256 }),
+    ).rejects.toThrow("digest");
+  });
+
+  test("fails explicitly without bounded primitives, before uploading", async () => {
+    for (const primitive of ["headObject", "getObjectRange", "putObjectStreamIfAbsent"] as const) {
+      const { storage } = fixture();
+      delete storage[primitive];
+      await expect(uploadWorkspaceArchiveSpool(storage, key, source())).rejects.toThrow(
+        "unsupported",
+      );
+      await expect(uploadWorkspaceArchiveSpool(storage, key, source())).rejects.toMatchObject({
+        code: "archive_hydration_failed",
+        retryable: false,
+      });
+      if (primitive !== "putObjectStreamIfAbsent") {
+        await expect(downloadWorkspaceArchiveSpool(storage, key, expected)).rejects.toThrow(
+          "unsupported",
+        );
+        await expect(downloadWorkspaceArchiveSpool(storage, key, expected)).rejects.toMatchObject({
+          code: "archive_hydration_failed",
+          retryable: false,
+        });
+      }
+    }
+  });
+
+  test("invalid expected integrity metadata is nonretryable configuration failure", async () => {
+    for (const invalid of [
+      { bytes: -1, sha256: expected.sha256 },
+      { bytes: 1, sha256: "invalid" },
+    ]) {
+      const { storage } = fixture();
+      await expect(downloadWorkspaceArchiveSpool(storage, key, invalid)).rejects.toMatchObject({
+        code: "archive_hydration_failed",
+        retryable: false,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Linux host-backed Local/Docker workspace snapshots currently retain file buffers and base64 values, stringify the entire SDK v1 archive, and materialize additional whole-body buffers for publication and restoration. Large workspaces can fail capture before publication, leaving the existing recovery fence correctly closed but unable to make progress.

This change preserves the SDK-produced v1 JSON format while spooling capture, object publication, and cold restoration through bounded chunks. It covers warm snapshots, lease drains, worker restoration, and API/viewer rematerialization. Provider identity, capture takeover, publication, and teardown authority are unchanged.

## Integrity and lifecycle

- Verify source/captured/restored fingerprints; retain canonical SDK-produced archive compatibility.
- Allocate a fresh physical upload UUID for each invocation, hash/count the outgoing stream, and verify actual stored bytes through version-pinned range reads. Do not depend on conditional PUT support.
- Bind publication locators to scope, revision, hash, and size. Delete only a fresh candidate explicitly reported unused by its sole publication transaction; retain objects after ambiguous database outcomes and retain displaced objects without retirement proof.
- Pin expected integrity metadata before asynchronous work. Validate archive structure, paths, filename component sizes, base64, and configured limits before destination mutation.
- Download and validate object integrity before creating a replacement provider; preserve existing missing/corrupt-object failure classification.
- Own private spool cleanup through publication/restore, including failure paths. Capture/publication failure never authorizes provider deletion or recovery-fence removal.

## Verification

- Isolated Garage 2.3.0: 16 checks, zero failures/skips (15 acceptance cases plus the conditional-PUT incompatibility diagnostic). Includes unique concurrent uploads, mandatory pinned readback, wrong-digest/short/interrupted producer settlement, corruption rejection, retained objects, and candidate cleanup. Small-fixture transport evidence is separate from real database and large-memory tests.
- Red/green regressions: whole-payload publication access; allocation churn (96 large buffer copies to zero); changed upload bytes; incomplete/swallowed producer errors; mutable integrity expectations; overlong filenames rejected before destination cleanup.
- Final focused codec/storage/worker roundtrip suite: 69 tests / 958 assertions. Storage adapter producer-error correction separately demonstrated five red regressions before passing.
- Contracts: 576 tests pass. Database publication suite: 89 tests / 663 assertions, including 19 new locator-binding and candidate-disposition cases.
- 124 broader provider/lifecycle tests / 624 assertions.
- Disposable PostgreSQL 17 + pgvector with real migrations, grants, and RLS: 59 exercised lease tests / 620 assertions (gated live-Modal test not exercised); API restore 5 tests / 50 assertions; worker restore 22 tests / 110 assertions.
- Runtime, storage, contracts, database, worker, and API typechecks; changed-file lint and formatting pass.
- Opt-in full roundtrip: three 512 MiB source files, 2,147,483,860-byte archive, exact restored file hashes and 4,114 assertions. Peak RSS 643,149,824 bytes; RSS growth 300,900,352 bytes; peak VM heap capacity 168,006,656 bytes. Capture raw heap, VM heap capacity, and total RSS budgets pass without forced GC. Raw Bun heapUsed is recorded diagnostically because its external-allocation accounting can exceed both heapTotal and RSS.

Large test: `OPENGENI_TEST_LARGE_WORKSPACE_ARCHIVE=1 bun test apps/worker/test/workspace-archive-spool-roundtrip.test.ts`.

## Limits and rollout

Requires Linux descriptor-relative filesystem access plus storage streaming upload and versioned head/range reads. Unsupported storage fails explicitly. Isolated Garage 2.3.0 testing showed conditional PUT can overwrite existing keys, so this archive path deliberately uses unique keys and unconditional upload with mandatory readback. Other pre-existing conditional-upload consumers are outside this correction. Non-Linux, no-object-storage inline, and remote-provider protocols keep their existing compatibility paths; those paths do not gain this memory guarantee. Metadata scales with member count and spooling needs temporary disk capacity. Displaced and ambiguously published objects are retained; this change does not implement safe garbage collection.

The reader supports canonical SDK-produced archives, not all malformed base64 forms tolerated by the SDK reader. Restore requires an exclusively owned, unpublished destination with trusted ancestors; descriptor-relative access does not prevent an external actor moving an already-open directory. Restore is not transactional against subsequent disk I/O failure.

No production deployment or live provider recovery has been performed. New readers accept legacy and UUID-suffixed locators; old readers reject the suffix. Deploy compatible API/readers before activating new worker writers, and retain compatible readers during rollback. API and worker should consume the matched release when deploying the new restore path.