### PR TITLE
fix(runtime): make advertised repository skills readable

### DIFF
--- a/.changeset/repository-skill-reading.md
+++ b/.changeset/repository-skill-reading.md
@@ -2,4 +2,4 @@
 "@opengeni/runtime": patch
 ---
 
-Read repository Skill descriptions as YAML and advertise exact source-qualified identifiers with a live repository reader. Preserve sandbox-free managed Skill reading and sandbox attempt authorization.
+Read repository Skill descriptions as YAML and advertise exact source-qualified identifiers with a live repository reader. Preserve sandbox-free managed Skill reading and sandbox attempt authorization. Valid multiline YAML descriptions retain their text; symlink entrypoints are excluded consistently with repository reads.

--- a/.changeset/repository-skill-reading.md
+++ b/.changeset/repository-skill-reading.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Read repository Skill descriptions as YAML and advertise exact source-qualified identifiers with a live repository reader. Preserve sandbox-free managed Skill reading and sandbox attempt authorization.

--- a/apps/worker/test/skill-read.test.ts
+++ b/apps/worker/test/skill-read.test.ts
@@ -1,3 +1,6 @@
+import { buildOpenGeniAgent } from "@opengeni/runtime";
+import { testSettings } from "@opengeni/testing";
+import { Capability, Manifest, type SandboxSessionLike } from "@openai/agents/sandbox";
 import { describe, expect, test } from "bun:test";
 import { createAttemptToolEnvironment } from "@opengeni/codemode";
 import { createSkillReadAttemptToolDefinition } from "../src/activities/agent-turn/skill-read";
@@ -13,6 +16,120 @@ const scope = {
 };
 
 describe("skill_read gateway definition", () => {
+  test("worker host catalog coexists with exact repository reader for real OpenGeni skills", async () => {
+    const names = ["opengeni", "opengeni-client"];
+    const markdown = new Map(
+      await Promise.all(
+        names.map(
+          async (name) =>
+            [
+              name,
+              await Bun.file(
+                new URL(`../../../.agents/skills/${name}/SKILL.md`, import.meta.url),
+              ).text(),
+            ] as const,
+        ),
+      ),
+    );
+    let allowed = true;
+    const authorize = async () => {
+      if (!allowed) throw new Error("attempt ended");
+    };
+    const managedReader = createSkillReadAttemptToolDefinition({
+      authorize,
+      load: async (skill) => {
+        if (skill !== "session:opengeni" && skill !== "opengeni")
+          throw new Error("Skill is not available in this session.");
+        return [{ path: "SKILL.md", content: "Selected session guidance" }];
+      },
+    });
+    const settings = testSettings({ sandboxBackend: "docker" });
+    const agent = buildOpenGeniAgent(
+      settings,
+      [
+        {
+          kind: "repository",
+          uri: "https://github.com/Cloudgeni-ai/opengeni.git",
+          ref: "main",
+          mountPath: "repos/opengeni",
+        },
+      ],
+      {
+        skillCatalog: [
+          {
+            id: "session:opengeni",
+            name: "opengeni",
+            description: "Explicitly selected session guidance",
+          },
+        ],
+        authorizeAttemptExecution: authorize,
+      },
+    );
+    const session = {
+      state: { manifest: new Manifest({ root: "/workspace" }) },
+      listDir: async ({ path }: { path: string }) =>
+        path === ".agents/skills"
+          ? names.map((name) => ({ name, path: `${path}/${name}`, type: "dir" as const }))
+          : [{ name: "SKILL.md", path: `${path}/SKILL.md`, type: "file" as const }],
+      readFile: async ({ path }: { path: string }) => markdown.get(path.split("/").at(-2)!)!,
+    } as SandboxSessionLike;
+    const capability = (agent as unknown as { capabilities: Capability[] }).capabilities
+      .find((entry) => entry.type === "workspace-skills")!
+      .clone()
+      .bind(session);
+    const catalog = await capability.instructions(session.state.manifest);
+    const repositoryReader = capability
+      .tools()
+      .find((entry) => entry.type === "function" && entry.name === "repository_skill_read")!;
+    if (repositoryReader.type !== "function") throw new Error("missing repository reader");
+    const environment = createAttemptToolEnvironment({
+      scope,
+      generation: 1,
+      definitions: [managedReader],
+    });
+    // This is the incident's old route, and remains correctly unavailable to the managed reader.
+    await expect(
+      environment.callModel({
+        modelName: "skill_read",
+        arguments: { skill: "opengeni-client" },
+        subjectId: "agent:test",
+      }),
+    ).rejects.toThrow("not available");
+    for (const name of names) {
+      const skill = `repository:.agents/skills/${name}/SKILL.md`;
+      expect(catalog).toContain(skill);
+      expect(catalog).toContain('"reader":"repository_skill_read"');
+      const output = JSON.parse(
+        (await repositoryReader.invoke(undefined!, JSON.stringify({ skill }))) as string,
+      );
+      expect(output.files).toEqual([{ path: "SKILL.md", content: markdown.get(name) }]);
+    }
+    expect(catalog).not.toContain('"description":">-"');
+    const managed = await environment.callModel({
+      modelName: "skill_read",
+      arguments: { skill: "opengeni" },
+      subjectId: "agent:test",
+    });
+    expect(managed.structuredContent).toEqual({
+      files: [{ path: "SKILL.md", content: "Selected session guidance" }],
+    });
+    allowed = false;
+    await expect(
+      repositoryReader.invoke(
+        undefined!,
+        JSON.stringify({ skill: "repository:.agents/skills/opengeni/SKILL.md" }),
+      ),
+    ).rejects.toThrow("attempt ended");
+    const noSandbox = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      skillCatalog: [],
+    });
+    expect(
+      noSandbox.tools.some(
+        (entry) => entry.type === "function" && entry.name === "repository_skill_read",
+      ),
+    ).toBe(false);
+  });
+
   test("selected Projects reads exact packaged guidance without sandbox access; host [] excludes it", async () => {
     const markdown = await Bun.file(
       new URL(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -870,16 +870,18 @@ fences. Approval-required tools remain approval-required regardless of access
 path.
 
 The closed always-visible local first-request set is `exec_command`,
-`write_stdin`, `apply_patch`, `view_image`, `skill_read`,
+`write_stdin`, `apply_patch`, `view_image`, `skill_read`, `repository_skill_read`,
 `request_human_input`, and `list_models`. The last tool returns the current
 workspace's selectable model IDs and deployment-defined costs; it does not
 switch the session model. Other non-MCP function tools and non-eager MCP schemas
 remain behind progressive search.
 
+Repository descriptors route IDs through sandbox-bound `repository_skill_read`;
+managed `skill_read` remains separate. See [run lifecycle](run-lifecycle.md).
+
 Repository `.agents/skills` contains only maintainer (`opengeni`) and external
-integration (`opengeni-client`) guidance. Runtime skills are authored directly in
-`packages/runtime/src/bundled_*_skills`; these directories are authoritative and
-shipped as runtime assets, without repository-agent copies or a synchronization step.
+integration (`opengeni-client`) guidance. Runtime skills live in
+`packages/runtime/src/bundled_*_skills`, shipped without repository-agent copies.
 
 Sandbox-free reading, lazy management, and host selection: [Skill design](design/skills-system.md).
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -869,7 +869,14 @@ their existing checkout available; runtime then indexes canonical
 `.agents/skills` and compatible `.claude/skills` directories through the bound
 sandbox session before the first model call. This performs no second clone,
 copy, or manifest materialization. With no repository resource, that workspace
-discovery capability is absent and cannot force provisioning.
+discovery capability is absent and cannot force provisioning. Repository descriptors
+carry an exact `repository:` identifier and `repository_skill_read` reader; that
+sandbox capability reads current files in place, including referenced text and
+bounded file inventories. Configured `skill_read` stays sandbox-free and does
+not resolve repository names. Identifiers cannot silently switch between these
+sources, even when names match. Repository metadata uses the same YAML parser as
+portable Skills. The repository index is fixed for the bound capability; reads
+observe live edits or report missing files, and rebinding refreshes discovery.
 
 Host-owned rotating sandbox run credentials split resolution from sandbox
 materialization when lazy provisioning is enabled. The worker binds and resolves

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -875,7 +875,10 @@ sandbox capability reads current files in place, including referenced text and
 bounded file inventories. Configured `skill_read` stays sandbox-free and does
 not resolve repository names. Identifiers cannot silently switch between these
 sources, even when names match. Repository metadata uses the same YAML parser as
-portable Skills. The repository index is fixed for the bound capability; reads
+portable Skills, retaining multiline description text in the JSON descriptor.
+Discovery, inventories, and reading accept ordinary files and directories;
+symlink Skill entrypoints are excluded because portable filesystem APIs cannot
+prove target containment. The repository index is fixed for the bound capability; reads
 observe live edits or report missing files, and rebinding refreshes discovery.
 
 Host-owned rotating sandbox run credentials split resolution from sandbox

--- a/packages/runtime/src/lazy-tool-transport.ts
+++ b/packages/runtime/src/lazy-tool-transport.ts
@@ -33,6 +33,8 @@ const ALWAYS_VISIBLE_BASE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "apply_patch",
   // The server-backed reader needs neither sandbox setup nor tool search.
   "skill_read",
+  // Repository descriptors route to the live sandbox reader.
+  "repository_skill_read",
   "request_human_input",
   "list_models",
 ]);

--- a/packages/runtime/src/workspace-skills.ts
+++ b/packages/runtime/src/workspace-skills.ts
@@ -247,6 +247,18 @@ async function discoverWorkspaceSkillsUnmeasured(
       const skillMarkdownPath = joinWorkspacePath(entry.path, SKILL_FILE);
       let markdown: string;
       try {
+        // Match reader/inventory eligibility: symlink entrypoints are not
+        // advertised because the portable filesystem API cannot prove containment.
+        const skillEntries = await session.listDir({
+          path: entry.path,
+          ...(runAs ? { runAs } : {}),
+        });
+        if (
+          !skillEntries.some(
+            (candidate) => candidate.name === SKILL_FILE && candidate.type === "file",
+          )
+        )
+          continue;
         const content = await session.readFile({
           path: skillMarkdownPath,
           ...(runAs ? { runAs } : {}),
@@ -264,7 +276,7 @@ async function discoverWorkspaceSkillsUnmeasured(
       const key = name.toLowerCase();
       if (shadowedNames.has(key)) continue;
       const description = frontmatter.description?.trim() || "No description provided.";
-      if (description.length > 2_048 || /[\r\n]/.test(description)) {
+      if (description.length > 2_048) {
         throw new Error(`Repository skill "${name}" has an invalid description`);
       }
       if (reservedNames.has(key)) {

--- a/packages/runtime/src/workspace-skills.ts
+++ b/packages/runtime/src/workspace-skills.ts
@@ -1,4 +1,16 @@
 import { createHash } from "node:crypto";
+import { tool, type Tool } from "@openai/agents";
+import { parseSkillFrontmatter } from "@opengeni/contracts";
+import { z } from "zod";
+import {
+  assertSkillRelativePath,
+  listSkillPaths,
+  readSkillFiles,
+  SkillFileError,
+  SKILL_READ_MAX_PATHS,
+  SKILL_READ_MAX_OUTPUT_BYTES,
+  type SkillTextFile,
+} from "./skill-files";
 
 import {
   Capability,
@@ -64,24 +76,94 @@ export class WorkspaceSkillsCapability extends Capability {
     super();
   }
 
-  override async instructions(): Promise<string | null> {
+  override bind(session: SandboxSessionLike): this {
+    if (this._session !== session) delete this.discovery;
+    return super.bind(session);
+  }
+
+  private discover(): Promise<readonly WorkspaceSkill[]> {
     const session = requireWorkspaceSkillSession(this._session);
-    this.discovery ??= discoverWorkspaceSkills(
+    return (this.discovery ??= discoverWorkspaceSkills(
       session,
       this.searchPaths,
       this.reservedNames,
       this._runAs,
       this.shadowedNames,
-    );
-    const skills = await this.discovery;
+    ));
+  }
+
+  override tools(): Tool<unknown>[] {
+    return [
+      tool({
+        name: "repository_skill_read",
+        description:
+          "Read current repository Skill files from the bound workspace. Use the exact repository: identifier from the Repository skills index. Omit paths for SKILL.md; explicit relative paths read only those files. Set listFiles:true without paths for a bounded file inventory. This reads live files through the sandbox, including Connected Machines.",
+        parameters: z.object({
+          skill: z.string().min(1),
+          paths: z.array(z.string().min(1).max(1024)).min(1).max(SKILL_READ_MAX_PATHS).optional(),
+          listFiles: z.boolean().optional(),
+        }),
+        execute: async (request) => {
+          if (request.listFiles && request.paths !== undefined)
+            throw new SkillFileError(
+              "invalid_request",
+              "listFiles:true cannot be combined with paths.",
+            );
+          const skill = (await this.discover()).find(
+            (entry) => repositorySkillId(entry) === request.skill,
+          );
+          if (!skill)
+            throw new SkillFileError(
+              "missing_file",
+              "Repository Skill is not in this index. Use its exact repository: identifier.",
+            );
+          const session = requireWorkspaceSkillSession(this._session);
+          const root = skill.path.slice(0, -SKILL_FILE.length - 1);
+          const result = request.listFiles
+            ? listSkillPaths(
+                await repositorySkillInventory(session, root, this._runAs),
+                MAX_SKILL_ENTRIES,
+              )
+            : readSkillFiles(
+                await repositorySkillFiles(
+                  session,
+                  root,
+                  request.paths ?? [SKILL_FILE],
+                  this._runAs,
+                ),
+                request.paths,
+              );
+          const output = JSON.stringify({
+            skillId: request.skill,
+            source: "repository",
+            root,
+            ...result,
+          });
+          if (new TextEncoder().encode(output).byteLength > SKILL_READ_MAX_OUTPUT_BYTES) {
+            throw new SkillFileError(
+              "output_too_large",
+              "Repository Skill response exceeds the read output limit. Request fewer paths.",
+            );
+          }
+          return output;
+        },
+      }),
+    ];
+  }
+
+  override async instructions(): Promise<string | null> {
+    const skills = await this.discover();
     if (skills.length === 0) return null;
 
     const available = skills
-      .map((skill) => `- ${skill.name}: ${skill.description} (file: ${skill.path})`)
+      .map(
+        (skill) =>
+          `- ${JSON.stringify({ id: repositorySkillId(skill), name: skill.name, description: skill.description, reader: "repository_skill_read", path: skill.path })}`,
+      )
       .join("\n");
     return `## Repository skills
 
-Repository skills are instructions already present in the live workspace. They do not need to be loaded or copied.
+Repository skills are instructions already present in the live workspace. Read them with repository_skill_read using the exact repository: id below. The reader returns current live files; ordinary filesystem tools execute referenced scripts and read binary assets. Configured Skills use their separate skill_read index.
 
 ### Available repository skills
 ${available}
@@ -267,34 +349,80 @@ async function fingerprintWorkspaceDirectory(
   return hash.digest("hex");
 }
 
-function parseSkillFrontmatter(markdown: string): {
-  name?: string;
-  description?: string;
-} {
-  const lines = markdown.split(/\r?\n/);
-  if (lines[0]?.trim() !== "---") return {};
-  const end = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
-  if (end === -1) return {};
-  const values: Record<string, string> = {};
-  for (const line of lines.slice(1, end)) {
-    const separator = line.indexOf(":");
-    if (separator === -1) continue;
-    const key = line.slice(0, separator).trim();
-    if (key !== "name" && key !== "description") continue;
-    values[key] = unquote(line.slice(separator + 1).trim());
-  }
-  return values;
+function repositorySkillId(skill: WorkspaceSkill): string {
+  return `repository:${skill.path}`;
 }
 
-function unquote(value: string): string {
-  if (
-    value.length >= 2 &&
-    value[0] === value[value.length - 1] &&
-    (value[0] === '"' || value[0] === "'")
-  ) {
-    return value.slice(1, -1);
+/** Resolve only ordinary directory entries under the discovered Skill root.
+ * Never treat a caller identifier as a path or follow a listed symlink. The
+ * bound sandbox remains the filesystem authority, including concurrent edits.
+ */
+async function repositorySkillFiles(
+  session: SandboxSessionLike,
+  root: string,
+  paths: readonly string[],
+  runAs?: string,
+): Promise<SkillTextFile[]> {
+  // Validate the entire request before touching the filesystem.
+  readSkillFiles(
+    paths.map((path) => ({ path, content: "" })),
+    paths,
+  );
+  const files: SkillTextFile[] = [];
+  for (const path of paths) {
+    let directory = root;
+    const segments = path.split("/");
+    for (const [index, name] of segments.entries()) {
+      const entries = await session.listDir!({ path: directory, ...(runAs ? { runAs } : {}) });
+      const entry = entries.find((candidate) => candidate.name === name);
+      const expected = index === segments.length - 1 ? "file" : "dir";
+      if (entry?.type !== expected)
+        throw new SkillFileError("missing_file", `Repository Skill file is unavailable: ${path}`);
+      directory = joinWorkspacePath(directory, name);
+    }
+    const content = await session.readFile!({ path: directory, ...(runAs ? { runAs } : {}) });
+    files.push({
+      path,
+      content:
+        typeof content === "string"
+          ? content
+          : new TextDecoder("utf-8", { fatal: true }).decode(content),
+    });
+    // Bound aggregate output as each file arrives; do not truncate accepted text.
+    readSkillFiles(
+      files,
+      files.map((file) => file.path),
+    );
   }
-  return value;
+  return files;
+}
+
+async function repositorySkillInventory(
+  session: SandboxSessionLike,
+  root: string,
+  runAs?: string,
+): Promise<SkillTextFile[]> {
+  const files: SkillTextFile[] = [];
+  let count = 0;
+  async function visit(relative: string): Promise<void> {
+    const entries = await session.listDir!({
+      path: relative ? joinWorkspacePath(root, relative) : root,
+      ...(runAs ? { runAs } : {}),
+    });
+    for (const entry of entries) {
+      if (++count > MAX_SKILL_ENTRIES)
+        throw new SkillFileError("output_too_large", "Repository Skill inventory is too large.");
+      // Paths derive from validated names, never provider-returned absolute paths.
+      assertSkillRelativePath(entry.name);
+      if (entry.name.includes("/"))
+        throw new SkillFileError("invalid_path", "Invalid repository directory entry.");
+      const path = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.type === "dir") await visit(path);
+      else if (entry.type === "file") files.push({ path, content: "" });
+    }
+  }
+  await visit("");
+  return files;
 }
 
 function joinWorkspacePath(parent: string, child: string): string {

--- a/packages/runtime/test/lazy-tool-transport.test.ts
+++ b/packages/runtime/test/lazy-tool-transport.test.ts
@@ -933,12 +933,42 @@ describe("generic lazy tool dispatch", () => {
     ).toEqual(["interaction__browser_act"]);
   });
 
+  test("repository reader stays directly callable across every transport", async () => {
+    for (const transport of ["codex_native", "openai_native", "generic_dispatch"] as const) {
+      const reader = firstPartyTool("repository_skill_read", "Read live repository guidance");
+      const agent = new Agent({
+        name: "repository-skills",
+        instructions: "Read repository guidance.",
+        model: "scripted",
+        tools: [reader],
+      });
+      const runtime = installLazyToolRuntime(agent, transport, new Set());
+      const visible = await agent.getAllTools(undefined as never);
+      const inner = new CapturingModel();
+      const wrapped = await new LazyToolModelProvider(providerFor(inner), runtime).getModel("test");
+      await wrapped.getResponse(baseRequest(visible.map(serializedFunction)));
+      expect(inner.requests[0]!.tools.map((candidate) => candidate.name)).toContain(
+        "repository_skill_read",
+      );
+      expect(
+        visible.some(
+          (candidate) =>
+            candidate.type === "function" && candidate.name === "repository_skill_read",
+        ),
+      ).toBe(true);
+    }
+  });
+
   test("keeps the always-visible base set in the first request and out of search", async () => {
     const exec = firstPartyTool("exec_command", "Run a shell command in the sandbox");
     const stdin = firstPartyTool("write_stdin", "Write to a running command's stdin");
     const image = firstPartyTool("view_image", "Return an image from a sandbox path");
     const patch = firstPartyTool("apply_patch", "Apply a create, update, or delete file patch");
     const skillRead = firstPartyTool("skill_read", "Read Skill text without a sandbox");
+    const repositoryRead = firstPartyTool(
+      "repository_skill_read",
+      "Read live repository Skill files",
+    );
     const skillSave = firstPartyTool("skill_save", "Save workspace Skill file changes");
     const human = firstPartyTool(
       "request_human_input",
@@ -953,7 +983,18 @@ describe("generic lazy tool dispatch", () => {
       name: "lazy-test",
       instructions: "Use tools.",
       model: "scripted",
-      tools: [exec, stdin, image, patch, skillRead, skillSave, human, models, browser],
+      tools: [
+        exec,
+        stdin,
+        image,
+        patch,
+        skillRead,
+        repositoryRead,
+        skillSave,
+        human,
+        models,
+        browser,
+      ],
     });
     const runtime = installLazyToolRuntime(agent, "generic_dispatch", new Set());
     const visible = await agent.getAllTools(undefined as never);
@@ -968,6 +1009,7 @@ describe("generic lazy tool dispatch", () => {
       "view_image",
       "apply_patch",
       "skill_read",
+      "repository_skill_read",
       "request_human_input",
       "list_models",
       "tool_search",
@@ -980,6 +1022,7 @@ describe("generic lazy tool dispatch", () => {
       "view_image",
       "apply_patch",
       "skill_read",
+      "repository_skill_read",
       "request_human_input",
       "list_models",
     ]) {

--- a/packages/runtime/test/workspace-skills.test.ts
+++ b/packages/runtime/test/workspace-skills.test.ts
@@ -15,9 +15,138 @@ import {
   recordModelPreparationMeasurement,
   withModelPreparationObserver,
 } from "../src/model-preparation-diagnostics";
-import { discoverWorkspaceSkills } from "../src/workspace-skills";
+import { discoverWorkspaceSkills, workspaceSkills } from "../src/workspace-skills";
 
 describe("workspace repository skills", () => {
+  test("repository YAML descriptions preserve folded text", async () => {
+    const session = fakeSession({
+      ".agents/skills/opengeni/SKILL.md":
+        "---\nname: opengeni\ndescription: >-\n  Maintain OpenGeni\n  source code.\n---\n# Guidance",
+    });
+    const entries = await discoverWorkspaceSkills(session, [
+      { path: ".agents/skills", source: "repository" },
+    ]);
+    expect(entries[0]?.description).toBe("Maintain OpenGeni source code.");
+  });
+
+  test("advertised repository skills have an explicit live reader", async () => {
+    const session = fakeSession({
+      ".agents/skills/opengeni/SKILL.md":
+        "---\nname: opengeni\ndescription: Maintain OpenGeni.\n---\n# Guidance",
+    });
+    const capability = workspaceSkills([{ path: ".agents/skills", source: "repository" }]).bind(
+      session,
+    );
+    const instructions = await capability.instructions();
+    expect(instructions).toContain("repository_skill_read");
+    const tool = capability
+      .tools()
+      .find(
+        (candidate) => candidate.type === "function" && candidate.name === "repository_skill_read",
+      );
+    expect(tool).toBeDefined();
+    if (tool?.type !== "function") throw new Error("missing reader");
+    const result = JSON.parse(
+      (await tool.invoke(
+        undefined!,
+        JSON.stringify({ skill: "repository:.agents/skills/opengeni/SKILL.md" }),
+      )) as string,
+    );
+    expect(result.files[0].content).toContain("# Guidance");
+  });
+
+  test("repository reader uses exact paths, reads live content, and inventories without file bodies", async () => {
+    const session = fakeSession({
+      ".agents/skills/example/SKILL.md": "# Example",
+      ".agents/skills/example/references/readme.md": "original",
+    });
+    const capability = workspaceSkills([{ path: ".agents/skills", source: "repository" }])
+      .bind(session)
+      .bindRunAs("agent");
+    await capability.instructions();
+    const read = session.readFile!;
+    const calls: string[] = [];
+    session.readFile = async (args) => {
+      expect(args.runAs).toBe("agent");
+      calls.push(args.path);
+      return args.path.endsWith("readme.md") ? "edited" : read(args);
+    };
+    const tool = capability.tools()[0]!;
+    if (tool.type !== "function") throw new Error("missing reader");
+    const skill = "repository:.agents/skills/example/SKILL.md";
+    const invoke = (args: object) => tool.invoke(undefined!, JSON.stringify({ skill, ...args }));
+    expect(JSON.parse((await invoke({ listFiles: true })) as string).paths).toEqual([
+      "SKILL.md",
+      "references/readme.md",
+    ]);
+    expect(calls).toEqual([]);
+    expect(JSON.parse((await invoke({ paths: ["references/readme.md"] })) as string).files).toEqual(
+      [{ path: "references/readme.md", content: "edited" }],
+    );
+    expect(calls).toEqual([".agents/skills/example/references/readme.md"]);
+    for (const args of [
+      { paths: ["../outside"] },
+      { paths: ["/etc/passwd"] },
+      { paths: ["SKILL.md", "SKILL.md"] },
+      { listFiles: true, paths: ["SKILL.md"] },
+      { skill: "example" },
+      { skill: "repository:other/SKILL.md" },
+    ]) {
+      expect(await invoke(args)).toContain("Error");
+    }
+    expect(calls).toHaveLength(1);
+    session.readFile = async () => "x".repeat(512 * 1024);
+    expect(await invoke({})).toContain("exceed");
+    // Inner file output fits exactly, but source metadata must also fit the final envelope.
+    const overhead = JSON.stringify({ files: [{ path: "SKILL.md", content: "" }] }).length;
+    session.readFile = async () => "x".repeat(512 * 1024 - overhead);
+    expect(await invoke({})).toContain("response exceeds");
+    session.listDir = async () => [];
+    expect(await invoke({})).toContain("unavailable");
+  });
+
+  test("repository tool authorization survives SDK clone and bind", async () => {
+    let authorized = true;
+    const caps = buildAgentCapabilities(testSettings(), [], {
+      workspaceSkillPaths: [{ path: ".agents/skills", source: "repository" }],
+      authorizeAttemptExecution: () => {
+        if (!authorized) throw new Error("attempt ended");
+      },
+      structuredToolTransport: false,
+    });
+    const original = caps.find((entry) => entry.type === "workspace-skills")!;
+    const bound = original
+      .clone()
+      .bind(fakeSession({ ".agents/skills/example/SKILL.md": "# Example" }));
+    const tool = bound
+      .tools()
+      .find((entry) => entry.type === "function" && entry.name === "repository_skill_read")!;
+    if (tool.type !== "function") throw new Error("missing reader");
+    await bound.instructions(new Manifest({ root: "/workspace" }));
+    expect(
+      await tool.invoke(
+        undefined!,
+        JSON.stringify({ skill: "repository:.agents/skills/example/SKILL.md" }),
+      ),
+    ).toContain("# Example");
+    authorized = false;
+    await expect(
+      tool.invoke(
+        undefined!,
+        JSON.stringify({ skill: "repository:.agents/skills/example/SKILL.md" }),
+      ),
+    ).rejects.toThrow("attempt ended");
+  });
+
+  test("rebound repository capability cannot reuse another sandbox's catalog", async () => {
+    const capability = workspaceSkills([{ path: ".agents/skills", source: "repository" }]).bind(
+      fakeSession({ ".agents/skills/example/SKILL.md": "# Example" }),
+    );
+    expect(await capability.instructions()).toContain("example");
+    const rebound = capability.clone().bind(fakeSession({}));
+    expect(await rebound.instructions(new Manifest({ root: "/workspace" }))).toBeNull();
+  });
+
   for (const Missing of [SandboxFilesystemNotFoundError, SandboxWorkspaceReadNotFoundError]) {
     test(`skips optional roots and SKILL.md with real ${Missing.name}`, async () => {
       const session = fakeSession({ ".agents/skills/example/SKILL.md": "# Example" });

--- a/packages/runtime/test/workspace-skills.test.ts
+++ b/packages/runtime/test/workspace-skills.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { UnixLocalSandboxClient } from "@openai/agents/sandbox/local";
 
 import {
   Manifest,
@@ -18,6 +21,79 @@ import {
 import { discoverWorkspaceSkills, workspaceSkills } from "../src/workspace-skills";
 
 describe("workspace repository skills", () => {
+  for (const [description, expected] of [
+    ["|-\n  First line.\n  Second line.", "First line.\nSecond line."],
+    [">-\n  First paragraph.\n\n  Second paragraph.", "First paragraph.\nSecond paragraph."],
+  ]) {
+    test(`capability preparation accepts multiline YAML ${description!.slice(0, 2)}`, async () => {
+      const markdown = `---\nname: example\ndescription: ${description}\n---\n# Guidance`;
+      const capability = workspaceSkills([{ path: ".agents/skills", source: "repository" }]).bind(
+        fakeSession({ ".agents/skills/example/SKILL.md": markdown }),
+      );
+      const instructions = await capability.instructions();
+      const descriptor = JSON.parse(
+        instructions!
+          .split("\n")
+          .find((line) => line.startsWith("- {"))!
+          .slice(2),
+      );
+      expect(descriptor.description).toBe(expected);
+      const reader = capability.tools()[0]!;
+      if (reader.type !== "function") throw new Error("missing reader");
+      const output = JSON.parse(
+        (await reader.invoke(undefined!, JSON.stringify({ skill: descriptor.id }))) as string,
+      );
+      expect(output.files[0].content).toBe(markdown);
+    });
+  }
+
+  test.skipIf(process.platform === "win32")(
+    "Unix-local discovery excludes symlink Skill entrypoints consistently with reading",
+    async () => {
+      const session = await new UnixLocalSandboxClient().create(
+        new Manifest({ root: "/workspace" }),
+      );
+      try {
+        const root = session.state.workspaceRootPath;
+        for (const name of ["ordinary", "linked"])
+          await mkdir(join(root, ".agents/skills", name), { recursive: true });
+        const markdown = "---\nname: linked\ndescription: Linked guidance.\n---\n# Linked";
+        await writeFile(join(root, "shared-skill.md"), markdown);
+        await symlink("../../../shared-skill.md", join(root, ".agents/skills/linked/SKILL.md"));
+        await writeFile(join(root, ".agents/skills/ordinary/SKILL.md"), "# Ordinary");
+        await symlink(
+          "../../../shared-skill.md",
+          join(root, ".agents/skills/ordinary/reference.md"),
+        );
+        // Actual adapter behavior: direct reads follow the symlink, listing marks it other.
+        expect(
+          new TextDecoder().decode(
+            await session.readFile({ path: ".agents/skills/linked/SKILL.md" }),
+          ),
+        ).toBe(markdown);
+        expect((await session.listDir({ path: ".agents/skills/linked" }))[0]?.type).toBe("other");
+        const capability = workspaceSkills([{ path: ".agents/skills", source: "repository" }]).bind(
+          session,
+        );
+        const instructions = await capability.instructions();
+        expect(instructions).not.toContain('"name":"linked"');
+        expect(instructions).toContain('"name":"ordinary"');
+        const reader = capability.tools()[0]!;
+        if (reader.type !== "function") throw new Error("missing reader");
+        const call = (args: object) =>
+          reader.invoke(
+            undefined!,
+            JSON.stringify({ skill: "repository:.agents/skills/ordinary/SKILL.md", ...args }),
+          );
+        expect(JSON.parse((await call({ listFiles: true })) as string).paths).toEqual(["SKILL.md"]);
+        expect(JSON.parse((await call({})) as string).files[0].content).toBe("# Ordinary");
+        expect(await call({ paths: ["reference.md"] })).toContain("unavailable");
+      } finally {
+        await session.delete();
+      }
+    },
+  );
+
   test("repository YAML descriptions preserve folded text", async () => {
     const session = fakeSession({
       ".agents/skills/opengeni/SKILL.md":
@@ -386,7 +462,7 @@ description: Prepare a safe release.
       { path: ".agents/skills", source: ".agents/skills" },
     ]);
     expect(skills.map((entry) => entry.name)).toEqual(["deploy", "release"]);
-    expect(listed).toEqual([".agents/skills"]);
+    expect(listed).toEqual([".agents/skills", ".agents/skills/deploy", ".agents/skills/release"]);
     expect(reads).toEqual([".agents/skills/deploy/SKILL.md", ".agents/skills/release/SKILL.md"]);
   });
 


### PR DESCRIPTION
Repository Skills were advertised with file paths while the eager `skill_read` only resolved configured/managed Skills. In the reported session, `skill_read("opengeni-client")` therefore returned “Skill is not available in this session.” Repository metadata also interpreted folded YAML `description: >-` as the literal `>-`.

This change gives repository descriptors an exact `repository:` identifier and an eager `repository_skill_read` capability, sharing discovery through the bound sandbox. It reads current files and referenced text, returns bounded inventories, preserves attempt authorization and run-as identity, and never falls back to a managed Skill with the same name. Managed `skill_read` remains sandbox-free with its existing revision and authorization lifecycle. Repository files remain in place; no registry, installation, or snapshot is introduced. Metadata now uses the canonical YAML parser.

Validation:
- Reproduced folded-description and missing-reader regressions on base `5ef34cf500` before implementation.
- 94 focused tests pass: worker host-catalog construction with an attached repository and the actual `opengeni`/`opengeni-client` Skill files, same-name managed/repository routing, exact paths, live edits and missing files, run-as/attempt denial, rebinding, output-envelope limits, inventories, and visibility on all three tool transports.
- 332 broader runtime, operational-instruction, and hosted-tool tests pass.
- Runtime and worker typechecks, targeted lint/format, and documentation guards pass.
- Independent proposal/code review identified the final response-envelope bound; fixed and covered near 512 KiB.

The worker test uses the production agent builder and managed gateway definition with fixture authorization/content callbacks and a simulated sandbox filesystem; it does not claim a live-provider or database integration run. Output is bounded, but a provider may load a whole file before that check. Concurrent filesystem changes retain the existing sandbox filesystem semantics. This fixes Skill discovery/read routing, not the separate upstream provider outage.

Related: OPE-424. Prepared for Bendik's review; no merge or deployment requested.

## Summary by Sourcery

Make advertised repository Skills directly readable through an explicit live repository reader while keeping managed Skill reading separate and sandbox-free.

New Features:
- Advertise repository Skills with exact source-qualified identifiers and provide a live sandbox-bound repository_skill_read capability for reading files, referenced text, and bounded inventories.

Bug Fixes:
- Parse repository Skill metadata with canonical YAML handling so folded and multiline descriptions retain their intended text.
- Prevent repository Skill requests from being misrouted to same-named managed Skills while preserving managed skill_read behavior.

Enhancements:
- Preserve repository read authorization and run-as identity across capability cloning and rebinding, refresh discovery on rebinding, observe live file changes, and consistently exclude symlink entrypoints.
- Keep repository_skill_read directly visible across all supported tool transports.

Documentation:
- Document repository Skill identifiers, live reading behavior, source separation, filesystem constraints, and lifecycle semantics.

Tests:
- Add focused coverage for repository discovery, routing, YAML descriptions, live reads, inventories, limits, authorization, rebinding, symlinks, and tool transport visibility.


External review corrections:
- Accept valid literal and folded-paragraph YAML descriptions during capability preparation. JSON descriptors preserve the logical multiline text; Skill bytes remain unchanged.
- Require an ordinary SKILL.md entry during discovery, matching reader and inventory eligibility. Symlink entrypoints are consistently excluded because the portable API cannot prove target containment.
- Both issues reproduced first: two preparation regressions and one actual UnixLocal adapter symlink test failed at 3044c402 and pass after the fix. Current focused/runtime run: 364 tests pass; runtime typecheck, targeted lint/format, and documentation guards pass.
- Prior CI's failed leaf was an ARM64 @llamaindex/liteparse dependency tarball download/extraction. Failed jobs were rerun on the unchanged old head before this substantive source correction; no CI workaround was added.