### PR TITLE
fix(web): restore Codex and SuperGrok sign-in styling

### DIFF
--- a/.changeset/restore-subscription-device-signin.md
+++ b/.changeset/restore-subscription-device-signin.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Allow host rendering of DeviceAuthorization while retaining shared clipboard state and URL validation. Restore the native Codex and SuperGrok subscription sign-in panels without changing embedded defaults or integration setup.

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -22,8 +22,7 @@ import type {
 import type { OpenGeniBrowserClient } from "@opengeni/sdk/browser";
 import { Link } from "@tanstack/react-router";
 import { pollDeviceAuthorization } from "@opengeni/connect";
-import { DeviceAuthorization } from "@opengeni/react/connect";
-import "@opengeni/react/connect.css";
+import { SubscriptionDeviceCodePanel } from "@/components/subscription-device-code-panel";
 import {
   Loader2Icon,
   RefreshCwIcon,
@@ -690,12 +689,11 @@ export function CodexDeviceCodePanel({
   loadClipboard?: () => Promise<ClipboardModule>;
 }) {
   return (
-    <DeviceAuthorization
+    <SubscriptionDeviceCodePanel
+      provider="codex"
       userCode={userCode}
       verificationUri={verificationUri}
       loadClipboard={loadClipboard}
-      codeAttributes={{ "data-codex-device-code": "" }}
-      description="Enter this code at the OpenAI page (opened in a new tab). Authorization continues if you navigate away."
       onCopyResult={(copied) =>
         copied
           ? toast.success("Code copied")

--- a/apps/web/src/components/subscription-device-code-panel.test.tsx
+++ b/apps/web/src/components/subscription-device-code-panel.test.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DeviceAuthorization } from "@opengeni/react/connect";
+import { SubscriptionDeviceCodePanel } from "./subscription-device-code-panel";
+
+for (const provider of ["codex", "supergrok"] as const) {
+  test(`${provider} native presentation retains URL validation`, () => {
+    for (const verificationUri of [
+      "javascript:alert(1)",
+      "https://user:password@example.com",
+      "invalid",
+    ]) {
+      const html = renderToStaticMarkup(
+        <SubscriptionDeviceCodePanel
+          provider={provider}
+          userCode="ABCD-1234"
+          verificationUri={verificationUri}
+        />,
+      );
+      expect(html).not.toContain("href=");
+      expect(html).toContain("Authorization address unavailable.");
+      expect(html).toContain('role="alert"');
+      expect(html).toContain("ABCD-1234");
+      expect(html).toContain('aria-label="Copy code"');
+    }
+  });
+}
+
+test("embedded device presentation remains available without a native renderer", () => {
+  const html = renderToStaticMarkup(
+    <DeviceAuthorization userCode="HOST-1234" verificationUri="https://example.com/device" />,
+  );
+  expect(html).toContain('class="og-connect ');
+  expect(html).toContain("Enter this code at the provider.");
+  expect(html).toContain('href="https://example.com/device"');
+  expect(html).toContain('rel="noopener noreferrer"');
+  expect(html).toContain('role="status"');
+  expect(html).not.toContain("<svg");
+});

--- a/apps/web/src/components/subscription-device-code-panel.tsx
+++ b/apps/web/src/components/subscription-device-code-panel.tsx
@@ -1,0 +1,89 @@
+import { DeviceAuthorization, type DeviceAuthorizationProps } from "@opengeni/react/connect";
+import { CheckIcon, CopyIcon, ExternalLinkIcon, Loader2Icon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/** Native subscription styling over the shared clipboard and URL-validation behavior. */
+export function SubscriptionDeviceCodePanel({
+  provider,
+  ...props
+}: Pick<
+  DeviceAuthorizationProps,
+  "userCode" | "verificationUri" | "loadClipboard" | "onCopyResult"
+> & {
+  provider: "codex" | "supergrok";
+}) {
+  const codex = provider === "codex";
+  return (
+    <DeviceAuthorization
+      {...props}
+      render={({ copied, copyError, copy, verificationHref }) => (
+        <section
+          aria-label={codex ? "Codex device authorization" : "SuperGrok device authorization"}
+          className={
+            codex
+              ? "grid gap-2 rounded-md border border-border bg-bg p-3"
+              : "grid gap-3 rounded-lg border border-brand/30 bg-brand/5 p-3"
+          }
+        >
+          {codex ? (
+            <p className="text-xs text-fg-muted">
+              Enter this code at the OpenAI page (opened in a new tab). Authorization continues if
+              you navigate away.
+            </p>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            <code
+              {...(codex ? { "data-codex-device-code": "" } : { "data-supergrok-device-code": "" })}
+              className={
+                codex
+                  ? "min-w-0 wrap-anywhere rounded bg-surface-2 px-3 py-1.5 text-lg font-semibold tracking-widest"
+                  : "min-w-0 wrap-anywhere rounded bg-bg px-2 py-1 font-mono text-sm"
+              }
+            >
+              {props.userCode}
+            </code>
+            <Button
+              type="button"
+              variant={codex ? "secondary" : "outline"}
+              size="sm"
+              aria-label={copied ? "Code copied" : "Copy code"}
+              onClick={() => void copy()}
+            >
+              {copied ? (
+                <CheckIcon className="size-3.5" aria-hidden="true" />
+              ) : (
+                <CopyIcon className="size-3.5" aria-hidden="true" />
+              )}
+              {copied ? "Copied" : "Copy code"}
+            </Button>
+            {verificationHref ? (
+              <Button asChild variant={codex ? "secondary" : "outline"} size="sm">
+                <a href={verificationHref} target="_blank" rel="noopener noreferrer">
+                  {codex ? "Open auth page" : "Open xAI"}
+                  <ExternalLinkIcon className="size-3.5" aria-hidden="true" />
+                </a>
+              </Button>
+            ) : (
+              <span role="alert" className="text-xs text-destructive">
+                Authorization address unavailable.
+              </span>
+            )}
+          </div>
+          {copyError ? (
+            <p role="alert" className="text-xs text-destructive">
+              Couldn't copy the code. Copy it manually instead.
+            </p>
+          ) : null}
+          <p role="status" className="flex items-center gap-2 text-xs text-fg-subtle">
+            <Loader2Icon
+              className="size-3.5 animate-spin motion-reduce:animate-none"
+              aria-hidden="true"
+            />
+            {codex ? "Waiting for authorization…" : "Waiting for xAI authorization…"}
+          </p>
+        </section>
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/supergrok-connection.tsx
+++ b/apps/web/src/components/supergrok-connection.tsx
@@ -12,8 +12,7 @@ import { SparklesIcon, Loader2Icon, Trash2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { DeviceAuthorization } from "@opengeni/react/connect";
-import "@opengeni/react/connect.css";
+import { SubscriptionDeviceCodePanel } from "@/components/subscription-device-code-panel";
 
 import { ModelConnectionSection } from "@/components/model-connection-section";
 import { Button } from "@/components/ui/button";
@@ -30,13 +29,7 @@ type PendingDeviceCode = {
 };
 
 export function SuperGrokDeviceCodePanel(props: PendingDeviceCode) {
-  return (
-    <DeviceAuthorization
-      {...props}
-      providerLabel="xAI"
-      codeAttributes={{ "data-supergrok-device-code": "" }}
-    />
-  );
+  return <SubscriptionDeviceCodePanel {...props} provider="supergrok" />;
 }
 
 function accountLabel(account: SuperGrokAccount): string {

--- a/apps/web/test/subscription-device-signin-fixture.tsx
+++ b/apps/web/test/subscription-device-signin-fixture.tsx
@@ -1,0 +1,27 @@
+import { createRoot } from "react-dom/client";
+import { CodexDeviceCodePanel } from "../src/components/codex-connection";
+import { SuperGrokDeviceCodePanel } from "../src/components/supergrok-connection";
+import { DeviceAuthorization } from "@opengeni/react/connect";
+import "../src/styles.css";
+import "@opengeni/react/connect.css";
+
+createRoot(document.getElementById("root")!).render(
+  <main className="mx-auto grid max-w-3xl gap-8 px-5 py-10 text-fg">
+    <h1 className="text-xl font-semibold">Subscription sign-in</h1>
+    <section aria-label="Codex" className="grid gap-3">
+      <h2 className="text-sm font-medium">Codex</h2>
+      <CodexDeviceCodePanel
+        userCode="ABCD-1234"
+        verificationUri="https://auth.openai.com/codex/device"
+      />
+    </section>
+    <section aria-label="SuperGrok" className="grid gap-3">
+      <h2 className="text-sm font-medium">SuperGrok</h2>
+      <SuperGrokDeviceCodePanel userCode="XAI-5678" verificationUri="https://auth.x.ai/device" />
+    </section>
+    <section aria-label="Embedded default" className="grid gap-3">
+      <h2 className="text-sm font-medium">Embedded default (unchanged)</h2>
+      <DeviceAuthorization userCode="HOST-1234" verificationUri="https://example.com/device" />
+    </section>
+  </main>,
+);

--- a/apps/web/test/subscription-device-signin.html
+++ b/apps/web/test/subscription-device-signin.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subscription sign-in preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/test/subscription-device-signin-fixture.tsx"></script>
+  </body>
+</html>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
               // Inspector changes must not pull account-management forms into
               // the direct-session graph through entry-aware chunk merging.
               name: "model-connection-settings",
-              test: /(?:components[\\/](?:codex-source-settings|connection-access-settings|model-connection-section|subscription-account-row|subscription-connect-action)\.tsx$|lucide-react[\\/]dist[\\/]esm[\\/]icons[\\/](?:external-link|route|ticket-check)\.mjs$)/,
+              test: /(?:components[\\/](?:codex-source-settings|connection-access-settings|model-connection-section|subscription-account-row|subscription-connect-action|subscription-device-code-panel)\.tsx$|lucide-react[\\/]dist[\\/]esm[\\/]icons[\\/](?:external-link|route|ticket-check)\.mjs$)/,
               includeDependenciesRecursively: false,
               priority: 20,
             },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -32,6 +32,9 @@ Optional `@opengeni/react/connect` exports `useConnect`, `ConnectChooser`,
 when that scope changes. The controller uses your authenticated backend proxy;
 never place an organization key in browser props. Import
 `@opengeni/react/connect.css` for opt-in, scoped styles without Tailwind.
+`DeviceAuthorization` also accepts an optional `render` callback for host presentation;
+it receives shared copy state, the copy action, and the validated verification URL.
+Omitting it preserves the default embedded presentation.
 
 ```tsx
 import { ConnectPanel } from "@opengeni/react/connect";

--- a/packages/react/src/device-authorization.tsx
+++ b/packages/react/src/device-authorization.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { copyTextToClipboard } from "./clipboard";
 
 export type DeviceAuthorizationProps = {
@@ -10,6 +10,13 @@ export type DeviceAuthorizationProps = {
   codeAttributes?: Record<`data-${string}`, string>;
   loadClipboard?: () => Promise<{ copyTextToClipboard(text: string): Promise<boolean> }>;
   onCopyResult?: (copied: boolean) => void;
+  /** Optional host presentation; clipboard state and URL validation remain shared. */
+  render?: (state: {
+    copied: boolean;
+    copyError: boolean;
+    copy: () => Promise<void>;
+    verificationHref: string | undefined;
+  }) => ReactNode;
 };
 
 /** Optional presentation for the existing model-account device APIs. It neither
@@ -61,6 +68,7 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
   } catch {
     /* A malformed provider URL must never become an executable link. */
   }
+  if (props.render) return props.render({ copied, copyError, copy, verificationHref: href });
   return (
     <section className={`og-connect ${props.className ?? ""}`} aria-label="Device authorization">
       <p>{props.description ?? `Enter this code at ${props.providerLabel ?? "the provider"}.`}</p>


### PR DESCRIPTION
Connecting Codex or SuperGrok lost its native card, code emphasis, button styling, icons, and waiting spinner when #2290 moved device authorization into shared Connect. Restore those panels in workspace and organization settings through a native renderer, while retaining the shared clipboard state and URL validation. Polling, account APIs, integration dialogs, and default embedded presentation are unchanged.

The new panel stays in the existing lazy model-settings chunk so it does not increase the direct-session bundle graph.

Validation:
- 22 focused tests pass, including stale-copy/unmount races, exact codes, unsafe URL rejection, shared defaults, and provider polling.
- Web and React typechecks, lint, and production web build/bundle budgets pass.
- Browser checks cover dark/light at 1280px and 375px, card/code/button styling, keyboard clipboard copying for both providers, external-link attributes, reduced motion, no horizontal overflow, and zero axe violations. The preview mounts the production panels with synthetic codes; no provider authorization is started.
- Independent AI review found no actionable issues.

Fixes OPE-481. Preview fixture: `/test/subscription-device-signin.html`.

## Summary by Sourcery

Restore native Codex and SuperGrok device authorization panels while retaining shared authorization behavior and the default embedded presentation.

New Features:
- Add native Codex and SuperGrok device sign-in panels with provider-specific styling, controls, icons, and authorization status indicators.
- Support custom host rendering for DeviceAuthorization while preserving shared clipboard behavior and validated verification URLs.

Bug Fixes:
- Restore the native subscription sign-in presentation in workspace and organization settings without changing embedded defaults or authorization flows.

Enhancements:
- Keep the new subscription panel in the existing lazy model-settings bundle and document the DeviceAuthorization render API.

Documentation:
- Document the optional DeviceAuthorization render callback and its shared state contract.

Tests:
- Add coverage for provider panels, unsafe verification URLs, and unchanged embedded device authorization rendering.

Chores:
- Add a production-panel preview fixture for subscription sign-in styling checks.