### PR TITLE
fix(release): automatically publish missing production npm packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,5 @@
 name: Publish npm packages
+run-name: publish-packages:${{ inputs.source_sha }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/reconcile-production-packages.yml
+++ b/.github/workflows/reconcile-production-packages.yml
@@ -1,0 +1,31 @@
+name: Reconcile production npm packages
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: reconcile-production-packages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  reconcile:
+    if: github.repository == 'Cloudgeni-ai/opengeni'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+      - name: Publish missing packages for the healthy production revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/reconcile-production-packages.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,10 @@ operator procedure.
 
 ## Keeping these notes current
 
+Managed production package availability is reconciled automatically after the
+runtime becomes healthy; it does not wait for later acceptance. See
+`reconcile-production-packages.yml` and `docs/deployment.md`.
+
 If a change alters architecture, terminology, the run lifecycle, the memory model, or a "do not" guardrail above, update this file, [`docs/architecture.md`](docs/architecture.md), and the relevant `docs/*.md` in the same change. In particular, structural changes (an app/package/sandbox backend added, removed, or renamed; a moved responsibility; a changed invariant, data-flow, or canonical source) belong in `docs/architecture.md` — see its "Keeping this current" section. An out-of-date AGENTS.md or doc is a bug, not a nicety.
 
 ## Keeping docs true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1537,9 +1537,9 @@ container images, the Helm chart, the Rust agent, and retained source identity.
 Package manifests, Changesets configuration, CI workflows, and release scripts
 own the exact closure and procedure. Web image assets compile natively for both CPU targets.
 
-Canonical commands and contribution rules are in
+Commands:
 [`../AGENTS.md`](../AGENTS.md) and [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
-Toolchain details are in [`toolchain.md`](toolchain.md).
+Toolchain: [`toolchain.md`](toolchain.md).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1525,6 +1525,10 @@ Canonical: [`../SECURITY.md`](../SECURITY.md),
 
 ## 11. Build, test, and release
 
+`reconcile-production-packages.yml` independently checks the healthy managed
+production revision and dispatches exact candidate npm publication when missing.
+It retries without depending on post-deployment acceptance; see `deployment.md`.
+
 The TypeScript stack uses Bun with strict TypeScript. The Rust agent and relay
 use Cargo. Unit tests and typechecking are infrastructure-free; integration,
 end-to-end, browser, artifact-runtime, and live lanes add their required

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1525,9 +1525,7 @@ Canonical: [`../SECURITY.md`](../SECURITY.md),
 
 ## 11. Build, test, and release
 
-`reconcile-production-packages.yml` independently checks the healthy managed
-production revision and dispatches exact candidate npm publication when missing.
-It retries without depending on post-deployment acceptance; see `deployment.md`.
+Production npm availability reconciles independently of acceptance; see `reconcile-production-packages.yml`.
 
 The TypeScript stack uses Bun with strict TypeScript. The Rust agent and relay
 use Cargo. Unit tests and typechecking are infrastructure-free; integration,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1349,6 +1349,18 @@ For production Helm releases, pin API, worker, web, and migration images by dige
 
 ## Verified public release
 
+Managed production npm packages are reconciled automatically by
+`reconcile-production-packages.yml` every five minutes (GitHub scheduling may
+delay a run). It reads the healthy production revision and that source's
+immutable candidate package list, then dispatches the existing exact-source
+`publish-packages.yml` when versions are missing. Publication is independent of
+later live acceptance. This is an availability trigger: `/healthz` identifies
+the serving API revision, not proof that every rollout replica is ready.
+Failed publication retries on subsequent checks;
+workflow failures remain visible in Actions. A short deployment-to-publication
+gap is intentional; Site builds can fail during that gap. Full official release
+publication and acceptance evidence remain separate.
+
 `main` is the daily integration branch and remains GitHub's default branch.
 
 Site authoring installs exact registry versions. Stable builds use their source

--- a/scripts/reconcile-production-packages.test.ts
+++ b/scripts/reconcile-production-packages.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+import { candidatePackages, deployedSource, reconcile } from "./reconcile-production-packages";
+
+const sha = "a".repeat(40);
+test("registry outages fail visibly rather than dispatching or declaring success", async () => {
+  const request = (async (url: string) =>
+    url.endsWith("/healthz")
+      ? Response.json({ ok: true, service: "opengeni", deploymentRevision: sha })
+      : new Response("unavailable", { status: 503 })) as typeof fetch;
+  const gh = (...args: string[]) => {
+    expect(args[0]).toBe("release");
+    return JSON.stringify({
+      schemaVersion: 2,
+      sourceSha: sha,
+      packages: [{ name: "@opengeni/sdk", version: "5.0.3" }],
+    });
+  };
+  await expect(reconcile(gh, request)).rejects.toThrow("Registry probe failed: HTTP 503");
+});
+test("requires a healthy exact production revision", () => {
+  expect(deployedSource({ ok: true, service: "opengeni", deploymentRevision: sha })).toBe(sha);
+  for (const value of [
+    null,
+    {},
+    { ok: false },
+    { ok: true, service: "opengeni", deploymentRevision: "main" },
+  ]) {
+    expect(() => deployedSource(value)).toThrow();
+  }
+});
+
+test("retries failed publication, avoids active duplicates, and stops when available", async () => {
+  for (const [registryStatus, status, shouldDispatch] of [
+    [404, "completed", true],
+    [404, "in_progress", false],
+    [200, "completed", false],
+  ] as const) {
+    const calls: string[][] = [];
+    const gh = (...args: string[]) => {
+      calls.push(args);
+      if (args[0] === "release")
+        return JSON.stringify({
+          schemaVersion: 2,
+          sourceSha: sha,
+          packages: [{ name: "@opengeni/sdk", version: "5.0.3" }],
+        });
+      if (args[0] === "api")
+        return JSON.stringify({
+          workflow_runs: [
+            { display_title: `publish-packages:${sha}`, status, conclusion: "failure" },
+          ],
+        });
+      return "";
+    };
+    const request = (async (url: string) =>
+      url.endsWith("/healthz")
+        ? Response.json({ ok: true, service: "opengeni", deploymentRevision: sha })
+        : new Response("{}", { status: registryStatus })) as typeof fetch;
+    await reconcile(gh, request);
+    const dispatch = calls.find((args) => args[0] === "workflow");
+    expect(Boolean(dispatch)).toBe(shouldDispatch);
+    if (dispatch) {
+      expect(dispatch).toContain(`source_sha=${sha}`);
+      expect(dispatch).toContain("expected_packages=@opengeni/sdk@5.0.3");
+    }
+  }
+});
+test("publication uses immutable candidate versions, not latest tags", () => {
+  const candidate = {
+    schemaVersion: 2,
+    sourceSha: sha,
+    packages: [{ name: "@opengeni/sdk", version: "5.0.3" }],
+  };
+  expect(candidatePackages(candidate, sha)).toEqual(["@opengeni/sdk@5.0.3"]);
+  expect(() => candidatePackages(candidate, "b".repeat(40))).toThrow();
+  for (const version of ["latest", "5.0.3-canary.0", "^5.0.3"]) {
+    expect(() =>
+      candidatePackages({ ...candidate, packages: [{ name: "@opengeni/sdk", version }] }, sha),
+    ).toThrow();
+  }
+  expect(() =>
+    candidatePackages(
+      { ...candidate, packages: [...candidate.packages, ...candidate.packages] },
+      sha,
+    ),
+  ).toThrow();
+});

--- a/scripts/reconcile-production-packages.ts
+++ b/scripts/reconcile-production-packages.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+
+const repository = "Cloudgeni-ai/opengeni";
+
+export function deployedSource(value: unknown): string {
+  const health = value as { ok?: unknown; service?: unknown; deploymentRevision?: unknown };
+  if (
+    !health ||
+    health.ok !== true ||
+    health.service !== "opengeni" ||
+    typeof health.deploymentRevision !== "string" ||
+    !/^[a-f0-9]{40}$/.test(health.deploymentRevision)
+  ) {
+    throw new Error("Production must report a healthy exact source revision");
+  }
+  return health.deploymentRevision;
+}
+
+export function candidatePackages(value: unknown, sourceSha: string): string[] {
+  const candidate = value as { sourceSha?: unknown; schemaVersion?: unknown; packages?: unknown };
+  if (
+    !candidate ||
+    candidate.sourceSha !== sourceSha ||
+    candidate.schemaVersion !== 2 ||
+    !Array.isArray(candidate.packages)
+  ) {
+    throw new Error("Candidate must match the deployed source");
+  }
+  const seen = new Set<string>();
+  return candidate.packages.map((pkg: { name: string; version: string }) => {
+    if (
+      !pkg ||
+      typeof pkg.name !== "string" ||
+      !/^@opengeni\/[a-z0-9-]+$/.test(pkg.name) ||
+      typeof pkg.version !== "string" ||
+      !/^\d+\.\d+\.\d+$/.test(pkg.version) ||
+      seen.has(pkg.name)
+    ) {
+      throw new Error("Candidate must contain unique stable package versions");
+    }
+    seen.add(pkg.name);
+    return `${pkg.name}@${pkg.version}`;
+  });
+}
+
+function gh(...args: string[]): string {
+  const result = spawnSync("gh", args, { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(result.stderr || "GitHub request failed");
+  return result.stdout;
+}
+
+async function json(url: string, request: typeof fetch): Promise<unknown> {
+  const response = await request(url, { signal: AbortSignal.timeout(30_000), redirect: "error" });
+  if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+  return response.json();
+}
+
+export async function reconcile(runGh = gh, request: typeof fetch = fetch): Promise<void> {
+  const sourceSha = deployedSource(await json("https://app.opengeni.ai/healthz", request));
+  const candidate = JSON.parse(
+    runGh(
+      "release",
+      "download",
+      `opengeni-candidate-${sourceSha}`,
+      "--repo",
+      repository,
+      "--pattern",
+      "release-candidate.json",
+      "--output",
+      "-",
+    ),
+  );
+  const packages = candidatePackages(candidate, sourceSha);
+  // Probe availability only. The publisher independently verifies source CI,
+  // production ancestry, the complete package closure and registry identity.
+  const missing = await Promise.all(
+    packages.map(async (spec) => {
+      const split = spec.lastIndexOf("@");
+      const response = await request(
+        `https://registry.npmjs.org/${encodeURIComponent(spec.slice(0, split))}/${spec.slice(split + 1)}`,
+        { signal: AbortSignal.timeout(30_000) },
+      );
+      if (response.status === 404) return true;
+      if (!response.ok) throw new Error(`Registry probe failed: HTTP ${response.status}`);
+      return false;
+    }),
+  );
+  if (!missing.some(Boolean)) {
+    console.log(`${sourceSha}: packages already available`);
+    return;
+  }
+  const runs = JSON.parse(
+    runGh("api", `repos/${repository}/actions/workflows/publish-packages.yml/runs?per_page=100`),
+  );
+  if (
+    runs.workflow_runs.some(
+      (run: { display_title: string; status: string }) =>
+        run.display_title === `publish-packages:${sourceSha}` && run.status !== "completed",
+    )
+  ) {
+    console.log(`${sourceSha}: publication already running`);
+    return;
+  }
+  runGh(
+    "workflow",
+    "run",
+    "publish-packages.yml",
+    "--repo",
+    repository,
+    "--ref",
+    "main",
+    "-f",
+    `source_sha=${sourceSha}`,
+    "-f",
+    `expected_packages=${packages.join(",")}`,
+    "-f",
+    "confirm=true",
+  );
+  console.log(`${sourceSha}: dispatched exact package publication`);
+}
+
+if (import.meta.main) await reconcile();

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -42,7 +42,11 @@
     },
     {
       "path": ".github/workflows/publish-packages.yml",
-      "sha256": "35ea669e9119244185608d6b3ba36bd1594b1cf51dc8e7e800fcee91c7b0a495"
+      "sha256": "8d13c059295343b1238467af8ddec4cf750cdef48ac3e62c645a36839a21fdb8"
+    },
+    {
+      "path": ".github/workflows/reconcile-production-packages.yml",
+      "sha256": "d05f65de51d9684c0c2ee08ffdacde3ab7a7ae7e1c09322edbd06ef37636014b"
     },
     {
       "path": ".github/workflows/release-acceptance.yml",
@@ -848,6 +852,12 @@
       "job": "publish",
       "step": "Verify publishable closure",
       "sha256": "c18d0e2815c7263404fd08bd381f6afc66620c8bbba61f13828a0f6f6b22eda4"
+    },
+    {
+      "workflow": ".github/workflows/reconcile-production-packages.yml",
+      "job": "reconcile",
+      "step": "Publish missing packages for the healthy production revision",
+      "sha256": "403bf534ac1eb6c2465f2260ec881f48c0b5744b28dd51d22e1633e113ddc59c"
     },
     {
       "workflow": ".github/workflows/release-acceptance.yml",

--- a/scripts/workflow-execution-graph.test.ts
+++ b/scripts/workflow-execution-graph.test.ts
@@ -209,9 +209,9 @@ describe("workflow execution graph manifest", () => {
 
     expect(inspection.violations).toEqual([]);
     expect(compareWorkflowExecutionManifest(committed, inspection.manifest)).toEqual([]);
-    expect(inspection.manifest.workflows).toHaveLength(21);
+    expect(inspection.manifest.workflows).toHaveLength(22);
     expect(inspection.manifest.actions).toHaveLength(2);
-    expect(inspection.manifest.uncappedRuns).toHaveLength(202);
+    expect(inspection.manifest.uncappedRuns).toHaveLength(203);
     expect(inspection.manifest.generatedLocalTargets).toHaveLength(3);
     for (const record of [
       ...inspection.manifest.workflows,


### PR DESCRIPTION
## Summary
Automatically reconcile npm package availability for the revision served by managed production. Every five minutes, resolve its immutable candidate package list and dispatch the existing exact-source publisher if versions are missing. Failed attempts retry; active attempts deduplicate. No post-deployment acceptance dependency.

This intentionally triggers on serving API availability, not whole-rollout certification. GitHub schedule latency and a short package-availability gap are accepted. Existing publication CI, production ancestry, closure and registry identity checks remain unchanged.

## Validation
- Four focused tests: exact revision, stable pins, retry/deduplication, registry errors.
- Formatting, lint and diff checks passed.
- Independent review: no blockers.

No private incident data or credentials included.

## Summary by Sourcery

Automatically reconcile missing production npm packages from the exact serving revision on a recurring schedule.

New Features:
- Add a scheduled workflow that reconciles npm package availability for the healthy managed production revision and dispatches publication when packages are missing.

Bug Fixes:
- Automatically retry missing package publication while avoiding duplicate active publication runs.

Enhancements:
- Validate exact production revisions and immutable stable candidate package lists before publication, while preserving existing publisher safeguards.

CI:
- Add workflow run naming and update the workflow execution graph manifest for the new reconciliation workflow.

Documentation:
- Document that production package availability is reconciled independently of acceptance and may have a short intentional publication gap.

Tests:
- Add focused coverage for revision validation, immutable candidate packages, registry failures, retries, and deduplication.