### PR TITLE
fix(web): preserve draft tool policy when starting sessions

### DIFF
--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -382,6 +382,7 @@ export type AppContextValue = {
       installedSkillIds?: string[];
       /** Exact session MCP policy. Omit to use the product UI's workspace selection. */
       sessionTools?: ToolRef[];
+      newSessionDraftToolPolicy?: { tools: ToolRef[]; toolsProvided: boolean };
       targetSandboxId?: string | null;
       workingDir?: string | null;
       /** Workspace folder to file the new session under. */
@@ -1865,6 +1866,7 @@ export function RootRouteComponent() {
       installedSkillIds?: string[];
       /** Exact session MCP policy. Omit to use the product UI's workspace selection. */
       sessionTools?: ToolRef[];
+      newSessionDraftToolPolicy?: { tools: ToolRef[]; toolsProvided: boolean };
       targetSandboxId?: string | null;
       workingDir?: string | null;
       channelId?: string | null;
@@ -1933,6 +1935,7 @@ export function RootRouteComponent() {
           installedSkillIds: options?.installedSkillIds,
           omitWorkspaceResources: options?.omitWorkspaceResources,
           selectedTools,
+          newSessionDraftToolPolicy: options?.newSessionDraftToolPolicy,
           defaultModel: model,
           defaultReasoningEffort: reasoningEffort,
           defaultLatencyMode: latencyMode,

--- a/apps/web/src/lib/session-create-request.test.ts
+++ b/apps/web/src/lib/session-create-request.test.ts
@@ -200,6 +200,33 @@ describe("buildCreateSessionRequest", () => {
     expect(result).not.toHaveProperty("tools");
   });
 
+  test("preserves the acknowledged draft policy when explicit tools equal defaults", () => {
+    const tools = [{ kind: "mcp" as const, id: "docs" }];
+    const result = build([], [], {
+      selectedTools: tools,
+      workspaceDefaultMcpServerIds: ["docs"],
+      workspaceMcpCatalogReady: true,
+      expectedNewSessionDraftRevision: 7,
+      newSessionDraftToolPolicy: { tools, toolsProvided: true },
+    });
+    expect(result.tools).toEqual(tools);
+    expect(result.expectedNewSessionDraftRevision).toBe(7);
+  });
+
+  test("preserves explicit empty and omitted draft policies across catalog changes", () => {
+    for (const toolsProvided of [true, false]) {
+      const result = build([], [], {
+        selectedTools: [{ kind: "mcp", id: "docs" }],
+        workspaceDefaultMcpServerIds: ["files"],
+        workspaceMcpCatalogReady: true,
+        expectedNewSessionDraftRevision: 7,
+        newSessionDraftToolPolicy: { tools: [], toolsProvided },
+      });
+      if (toolsProvided) expect(result.tools).toEqual([]);
+      else expect(result).not.toHaveProperty("tools");
+    }
+  });
+
   test("keeps explicit empty, subset, and partially hydrated selections on the wire", () => {
     const common = {
       workspaceDefaultMcpServerIds: ["docs"],

--- a/apps/web/src/lib/session-create.ts
+++ b/apps/web/src/lib/session-create.ts
@@ -196,6 +196,8 @@ export type BuildCreateSessionRequestInput = {
   visibility?: "private" | "workspace";
   omitWorkspaceResources?: boolean;
   selectedTools: ToolRef[];
+  /** Exact policy acknowledged by the revision-fenced new-session draft. */
+  newSessionDraftToolPolicy?: { tools: ToolRef[]; toolsProvided: boolean };
   defaultModel: string;
   defaultReasoningEffort: ReasoningEffort;
   defaultLatencyMode: LatencyMode;
@@ -271,11 +273,14 @@ export function buildCreateSessionRequest(
   const defaultToolIds = input.workspaceDefaultMcpServerIds
     ? [...new Set(input.workspaceDefaultMcpServerIds)].sort()
     : null;
-  const tools =
-    input.workspaceMcpCatalogReady === true &&
-    defaultToolIds &&
-    selectedToolIds.join("\u0000") ===
-      [...new Set(buildTools([], defaultToolIds).map((tool) => tool.id))].sort().join("\u0000")
+  const tools = input.newSessionDraftToolPolicy
+    ? input.newSessionDraftToolPolicy.toolsProvided
+      ? [...input.newSessionDraftToolPolicy.tools]
+      : undefined
+    : input.workspaceMcpCatalogReady === true &&
+        defaultToolIds &&
+        selectedToolIds.join("\u0000") ===
+          [...new Set(buildTools([], defaultToolIds).map((tool) => tool.id))].sort().join("\u0000")
       ? undefined
       : [...input.selectedTools];
   return {

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -991,6 +991,7 @@ function SessionsIndexRouteContent({
                     : undefined,
                   startMode: "realtime",
                   expectedNewSessionDraftRevision: flushed.revision,
+                  newSessionDraftToolPolicy: persistedToolPolicy,
                   visibility: newSessionCreateVisibility(
                     personalWorkspace,
                     submission.options.visibility ?? "workspace",
@@ -1045,6 +1046,7 @@ function SessionsIndexRouteContent({
                   ? [launch.skillCapabilityId]
                   : undefined,
                 expectedNewSessionDraftRevision: flushed.revision,
+                newSessionDraftToolPolicy: persistedToolPolicy,
                 visibility: newSessionCreateVisibility(
                   personalWorkspace,
                   submission.options.visibility ?? "workspace",


### PR DESCRIPTION
An explicit tool selection that matches workspace defaults was saved as explicit but omitted during session creation. The server rejected the unchanged draft with `NEW_SESSION_DRAFT_CONFLICT`, and both recovery choices returned users to the same failure.

Forward the acknowledged draft's exact tools and explicitness through the stock create adapter. Explicit, empty, and inherited selections now remain consistent with the saved revision, while ordinary callers retain their existing default-selection behavior.

Validation: 61 focused create-request and draft-hook tests pass on this branch; web typecheck and targeted lint pass. Browser reproduction confirmed the old UI failed again after Keep mine; the corrected flow accepted the same draft against the local API. The user reported this on staging; staging verification follows deployment.

Related: OPE-9.

## Summary by Sourcery

Preserve acknowledged draft tool policies through session creation so recovery flows can create sessions from the saved draft consistently.

Bug Fixes:
- Preserve the acknowledged new-session tool policy when creating sessions, preventing draft conflicts when explicit selections match workspace defaults or are empty or inherited.

Enhancements:
- Allow session creation callers to pass the exact draft tool policy while retaining existing default-selection behavior for ordinary callers.

Tests:
- Add coverage for preserving explicit, empty, and inherited draft tool policies across workspace catalog changes.