### PR TITLE
fix: unblock sandbox waiters after failed archive captures

### DIFF
--- a/.changeset/tidy-captures-wait.md
+++ b/.changeset/tidy-captures-wait.md
@@ -1,0 +1,10 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Bound sandbox acquisition and workspace mutation waits across repeated archive capture attempts. Honor the first observed capture's persisted timeout once, without letting expired or renewed claims replenish the caller's deadline; retain all capture and writer fences.
+
+Release an exact unpublished drain capture after its provider promise rejects, including after a local timeout, so waiting turns can resume the intact live sandbox. Unresolved captures, published archives, successors, and provider teardown remain fenced.
+
+Fresh claims allocate a new provider request identity; uninterrupted replacements retain it, preventing stale snapshot replay after an intervening writer re-arms the lease.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,15 @@ Use [`docs/README.md`](docs/README.md) as the docs map. When you move or rename 
 
 ## Sandbox Notes
 
+Sandbox acquisition and workspace mutation waits honor the first observed
+capture's durable remaining timeout once, within the lifecycle ceiling.
+Expired or replacement captures never replenish a caller's wait. Budget expiry
+returns a fence, not authority to admit a writer or abandon an archive capture.
+A settled capture rejection may release only its exact unpublished claim so a
+waiting turn can re-arm the live box. A timeout alone or an ambiguous teardown
+failure must never release that ownership. See `docs/run-lifecycle.md` for
+capture ownership and recovery.
+
 Sandbox execution is pluggable. `OPENGENI_SANDBOX_BACKEND` selects one of the backends defined by the `SandboxBackend` enum in `packages/contracts/src/index.ts` (the canonical list): `docker`, `modal`, `local`, `none`, `daytona`, `runloop`, `e2b`, `blaxel`, `cloudflare`, `vercel`, `selfhosted`, and `opensandbox`. `docker` is the default and the usual local-dev choice; `modal`, `opensandbox`, and the other cloud backends are provisioned, swappable boxes. OpenSandbox is optional and Kubernetes-native: exact attach is by persisted ID, workspace recovery uses OpenGeni portable tar archives in object storage (required; never silent jsonb stuffing), provider TTL is renewable, and a desktop-class image reports ttyd PTY plus desktop/recording over signed URI-mode ingress when `OPENGENI_OPENSANDBOX_SIGNED_ENDPOINTS=true` (unsigned keeps the lifecycle proxy); native snapshots and `runAs` stay unavailable. When you change the set of backends, update the enum first and treat it as the source of truth — this file and the README follow it.
 
 There are two stock sandbox images. `docker/sandbox.Dockerfile` is the official headless release image (the 7-image BOM). `docker/desktop.Dockerfile` is the Modal Computer/Browser box (Xvfb, XFCE, Chrome, `opengeni-browserd-up`). It is **not** in the BOM and does not ride an API/worker Helm upgrade. Publish it with `.github/workflows/publish-desktop-image.yml` and pin `desktop.imageRef` / `OPENGENI_MODAL_IMAGE_REF` to that digest. Helm and production boot fail closed when Modal desktop is on without a `@sha256:` pin. Never point Modal Computer/Browser at `opengeni-sandbox`. A new pin applies to new sandbox creates only; an existing warm lease stays on the old box until rotate/reap.

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -26,6 +26,7 @@ import {
   appendSessionEventToSandboxGroup,
   bindRetainedProcessProviderIdentity,
   claimWorkspaceArchiveCapture,
+  releaseWorkspaceArchiveCapture,
   claimSandboxCheckpointArtifactsForGc,
   claimTerminalRetainedProcesses,
   countActiveRetainedProcessesByOwnerState,
@@ -249,6 +250,7 @@ export type TerminateBoxFn = (
   captureDisposition?: DrainCaptureDisposition,
   capturePolicy?: ProviderWorkspaceCapturePolicy | null,
   diskBackedArchives?: boolean,
+  releaseFailedCapture?: () => Promise<void>,
 ) => Promise<boolean | ProviderTerminationOutcome>;
 
 export type SweepModalOrphansFn = (
@@ -350,12 +352,13 @@ export class SandboxProviderCaptureTimeoutError extends Error {
   }
 }
 
-async function awaitProviderCaptureWithLatePublication<T>(input: {
+export async function awaitProviderCaptureWithLatePublication<T>(input: {
   capture: Promise<T>;
   timeoutMs: number;
   timeoutError: SandboxProviderCaptureTimeoutError;
   publishLate: (value: T) => Promise<void>;
   observeLateFailure: (error: unknown) => void;
+  observeLatePublicationFailure: (error: unknown) => void;
 }): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutError = input.timeoutError;
@@ -373,7 +376,9 @@ async function awaitProviderCaptureWithLatePublication<T>(input: {
     // durable archive publication: never provider teardown or a cold commit from
     // an activity Temporal has already rejected. A replaced claim fences this
     // callback; Modal candidates then flow to artifact-ledger GC.
-    void input.capture.then(input.publishLate).catch(input.observeLateFailure);
+    void input.capture
+      .then(input.publishLate, input.observeLateFailure)
+      .catch(input.observeLatePublicationFailure);
     throw error;
   } finally {
     if (timeout) clearTimeout(timeout);
@@ -482,6 +487,7 @@ export function createSandboxLeaseActivities(
       captureDisposition,
       capturePolicy,
       diskBackedArchives,
+      releaseFailedCapture,
     ) =>
       await terminateProviderBox(
         settings,
@@ -494,6 +500,7 @@ export function createSandboxLeaseActivities(
         captureDisposition,
         capturePolicy,
         diskBackedArchives,
+        releaseFailedCapture,
       ));
   const sweepModalOrphans: SweepModalOrphansFn =
     options.sweepModalOrphans ?? sweepModalOrphansForConfiguredBackend;
@@ -2803,6 +2810,17 @@ async function terminateDrainableBox(
         captureDisposition,
         capturePolicy,
         Boolean(objectStorage),
+        async () => {
+          if (!captureClaim || !lease.instanceId) return;
+          await releaseWorkspaceArchiveCapture(db, {
+            accountId,
+            workspaceId: row.workspaceId,
+            sandboxGroupId: row.sandboxGroupId,
+            captureId: captureClaim.id,
+            expectedEpoch: row.leaseEpoch,
+            expectedInstanceId: lease.instanceId,
+          });
+        },
       );
   const terminated = typeof termination === "boolean" ? termination : termination.terminated;
   if (!terminated) {
@@ -2936,10 +2954,21 @@ export async function terminateProviderBox(
   captureDisposition: DrainCaptureDisposition = "capture_required",
   claimedCapturePolicy?: ProviderWorkspaceCapturePolicy | null,
   diskBackedArchives = false,
+  releaseFailedCapture?: () => Promise<void>,
 ): Promise<ProviderTerminationOutcome> {
   const durableBackendId = (lease.resumeBackendId ?? lease.backend) as string;
   const backend = sandboxBackendForSdkBackendId(durableBackendId) ?? durableBackendId;
   const logIdentity = providerDrainLogIdentity(lease, backend);
+  const releaseAfterCaptureFailure = async (): Promise<void> => {
+    try {
+      await releaseFailedCapture?.();
+    } catch (error) {
+      observability.warn("sandbox reaper: failed capture claim release failed", {
+        ...logIdentity,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
   // 'none' / no backend -> nothing to terminate.
   if (!backend || backend === "none") {
     return { terminated: true, providerMissingBeforeCapture: false };
@@ -3187,7 +3216,17 @@ export async function terminateProviderBox(
             await disposeWorkspaceArchive(archive);
           }
         },
+        observeLatePublicationFailure: (error) => {
+          observability.warn("sandbox reaper: late capture publication cleanup failed", {
+            ...logIdentity,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
         observeLateFailure: (error) => {
+          // Capture has now rejected and this timed-out path can never reach
+          // provider teardown. Release only our unpublished claim so a waiting
+          // turn can re-arm the intact live box; stale callbacks are DB-fenced.
+          void releaseAfterCaptureFailure();
           observability.warn("sandbox reaper: timed-out provider capture later failed", {
             ...logIdentity,
             error: error instanceof Error ? error.message : String(error),
@@ -3209,6 +3248,12 @@ export async function terminateProviderBox(
         error: error instanceof Error ? error.message : String(error),
       },
     );
+    // An unresolved timeout is not proof of capture failure: retain the fence
+    // until its provider promise settles. A settled failure cannot enter the
+    // teardown path below, so its unpublished claim may safely be released.
+    if (!(error instanceof SandboxProviderCaptureTimeoutError)) {
+      await releaseAfterCaptureFailure();
+    }
     // NEVER terminate a box whose snapshot we could not capture.
     throw error;
   }

--- a/apps/worker/test/reaper-terminate-roundtrip.test.ts
+++ b/apps/worker/test/reaper-terminate-roundtrip.test.ts
@@ -24,6 +24,7 @@ import { testSettings } from "@opengeni/testing";
 import * as runtime from "@opengeni/runtime";
 import {
   SandboxProviderCaptureTimeoutError,
+  awaitProviderCaptureWithLatePublication,
   terminateProviderBox,
 } from "../src/activities/sandbox-lease";
 
@@ -412,79 +413,190 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
     expect(deleteCalls).toEqual(["sb-published"]);
   });
 
-  test("a generic provider timeout preserves and late-publishes the exact capture without teardown", async () => {
-    let resolveCapture!: (bytes: Uint8Array) => void;
-    const providerCapture = new Promise<Uint8Array>((resolve) => {
-      resolveCapture = resolve;
+  test("late publication rejection is never mistaken for capture rejection", async () => {
+    let resolveCapture!: (value: string) => void;
+    let resolveFailure!: () => void;
+    const observed = new Promise<void>((resolve) => {
+      resolveFailure = resolve;
     });
-    let deleteCount = 0;
-    const client = {
-      backendId: "modal",
-      async deserializeSessionState(state: Record<string, unknown>) {
-        return { ...state };
-      },
-      async resume(state: { sandboxId?: unknown }) {
-        return {
-          state: { sandboxId: state.sandboxId },
-          exec: async () => ({ stdout: TEST_WORKSPACE_FINGERPRINT }),
-          persistWorkspace: async () => await providerCapture,
-          kill: async () => {},
-          closed: false,
-          modal: { images: { delete: async () => {} } },
-        };
-      },
-      async resumeExact(state: { sandboxId?: unknown }) {
-        return await this.resume(state);
-      },
-      async delete() {
-        deleteCount += 1;
-      },
-    };
-    let resolvePublished!: () => void;
-    const published = new Promise<void>((resolve) => {
-      resolvePublished = resolve;
-    });
-    let publishedArchive: string | null = null;
-    const operation = terminateProviderBox(
-      testSettings({
-        sandboxBackend: "modal",
-        sandboxOwnershipEnabled: true,
-        sandboxSnapshotTimeoutMs: 10,
-      }),
-      {
-        sandboxGroupId: "group-late-capture",
-        leaseEpoch: 3,
-        backend: "modal",
-        instanceId: "sb-late-capture",
-        resumeBackendId: "modal",
-        resumeState: {
-          backendId: "modal",
-          sessionState: { providerState: { sandboxId: "sb-late-capture" } },
+    let captureFailures = 0;
+    const timeout = new SandboxProviderCaptureTimeoutError("group", "modal", 10, 1, "sb");
+    await expect(
+      awaitProviderCaptureWithLatePublication({
+        capture: new Promise<string>((resolve) => {
+          resolveCapture = resolve;
+        }),
+        timeoutMs: 10,
+        timeoutError: timeout,
+        publishLate: async () => {
+          throw new Error("spool cleanup failed");
         },
-      } as never,
-      observability,
-      async (archive) => {
-        publishedArchive = archive;
-        resolvePublished();
-        return { wrote: true };
-      },
-      (() => client) as never,
-    );
-
-    await expect(operation).rejects.toBeInstanceOf(SandboxProviderCaptureTimeoutError);
-    expect(deleteCount).toBe(0);
-    resolveCapture(
-      new TextEncoder().encode('MODAL_SANDBOX_FS_SNAPSHOT_V1\n{"snapshot_id":"im-late"}'),
-    );
-    await Promise.race([
-      published,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("late capture did not publish")), 1_000),
-      ),
-    ]);
-    expect(publishedArchive).not.toBeNull();
-    expect(deleteCount).toBe(0);
+        observeLateFailure: () => {
+          captureFailures++;
+        },
+        observeLatePublicationFailure: () => {
+          resolveFailure();
+        },
+      }),
+    ).rejects.toBe(timeout);
+    resolveCapture("successful snapshot");
+    await observed;
+    expect(captureFailures).toBe(0);
   });
+
+  test.each(["success", "failure"])(
+    "a timed-out capture settles safely after late %s",
+    async (outcome) => {
+      let resolveCapture!: (bytes: Uint8Array) => void;
+      let rejectCapture!: (error: Error) => void;
+      const providerCapture = new Promise<Uint8Array>((resolve, reject) => {
+        resolveCapture = resolve;
+        rejectCapture = reject;
+      });
+      let releaseCount = 0;
+      let resolveReleased!: () => void;
+      const released = new Promise<void>((resolve) => {
+        resolveReleased = resolve;
+      });
+      let deleteCount = 0;
+      const client = {
+        backendId: "modal",
+        async deserializeSessionState(state: Record<string, unknown>) {
+          return { ...state };
+        },
+        async resume(state: { sandboxId?: unknown }) {
+          return {
+            state: { sandboxId: state.sandboxId },
+            exec: async () => ({ stdout: TEST_WORKSPACE_FINGERPRINT }),
+            persistWorkspace: async () => await providerCapture,
+            kill: async () => {},
+            closed: false,
+            modal: { images: { delete: async () => {} } },
+          };
+        },
+        async resumeExact(state: { sandboxId?: unknown }) {
+          return await this.resume(state);
+        },
+        async delete() {
+          deleteCount += 1;
+        },
+      };
+      let resolvePublished!: () => void;
+      const published = new Promise<void>((resolve) => {
+        resolvePublished = resolve;
+      });
+      let publishedArchive: string | null = null;
+      const operation = terminateProviderBox(
+        testSettings({
+          sandboxBackend: "modal",
+          sandboxOwnershipEnabled: true,
+          sandboxSnapshotTimeoutMs: 10,
+        }),
+        {
+          sandboxGroupId: "group-late-capture",
+          leaseEpoch: 3,
+          backend: "modal",
+          instanceId: "sb-late-capture",
+          resumeBackendId: "modal",
+          resumeState: {
+            backendId: "modal",
+            sessionState: { providerState: { sandboxId: "sb-late-capture" } },
+          },
+        } as never,
+        observability,
+        async (archive) => {
+          publishedArchive = archive;
+          resolvePublished();
+          return { wrote: true };
+        },
+        (() => client) as never,
+        undefined,
+        undefined,
+        "capture_required",
+        undefined,
+        false,
+        async () => {
+          releaseCount++;
+          resolveReleased();
+        },
+      );
+
+      await expect(operation).rejects.toBeInstanceOf(SandboxProviderCaptureTimeoutError);
+      expect(deleteCount).toBe(0);
+      expect(releaseCount).toBe(0);
+      if (outcome === "success") {
+        resolveCapture(
+          new TextEncoder().encode('MODAL_SANDBOX_FS_SNAPSHOT_V1\n{"snapshot_id":"im-late"}'),
+        );
+      } else {
+        rejectCapture(new Error("provider capture failed"));
+      }
+      await Promise.race([
+        outcome === "success" ? published : released,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("late capture did not publish")), 1_000),
+        ),
+      ]);
+      expect(releaseCount).toBe(outcome === "success" ? 0 : 1);
+      if (outcome === "success") expect(publishedArchive).not.toBeNull();
+      else expect(publishedArchive).toBeNull();
+      expect(deleteCount).toBe(0);
+    },
+  );
+
+  test.each(["capture", "publish", "delete"])(
+    "releases an unpublished claim only for a settled capture failure (%s)",
+    async (phase) => {
+      const client = makeFakeModalClient();
+      const resume = client.resumeExact;
+      client.resumeExact = async (state) => {
+        const session = await resume(state);
+        if (phase === "capture")
+          session.persistWorkspace = async () => {
+            throw new Error("capture failed");
+          };
+        return session;
+      };
+      let deleted = false;
+      client.delete = async () => {
+        deleted = true;
+        throw new Error("delete failed");
+      };
+      let released = 0;
+      await expect(
+        terminateProviderBox(
+          testSettings({ sandboxBackend: "modal", sandboxOwnershipEnabled: true }),
+          {
+            sandboxGroupId: "failed-capture",
+            leaseEpoch: 3,
+            backend: "modal",
+            instanceId: "sb-failed",
+            resumeBackendId: "modal",
+            resumeState: {
+              backendId: "modal",
+              sessionState: { providerState: { sandboxId: "sb-failed" } },
+            },
+          } as never,
+          observability,
+          async () => {
+            if (phase === "publish") throw new Error("publish failed");
+            return { wrote: true };
+          },
+          (() => client) as never,
+          undefined,
+          undefined,
+          "capture_required",
+          undefined,
+          false,
+          async () => {
+            released++;
+          },
+        ),
+      ).rejects.toThrow(`${phase} failed`);
+      expect(released).toBe(phase === "capture" ? 1 : 0);
+      expect(deleted).toBe(phase === "delete");
+    },
+  );
 
   test("a Modal warming-death record uses the exact attributed instance without guessing an envelope", async () => {
     const directTerminateCalls: string[] = [];

--- a/apps/worker/test/sandbox-reaper-timeout-contract.test.ts
+++ b/apps/worker/test/sandbox-reaper-timeout-contract.test.ts
@@ -144,10 +144,11 @@ describe("sandbox reaper per-box timeout contract", () => {
       "utf8",
     );
     expect(dbSource.match(/archive_capture_deadline_at - clock_timestamp\(\)/gu)).toHaveLength(2);
-    expect(dbSource.match(/extendSandboxTransitionDeadline\(/gu)).toHaveLength(3);
-    expect(dbSource).toContain(
-      "hardDeadline = startedAt + SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS",
-    );
+    expect(
+      dbSource.match(/new SandboxTransitionWaitBudget\(captureWaitMs, startedAt\)/gu),
+    ).toHaveLength(2);
+    expect(dbSource.match(/waitBudget.observeCapture\(/gu)).toHaveLength(2);
+    expect(dbSource.match(/now >= waitBudget.deadline/gu)).toHaveLength(2);
     expect(dbSource).toContain("captureWaitMs > 0");
   });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -426,28 +426,29 @@ must prove that the current turn context can establish the target, and a stale
 or structurally invalid pointer is reconciled visibly rather than silently
 routing to an arbitrary provider.
 
-Managed sandbox lifecycle belongs to the lease and reaper. An API or viewer
-that resumes a box receives a non-owned handle and must not terminate it when
-the request ends. Provider create/restore identity is persisted before setup,
-and workspace capture is fenced against every live writer. A provider loss may
-retire only the exact matching instance and must never cause an ambiguous
-operation to be replayed. Ordinary periodic and turn-end snapshots keep the
-short `OPENGENI_SANDBOX_SNAPSHOT_TIMEOUT_MS` provider budget. Zero-holder drain
-and rotation captures may use the independent
-`OPENGENI_SANDBOX_DRAIN_SNAPSHOT_TIMEOUT_MS` budget; when unset it inherits the
-ordinary timeout. Deployment admission always reserves provider-deadline
-rotation headroom for the larger configured capture budget plus one reaper
-period, including after the default backend changes because historical Modal
-leases remain durable. A drain timeout therefore cannot outlive the rotation
-window. An explicit drain budget is also admitted only when one reaper period,
-the full durable capture, and retry handoff fit inside the lifecycle transition
-wait ceiling. A caller's current configuration supplies only its initial wait:
-after it observes an active capture, PostgreSQL's remaining
-`archive_capture_deadline_at` plus the fixed handoff grace extends that wait up
-to the same one-hour ceiling. Lowering the timeout or rolling the setting across
-processes therefore cannot make an opted-in viewer, turn, or mutation caller
-abandon a still-valid child whose timeout was frozen earlier. Zero-wait internal
-probes remain immediate.
+Managed sandbox lifecycle belongs to the lease and reaper. API/viewer handles
+are non-owned: request completion must not terminate them. Provider identity is
+persisted before setup; workspace capture fences every writer. Provider loss
+retires only the matching instance and never licenses ambiguous effect replay.
+
+Ordinary snapshots use `OPENGENI_SANDBOX_SNAPSHOT_TIMEOUT_MS`; zero-holder drains
+and rotations may use `OPENGENI_SANDBOX_DRAIN_SNAPSHOT_TIMEOUT_MS` (unset inherits
+the ordinary budget). Boot admission reserves rotation headroom for the larger
+budget plus a reaper period, including historical Modal leases after a backend
+change. Explicit drain budgets must fit dispatch, capture and retry handoff
+inside the lifecycle ceiling.
+
+Acquisition/mutation waiters may extend their configured budget once for the
+first observed durable capture deadline plus handoff grace, capped at one hour.
+Expired/replacement claims cannot replenish it; zero-wait probes remain immediate.
+Expiry returns a fence, never capture takeover or writer authority. The shared
+policy is `packages/db/src/sandbox-transition-wait.ts`.
+
+A settled capture rejection releases only its exact unpublished claim, allowing
+waiters to re-arm the intact instance. Unresolved timeouts and publication/teardown
+failures retain ownership. Fresh claims receive fresh provider request IDs;
+uninterrupted replacements retain the stored ID so late results remain adoptable
+without reusing pre-mutation snapshots after a release.
 
 Rotation recovery: [lifecycle](run-lifecycle.md).
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1389,12 +1389,25 @@ durable across that rollout. The explicit drain budget is independently
 rejected unless reaper dispatch, the full durable capture, and retry handoff fit
 inside the caller/DB transition wait ceiling. Process-local configuration is
 only the initial observational budget. Once an opted-in acquisition or mutation
-waiter sees the durable capture claim, it follows PostgreSQL's authoritative
-remaining `archive_capture_deadline_at` plus retry-handoff grace, still capped by
-the one-hour lifecycle ceiling. This keeps a timeout reduction and mixed-config
-rolling activation aligned with the older child's frozen input without turning
-the wait into capture-takeover authority or an unbounded request. Explicit
-zero-wait probes preserve their immediate fenced result.
+waiter first sees a valid durable capture deadline, it may extend its wait once
+using PostgreSQL's authoritative remaining `archive_capture_deadline_at` plus
+retry-handoff grace, capped by the one-hour lifecycle ceiling. Later expired or
+replacement capture claims cannot reset the wait or its grace. This honors an
+older child's frozen input during a rolling timeout reduction without letting
+repeated failed drain attempts starve a caller. Budget expiry returns the typed
+capture fence; it grants no takeover, teardown, or writer admission authority.
+Explicit zero-wait probes preserve their immediate fenced result.
+
+A rejected drain capture releases only its exact unpublished claim. This also
+applies when the provider promise rejects after the local timeout: that detached
+path cannot enter teardown, and release wakes waiters so they can re-arm the
+intact live instance. The timeout alone never releases ownership. Late success
+still publishes under the durable fence; publication or teardown failures retain
+ownership, and an older failed callback cannot clear a replacement claim. A
+provider-deadline/operator rotation is retained by the DB release operation.
+Every fresh claim gets a new provider request ID; replacement attempts of an
+uninterrupted claim retain its stored ID. A workflow retry after release and
+intervening writes therefore cannot adopt an older snapshot as a newer generation.
 
 Concurrent routed calls may all discover the same missing provider. Exactly one
 observer wins the lease-loss transition; the others receive typed `superseded`

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -335,7 +335,6 @@ import {
 } from "@opengeni/contracts";
 import {
   environmentsEncryptionKeyBytes,
-  SANDBOX_LIFECYCLE_RETRY_HANDOFF_GRACE_MS,
   SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS,
   WORKSPACE_OPENROUTER_CONNECTION_DOMAIN,
   WORKSPACE_OPENROUTER_CONNECTION_ROLE,
@@ -343,6 +342,7 @@ import {
   VERCEL_AI_GATEWAY_CONNECTION_ROLE,
   type Settings,
 } from "@opengeni/config";
+import { SandboxTransitionWaitBudget } from "./sandbox-transition-wait";
 import { normalizeWorkspaceMembershipPermissions } from "./workspace-membership-permissions";
 import {
   canonicalizePersistedHistoryItem,
@@ -43119,19 +43119,6 @@ function archiveCaptureRemainingMs(
     : null;
 }
 
-function extendSandboxTransitionDeadline(
-  currentDeadline: number,
-  hardDeadline: number,
-  remainingCaptureMs: number | null | undefined,
-  now: number,
-): number {
-  if (remainingCaptureMs === null || remainingCaptureMs === undefined) return currentDeadline;
-  return Math.min(
-    hardDeadline,
-    Math.max(currentDeadline, now + remainingCaptureMs + SANDBOX_LIFECYCLE_RETRY_HANDOFF_GRACE_MS),
-  );
-}
-
 function providerlessLeaseBackendPredicateSql() {
   const providerlessBackends = Object.entries(SANDBOX_PROVIDER_INSTANCE_ID_FIELDS_BY_BACKEND)
     .filter(([, fields]) => fields.length === 0)
@@ -43976,33 +43963,27 @@ export async function acquireLease(
   // NTP/VM resume may change timestamp interpretation, but must never stretch
   // or prematurely consume the caller's resource budget. PostgreSQL projects
   // an active claim's remaining time on its own authoritative clock; that may
-  // extend a positive caller budget after a rolling config change, but never
-  // beyond the same one-hour lifecycle ceiling.
+  // extend a positive caller budget once after a rolling config change. Later
+  // capture retries must not keep renewing a waiter's observational budget.
   const startedAt = performance.now();
-  const hardDeadline = startedAt + SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS;
-  let deadline = Math.min(hardDeadline, startedAt + captureWaitMs);
+  const waitBudget = new SandboxTransitionWaitBudget(captureWaitMs, startedAt);
   let delayMs = 25;
   for (;;) {
     const result = await acquireLeaseOnce(db, input);
     const now = performance.now();
     if (captureWaitMs > 0 && result.role === "fenced" && result.reason === "capture_in_progress") {
-      deadline = extendSandboxTransitionDeadline(
-        deadline,
-        hardDeadline,
-        result.captureRemainingMs,
-        now,
-      );
+      waitBudget.observeCapture(result.captureRemainingMs, now);
     }
     if (
       result.role !== "fenced" ||
       result.reason === "superseded" ||
       result.reason === "rotation_in_progress" ||
-      now >= deadline
+      now >= waitBudget.deadline
     ) {
       return result;
     }
     await waitForSandboxTransition(
-      Math.min(delayMs, Math.max(1, deadline - now)),
+      Math.min(delayMs, Math.max(1, waitBudget.deadline - now)),
       input.waitSignal,
       "Sandbox lease transition wait cancelled",
     );
@@ -50128,8 +50109,7 @@ async function advanceWorkspaceGenerationForAuthority(
     throw new Error("Workspace archive capture wait is invalid");
   }
   const startedAt = performance.now();
-  const hardDeadline = startedAt + SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS;
-  let deadline = Math.min(hardDeadline, startedAt + captureWaitMs);
+  const waitBudget = new SandboxTransitionWaitBudget(captureWaitMs, startedAt);
   let delayMs = 25;
   let captureWaitStartedAt: number | undefined;
   let captureWaitOutcome: "completed" | "failed" = "failed";
@@ -50150,23 +50130,18 @@ async function advanceWorkspaceGenerationForAuthority(
           error instanceof SandboxWorkspaceMutationFencedError &&
           error.code === "capture_in_progress"
         ) {
-          deadline = extendSandboxTransitionDeadline(
-            deadline,
-            hardDeadline,
-            error.captureRemainingMs,
-            now,
-          );
+          waitBudget.observeCapture(error.captureRemainingMs, now);
         }
         if (
           !(error instanceof SandboxWorkspaceMutationFencedError) ||
           error.code !== "capture_in_progress" ||
-          now >= deadline
+          now >= waitBudget.deadline
         ) {
           throw error;
         }
         captureWaitStartedAt ??= performance.now();
         await waitForSandboxTransition(
-          Math.min(delayMs, Math.max(1, deadline - now)),
+          Math.min(delayMs, Math.max(1, waitBudget.deadline - now)),
           waitSignal,
           "Sandbox workspace mutation wait cancelled",
         );
@@ -52240,12 +52215,12 @@ export async function claimWorkspaceArchiveCapture(
     throw new Error("Workspace archive capture timeout is invalid");
   }
   const operationId = input.operationId ?? input.captureId;
-  // captureId owns one DB callback; providerRequestId owns the external
-  // operation. Modal's wire contract explicitly defines snapshotId as an
-  // idempotency key, so every Temporal retry of one logical capture must reuse
-  // it. Other providers still retain the stable lineage for late-result
-  // adoption, but may not replay the physical request before its deadline.
-  const providerRequestId = operationId;
+  // A fresh admission-fenced capture gets a fresh provider request identity.
+  // After a released failure, writers may re-arm this same lease epoch before
+  // the drain workflow retries. Reusing its operationId could then retrieve an
+  // older provider snapshot as the newer workspace generation. Replacements of
+  // an uninterrupted claim retain this stored identity for late-result adoption.
+  const providerRequestId = randomUUID();
   const captureAttempt = input.attempt ?? 1;
   const providerReplaySafe = input.providerReplaySafe === true;
   const takeoverSafe = input.takeoverSafe === true;

--- a/packages/db/src/sandbox-transition-wait.ts
+++ b/packages/db/src/sandbox-transition-wait.ts
@@ -1,0 +1,45 @@
+import {
+  SANDBOX_LIFECYCLE_RETRY_HANDOFF_GRACE_MS,
+  SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS,
+} from "@opengeni/config";
+
+/** Observational only: expiring a caller's wait never revokes a capture fence. */
+export class SandboxTransitionWaitBudget {
+  private observedCapture = false;
+  private currentDeadline: number;
+  private readonly hardDeadline: number;
+
+  constructor(
+    private readonly waitMs: number,
+    startedAt: number,
+  ) {
+    this.hardDeadline = startedAt + SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS;
+    this.currentDeadline = Math.min(this.hardDeadline, startedAt + waitMs);
+  }
+
+  get deadline(): number {
+    return this.currentDeadline;
+  }
+
+  observeCapture(remainingMs: number | null | undefined, now: number): void {
+    if (
+      this.waitMs === 0 ||
+      this.observedCapture ||
+      remainingMs === null ||
+      remainingMs === undefined ||
+      !Number.isSafeInteger(remainingMs) ||
+      remainingMs < 0 ||
+      remainingMs > SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS
+    )
+      return;
+
+    // Honor the first observed child's frozen timeout across rolling settings
+    // changes. Neither an expired claim (remaining=0) nor a replacement capture
+    // can replenish the grace/budget on every poll and starve this caller.
+    this.observedCapture = true;
+    this.currentDeadline = Math.min(
+      this.hardDeadline,
+      Math.max(this.currentDeadline, now + remainingMs + SANDBOX_LIFECYCLE_RETRY_HANDOFF_GRACE_MS),
+    );
+  }
+}

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import { createHash } from "node:crypto";
 import { sql } from "drizzle-orm";
@@ -8,6 +8,8 @@ import {
   acquireLease,
   acquireSandboxLeaseReaperHold,
   advanceWorkspaceGenerationForDirectRequest,
+  advanceWorkspaceGeneration,
+  SandboxWorkspaceMutationFencedError,
   adoptLegacyModalCheckpointArtifact,
   beginSandboxRematerialization,
   claimTemporalScheduleCleanups,
@@ -506,6 +508,112 @@ describe("archive object publication binding and disposition", () => {
         ? persistWarmSnapshot(db, { ...input, workspaceArchiveRef: ref, ...overrides })
         : persistDrainSnapshotRaw(db, { ...input, workspaceArchiveRef: ref, ...overrides });
     return { ids, scope, source, input, descriptor, publish };
+  }
+
+  test("a released drain retry cannot reuse a snapshot from before intervening writes", async () => {
+    if (!available) return;
+    const f = await fixture("draining");
+    await admin`
+      update sandbox_leases set resume_state = jsonb_set(resume_state,
+        '{sessionState,providerState}', jsonb_build_object('sandboxId', ${f.input.expectedInstanceId}::text))
+      where id = ${f.source.id}`;
+    expect(await releaseWorkspaceArchiveCapture(db, f.input)).toBe(true);
+    const resumed = await acquireLease(db, {
+      ...f.scope,
+      kind: "turn",
+      holderId: f.input.holderId,
+      subjectId: f.input.sessionId,
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(resumed).toMatchObject({ role: "rearmed" });
+    // Model writes performed by the resumed holder before the next idle drain.
+    await admin`update sandbox_leases set workspace_generation = workspace_generation + 1 where id = ${f.source.id}`;
+    await releaseLeaseHolder(db, {
+      ...f.scope,
+      kind: "turn",
+      holderId: f.input.holderId,
+      idleGraceMs: 0,
+    });
+    const next = await claimWorkspaceArchiveCapture(db, {
+      ...f.scope,
+      // The same drain workflow retries with a new attempt and stable operation.
+      captureId: crypto.randomUUID(),
+      operationId: f.input.captureId,
+      expectedEpoch: f.source.leaseEpoch,
+      expectedInstanceId: f.input.expectedInstanceId,
+      liveness: "draining",
+      captureTimeoutMs: 60_000,
+      minIntervalMs: 0,
+    });
+    expect(next.status).toBe("claimed");
+    if (next.status !== "claimed") throw new Error("expected fresh capture");
+    expect(next.claim.workspaceGeneration).toBe(1);
+    expect(next.claim.providerRequestId).not.toBe(f.input.providerRequestId);
+    // A genuinely stale callback must not release a different owner.
+    expect(await releaseWorkspaceArchiveCapture(db, f.input)).toBe(false);
+  }, 60_000);
+
+  for (const operation of ["acquire", "mutate"] as const) {
+    test(`expired capture bounds ${operation} retries without granting writer authority`, async () => {
+      if (!available) return;
+      const f = await fixture(operation === "acquire" ? "draining" : "warm");
+      await admin`
+        update sandbox_lease_holders set subject_id = ${f.input.sessionId}
+        where lease_id = ${f.source.id} and holder_id = ${f.input.holderId}`;
+      await admin`
+        update sandbox_leases
+        set archive_capture_started_at = now() - interval '2 minutes',
+            archive_capture_deadline_at = now() - interval '1 minute'
+        where id = ${f.source.id}`;
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(new Error("capture wait did not expire")),
+        2_000,
+      );
+      let clockCalls = 0;
+      const clock = spyOn(performance, "now").mockImplementation(() =>
+        ++clockCalls <= 2 ? 0 : 20_000,
+      );
+      try {
+        if (operation === "acquire") {
+          expect(
+            await acquireLease(db, {
+              ...f.scope,
+              kind: "turn",
+              holderId: "bounded-successor",
+              backend: "modal",
+              leaseTtlMs: 45_000,
+              captureWaitMs: 25,
+              waitSignal: controller.signal,
+            }),
+          ).toMatchObject({ role: "fenced", reason: "capture_in_progress" });
+        } else {
+          const rejection = await advanceWorkspaceGeneration(db, {
+            ...f.input,
+            executionGeneration: 1,
+            operation: "exec",
+            captureWaitMs: 25,
+            waitSignal: controller.signal,
+          }).catch((error: unknown) => error);
+          expect(rejection).toBeInstanceOf(SandboxWorkspaceMutationFencedError);
+          expect(rejection).toMatchObject({ code: "capture_in_progress" });
+        }
+      } finally {
+        clock.mockRestore();
+        clearTimeout(timer);
+      }
+      const [lease] = await admin`
+        select archive_capture_id, workspace_generation,
+          (select count(*)::int from sandbox_lease_holders where lease_id = sandbox_leases.id
+            and holder_id = 'bounded-successor') as successor_holders
+        from sandbox_leases where id = ${f.source.id}`;
+      expect(lease).toMatchObject({
+        archive_capture_id: f.input.captureId,
+        workspace_generation: 0,
+        successor_holders: 0,
+      });
+    }, 60_000);
   }
 
   for (const liveness of ["warm", "draining"] as const) {
@@ -4278,7 +4386,11 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     expect(after?.liveness).toBe("draining");
     expect(after?.refcount).toBe(0);
     expect(after?.viewer_holders).toBe(0);
-    expect(after?.expires_at.getTime()).toBeLessThanOrEqual(Date.now());
+    // Lease expiry is stamped by Postgres; host/DB clocks may differ by milliseconds.
+    const [expiry] = await admin`
+      select expires_at <= clock_timestamp() as expired from sandbox_leases
+      where workspace_id = ${ids.workspaceId} and sandbox_group_id = ${ids.groupId}`;
+    expect(expiry?.expired).toBe(true);
     expect(drained).toContainEqual(
       expect.objectContaining({
         workspaceId: ids.workspaceId,
@@ -4850,7 +4962,7 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     expect(beforeCallback?.recovery).toMatchObject({
       archive: { status: "available", current: { revision: priorDescriptor.revision } },
       restore: { status: "pending", selectedRevision: priorDescriptor.revision },
-      lateArchiveCapture: { providerRequestId: operationId },
+      lateArchiveCapture: { providerRequestId: claim.claim.providerRequestId },
     });
 
     expect(

--- a/packages/db/test/sandbox-transition-wait.test.ts
+++ b/packages/db/test/sandbox-transition-wait.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SANDBOX_LIFECYCLE_RETRY_HANDOFF_GRACE_MS as GRACE,
+  SANDBOX_LIFECYCLE_TRANSITION_MAX_WAIT_MS as MAX_WAIT,
+} from "@opengeni/config";
+import { SandboxTransitionWaitBudget } from "../src/sandbox-transition-wait";
+
+describe("sandbox transition wait budget", () => {
+  test("a rolling timeout reduction still waits for the first child's frozen deadline", () => {
+    const budget = new SandboxTransitionWaitBudget(25, 0);
+    budget.observeCapture(60_000, 10);
+    expect(budget.deadline).toBe(60_010 + GRACE);
+    expect(75).toBeLessThan(budget.deadline);
+  });
+
+  test("139 renewed drain attempts cannot stretch the caller's wait to an hour", () => {
+    const budget = new SandboxTransitionWaitBudget(110_000, 0);
+    budget.observeCapture(70_000, 0);
+    for (let attempt = 1; attempt <= 139; attempt++) {
+      budget.observeCapture(70_000, attempt * 90_000);
+    }
+    expect(budget.deadline).toBe(110_000);
+    expect(180_000).toBeGreaterThan(budget.deadline);
+  });
+
+  test("an expired durable claim cannot renew handoff grace on every poll", () => {
+    const budget = new SandboxTransitionWaitBudget(25, 0);
+    budget.observeCapture(0, 0);
+    for (let now = 500; now <= MAX_WAIT; now += 500) budget.observeCapture(0, now);
+    expect(budget.deadline).toBe(Math.max(25, GRACE));
+  });
+
+  test("a caller retains its configured budget when the first capture expires sooner", () => {
+    const budget = new SandboxTransitionWaitBudget(120_000, 100);
+    budget.observeCapture(1_000, 200);
+    expect(budget.deadline).toBe(120_100);
+  });
+
+  test("zero-wait probes stay immediate even with an active capture", () => {
+    const budget = new SandboxTransitionWaitBudget(0, 100);
+    budget.observeCapture(60_000, 101);
+    expect(budget.deadline).toBe(100);
+  });
+
+  test("invalid observations do not consume the first valid child's allowance", () => {
+    const budget = new SandboxTransitionWaitBudget(25, 0);
+    for (const value of [undefined, null, -1, NaN, Infinity, 1.5, MAX_WAIT + 1]) {
+      budget.observeCapture(value, 10);
+      expect(budget.deadline).toBe(25);
+    }
+    budget.observeCapture(60_000, 20);
+    expect(budget.deadline).toBe(60_020 + GRACE);
+  });
+
+  test("the first observed claim cannot exceed the absolute lifecycle ceiling", () => {
+    const budget = new SandboxTransitionWaitBudget(25, 100);
+    budget.observeCapture(MAX_WAIT, 500);
+    expect(budget.deadline).toBe(100 + MAX_WAIT);
+  });
+});


### PR DESCRIPTION
A drain capture that exceeded the local timeout and subsequently rejected retained its unpublished claim. Repeated drain retries blocked new turns from re-arming the still-live sandbox; acquisition also kept extending its deadline on each observation, including expired claims.

This releases only the exact unpublished claim after the capture promise rejects, including late rejection. An unresolved timeout, successful capture awaiting publication, publication failure, or ambiguous teardown failure retains its fence. Late publication errors are handled separately from capture rejection, and cleanup failures preserve the original error.

Fresh claims now allocate a fresh provider request ID. Uninterrupted replacement attempts retain the stored ID, preventing a retry from recovering a stale snapshot after the sandbox was re-armed and modified. Acquisition and mutation waits honor the first observed persisted capture deadline once, preserving rolling timeout compatibility without renewing the wait on every retry.

Validation:
- 92 real-Postgres lease tests passed, including release → re-arm → intervening writes → new capture, stale callbacks, and actual acquisition/mutation wait expiry.
- 39 focused runtime/timeout tests passed; 2 existing Linux-only spool tests skipped on macOS.
- DB and worker typechecks, targeted lint, formatting, and documentation guards passed.
- Independent review covered capture/publication rejection boundaries and provider request identity across re-arm.

Includes patch changesets for `@opengeni/db` and `@opengeni/worker-bundle`. No schema migration. Provider snapshot failures remain failures; this restores safe availability of the intact box and bounded observation, without discarding files or weakening teardown ownership.

## Summary by Sourcery

Restore safe sandbox availability after failed archive captures while keeping capture fences and waiter timeouts bounded.

Bug Fixes:
- Release an exact unpublished archive capture claim when its provider capture settles with an error, including late rejection after a local timeout, so waiters can safely re-arm the intact sandbox.
- Prevent stale snapshot reuse by assigning fresh provider request identities to newly admitted capture claims.

Enhancements:
- Bound acquisition and workspace mutation waits using the first observed persisted capture deadline without allowing expired or replacement captures to renew the caller's budget.
- Preserve capture ownership across unresolved timeouts, successful late publication, publication failures, and ambiguous teardown failures while separating late publication errors from capture errors.

Documentation:
- Document sandbox capture ownership, bounded waiter behavior, and provider request identity across retries and re-arming.

Tests:
- Add focused unit and real-Postgres coverage for late capture outcomes, exact claim release, stale callbacks, re-arm flows, request identity, and bounded acquisition/mutation waits.