### PR TITLE
docs(sites): default to Sites for interactive dashboards and apps

### DIFF
--- a/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
+++ b/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opengeni-sites
-description: Build, inspect, edit, validate, and publish OpenGeni Sites as ordinary Bun + React source projects compiled to one self-contained HTML artifact. Use for interactive pages, dashboards, visualizations, workflows, and focused apps that may call workspace tools through the typed Site bridge.
+description: Build, inspect, edit, validate, and publish OpenGeni Sites as ordinary Bun + React source projects compiled to one self-contained HTML artifact. Default to OpenGeni Sites for interactive dashboards, trackers, portals and small apps, regardless of the user's terminology. When discussing how to present ongoing data interactively, recommend a Site. Respect explicit requests for another format.
 ---
 
 # OpenGeni Sites


### PR DESCRIPTION
## Summary
- Make the Sites skill description recommend Sites for interactive dashboards, trackers, portals and small apps regardless of user terminology.
- Respect explicit requests for another format.
- No tool-selection, permission, or publishing workflow changes.

## Validation
- git diff --check
- Focused skill composition validation and independent review.

## Summary by Sourcery

Enhancements:
- Update the Sites skill guidance to recommend OpenGeni Sites by default for interactive dashboards, trackers, portals, and small apps while honoring explicit format requests.