### PR TITLE
feat(react): add configurable genie startup loading and diagnostics

### DIFF
--- a/.changeset/genie-loading.md
+++ b/.changeset/genie-loading.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Replace startup timing rows with a quiet animated genie and rotating loading copy. Retain timing evidence in diagnostics, support a browser-local detail preference, and keep failures visible. Add a replayable loading studio.

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -1,5 +1,8 @@
 import { useWorkspaceRigs } from "@/lib/use-workspace-rigs";
 import { useWorkspaceMachines } from "@/lib/use-workspace-machines";
+import { StartupTimings, useStartupDetails, setStartupDetails } from "@opengeni/react/session-ui";
+import { buildTimeline } from "@opengeni/react";
+import { PreferenceToggleRow } from "@/components/transcription-settings";
 import {
   SessionStatus as SessionStatusBadge,
   type SessionEventsConnectionState,
@@ -46,6 +49,11 @@ export function SessionInspector(props: {
   connectionState: SessionEventsConnectionState;
   onReloadSession: () => Promise<void>;
 }) {
+  const startupDetails = useStartupDetails();
+  const startupPhases = useMemo(
+    () => buildTimeline(props.events).filter((item) => item.kind === "startup-phase"),
+    [props.events],
+  );
   const context = useAppContext();
   const navigate = useNavigate();
   const variableSets = useVariableSets({ workspaceId: props.session.workspaceId });
@@ -214,12 +222,29 @@ export function SessionInspector(props: {
             <TabsTrigger value="timeline" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Timeline
             </TabsTrigger>
+            <TabsTrigger value="startup" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
+              Startup
+            </TabsTrigger>
             <TabsTrigger value="raw" className="h-7 min-w-max flex-none rounded px-2 text-2xs">
               Raw
             </TabsTrigger>
           </TabsList>
         </div>
 
+        <TabsContent value="startup" className="min-h-0 min-w-0 overflow-hidden">
+          <ScrollArea className="h-full min-w-0">
+            <div className="space-y-5 p-3">
+              <PreferenceToggleRow
+                label="Show startup details in chat"
+                description="Remembered in this browser. Timings are always recorded."
+                checked={startupDetails}
+                onToggle={() => setStartupDetails(!startupDetails)}
+                wrapDescription
+              />
+              <StartupTimings phases={startupPhases} />
+            </div>
+          </ScrollArea>
+        </TabsContent>
         <TabsContent value="overview" className="min-h-0 min-w-0 overflow-hidden">
           <ScrollArea className="h-full min-w-0">
             <div className="min-w-0 space-y-4 p-3">

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -229,6 +229,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: "127.0.0.1",
     port: 3000,
     ...(allowedHosts?.length ? { allowedHosts } : {}),
   },

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "2.12.1",
+      "version": "2.12.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -167,7 +167,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.28.1",
+      "version": "0.28.4",
       "bin": {
         "opengeni-artifact-materializer-worker": "./src/artifact-materializer-entry.ts",
         "opengeni-artifact-outbox-dispatcher": "./src/artifact-outbox-entry.ts",
@@ -209,7 +209,7 @@
     },
     "examples/chat-quickstart": {
       "name": "@opengeni/example-chat-quickstart",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
         "@opengeni/sdk": "workspace:*",
       },
@@ -219,7 +219,7 @@
     },
     "examples/embedded-product": {
       "name": "@opengeni/example-embedded-product",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@opengeni/connect": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -239,7 +239,7 @@
     },
     "examples/northstar-support": {
       "name": "@opengeni/example-northstar-support",
-      "version": "0.0.144",
+      "version": "0.0.147",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/connect": "workspace:*",
@@ -285,19 +285,19 @@
     },
     "packages/artifact-kernel-wasm-document": {
       "name": "@opengeni/artifact-kernel-wasm-document",
-      "version": "0.3.24",
+      "version": "0.3.26",
     },
     "packages/artifact-kernel-wasm-presentation": {
       "name": "@opengeni/artifact-kernel-wasm-presentation",
-      "version": "0.3.24",
+      "version": "0.3.26",
     },
     "packages/artifact-kernel-wasm-spreadsheet": {
       "name": "@opengeni/artifact-kernel-wasm-spreadsheet",
-      "version": "0.3.24",
+      "version": "0.3.26",
     },
     "packages/artifact-tool": {
       "name": "@opengeni/artifact-tool",
-      "version": "0.3.24",
+      "version": "0.3.26",
       "bin": {
         "opengeni-artifact-materializer": "./src/materializer-cli-entry.ts",
         "opengeni-artifact-runtime": "./src/runtime-cli-entry.ts",
@@ -319,7 +319,7 @@
     },
     "packages/browserd": {
       "name": "@opengeni/browserd",
-      "version": "0.1.39",
+      "version": "0.1.41",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/interaction": "workspace:*",
@@ -346,7 +346,7 @@
     },
     "packages/codemode": {
       "name": "@opengeni/codemode",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/tool-gateway": "workspace:*",
@@ -370,7 +370,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -392,7 +392,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "yaml": "2.9.0",
@@ -405,7 +405,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "2.9.1",
+      "version": "2.9.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/capabilities": "workspace:*",
@@ -430,7 +430,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "4.3.0",
+      "version": "4.3.3",
       "dependencies": {
         "@opengeni/codemode": "workspace:*",
         "@opengeni/codex": "workspace:*",
@@ -460,7 +460,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.8.24",
+      "version": "0.8.27",
       "dependencies": {
         "@llamaindex/liteparse": "2.14.2",
         "@opengeni/config": "workspace:*",
@@ -479,7 +479,7 @@
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.4.22",
+      "version": "0.4.25",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -492,7 +492,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.7.8",
+      "version": "0.7.10",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -506,7 +506,7 @@
     },
     "packages/interaction": {
       "name": "@opengeni/interaction",
-      "version": "0.4.31",
+      "version": "0.4.33",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
       },
@@ -528,7 +528,7 @@
     },
     "packages/observability": {
       "name": "@opengeni/observability",
-      "version": "0.8.24",
+      "version": "0.8.26",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "prom-client": "^15.1.3",
@@ -540,7 +540,7 @@
     },
     "packages/ogtool": {
       "name": "@opengeni/ogtool",
-      "version": "0.3.36",
+      "version": "0.3.38",
       "bin": {
         "ogtool": "./dist/bin/ogtool.cjs",
       },
@@ -554,7 +554,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "5.0.2",
+      "version": "5.0.5",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -573,6 +573,7 @@
         "react-resizable-panels": "^4.11.2",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
+        "thinking-orbs": "^0.3.1",
         "virtua": "^0.49.2",
       },
       "devDependencies": {
@@ -648,7 +649,7 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "2.5.1",
+      "version": "2.5.3",
       "dependencies": {
         "@alibaba-group/opensandbox": "0.1.11",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -679,7 +680,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "5.0.0",
+      "version": "5.0.5",
       "dependencies": {
         "@opengeni/connect": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -699,7 +700,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.125",
+      "version": "0.2.127",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -738,7 +739,7 @@
     },
     "packages/tool-gateway": {
       "name": "@opengeni/tool-gateway",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "ajv": "^8.20.0",
@@ -3571,6 +3572,8 @@
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "thingies": ["thingies@2.6.1", "", { "peerDependencies": { "tslib": "^2" } }, "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw=="],
+
+    "thinking-orbs": ["thinking-orbs@0.3.1", "", { "peerDependencies": { "react": ">=18.0.0" } }, "sha512-3BG1aeB1RUTxItCml/BBuIz5JRM4kZqGuyx+vouv0fXTtcR9ZNoKjWGneHPx94y74GxgArwJZ1qbJR5dt54kSw=="],
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,12 @@ services:
       POSTGRES_USER: opengeni
       POSTGRES_PWD: opengeni
       POSTGRES_SEEDS: postgres
+      # All four Temporal services share this local Postgres with the app.
+      # Production-sized defaults can exhaust its 100 connection slots.
+      SQL_MAX_CONNS: "5"
+      SQL_MAX_IDLE_CONNS: "5"
+      SQL_VIS_MAX_CONNS: "2"
+      SQL_VIS_MAX_IDLE_CONNS: "2"
       BIND_ON_IP: 0.0.0.0
       DYNAMIC_CONFIG_FILE_PATH: config/dynamicconfig/docker.yaml
     depends_on:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1630,6 +1630,7 @@ External actors and Site viewer authority: [embedding authority internals](embed
 | OpenGeni Review Bot and pull-request automation | `packages/core/src/domain/pr-review.ts`, `apps/api/src/routes/pr-review.ts`, `apps/api/src/routes/pr-review-github.ts` | [`automations.md`](automations.md), [`pr-review-pack.md`](pr-review-pack.md) |
 | HTTP routes or SSE | `apps/api/src/app.ts`, `apps/api/src/http/sse.ts` | §4 and [`../packages/sdk/README.md`](../packages/sdk/README.md) |
 | SDK, React, or browser bundle surface | `packages/sdk/src/`, `packages/react/src/`, `packages/sdk/test/core-bundle-boundary.test.ts`, `packages/sdk/test/browser-client-surface.test.ts` | Package READMEs, §3.10, and §7.6 |
+| Startup loading UI and timing diagnostics | `packages/react/src/timeline/activity-rail.tsx`, `apps/web/src/components/session/inspector.tsx` | [`design/genie-loading.md`](design/genie-loading.md) |
 | Stock web console | `apps/web/src/` | [`command-palette.md`](command-palette.md) for command behavior |
 | Standalone product integration and implementation Pack | `packages/sdk/`, `packages/react/`, `packages/core/src/domain/product-integration-pack.ts` | [`product-integration.md`](product-integration.md), [`packs.md`](packs.md), and [`embedding-workbench.md`](embedding-workbench.md) |
 | Advanced in-process embedding | `packages/core/`, `apps/api/`, `apps/worker/` | [`embedding.md`](embedding.md) |

--- a/docs/design/genie-loading.md
+++ b/docs/design/genie-loading.md
@@ -1,0 +1,18 @@
+# Genie loading
+
+Startup presentation lives in `packages/react/src/timeline/activity-rail.tsx`.
+Normal preparation shows the MIT-licensed `thinking-orbs` React component (`searching`, 64px, speed 0.8) with a fixed list of playful phrases,
+randomly selected every five seconds. After 30 seconds, factual waiting copy
+replaces the phrases. Failure and cancellation stop the animation; actual
+reasoning/tool activity replaces it. Reduced-motion preferences disable animation.
+
+Startup phase events and their projection remain unchanged. The Debug inspector's
+Startup tab displays recorded durations, including overlapping phases. Its
+“Show startup details in chat” switch is off by default and stored only in the
+current browser under `opengeni:startup-details:v1`. “Behind the magic” appears after 15 seconds and reveals
+one activity group's details without changing that preference.
+
+Run `bun run --cwd packages/react demo`, then open `/genie-loading.html` for
+replayable quick, unhurried, long-wait, and failure scenarios, a light/dark switch,
+and diagnostics. The studio renders the production MessageTimeline from simulated
+SessionEvents and requires no model calls. The full stack runs with `bun run dev`.

--- a/docs/design/genie-loading.md
+++ b/docs/design/genie-loading.md
@@ -31,3 +31,16 @@ Hosts can customize the SDK without editing its source:
 
 Orb states use the `thinking-orbs` component's typed options. Omitted settings
 keep the defaults; an empty phrase list also falls back to the defaults.
+
+For an entirely different visual, supply `genieLoading.render`:
+
+```tsx
+<MessageTimeline
+  events={events}
+  genieLoading={{ render: () => <MyLoadingIndicator /> }}
+/>
+```
+
+The renderer receives `startedAt`, `detailsOpen`, and `onShowDetails` to optionally
+keep the diagnostics affordance. The SDK still owns loading visibility and exit
+transitions. Returning `null` hides the visual.

--- a/docs/design/genie-loading.md
+++ b/docs/design/genie-loading.md
@@ -16,3 +16,18 @@ Run `bun run --cwd packages/react demo`, then open `/genie-loading.html` for
 replayable quick, unhurried, long-wait, and failure scenarios, a light/dark switch,
 and diagnostics. The studio renders the production MessageTimeline from simulated
 SessionEvents and requires no model calls. The full stack runs with `bun run dev`.
+
+Hosts can customize the SDK without editing its source:
+
+```tsx
+<MessageTimeline
+  events={events}
+  genieLoading={{
+    phrases: ["Polishing the lamp…", "Consulting the carpet…"],
+    orb: { state: "searching", size: 64, speed: 0.8 },
+  }}
+/>
+```
+
+Orb states use the `thinking-orbs` component's typed options. Omitted settings
+keep the defaults; an empty phrase list also falls back to the defaults.

--- a/packages/react/demo/genie-loading-harness.tsx
+++ b/packages/react/demo/genie-loading-harness.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { MessageTimeline } from "../src/components/message-timeline";
+import { buildTimeline } from "../src/timeline/projection";
+import { StartupTimings } from "../src/timeline/startup-timings";
+import { setStartupDetails, useStartupDetails } from "../src/timeline/startup-preference";
+import type { SessionEvent } from "@opengeni/sdk";
+import "./styles.css";
+
+type Scenario = "Unhurried" | "Quick" | "Long wait" | "Failure";
+const BUTTON =
+  "rounded-lg border border-og-border px-3 py-2 text-og-sm text-og-fg-muted transition hover:bg-og-surface-2 focus-visible:outline-2 focus-visible:outline-og-accent";
+function App() {
+  const [scenario, setScenario] = useState<Scenario>("Unhurried");
+  const [run, setRun] = useState(0);
+  const [dark, setDark] = useState(true);
+  const [inspect, setInspect] = useState(false);
+  const [events, setEvents] = useState<SessionEvent[]>([]);
+  const debug = useStartupDetails();
+  useEffect(() => {
+    document.documentElement.setAttribute("data-og-theme", dark ? "dark" : "light");
+  }, [dark]);
+  useEffect(() => {
+    const history: SessionEvent[] = [];
+    const timers: number[] = [];
+    const emit = (type: string, payload: unknown) => {
+      history.push({
+        id: `demo-${run}-${history.length}`,
+        sequence: history.length + 1,
+        workspaceId: "demo",
+        sessionId: "genie",
+        turnId: "wish",
+        type,
+        payload,
+        occurredAt: new Date().toISOString(),
+      });
+      setEvents([...history]);
+    };
+    const schedule = (ms: number, type: string, payload: unknown) =>
+      timers.push(window.setTimeout(() => emit(type, payload), ms));
+    emit("user.message", { text: "Help me turn this idea into something wonderful." });
+    emit("turn.queued", { turnId: "wish", triggerEventId: `demo-${run}-0` });
+    const duration = scenario === "Quick" ? 2000 : scenario === "Long wait" ? 60000 : 16000;
+    schedule(300, "turn.started", { triggerEventId: `demo-${run}-0` });
+    schedule(350, "turn.startup.phase.started", { phase: "model_preparation" });
+    schedule(400, "sandbox.operation.started", { name: "sandbox.provision" });
+    if (scenario === "Failure") {
+      schedule(6000, "sandbox.operation.failed", {
+        name: "sandbox.provision",
+        error: "Could not start your workspace. Try again.",
+      });
+      schedule(6050, "turn.failed", { error: "Could not start your workspace. Try again." });
+    } else {
+      schedule(duration * 0.4, "sandbox.operation.completed", {
+        name: "sandbox.provision",
+        origin: "restored",
+        durationMs: duration * 0.4 - 400,
+      });
+      schedule(duration * 0.4 + 10, "turn.startup.phase.started", { phase: "tools" });
+      schedule(duration * 0.7, "turn.startup.phase.completed", {
+        phase: "tools",
+        durationMs: duration * 0.3,
+      });
+      schedule(duration * 0.75, "turn.startup.phase.completed", {
+        phase: "model_preparation",
+        durationMs: duration * 0.75 - 350,
+      });
+      schedule(duration * 0.75 + 10, "agent.model.request", { phase: "started" });
+      schedule(duration, "agent.model.request", {
+        phase: "first_byte",
+        durationMs: duration * 0.25,
+      });
+      schedule(duration + 50, "agent.message.completed", {
+        text: "Every good idea starts with a little possibility. Let's make yours real.",
+        messageId: "answer",
+      });
+      schedule(duration + 100, "turn.completed", {});
+    }
+    return () => timers.forEach(window.clearTimeout);
+  }, [scenario, run]);
+  const phases = useMemo(
+    () => buildTimeline(events).filter((item) => item.kind === "startup-phase"),
+    [events],
+  );
+  return (
+    <div className="mx-auto flex min-h-screen max-w-5xl flex-col px-6 py-8 sm:px-12">
+      <header className="flex items-center justify-between border-b border-og-border pb-6">
+        <div className="text-og-sm font-medium tracking-wide">
+          ✦ OpenGeni <span className="ml-2 font-normal text-og-fg-subtle">/ Loading studio</span>
+        </div>
+        <button className={BUTTON} onClick={() => setDark(!dark)}>
+          {dark ? "Light mode" : "Dark mode"}
+        </button>
+      </header>
+      <main className="py-12 sm:py-20">
+        <p className="text-og-xs uppercase tracking-[.2em] text-og-fg-subtle">
+          A moment of possibility
+        </p>
+        <h1 className="mt-4 text-4xl font-medium tracking-tight sm:text-5xl">
+          Good things take a little magic.
+        </h1>
+        <p className="mt-5 max-w-lg text-og-base leading-7 text-og-fg-muted">
+          A quieter beginning. A little personality. Then, straight to your work.
+        </p>
+        <div className="mt-9 flex flex-wrap items-center gap-2" aria-label="Loading scenarios">
+          {(["Unhurried", "Quick", "Long wait", "Failure"] as Scenario[]).map((value) => (
+            <button
+              key={value}
+              className={BUTTON}
+              aria-pressed={scenario === value}
+              style={scenario === value ? { background: "var(--og-color-surface-2)" } : undefined}
+              onClick={() => {
+                setScenario(value);
+                setRun((v) => v + 1);
+              }}
+            >
+              {value}
+            </button>
+          ))}
+          <button className={BUTTON} onClick={() => setRun((v) => v + 1)}>
+            Replay ↻
+          </button>
+        </div>
+        <section
+          aria-label="Live conversation preview"
+          className="mt-8 min-h-64 rounded-2xl border border-og-border bg-og-surface-1/30 p-5 sm:p-8"
+        >
+          <MessageTimeline key={`${run}-${scenario}`} events={events} />
+        </section>
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-og-xs text-og-fg-subtle">Live components · Simulated startup events</p>
+          <button className={BUTTON} onClick={() => setInspect(!inspect)} aria-expanded={inspect}>
+            {inspect ? "Close diagnostics" : "Open diagnostics"}
+          </button>
+        </div>
+        {inspect ? (
+          <section className="mt-6 rounded-xl border border-og-border p-5">
+            <label className="mb-5 flex cursor-pointer items-center gap-3 text-og-sm">
+              <input
+                type="checkbox"
+                checked={debug}
+                onChange={(event) => setStartupDetails(event.target.checked)}
+              />
+              Show startup details in chat
+            </label>
+            <StartupTimings phases={phases} />
+          </section>
+        ) : null}
+      </main>
+      <footer className="mt-auto border-t border-og-border pt-5 text-og-xs text-og-fg-subtle">
+        Less machinery. More imagination.
+      </footer>
+    </div>
+  );
+}
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/react/demo/genie-loading.html
+++ b/packages/react/demo/genie-loading.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenGeni · A little magic</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/genie-loading-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vite";
 const demoApiTarget = process.env.OPENGENI_REACT_DEMO_API_TARGET ?? "http://127.0.0.1:8000";
 const timelineScrollTestBuild = process.env.OPENGENI_TIMELINE_SCROLL_TEST_BUILD === "1";
 const demoInputs = {
+  genieLoading: resolve(__dirname, "genie-loading.html"),
   main: resolve(__dirname, "index.html"),
   timeline: resolve(__dirname, "timeline.html"),
   fleetPolicy: resolve(__dirname, "fleet-policy.html"),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -144,6 +144,7 @@
     "react-resizable-panels": "^4.11.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
+    "thinking-orbs": "^0.3.1",
     "virtua": "^0.49.2"
   },
   "devDependencies": {

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1,3 +1,4 @@
+import { GenieLoadingOptionsContext, type GenieLoadingOptions } from "../timeline/genie-loading";
 import { ChildSessionLink } from "./child-session-link";
 import { useStartupDetails } from "../timeline/startup-preference";
 import type {
@@ -192,6 +193,7 @@ export type MessageTimelineProps = {
    */
   computeLabel?: string | null | undefined;
   /** Customize collapsed turn facets for this timeline instance. */
+  genieLoading?: GenieLoadingOptions | undefined;
   turnSummary?: TurnSummaryOptions | undefined;
   /** Follow new events when pinned to the bottom. Defaults to true. */
   autoFollow?: boolean | undefined;
@@ -418,6 +420,7 @@ export function MessageTimeline({
   loadRetainedArtifact,
   loadVideoArtifactPlayback,
   computeLabel = null,
+  genieLoading,
   turnSummary,
   autoFollow = true,
   onAnnotate,
@@ -934,6 +937,7 @@ export function MessageTimeline({
         loadRetainedScreenshot,
         loadRetainedArtifact,
         loadVideoArtifactPlayback,
+        genieLoading,
         turnSummary,
       },
     }),
@@ -949,6 +953,7 @@ export function MessageTimeline({
       renderMessageText,
       resolveProviderLogo,
       toolRegistry,
+      genieLoading,
       turnSummary,
       userMessageDisclosureContext,
     ],
@@ -2356,6 +2361,7 @@ type TimelineGroupBehaviorProps = {
   loadRetainedScreenshot: MessageTimelineProps["loadRetainedScreenshot"];
   loadRetainedArtifact: MessageTimelineProps["loadRetainedArtifact"];
   loadVideoArtifactPlayback: MessageTimelineProps["loadVideoArtifactPlayback"];
+  genieLoading: MessageTimelineProps["genieLoading"];
   turnSummary: MessageTimelineProps["turnSummary"];
 };
 
@@ -2384,24 +2390,26 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
         ? 1
         : 0;
   return (
-    <div data-og-timeline-group-anchor="" data-og-group-key={groupKey}>
-      <EntranceAnimationProvider value={entranceEnabled} liveValue={liveEntranceEnabled}>
-        <TimelineGroupRenderBoundary resetKeys={[group, behavior]}>
-          <UserMessageDisclosureProvider value={userMessageDisclosureContext}>
-            <TimelineGroupView
-              {...behavior}
-              group={group}
-              foldLiveCluster={isAgentProgress(nextGroup)}
-              startupDismissed={startupDismissed}
-              trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
-              contextCompactionCount={
-                contextCompactionCount > 0 ? contextCompactionCount : undefined
-              }
-            />
-          </UserMessageDisclosureProvider>
-        </TimelineGroupRenderBoundary>
-      </EntranceAnimationProvider>
-    </div>
+    <GenieLoadingOptionsContext.Provider value={behavior.genieLoading}>
+      <div data-og-timeline-group-anchor="" data-og-group-key={groupKey}>
+        <EntranceAnimationProvider value={entranceEnabled} liveValue={liveEntranceEnabled}>
+          <TimelineGroupRenderBoundary resetKeys={[group, behavior]}>
+            <UserMessageDisclosureProvider value={userMessageDisclosureContext}>
+              <TimelineGroupView
+                {...behavior}
+                group={group}
+                foldLiveCluster={isAgentProgress(nextGroup)}
+                startupDismissed={startupDismissed}
+                trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
+                contextCompactionCount={
+                  contextCompactionCount > 0 ? contextCompactionCount : undefined
+                }
+              />
+            </UserMessageDisclosureProvider>
+          </TimelineGroupRenderBoundary>
+        </EntranceAnimationProvider>
+      </div>
+    </GenieLoadingOptionsContext.Provider>
   );
 });
 

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -28,7 +28,7 @@ import {
   XCircleIcon,
 } from "lucide-react";
 import type { ComponentType } from "react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Collapsible } from "radix-ui";
 import {
   Component,
@@ -2379,6 +2379,7 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
   liveEntranceEnabled,
   context,
 }: TimelineGroupEntryProps) {
+  const reducedMotion = useReducedMotion();
   const { behavior, userMessageDisclosureContext } = context;
   const contextCompactionCount =
     group.kind === "turn"
@@ -2395,16 +2396,31 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
         <EntranceAnimationProvider value={entranceEnabled} liveValue={liveEntranceEnabled}>
           <TimelineGroupRenderBoundary resetKeys={[group, behavior]}>
             <UserMessageDisclosureProvider value={userMessageDisclosureContext}>
-              <TimelineGroupView
-                {...behavior}
-                group={group}
-                foldLiveCluster={isAgentProgress(nextGroup)}
-                startupDismissed={startupDismissed}
-                trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
-                contextCompactionCount={
-                  contextCompactionCount > 0 ? contextCompactionCount : undefined
-                }
-              />
+              <AnimatePresence initial={false}>
+                <motion.div
+                  key={
+                    !startupDismissed &&
+                    group.kind === "activity" &&
+                    group.items.every((item) => item.kind === "startup-phase")
+                      ? "preparation"
+                      : "content"
+                  }
+                  initial={false}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.2 }}
+                >
+                  <TimelineGroupView
+                    {...behavior}
+                    group={group}
+                    foldLiveCluster={isAgentProgress(nextGroup)}
+                    startupDismissed={startupDismissed}
+                    trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
+                    contextCompactionCount={
+                      contextCompactionCount > 0 ? contextCompactionCount : undefined
+                    }
+                  />
+                </motion.div>
+              </AnimatePresence>
             </UserMessageDisclosureProvider>
           </TimelineGroupRenderBoundary>
         </EntranceAnimationProvider>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1,4 +1,5 @@
 import { ChildSessionLink } from "./child-session-link";
+import { useStartupDetails } from "../timeline/startup-preference";
 import type {
   DraftTimelineAnnotation,
   MediaGenerationResult,
@@ -590,6 +591,20 @@ export function MessageTimeline({
     previousBulkFirstKeyRef.current !== firstGroupKey;
   const bulkRender = allGroups.length > 0 && (bulkActive || firstKeyChangedForBulk);
   const groups = useStableTimelineGroupKeys(allGroups, !bulkRender);
+  const turnsWithOutput = useMemo(
+    () =>
+      new Set(
+        resolvedItems.flatMap((item) =>
+          "turnId" in item &&
+          item.turnId &&
+          (item.kind === "tool-call" ||
+            ((item.kind === "agent-message" || item.kind === "reasoning") && item.text.trim()))
+            ? [item.turnId]
+            : [],
+        ),
+      ),
+    [resolvedItems],
+  );
 
   const applyCanSkipTipCatchup = useCallback((value: boolean) => {
     if (canSkipTipCatchupRef.current !== value) {
@@ -2007,6 +2022,12 @@ export function MessageTimeline({
                                 groupKey={key}
                                 group={group}
                                 nextGroup={groups[index + 1]?.group}
+                                startupDismissed={
+                                  group.kind === "activity" &&
+                                  group.items.some(
+                                    (item) => item.turnId && turnsWithOutput.has(item.turnId),
+                                  )
+                                }
                                 entranceEnabled={entranceEnabled}
                                 liveEntranceEnabled={
                                   group.kind === "activity" ? !bulkRender : undefined
@@ -2178,7 +2199,21 @@ function useStableTimelineGroupKeys(
         // Retain only same-kind matches. Activity → turn wrap must NOT keep the
         // activity chip's React key: that reused a collapsed TurnSummary and
         // skipped the settle beat (insta-collapse / content flash).
-        if (previous && previous.group.kind === group.kind && !usedKeys.has(previous.key)) {
+        const startupCompletion =
+          previous?.group.kind === "activity" &&
+          previous.group.items.every((item) => item.kind === "startup-phase") &&
+          group.kind === "turn" &&
+          group.outcome === "complete" &&
+          group.groups.every(
+            (child) =>
+              child.kind === "activity" &&
+              child.items.every((item) => item.kind === "startup-phase"),
+          );
+        if (
+          previous &&
+          (previous.group.kind === group.kind || startupCompletion) &&
+          !usedKeys.has(previous.key)
+        ) {
           retainedGroup = previous;
           break;
         }
@@ -2298,6 +2333,7 @@ type TimelineGroupEntryProps = {
   groupKey: string;
   group: TimelineGroup;
   nextGroup?: TimelineGroup | undefined;
+  startupDismissed: boolean;
   entranceEnabled: boolean;
   liveEntranceEnabled?: boolean | undefined;
   context: TimelineGroupEntryContext;
@@ -2332,6 +2368,7 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
   groupKey,
   group,
   nextGroup,
+  startupDismissed,
   entranceEnabled,
   liveEntranceEnabled,
   context,
@@ -2355,6 +2392,7 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
               {...behavior}
               group={group}
               foldLiveCluster={isAgentProgress(nextGroup)}
+              startupDismissed={startupDismissed}
               trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
               contextCompactionCount={
                 contextCompactionCount > 0 ? contextCompactionCount : undefined
@@ -2389,6 +2427,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   insideTurn = false,
   nestClusterChips = false,
   foldLiveCluster = false,
+  startupDismissed = false,
   trailingAgentText,
   contextCompactionCount,
 }: {
@@ -2412,6 +2451,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
       behind a neutral chip — the one place activity without an outcome still
       folds, bounding the DOM of days-long autonomous turns. */
   foldLiveCluster?: boolean;
+  startupDismissed?: boolean;
   /** Rendering inside an expanded turn group: the outer chip already owns the
       failure surface, so nested chips stay tinted but quiet (no repeated
       failure text, no auto-open) — one loud error, N calm sub-expands. */
@@ -2432,6 +2472,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   /** Secondary chip facet when this fold sits next to a compaction landmark. */
   contextCompactionCount?: number | undefined;
 }) {
+  const startupDetails = useStartupDetails();
   const enter = useEntranceAnimation();
   const settleChrome = useTurnSettleOpen();
   const foldMemory = useFoldMemory();
@@ -2463,6 +2504,26 @@ const TimelineGroupView = memo(function TimelineGroupView({
     group.kind === "turn" ? !!(enter && !insideTurn && !turnDefaultOpen) : liveActivitySettle;
   switch (group.kind) {
     case "activity":
+      // Preparation is one quiet surface, not a fold with eight technical steps.
+      if (
+        !startupDetails &&
+        !insideTurn &&
+        !group.outcome &&
+        group.items.every((item) => item.kind === "startup-phase")
+      ) {
+        return (
+          <ActivityRail
+            items={group.items}
+            startupActive={!startupDismissed && !foldLiveCluster}
+            bare
+            toolRegistry={toolRegistry}
+            onOpenSession={onOpenSession}
+            onMemoryClick={onMemoryClick}
+            loadRetainedScreenshot={loadRetainedScreenshot}
+            loadRetainedArtifact={loadRetainedArtifact}
+          />
+        );
+      }
       if (insideTurn) {
         // Nested chips whenever the parent has ≥2 clusters. During outer settle
         // chrome they stay force-open so structure is visible and height stays
@@ -2542,6 +2603,18 @@ const TimelineGroupView = memo(function TimelineGroupView({
       );
     case "turn": {
       const activityItems = flattenActivityItems(group.groups);
+      if (
+        !startupDetails &&
+        group.outcome === "complete" &&
+        group.groups.every(
+          (child) =>
+            child.kind === "activity" &&
+            child.items.every(
+              (item) => item.kind === "startup-phase" && item.status === "complete",
+            ),
+        )
+      )
+        return <ActivityRail items={activityItems} startupActive={false} bare />;
       // Second-layer chips only when there are natural multi-cluster seams —
       // otherwise the outer turn chip alone is enough ("N steps" wrapping one
       // more "N steps" was the redundant double fold).
@@ -2727,7 +2800,7 @@ function isAgentProgress(next: TimelineGroup | undefined): boolean {
   return (
     next.kind === "activity" ||
     next.kind === "turn" ||
-    (next.kind === "item" && next.item.kind === "agent-message")
+    (next.kind === "item" && next.item.kind === "agent-message" && next.item.text.trim().length > 0)
   );
 }
 

--- a/packages/react/src/session-ui.ts
+++ b/packages/react/src/session-ui.ts
@@ -45,3 +45,4 @@ export type {
 export { SessionCommandsPanel } from "./components/session-commands-panel";
 export { StartupTimings } from "./timeline/startup-timings";
 export { useStartupDetails, setStartupDetails } from "./timeline/startup-preference";
+export type { GenieLoadingOptions } from "./timeline/genie-loading";

--- a/packages/react/src/session-ui.ts
+++ b/packages/react/src/session-ui.ts
@@ -43,3 +43,5 @@ export type {
   SessionChromeSignalTone,
 } from "./components/session-chrome";
 export { SessionCommandsPanel } from "./components/session-commands-panel";
+export { StartupTimings } from "./timeline/startup-timings";
+export { useStartupDetails, setStartupDetails } from "./timeline/startup-preference";

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -1,5 +1,8 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { GenieLoading } from "./genie-loading";
+import { useStartupDetails } from "./startup-preference";
 import { ArrowRightIcon, BotIcon, BrainCircuitIcon } from "lucide-react";
-import { lazy, Suspense, useLayoutEffect, useRef } from "react";
+import { lazy, Suspense, useLayoutEffect, useRef, useState } from "react";
 import { jsx as rowJsx, jsxs as rowJsxs } from "react/jsx-runtime";
 import { Markdown } from "../components/markdown";
 import { cn } from "../lib/cn";
@@ -28,6 +31,8 @@ const LazyPlatformActivityRow = lazy(() => import("./platform-activity-row"));
 
 export type ActivityRailProps = {
   items: ActivityItem[];
+  /** The owning turn remains active between individual phase receipts. */
+  startupActive?: boolean;
   /** Renderer registry for tool calls. Defaults to {@link defaultToolRegistry}. */
   toolRegistry?: ToolRegistry | undefined;
   /** Drill into a spawned worker session. */
@@ -60,6 +65,7 @@ function familyOf(item: ActivityItem): string {
 
 export function ActivityRail({
   items,
+  startupActive,
   toolRegistry = defaultToolRegistry,
   onOpenSession,
   onMemoryClick,
@@ -68,6 +74,37 @@ export function ActivityRail({
   bare,
   className,
 }: ActivityRailProps) {
+  const debug = useStartupDetails();
+  const reducedMotion = useReducedMotion();
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const phases = items.filter((item) => item.kind === "startup-phase");
+  // Empty reasoning envelopes can arrive before any visible model output.
+  const hasWork = items.some(
+    (item) =>
+      item.kind !== "startup-phase" && (item.kind !== "reasoning" || item.text.trim().length > 0),
+  );
+  const interrupted = phases.some(
+    (item) => item.status === "failed" || item.status === "cancelled",
+  );
+  const providerResponded = phases.some(
+    (item) => item.phase === "provider_first_byte" && item.status === "complete",
+  );
+  const preparing =
+    !hasWork &&
+    !interrupted &&
+    (startupActive ?? (!providerResponded && phases.some((item) => item.status === "running")));
+  const visibleItems =
+    debug || detailsOpen
+      ? items
+      : items.filter((item) =>
+          item.kind === "startup-phase"
+            ? item.status === "failed" || item.status === "cancelled"
+            : item.kind !== "reasoning" || item.text.trim().length > 0,
+        );
+  const startedAt = phases.reduce(
+    (first, item) => (item.startedAt < first ? item.startedAt : first),
+    phases[0]?.startedAt ?? "",
+  );
   const enterMounted = useEntranceAnimation();
   // Live gate: rails born during bulk capture enter=false forever; with a
   // seen-id map we still want later live appends to fade (ids gate remounts).
@@ -102,7 +139,7 @@ export function ActivityRail({
         // Rows sit TIGHT by default (gap-0.5) so a same-family run reads as one
         // calm cluster; a family change opens real breathing room (mt-3) below,
         // so a long rail reads as a few clusters, not a metronome of rows.
-        "flex flex-col gap-0.5",
+        "relative flex flex-col gap-0.5",
         !bare && "border-l-2 border-og-border pl-3 sm:pl-4",
         // Whole-rail enter: standalone rails only (no seen-id map). Inside
         // MessageTimeline, unknown ids take per-row enter — remounts stay quiet.
@@ -110,8 +147,42 @@ export function ActivityRail({
         className,
       )}
     >
-      {items.map((item, index) => {
-        const newFamily = index > 0 && familyOf(item) !== familyOf(items[index - 1]!);
+      <AnimatePresence initial={false}>
+        {preparing && !debug ? (
+          <motion.div
+            key="startup"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{
+              opacity: 0,
+              height: 0,
+              pointerEvents: "none",
+            }}
+            transition={{
+              height: { duration: reducedMotion ? 0 : 0.32, ease: [0.22, 1, 0.36, 1] },
+              opacity: { duration: reducedMotion ? 0 : 0.16 },
+            }}
+            style={{ overflow: "hidden" }}
+          >
+            <GenieLoading
+              startedAt={startedAt}
+              detailsOpen={detailsOpen}
+              onShowDetails={() => setDetailsOpen((open) => !open)}
+            />
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+      {detailsOpen && !debug && !preparing ? (
+        <button
+          type="button"
+          className="og-genie-details self-start"
+          onClick={() => setDetailsOpen(false)}
+        >
+          Hide startup details
+        </button>
+      ) : null}
+      {visibleItems.map((item, index) => {
+        const newFamily = index > 0 && familyOf(item) !== familyOf(visibleItems[index - 1]!);
         const row = renderActivity(
           item,
           toolRegistry,

--- a/packages/react/src/timeline/genie-loading.tsx
+++ b/packages/react/src/timeline/genie-loading.tsx
@@ -1,0 +1,73 @@
+import { ThinkingOrb } from "thinking-orbs";
+import { useThemeType } from "../lib/use-theme-type";
+import { useEffect, useState } from "react";
+
+const PHRASES = [
+  "Polishing the lamp…",
+  "Consulting the carpet…",
+  "Untangling wishes…",
+  "Summoning a little cleverness…",
+  "Checking the fine print on infinity…",
+  "Warming up the abracadabra…",
+  "Rearranging the stars…",
+  "Negotiating with the lamp…",
+  "Dusting off a thousand years…",
+  "Wishful thinking…",
+  "Decanting a little magic…",
+  "Finding the good stardust…",
+  "Fluffing the magic carpet…",
+  "Putting a wish into motion…",
+  "A little hocus. A little pocus…",
+];
+
+/** Decorative copy never substitutes for a failure or claims measurable progress. */
+export function GenieLoading({
+  startedAt,
+  onShowDetails,
+  detailsOpen = false,
+}: {
+  startedAt: string;
+  onShowDetails: () => void;
+  detailsOpen?: boolean;
+}) {
+  const theme = useThemeType(undefined);
+  const [phrase, setPhrase] = useState(0);
+  const [showDetails, setShowDetails] = useState(false);
+  const [slow, setSlow] = useState(false);
+  useEffect(() => {
+    const update = () => {
+      setShowDetails(Date.now() - Date.parse(startedAt) >= 15_000);
+      setSlow(Date.now() - Date.parse(startedAt) >= 30_000);
+      if (!document.hidden) setPhrase(Math.floor(Math.random() * PHRASES.length));
+    };
+    update();
+    const timer = window.setInterval(update, 5_000);
+    return () => window.clearInterval(timer);
+  }, [startedAt]);
+  return (
+    <div className="og-genie-loading">
+      <div className="og-genie-orb" aria-hidden="true">
+        <ThinkingOrb state="searching" size={64} theme={theme} speed={0.8} />
+      </div>
+      <div className="og-genie-copy">
+        <span className="sr-only" role="status">
+          {slow ? "Preparing your task. Taking longer than usual." : "Preparing your task."}
+        </span>
+        <span key={slow ? "slow" : phrase} className="og-genie-phrase" aria-hidden="true">
+          {slow ? "A little longer than usual…" : PHRASES[phrase]}
+        </span>
+        {showDetails || detailsOpen ? (
+          <button
+            type="button"
+            className="og-genie-details"
+            aria-expanded={detailsOpen}
+            onClick={onShowDetails}
+          >
+            {detailsOpen ? "Hide details" : "Behind the magic"}
+            <span aria-hidden="true"> ↗</span>
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/timeline/genie-loading.tsx
+++ b/packages/react/src/timeline/genie-loading.tsx
@@ -1,6 +1,12 @@
 import { ThinkingOrb } from "thinking-orbs";
 import { useThemeType } from "../lib/use-theme-type";
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, type ComponentProps } from "react";
+
+export type GenieLoadingOptions = {
+  phrases?: readonly string[];
+  orb?: Pick<ComponentProps<typeof ThinkingOrb>, "state" | "size" | "speed">;
+};
+export const GenieLoadingOptionsContext = createContext<GenieLoadingOptions | undefined>(undefined);
 
 const PHRASES = [
   "Polishing the lamp…",
@@ -30,6 +36,8 @@ export function GenieLoading({
   onShowDetails: () => void;
   detailsOpen?: boolean;
 }) {
+  const options = useContext(GenieLoadingOptionsContext);
+  const phrases = options?.phrases?.length ? options.phrases : PHRASES;
   const theme = useThemeType(undefined);
   const [phrase, setPhrase] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
@@ -38,23 +46,23 @@ export function GenieLoading({
     const update = () => {
       setShowDetails(Date.now() - Date.parse(startedAt) >= 15_000);
       setSlow(Date.now() - Date.parse(startedAt) >= 30_000);
-      if (!document.hidden) setPhrase(Math.floor(Math.random() * PHRASES.length));
+      if (!document.hidden) setPhrase(Math.floor(Math.random() * phrases.length));
     };
     update();
     const timer = window.setInterval(update, 5_000);
     return () => window.clearInterval(timer);
-  }, [startedAt]);
+  }, [startedAt, phrases]);
   return (
     <div className="og-genie-loading">
       <div className="og-genie-orb" aria-hidden="true">
-        <ThinkingOrb state="searching" size={64} theme={theme} speed={0.8} />
+        <ThinkingOrb state="searching" size={64} theme={theme} speed={0.8} {...options?.orb} />
       </div>
       <div className="og-genie-copy">
         <span className="sr-only" role="status">
           {slow ? "Preparing your task. Taking longer than usual." : "Preparing your task."}
         </span>
         <span key={slow ? "slow" : phrase} className="og-genie-phrase" aria-hidden="true">
-          {slow ? "A little longer than usual…" : PHRASES[phrase]}
+          {slow ? "A little longer than usual…" : phrases[phrase % phrases.length]}
         </span>
         {showDetails || detailsOpen ? (
           <button

--- a/packages/react/src/timeline/genie-loading.tsx
+++ b/packages/react/src/timeline/genie-loading.tsx
@@ -1,8 +1,23 @@
 import { ThinkingOrb } from "thinking-orbs";
 import { useThemeType } from "../lib/use-theme-type";
-import { createContext, useContext, useEffect, useState, type ComponentProps } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+  type ComponentProps,
+} from "react";
+
+export type GenieLoadingRenderProps = {
+  startedAt: string;
+  detailsOpen: boolean;
+  onShowDetails: () => void;
+};
 
 export type GenieLoadingOptions = {
+  /** Replace the visual while preserving SDK loading visibility and transitions. */
+  render?: (props: GenieLoadingRenderProps) => ReactNode;
   phrases?: readonly string[];
   orb?: Pick<ComponentProps<typeof ThinkingOrb>, "state" | "size" | "speed">;
 };
@@ -52,9 +67,18 @@ export function GenieLoading({
     const timer = window.setInterval(update, 5_000);
     return () => window.clearInterval(timer);
   }, [startedAt, phrases]);
+  if (options?.render) return options.render({ startedAt, detailsOpen, onShowDetails });
   return (
     <div className="og-genie-loading">
-      <div className="og-genie-orb" aria-hidden="true">
+      <div
+        className="og-genie-orb"
+        aria-hidden="true"
+        style={{
+          width: options?.orb?.size ?? 64,
+          height: options?.orb?.size ?? 64,
+          flexBasis: options?.orb?.size ?? 64,
+        }}
+      >
         <ThinkingOrb state="searching" size={64} theme={theme} speed={0.8} {...options?.orb} />
       </div>
       <div className="og-genie-copy">

--- a/packages/react/src/timeline/startup-preference.ts
+++ b/packages/react/src/timeline/startup-preference.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from "react";
+
+const KEY = "opengeni:startup-details:v1";
+const EVENT = "opengeni:startup-details-changed";
+let fallback = false;
+function snapshot() {
+  try {
+    return window.localStorage.getItem(KEY) === "true";
+  } catch {
+    return fallback;
+  }
+}
+function subscribe(listener: () => void) {
+  window.addEventListener(EVENT, listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    window.removeEventListener(EVENT, listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+export function setStartupDetails(value: boolean) {
+  fallback = value;
+  try {
+    window.localStorage.setItem(KEY, String(value));
+  } catch {
+    /* Private storage is optional. */
+  }
+  window.dispatchEvent(new Event(EVENT));
+}
+/** Presentation preference only. Startup evidence is always retained. */
+export function useStartupDetails() {
+  return useSyncExternalStore(subscribe, snapshot, () => false);
+}

--- a/packages/react/src/timeline/startup-timings.tsx
+++ b/packages/react/src/timeline/startup-timings.tsx
@@ -1,0 +1,145 @@
+import type { StartupPhaseItem } from "./types";
+
+const LABELS: Record<StartupPhaseItem["phase"], string> = {
+  queue: "Worker queue",
+  sandbox: "Sandbox",
+  rig: "Rig",
+  repository: "Repository",
+  files: "Files",
+  tools: "Tools",
+  model_preparation: "Runtime & model request",
+  provider_first_byte: "First model response",
+};
+
+export function StartupTimings({ phases }: { phases: StartupPhaseItem[] }) {
+  if (!phases.length)
+    return <p className="text-og-sm text-og-fg-subtle">No startup timings recorded yet.</p>;
+  const byTurn = new Map<string | null, StartupPhaseItem[]>();
+  for (const phase of phases) {
+    const group = byTurn.get(phase.turnId) ?? [];
+    group.push(phase);
+    byTurn.set(phase.turnId, group);
+  }
+  const turns = [...byTurn.entries()]
+    .map(([turnId, phases]) => ({
+      turnId,
+      phases,
+      startedAt: phases.reduce(
+        (earliest, phase) => (phase.startedAt < earliest ? phase.startedAt : earliest),
+        phases[0]!.startedAt,
+      ),
+    }))
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  return (
+    <div className="space-y-3">
+      <p className="text-og-xs text-og-fg-subtle">
+        Each turn has its own startup. Phases can overlap; durations are not additive.
+      </p>
+      {turns.map((turn, index) => (
+        <StartupTurn
+          key={turn.turnId ?? "unassigned"}
+          {...turn}
+          latest={index === 0 && turn.turnId !== null}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StartupTurn({
+  turnId,
+  phases,
+  startedAt,
+  latest,
+}: {
+  turnId: string | null;
+  phases: StartupPhaseItem[];
+  startedAt: string;
+  latest: boolean;
+}) {
+  const status = phases.some((phase) => phase.status === "failed")
+    ? "Failed"
+    : phases.some((phase) => phase.status === "running")
+      ? "In progress"
+      : phases.some((phase) => phase.status === "cancelled")
+        ? "Interrupted"
+        : "Ready";
+  return (
+    <details open={latest} className="group border-b border-og-border pb-3">
+      <summary className="cursor-pointer rounded py-3 text-og-sm text-og-fg-muted focus-visible:outline-2 focus-visible:outline-og-accent">
+        <span className="font-medium">
+          {turnId === null ? "Unassigned events" : latest ? "Latest turn" : "Earlier turn"}
+        </span>
+        <span className="ml-2 text-og-xs text-og-fg-subtle">
+          {new Date(startedAt).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+          })}
+        </span>
+        <span
+          className={
+            status === "Failed"
+              ? "ml-2 text-og-xs text-og-status-failed"
+              : "ml-2 text-og-xs text-og-fg-subtle"
+          }
+        >
+          {status}
+        </span>
+        <span className="mt-1 block break-all pl-4 font-og-mono text-og-xs text-og-fg-subtle">
+          {turnId ?? "No turn ID recorded"}
+        </span>
+      </summary>
+      <div className="pb-2">
+        <p className="text-og-xs text-og-fg-subtle">
+          Started <time dateTime={startedAt}>{new Date(startedAt).toLocaleString()}</time>
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-og-xs">
+            <caption className="sr-only">
+              Startup phases for {turnId ?? "unassigned events"}
+            </caption>
+            <thead>
+              <tr className="border-b border-og-border text-og-fg-subtle">
+                <th scope="col" className="py-2 font-medium">
+                  Phase
+                </th>
+                <th scope="col" className="px-3 py-2 font-medium">
+                  Status
+                </th>
+                <th scope="col" className="py-2 text-right font-medium">
+                  Duration
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {phases.map((phase, index) => (
+                <tr
+                  key={`${phase.id}:${index}`}
+                  className="border-b border-og-border/40"
+                  title={`Turn: ${phase.turnId ?? "unknown"} · Started: ${phase.startedAt}`}
+                >
+                  <th scope="row" className="py-2.5 font-normal text-og-fg-muted">
+                    {LABELS[phase.phase]}
+                  </th>
+                  <td
+                    className={`px-3 py-2.5 ${phase.status === "failed" ? "text-og-status-failed" : "text-og-fg-subtle"}`}
+                  >
+                    {phase.status === "running" ? "In progress" : phase.status}
+                  </td>
+                  <td className="py-2.5 text-right font-og-mono tabular-nums text-og-fg-muted">
+                    {phase.durationMs === null
+                      ? "—"
+                      : phase.durationMs < 1000
+                        ? `${Math.round(phase.durationMs)} ms`
+                        : `${(phase.durationMs / 1000).toFixed(1)} s`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -571,9 +571,14 @@ function createTurnSummaryContext(
 const BUILT_IN_TURN_SUMMARY_FACETS: readonly TurnSummaryFacet[] = Object.freeze([
   {
     id: "steps",
-    summarize: ({ items }) => ({
-      content: `${items.length} ${items.length === 1 ? "step" : "steps"}`,
-    }),
+    summarize: ({ items }) => {
+      const count = items.filter((item) => item.kind !== "startup-phase").length;
+      return count
+        ? { content: `${count} ${count === 1 ? "step" : "steps"}` }
+        : items.length
+          ? { content: "Preparation" }
+          : null;
+    },
   },
   {
     id: "files",

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -847,6 +847,70 @@
   pointer-events: none !important;
   z-index: -1 !important;
 }
+:where(.og-root).og-genie-loading,:where(.og-root) .og-genie-loading {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 88px;
+  padding: 12px 0;
+}
+:where(.og-root).og-genie-orb,:where(.og-root) .og-genie-orb {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 64px;
+}
+:where(.og-root).og-genie-orb canvas,:where(.og-root) .og-genie-orb canvas {
+  display: block;
+}
+:where(.og-root).og-genie-copy,:where(.og-root) .og-genie-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+:where(.og-root).og-genie-phrase,:where(.og-root) .og-genie-phrase {
+  color: var(--og-color-fg-muted);
+  font-size: var(--og-font-size-sm);
+  line-height: 1.5;
+  animation: og-genie-phrase-in .65s ease-out both;
+}
+:where(.og-root).og-genie-details,:where(.og-root) .og-genie-details {
+  color: var(--og-color-fg-subtle);
+  font-size: var(--og-font-size-xs);
+  min-height: 28px;
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+  transition: color .2s;
+}
+:where(.og-root).og-genie-details:hover,:where(.og-root) .og-genie-details:hover {
+  color: var(--og-color-fg);
+}
+:where(.og-root).og-genie-details:focus-visible,:where(.og-root) .og-genie-details:focus-visible {
+  outline: 2px solid #a995e9;
+  outline-offset: 4px;
+}
+@keyframes og-genie-phrase-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (pointer: coarse) {
+  :where(.og-root).og-genie-details,:where(.og-root) .og-genie-details {
+    min-height: 44px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  :where(.og-root).og-genie-phrase,:where(.og-root) .og-genie-phrase {
+    animation: none;
+  }
+}
 :where(.og-root).pointer-events-auto,:where(.og-root) .pointer-events-auto {
     pointer-events: auto;
   }
@@ -2180,6 +2244,12 @@
 :where(.og-root).border-og-border-strong,:where(.og-root) .border-og-border-strong {
     border-color: var(--og-color-border-strong);
   }
+:where(.og-root).border-og-border\/40,:where(.og-root) .border-og-border\/40 {
+    border-color: var(--og-color-border);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--og-color-border) 40%, transparent);
+    }
+  }
 :where(.og-root).border-og-border\/50,:where(.og-root) .border-og-border\/50 {
     border-color: var(--og-color-border);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2964,6 +3034,9 @@
   }
 :where(.og-root).pl-3\.5,:where(.og-root) .pl-3\.5 {
     padding-left: calc(var(--spacing) * 3.5);
+  }
+:where(.og-root).pl-4,:where(.og-root) .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
   }
 :where(.og-root).pl-5,:where(.og-root) .pl-5 {
     padding-left: calc(var(--spacing) * 5);

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -579,3 +579,18 @@
   pointer-events: none !important;
   z-index: -1 !important;
 }
+
+/* The upstream ThinkingOrb owns motion, visibility pausing, and reduced motion. */
+.og-genie-loading { display: flex; align-items: center; gap: 14px; min-height: 88px; padding: 12px 0; }
+.og-genie-orb { width: 64px; height: 64px; flex: 0 0 64px; }
+.og-genie-orb canvas { display: block; }
+.og-genie-copy { min-width: 0; display: flex; flex-direction: column; align-items: flex-start; gap: 5px; }
+.og-genie-phrase { color: var(--og-color-fg-muted); font-size: var(--og-font-size-sm); line-height: 1.5; animation: og-genie-phrase-in .65s ease-out both; }
+.og-genie-details { color: var(--og-color-fg-subtle); font-size: var(--og-font-size-xs); min-height: 28px; cursor: pointer; border-radius: 4px; text-align: left; transition: color .2s; }
+.og-genie-details:hover { color: var(--og-color-fg); }
+.og-genie-details:focus-visible { outline: 2px solid #a995e9; outline-offset: 4px; }
+@keyframes og-genie-phrase-in { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
+@media (pointer: coarse) { .og-genie-details { min-height: 44px; } }
+@media (prefers-reduced-motion: reduce) {
+  .og-genie-phrase { animation: none; }
+}

--- a/packages/react/test/genie-loading.test.tsx
+++ b/packages/react/test/genie-loading.test.tsx
@@ -212,3 +212,29 @@ test("work mixed with startup receipts uses the normal Steps disclosure", async 
   expect(r.container.querySelector("button[aria-expanded]")).not.toBeNull();
   await r.unmount();
 });
+
+test("hosts can replace loading with an arbitrary component", async () => {
+  const r = await renderComponent(
+    <MessageTimeline
+      items={[phase()]}
+      genieLoading={{
+        render: ({ startedAt }) => <div data-start={startedAt}>Custom preparation</div>,
+      }}
+    />,
+  );
+  expect(r.container.textContent).toContain("Custom preparation");
+  expect(r.container.querySelector("canvas")).toBeNull();
+  await r.unmount();
+});
+
+test("hosts can customize phrases and orb dimensions", async () => {
+  const r = await renderComponent(
+    <MessageTimeline
+      items={[phase()]}
+      genieLoading={{ phrases: ["Custom wish"], orb: { size: 96 } }}
+    />,
+  );
+  expect(r.container.textContent).toContain("Custom wish");
+  expect((r.container.querySelector(".og-genie-orb") as HTMLElement).style.width).toBe("96px");
+  await r.unmount();
+});

--- a/packages/react/test/genie-loading.test.tsx
+++ b/packages/react/test/genie-loading.test.tsx
@@ -1,0 +1,214 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { ActivityRail } from "../src/timeline/activity-rail";
+import { MessageTimeline } from "../src/components/message-timeline";
+import { StartupTimings } from "../src/timeline/startup-timings";
+import { setStartupDetails } from "../src/timeline/startup-preference";
+import type { StartupPhaseItem } from "../src/timeline/types";
+import { registerDom, renderComponent, flush } from "./render-hook";
+registerDom();
+afterEach(() => setStartupDetails(false));
+function phase(overrides: Partial<StartupPhaseItem> = {}): StartupPhaseItem {
+  return {
+    kind: "startup-phase",
+    id: "start",
+    turnId: "turn",
+    phase: "sandbox",
+    status: "running",
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    durationMs: null,
+    outcome: null,
+    occurredAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+test("normal preparation has one accessible status and hides all timing rows", async () => {
+  const r = await renderComponent(
+    <ActivityRail items={[phase(), phase({ id: "tools", phase: "tools" })]} />,
+  );
+  expect(r.container.querySelectorAll('[role="status"]').length).toBe(1);
+  expect(r.container.textContent).not.toContain("Starting sandbox");
+  expect(r.container.textContent).not.toContain("Connecting tools");
+  expect(r.container.querySelector("button")).toBeNull();
+  await r.unmount();
+});
+test("details appear after 15 seconds without replacing playful copy", async () => {
+  const r = await renderComponent(
+    <ActivityRail items={[phase({ startedAt: new Date(Date.now() - 15_001).toISOString() })]} />,
+  );
+  expect(r.container.textContent).toContain("Behind the magic");
+  expect(r.container.textContent).not.toContain("A little longer than usual");
+  await act(async () => r.container.querySelector("button")!.click());
+  for (let i = 0; i < 20 && !r.container.textContent?.includes("Starting sandbox"); i++)
+    await flush(10);
+  expect(r.container.textContent).toContain("Starting sandbox");
+  expect(r.container.textContent).toContain("Hide details");
+  await r.unmount();
+});
+test("historical startup is quiet but recorded timings remain inspectable", async () => {
+  const item = phase({ status: "complete", durationMs: 1234 });
+  const r = await renderComponent(<ActivityRail items={[item]} />);
+  expect(r.container.textContent).toBe("");
+  await act(async () => setStartupDetails(true));
+  await flush();
+  expect(r.container.textContent).toContain("1.2s");
+  await act(async () => setStartupDetails(false));
+  expect(r.container.textContent).toBe("");
+  await r.unmount();
+  const table = await renderComponent(<StartupTimings phases={[item]} />);
+  expect(table.container.textContent).toContain("1.2 s");
+  expect(table.container.textContent).toContain("not additive");
+  await table.unmount();
+});
+test("long waits replace playful text with an honest status", async () => {
+  const r = await renderComponent(
+    <ActivityRail items={[phase({ startedAt: new Date(Date.now() - 31_000).toISOString() })]} />,
+  );
+  expect(r.container.textContent).toContain("A little longer than usual");
+  expect(r.container.textContent).toContain("Behind the magic");
+  await r.unmount();
+});
+test("failures and cancellation stop the wisp and stay visible", async () => {
+  for (const status of ["failed", "cancelled"] as const) {
+    const r = await renderComponent(
+      <ActivityRail items={[phase({ status }), phase({ id: "other", phase: "tools" })]} />,
+    );
+    await flush();
+    expect(r.container.querySelector(".og-genie-loading")).toBeNull();
+    expect(r.container.textContent).toContain(
+      status === "failed" ? "Sandbox didn’t start" : "Sandbox startup interrupted",
+    );
+    await r.unmount();
+  }
+});
+test("real work replaces loading even if a startup receipt is still running", async () => {
+  const r = await renderComponent(
+    <ActivityRail
+      items={[
+        phase(),
+        {
+          kind: "reasoning",
+          id: "thought",
+          turnId: "turn",
+          text: "Considering the design",
+          streaming: true,
+          occurredAt: new Date().toISOString(),
+        },
+      ]}
+    />,
+  );
+  await flush();
+  expect(r.container.querySelector(".og-genie-loading")).toBeNull();
+  expect(r.container.textContent).toContain("Thinking");
+  await r.unmount();
+});
+test("startup-only timeline groups have no verbose step-count shell", async () => {
+  const r = await renderComponent(<MessageTimeline items={[phase()]} />);
+  expect(r.container.textContent).not.toContain("steps");
+  expect(r.container.querySelector(".og-genie-loading")).not.toBeNull();
+  await r.unmount();
+});
+
+test("the same orb survives gaps between startup phases", async () => {
+  const first = phase();
+  const r = await renderComponent(<MessageTimeline items={[first]} />);
+  const canvas = r.container.querySelector("canvas");
+  expect(canvas).not.toBeNull();
+  const complete = { ...first, status: "complete" as const, durationMs: 100 };
+  await r.rerender(<MessageTimeline items={[complete]} />);
+  expect(r.container.querySelector("canvas")).toBe(canvas);
+  await r.rerender(<MessageTimeline items={[complete, phase({ id: "tools", phase: "tools" })]} />);
+  expect(r.container.querySelector("canvas")).toBe(canvas);
+  await r.unmount();
+});
+
+test("provider first byte does not remove the orb before visible response text", async () => {
+  const first = phase();
+  const r = await renderComponent(<MessageTimeline items={[first]} />);
+  const canvas = r.container.querySelector("canvas");
+  const ready = [
+    { ...first, status: "complete" as const },
+    phase({ id: "first-byte", phase: "provider_first_byte", status: "complete", durationMs: 100 }),
+  ];
+  await r.rerender(<MessageTimeline items={ready} />);
+  expect(r.container.querySelector("canvas")).toBe(canvas);
+  const message = {
+    kind: "agent-message" as const,
+    id: "answer",
+    turnId: "turn",
+    text: "",
+    streaming: true,
+    occurredAt: new Date().toISOString(),
+  };
+  await r.rerender(<MessageTimeline items={[...ready, message]} />);
+  expect(r.container.querySelector("canvas")).toBe(canvas);
+  await r.rerender(<MessageTimeline items={[...ready, { ...message, text: "Hello" }]} />);
+  expect(r.container.textContent).toContain("Hello");
+  await r.unmount();
+});
+
+test("empty reasoning keeps the orb until visible reasoning arrives", async () => {
+  const first = phase();
+  const thought = {
+    kind: "reasoning" as const,
+    id: "thought",
+    turnId: "turn",
+    text: " ",
+    streaming: true,
+    occurredAt: first.occurredAt,
+  };
+  const r = await renderComponent(<ActivityRail items={[first]} startupActive />);
+  const canvas = r.container.querySelector("canvas");
+  await r.rerender(<ActivityRail items={[first, thought]} startupActive />);
+  expect(r.container.querySelector("canvas")).toBe(canvas);
+  expect(r.container.textContent).not.toContain("Thinking");
+  await r.rerender(
+    <ActivityRail items={[first, { ...thought, text: "Considering options" }]} startupActive />,
+  );
+  await flush();
+  expect(r.container.textContent).toContain("Thinking");
+  await r.unmount();
+});
+
+test("late preparation cannot restart loading after output in the same turn", async () => {
+  const r = await renderComponent(
+    <MessageTimeline
+      items={[
+        {
+          kind: "agent-message",
+          id: "reply",
+          turnId: "turn",
+          text: "Starting research",
+          streaming: true,
+          occurredAt: new Date().toISOString(),
+        },
+        phase({ id: "late-start" }),
+      ]}
+    />,
+  );
+  expect(r.container.querySelector(".og-genie-loading")).toBeNull();
+  expect(r.container.textContent).toContain("Starting research");
+  await r.unmount();
+});
+
+test("work mixed with startup receipts uses the normal Steps disclosure", async () => {
+  const r = await renderComponent(
+    <MessageTimeline
+      items={[
+        phase(),
+        {
+          kind: "reasoning",
+          id: "thinking",
+          turnId: "turn",
+          text: "Considering options",
+          streaming: true,
+          occurredAt: new Date().toISOString(),
+        },
+      ]}
+    />,
+  );
+  expect(r.container.querySelector(".og-genie-loading")).toBeNull();
+  expect(r.container.querySelector("button[aria-expanded]")).not.toBeNull();
+  await r.unmount();
+});

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { setStartupDetails } from "../src/timeline/startup-preference";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
 import { act } from "react";
 import { registerDom, renderComponent, flush } from "./render-hook";
@@ -2601,6 +2602,8 @@ describe("StartupPhaseRow", () => {
     await r.unmount();
   });
 
+  beforeEach(() => setStartupDetails(true));
+  afterEach(() => setStartupDetails(false));
   test("shows the settled phase duration and truthful sandbox origin", async () => {
     const item: StartupPhaseItem = {
       kind: "startup-phase",


### PR DESCRIPTION
Replace verbose startup timing rows with a quiet animated orb and rotating genie phrases. Preserve diagnostics in the Startup inspector and a delayed Behind the magic disclosure. Hosts can customize phrases and orb state, size, and speed through MessageTimeline's genieLoading prop.

Dismiss loading once a turn produces visible output, and retain normal Steps grouping for tools and reasoning. Includes a replayable SDK demo and local Postgres/Vite fixes found during full-stack verification.

Validation: 99 timeline/rendering tests plus focused regression tests passed; React and web typechecks passed before configuration addition, React typecheck and 12 loading tests passed afterward. Verified local Modal execution and session rendering.

## Summary by Sourcery

Replace verbose startup timing rows with a quiet, configurable genie loading experience while retaining accessible diagnostics and truthful failure states.

New Features:
- Add a configurable genie loading experience to MessageTimeline with animated orb states, rotating phrases, and custom renderers.
- Expose browser-local startup detail preferences and a Startup inspector with recorded phase timings.
- Add a replayable loading studio covering normal, long-wait, and failure scenarios.

Bug Fixes:
- Keep loading visible until a turn produces visible reasoning, tool activity, or response output, including across delayed startup events.
- Keep startup failures and cancellations visible while replacing verbose startup rows during normal loading.

Enhancements:
- Preserve normal Steps grouping for turns containing tools or reasoning and support reduced-motion behavior for the loading presentation.

Build:
- Add the thinking-orbs dependency and loading studio entry point.
- Constrain local Temporal/Postgres connection pools and bind the web development server to localhost.

Documentation:
- Document the genie loading behavior, diagnostics, customization options, and replayable studio.

Tests:
- Add focused rendering and loading regression coverage for timing visibility, delayed output, failures, customization, and transitions.

Chores:
- Record the React package minor release changeset.