### PR TITLE
fix(db): attribute exported user messages to accepting turns

### DIFF
--- a/.changeset/host-export-message-attribution.md
+++ b/.changeset/host-export-message-attribution.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Preserve sender attribution for initial and follow-up user messages in host exports by resolving their exact triggering turn. Canonical events, existing exports, and checkpoints remain unchanged.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -953,6 +953,17 @@ Canonical sources: the `HostEventSink` / `HostUsageSink` contracts in
 registration repair in `0107_host_export_lineage_contract.sql`, and
 `createHostExportPump(options)` in `apps/worker/src/host-export-pump.ts`.
 
+Accepted `user.message` events intentionally have no direct turn ID. Migration
+`0460_host_export_message_attribution.sql` derives export initiator and origin
+from the exact same-account/workspace/session turn whose `trigger_event_id`
+references the message, after the accepting transaction commits its turn. It
+never derives sender authority from payload fields or the session creator.
+An unbound event stays unattributed. The event's own turn ID and the existing
+immutable export rows/checkpoints are unchanged; downstream historical
+attribution repair is a separate operator action. Analytics consumers must expose
+unattributed coverage instead of equating missing identity with zero messages.
+
+
 An embedded host can project OpenGeni's bounded durable session events and exact usage facts into
 its own business store without polling tenant routes or treating NATS as a durable log. This surface
 is optional. With no registered consumer, both export gates default to false and source transactions

--- a/packages/db/drizzle/0460_host_export_message_attribution.sql
+++ b/packages/db/drizzle/0460_host_export_message_attribution.sql
@@ -1,0 +1,177 @@
+-- deployment-mode: rolling
+-- Attribute accepted user messages through their exact triggering turn. The
+-- source event deliberately has no turn_id; the deferred INSERT trigger runs
+-- after the accepting transaction has installed its turn. Never infer a sender
+-- from the session creator or from arbitrary payload fields. Existing immutable
+-- export rows and consumer checkpoints are unchanged.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+DO $migration$
+DECLARE target_schema text := current_schema();
+BEGIN
+  EXECUTE format($create$
+    CREATE OR REPLACE FUNCTION opengeni_private.enqueue_host_session_event_export()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $function$
+    DECLARE
+      v_enabled boolean;
+      v_initiator jsonb;
+      v_context jsonb := '{}'::jsonb;
+      v_origin text;
+      v_attribution_turn_id uuid;
+      v_source_payload_bytes integer;
+      v_export_payload jsonb;
+      v_export_payload_codec_version smallint;
+      v_payload_bytes integer;
+    BEGIN
+      IF NEW.type IN (
+        'agent.message.delta', 'agent.reasoning.delta',
+        'sandbox.command.output.delta', 'terminal.pty.output.delta'
+      ) THEN
+        RETURN NEW;
+      END IF;
+
+      SELECT c.session_events_enabled INTO v_enabled
+      FROM %1$I.host_export_config c WHERE c.id = 1
+      FOR SHARE;
+      IF coalesce(v_enabled, false) = false THEN
+        RETURN NEW;
+      END IF;
+
+      v_attribution_turn_id := NEW.turn_id;
+      IF v_attribution_turn_id IS NULL AND NEW.type = 'user.message' THEN
+        SELECT min(t.id::text)::uuid INTO v_attribution_turn_id
+        FROM %1$I.session_turns t
+        WHERE t.account_id = NEW.account_id
+          AND t.workspace_id = NEW.workspace_id
+          AND t.session_id = NEW.session_id
+          AND t.trigger_event_id = NEW.id
+        HAVING count(*) = 1;
+      END IF;
+
+      IF v_attribution_turn_id IS NOT NULL THEN
+        SELECT
+          CASE WHEN octet_length(t.initiator_subject_id) <= 1024 THEN
+            jsonb_strip_nulls(jsonb_build_object(
+              'kind', t.initiator_kind,
+              'subjectId', t.initiator_subject_id,
+              'label', CASE
+                WHEN jsonb_typeof(t.initiator_context -> 'label') = 'string'
+                THEN left(t.initiator_context ->> 'label', 256)
+                ELSE NULL
+              END
+            ))
+          ELSE NULL END,
+          jsonb_strip_nulls(jsonb_build_object(
+            'label', CASE
+              WHEN jsonb_typeof(t.initiator_context -> 'label') = 'string'
+              THEN left(t.initiator_context ->> 'label', 256)
+              ELSE NULL
+            END,
+            'backfill', CASE
+              WHEN jsonb_typeof(t.initiator_context -> 'backfill') = 'boolean'
+              THEN t.initiator_context -> 'backfill'
+              ELSE NULL
+            END,
+            'attributionOmitted', CASE
+              WHEN octet_length(t.initiator_subject_id) > 1024 THEN 'subject_id_too_large'
+              ELSE NULL
+            END
+          )),
+          t.source
+        INTO v_initiator, v_context, v_origin
+        FROM %1$I.session_turns t
+        WHERE t.account_id = NEW.account_id
+          AND t.workspace_id = NEW.workspace_id
+          AND t.session_id = NEW.session_id
+          AND t.id = v_attribution_turn_id;
+      ELSIF NEW.type = 'session.created' THEN
+        SELECT
+          CASE WHEN octet_length(s.created_by_subject_id) <= 1024 THEN
+            jsonb_strip_nulls(jsonb_build_object(
+              'kind', s.created_by_kind,
+              'subjectId', s.created_by_subject_id,
+              'label', CASE
+                WHEN jsonb_typeof(s.created_by_context -> 'label') = 'string'
+                THEN left(s.created_by_context ->> 'label', 256)
+                ELSE NULL
+              END
+            ))
+          ELSE NULL END,
+          jsonb_strip_nulls(jsonb_build_object(
+            'label', CASE
+              WHEN jsonb_typeof(s.created_by_context -> 'label') = 'string'
+              THEN left(s.created_by_context ->> 'label', 256)
+              ELSE NULL
+            END,
+            'backfill', CASE
+              WHEN jsonb_typeof(s.created_by_context -> 'backfill') = 'boolean'
+              THEN s.created_by_context -> 'backfill'
+              ELSE NULL
+            END,
+            'attributionOmitted', CASE
+              WHEN octet_length(s.created_by_subject_id) > 1024 THEN 'subject_id_too_large'
+              ELSE NULL
+            END
+          )),
+          NULL
+        INTO v_initiator, v_context, v_origin
+        FROM %1$I.sessions s
+        WHERE s.workspace_id = NEW.workspace_id AND s.id = NEW.session_id;
+      END IF;
+
+      v_source_payload_bytes := octet_length(NEW.payload::text);
+      v_export_payload := NEW.payload;
+      v_export_payload_codec_version := NEW.payload_codec_version;
+      IF v_source_payload_bytes > 65536 THEN
+        v_export_payload := jsonb_build_object(
+          '_hostExport', jsonb_build_object(
+            'payloadMode', 'summary',
+            'payloadTruncated', true,
+            'originalBytes', v_source_payload_bytes,
+            'sourceEventId', NEW.id,
+            'fullPayload', 'retained in canonical session event'
+          ),
+          'preview', '[host-export payload omitted at bounded projection boundary]'
+        );
+        -- The projection is literal PostgreSQL JSON, not an application-codec
+        -- envelope. Preserve codec truth only when the original payload is kept.
+        v_export_payload_codec_version := NULL;
+      END IF;
+
+      v_payload_bytes := octet_length(v_export_payload::text)
+        + octet_length(NEW.type)
+        + coalesce(octet_length(NEW.client_event_id), 0)
+        + coalesce(octet_length(NEW.turn_association), 0)
+        + coalesce(octet_length(NEW.duplicate_reason), 0)
+        + octet_length(coalesce(v_initiator, 'null'::jsonb)::text)
+        + octet_length(v_context::text)
+        + 768;
+      INSERT INTO %1$I.host_export_outbox (
+        export_kind, source_id, account_id, workspace_id, session_id,
+        turn_id, turn_generation, turn_attempt_id, session_sequence,
+        client_event_id, turn_association, duplicate_of_event_id, duplicate_reason,
+        event_type, idempotency_key, initiator, initiator_context, origin,
+        payload, payload_codec_version, envelope_bytes, occurred_at,
+        source_recorded_at, enqueued_at
+      ) VALUES (
+        'session_event', NEW.id, NEW.account_id, NEW.workspace_id, NEW.session_id,
+        NEW.turn_id, NEW.turn_generation, NEW.turn_attempt_id, NEW.sequence,
+        NEW.client_event_id, NEW.turn_association, NEW.duplicate_of_event_id,
+        NEW.duplicate_reason,
+        NEW.type, 'session_event:' || NEW.id::text, v_initiator,
+        coalesce(v_context, '{}'::jsonb), v_origin, v_export_payload,
+        v_export_payload_codec_version, greatest(1, v_payload_bytes), NEW.occurred_at,
+        NEW.created_at, clock_timestamp()
+      )
+      ON CONFLICT (export_kind, source_id) DO NOTHING;
+      RETURN NEW;
+    END $function$;
+  $create$, target_schema);
+END
+$migration$;

--- a/packages/db/test/host-export.test.ts
+++ b/packages/db/test/host-export.test.ts
@@ -17,6 +17,8 @@ import {
   recordUsageEvent,
   registerHostExportConsumer,
   retireHostExportConsumer,
+  submitHumanPromptInTransaction,
+  withWorkspaceSubjectSessionActivityRls,
   resumeHostExportConsumer,
   type HostExportKind,
 } from "../src/index";
@@ -213,6 +215,22 @@ describe("durable host export (real PostgreSQL)", () => {
       idempotencyKey: `usage:test:${childStarted.turn!.id}`,
     });
 
+    const follower = `subject:follower:${crypto.randomUUID()}`;
+    const followup = await withWorkspaceSubjectSessionActivityRls(
+      app.db, active.grant.workspaceId!, active.subjectId, (db) =>
+        db.transaction((tx) => submitHumanPromptInTransaction(tx as unknown as typeof db, {
+          accountId: active.grant.accountId, workspaceId: active.grant.workspaceId!,
+          sessionId: active.session.id, subjectId: active.subjectId,
+          actor: { type: "human", subjectId: active.subjectId },
+          operationKey: crypto.randomUUID(), delivery: "send", text: "follow up",
+          resources: [], reasoningEffortFallback: "medium", source: "user",
+        })),
+    );
+    const [unboundMessage] = await appendSessionEvents(app.db, active.grant.workspaceId!, active.session.id, [{
+      type: "user.message",
+      payload: { text: "unbound", initiator: { kind: "subject", subjectId: follower } },
+    }]);
+
     const eventBatch = await claim("session_event", "host-test-events");
     expect(eventBatch?.events.length).toBeGreaterThan(0);
     expect(eventBatch?.events.some((item) => item.event.id === delta?.id)).toBe(false);
@@ -226,6 +244,22 @@ describe("durable host export (real PostgreSQL)", () => {
       subjectId: active.subjectId,
       label: "User active",
     });
+    const initialMessageExport = eventBatch?.events.find(
+      (item) => item.event.sessionId === active.session.id && item.event.type === "user.message",
+    );
+    expect(initialMessageExport?.event.turnId).toBeNull();
+    expect(initialMessageExport?.initiator?.subjectId).toBe(active.subjectId);
+    expect(initialMessageExport?.origin).toBe("user");
+    const followupExport = eventBatch?.events.find((item) =>
+      item.event.type === "user.message" && (item.event.payload as { text?: string })?.text === "follow up",
+    );
+    expect(followup.turnId).toBeTruthy();
+    expect(followupExport?.event.turnId).toBeNull();
+    expect(followupExport?.initiator?.subjectId).toBe(active.subjectId);
+    expect(followupExport?.origin).toBe("user");
+    const unboundExport = eventBatch?.events.find((item) => item.event.id === unboundMessage!.id);
+    expect(unboundExport?.initiator).toBeNull();
+    expect(unboundExport?.origin).toBeNull();
     const createdExport = eventBatch?.events.find((item) => item.event.type === "session.created");
     expect(createdExport?.origin).toBeNull();
     expect(createdExport?.initiator?.subjectId).toBe(active.subjectId);

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -203,6 +203,9 @@ describe("release schema contract", () => {
     const skillReviewWireCompatibility = completeSourceContract.migrations.some(
       (migration) => migration.path === "0458_skill_review_wire_compatibility.sql",
     );
+    const hostMessageAttribution = completeSourceContract.migrations.some(
+      (migration) => migration.path === "0460_host_export_message_attribution.sql",
+    );
     const mcpOperations = completeSourceContract.migrations.some(
       (migration) => migration.path === "0459_mcp_operations.sql",
     );
@@ -254,6 +257,7 @@ describe("release schema contract", () => {
         (socialConnectionVersions ? 1 : 0) +
         (canonicalSessionScopeSubject ? 1 : 0) +
         (skillReviewWireCompatibility ? 1 : 0) +
+        (hostMessageAttribution ? 1 : 0) +
         (mcpOperations ? 1 : 0) +
         437 +
         (unobservableDrain ? 1 : 0) +
@@ -264,7 +268,9 @@ describe("release schema contract", () => {
         (retainedProviderCommands ? 1 : 0) +
         (unifiedSkillLifecycle ? 1 : 0) +
         (skillChatConfirmation ? 1 : 0),
-      latestMigration: mcpOperations
+      latestMigration: hostMessageAttribution
+        ? "0460_host_export_message_attribution.sql"
+        : mcpOperations
         ? "0459_mcp_operations.sql"
         : skillReviewWireCompatibility
           ? "0458_skill_review_wire_compatibility.sql"
@@ -329,7 +335,7 @@ describe("release schema contract", () => {
                                                                     : "0428_scheduled_task_creator_policy.sql",
     });
     expect(completeSourceContract.migrations.at(-1)).toMatchObject({
-      path: "0459_mcp_operations.sql",
+      path: "0460_host_export_message_attribution.sql",
       deploymentMode: "rolling",
     });
     expect(
@@ -1421,6 +1427,7 @@ describe("release schema contract", () => {
   test("preserves published host-export history and appends the forward repair", async () => {
     const unfilteredSourceContract = await buildCompleteSchemaContract();
     let completeSourceContract = await contractWithoutMigrations([
+      "0460_host_export_message_attribution.sql",
       "0459_mcp_operations.sql",
       "0458_skill_review_wire_compatibility.sql",
       "0437_organization_scoped_external_workspaces.sql",
@@ -1696,6 +1703,7 @@ describe("release schema contract", () => {
       expect(taskTreeNotes).toMatchObject({ deploymentMode: "rolling" });
     }
     const appendedMigrationPaths = [
+      "0460_host_export_message_attribution.sql",
       "0459_mcp_operations.sql",
       "0458_skill_review_wire_compatibility.sql",
       "0437_organization_scoped_external_workspaces.sql",
@@ -4619,6 +4627,7 @@ async function contractWithoutMigrations(excludedPaths: readonly string[]) {
   directories.push(directory);
   const excluded = new Set([
     ...excludedPaths,
+    "0460_host_export_message_attribution.sql",
     "0397_sandbox_deadline_rotation_preemption.sql",
     "0429_message_boundary_session_forks.sql",
     "0430_session_personal_variable_set_continuations.sql",


### PR DESCRIPTION
Accepted `user.message` events intentionally have no direct turn ID. Host export therefore omitted their initiator and origin, and downstream identified analytics could report zero messages for active sessions.

Resolve the exact accepting turn through `session_turns.trigger_event_id` during the existing deferred export trigger. Preserve the canonical event, bounded payload projection, immutable historical exports and consumer checkpoints. Missing or ambiguous links remain unattributed; arbitrary payload sender fields and session creators do not supply message attribution.

Validation: reproduced missing attribution before the migration using real PostgreSQL, then passed the host-export regression covering initial messages, follow-up messages and unbound messages. Release-schema and host-export tests pass (9 tests, 334 assertions), DB typecheck and migration registration guard pass. Migration 0460 is rolling-compatible.

## Summary by Sourcery

Restore reliable sender attribution for accepted user messages in host exports without changing canonical event identity or existing export history.

Bug Fixes:
- Attribute accepted user-message exports to the exact accepting turn, restoring initiator and origin data for initial and follow-up messages while leaving unbound messages unattributed.

Enhancements:
- Preserve canonical events, immutable historical exports, consumer checkpoints, and bounded payload behavior while applying attribution during deferred host export.

Deployment:
- Add rolling migration 0460 to update host-export attribution and register it in the release schema contract.

Documentation:
- Document host-export message attribution rules, including the handling of unbound events and unattributed analytics coverage.

Tests:
- Extend real-PostgreSQL host-export coverage for initial, follow-up, and unbound user messages and update release-schema migration guards.