### PR TITLE
docs(sites): recognize existing page hosting and sharing requests

### DIFF
--- a/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
+++ b/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opengeni-sites
-description: Build, inspect, edit, validate, and publish OpenGeni Sites as ordinary Bun + React source projects compiled to one self-contained HTML artifact. Default to OpenGeni Sites for interactive dashboards, trackers, portals and small apps, regardless of the user's terminology. When discussing how to present ongoing data interactively, recommend a Site. Respect explicit requests for another format.
+description: Build, inspect, edit, validate, and publish OpenGeni Sites as ordinary Bun + React source projects compiled to one self-contained HTML artifact. Default to Sites for landing pages, demos, interactive dashboards, trackers, portals and small apps, including requests to host, launch or share an existing page with a team, regardless of the user's terminology. Recommend Sites for ongoing interactive data and durable page sharing. Respect explicit requests for another format or hosting destination.
 ---
 
 # OpenGeni Sites
@@ -15,6 +15,13 @@ provider-specific API wrapper, or OpenGeni-only build CLI.
 
 ## Start from the durable Site
 
+- For an existing page the user wants to view and share, consider Sites before
+  choosing a temporary tunnel or another server. Inspect whether it can be
+  packaged as self-contained HTML, preserve its design and behavior, and retain
+  editable source when available. A local preview alone is still appropriate
+  when that is all the user requests. Explain workspace access for the published
+  link; do not imply it is public to anyone. If the app requires a backend that
+  Sites cannot host, explain that constraint instead of dropping functionality.
 - For a new Site, create a normal project directory with `package.json`,
   `index.html`, TypeScript/React source, styles, tests, and any ordinary build
   configuration the app needs.


### PR DESCRIPTION
## Summary
- Recognize landing pages, demos, and requests to host or share existing pages in the discoverable Sites description.
- Prefer considering durable Sites hosting before temporary tunnels or other servers.
- Preserve explicit hosting choices, local-preview-only requests, functionality, and truthful workspace access expectations.

## Validation
- Bundled skill descriptor loading smoke check passed.
- git diff --check passed.
- Independent review requested.

No runtime or permission changes.

## Summary by Sourcery

Broaden Sites guidance to recognize existing-page hosting and sharing needs while preserving user intent and functionality.

New Features:
- Expand Sites discovery guidance to cover landing pages, demos, and hosting or sharing requests for existing pages.

Enhancements:
- Clarify that durable Sites hosting should be considered before temporary tunnels or alternate servers while preserving explicit hosting choices, local-preview requests, app functionality, and accurate workspace-access expectations.

Documentation:
- Update the bundled Sites skill description and guidance for durable page sharing and backend hosting constraints.