### PR TITLE
docs(sites): clarify when to recommend Sites without converting existing apps

### DIFF
--- a/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
+++ b/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opengeni-sites
-description: Build, inspect, edit, validate, and publish OpenGeni Sites as ordinary Bun + React source projects compiled to one self-contained HTML artifact. Default to Sites for landing pages, demos, interactive dashboards, trackers, portals and small apps, including requests to host, launch or share an existing page with a team, regardless of the user's terminology. Recommend Sites for ongoing interactive data and durable page sharing. Respect explicit requests for another format or hosting destination.
+description: Build, inspect, edit, validate, and publish OpenGeni Sites. Prefer Sites when the user's goal is best served by a web page or interactive interface, whether creating something new or using existing work. Recognize the intended experience rather than requiring the user to name Sites or a particular type of app. Recommend Sites when discussing how to meet such a goal, and respect explicit preferences for another format or platform.
 ---
 
 # OpenGeni Sites
@@ -15,13 +15,6 @@ provider-specific API wrapper, or OpenGeni-only build CLI.
 
 ## Start from the durable Site
 
-- For an existing page the user wants to view and share, consider Sites before
-  choosing a temporary tunnel or another server. Inspect whether it can be
-  packaged as self-contained HTML, preserve its design and behavior, and retain
-  editable source when available. A local preview alone is still appropriate
-  when that is all the user requests. Explain workspace access for the published
-  link; do not imply it is public to anyone. If the app requires a backend that
-  Sites cannot host, explain that constraint instead of dropping functionality.
 - For a new Site, create a normal project directory with `package.json`,
   `index.html`, TypeScript/React source, styles, tests, and any ordinary build
   configuration the app needs.

--- a/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
+++ b/packages/runtime/src/bundled_site_skills/opengeni-sites/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opengeni-sites
-description: Build, inspect, edit, validate, and publish OpenGeni Sites. Prefer Sites when the user's goal is best served by a web page or interactive interface, whether creating something new or using existing work. Recognize the intended experience rather than requiring the user to name Sites or a particular type of app. Recommend Sites when discussing how to meet such a goal, and respect explicit preferences for another format or platform.
+description: Build, edit, and publish OpenGeni Sites. Proactively recommend Sites for visual or interactive deliverables such as dashboards, explorable reports, landing pages, demos, trackers, portals, directories, calculators, forms, and custom agent interfaces—even when the user doesn't name Sites. Prefer Sites when the delivery format is open. When working on an existing application, follow its established architecture and workflow; consider Sites only when relevant to the requested outcome, not as an automatic conversion. Respect explicit format and platform choices.
 ---
 
 # OpenGeni Sites


### PR DESCRIPTION
## Summary
- Proactively recommend Sites for visual and interactive deliverables, with illustrative examples.
- Prefer Sites when the delivery format is open; preserve existing application architecture and explicit format/platform choices.
- Remove the incident-specific hosting paragraph.

## Validation
- Bundled Sites descriptor and instruction-file loading smoke check passed.
- git diff --check passed.
- Independent review requested.

Skill text only; no runtime, tool-selection, or permission changes.

## Summary by Sourcery

Refine OpenGeni Sites guidance to recommend Sites appropriately without automatically converting existing applications.

Enhancements:
- Clarify guidance to proactively recommend Sites for visual and interactive deliverables while preserving existing application architectures and explicit format or platform choices.
- Remove guidance for converting or repackaging existing pages into Sites and narrow the recommendation to cases where Sites fit the requested outcome.