### PR TITLE
fix(relay): install target musl headers for cross compilation

### DIFF
--- a/agent/crates/opengeni-relay/Dockerfile
+++ b/agent/crates/opengeni-relay/Dockerfile
@@ -34,6 +34,8 @@ COPY . .
 # target without emulation. The workspace profile already strips + LTOs the
 # release build; `xx-verify` fails if the output architecture drifts.
 ARG TARGETPLATFORM
+# Native clang still needs the target musl headers and GCC runtime for C crates.
+RUN xx-apk add --no-cache gcc musl-dev
 RUN set -eux; \
     rust_target="$(xx-cargo --print-target-triple)"; \
     rustup target add "${rust_target}"; \

--- a/scripts/relay-native-build-contract.test.ts
+++ b/scripts/relay-native-build-contract.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { expect, test } from "bun:test";
+
+function hasTargetSysroot(source: string): boolean {
+  const start = source.indexOf("FROM --platform=$BUILDPLATFORM rust:1.82-alpine AS build");
+  if (start < 0) return false;
+  const end = source.indexOf("\nFROM ", start + 1);
+  const stage = source.slice(start, end < 0 ? undefined : end);
+  const target = stage.indexOf("ARG TARGETPLATFORM");
+  const libraries = stage.indexOf("RUN xx-apk add --no-cache gcc musl-dev");
+  const build = stage.indexOf("xx-cargo build --release");
+  const verify = stage.indexOf('xx-verify "/build/target/${rust_target}/release/opengeni-relay"');
+  return (
+    stage.includes("COPY --from=xx / /") &&
+    stage.includes("RUN apk add --no-cache clang lld") &&
+    target >= 0 &&
+    libraries > target &&
+    build > libraries &&
+    verify > build
+  );
+}
+
+test("relay installs target C headers and runtime before native-speed musl cross compilation", async () => {
+  const source = await readFile(
+    resolve(import.meta.dir, "../agent/crates/opengeni-relay/Dockerfile"),
+    "utf8",
+  );
+  expect(hasTargetSysroot(source)).toBe(true);
+  expect(hasTargetSysroot(source.replace("RUN xx-apk add --no-cache gcc musl-dev", ""))).toBe(
+    false,
+  );
+  expect(
+    hasTargetSysroot(
+      source.replace(
+        "RUN xx-apk add --no-cache gcc musl-dev",
+        "RUN apk add --no-cache gcc musl-dev",
+      ),
+    ),
+  ).toBe(false);
+  expect(hasTargetSysroot(source.replace("ARG TARGETPLATFORM", "ARG BUILDPLATFORM"))).toBe(false);
+  expect(
+    hasTargetSysroot(
+      source.replace("FROM --platform=$BUILDPLATFORM rust:1.82-alpine", "FROM rust:1.82-alpine"),
+    ),
+  ).toBe(false);
+  expect(
+    hasTargetSysroot(
+      source.replace('xx-verify "/build/target/${rust_target}/release/opengeni-relay"', "true"),
+    ),
+  ).toBe(false);
+});


### PR DESCRIPTION
## Summary

Install target GCC runtime and musl development headers through `xx-apk` before building the relay. The native builder's Clang/LLD installation does not provide the target sysroot used by C dependencies during ARM64 cross compilation.

The existing ARM64 build fails compiling BLAKE3's NEON source because `assert.h` is missing. This keeps the native build platform, existing target selection, architecture verification, cryptographic implementation, and distroless runtime unchanged.

## Verification

- New build-contract regression fails against the original Dockerfile and passes with target packages installed.
- Mutation checks reject host-only package installation, absent target selection, emulated builds, and missing output verification.
- Relay, sandbox native-build, and release-image workflow contracts: 27 tests passed, 866 assertions.
- Repository lint: zero warnings/errors.
- Actual Docker builds from the exact PR source passed for `linux/amd64` and `linux/arm64`, including release compilation, `xx-verify`, and final non-root image export. Build-only verification; no registry push or deployment.
- Ordinary PR CI skips workload images, so the architecture builds were verified separately rather than treating the skipped jobs as proof.
- Agent CI passed Rust 1.82 compatibility, lint, tests/builds and installation smoke tests on Linux, macOS and Windows. The main CI run's only underlying failure was a DNS error downloading the Rust toolchain before compilation; failed jobs were retried without source or timeout changes.