### PR TITLE
perf(react): reduce timeline prepend commit overhead

### DIFF
--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -2393,41 +2393,49 @@ const TimelineGroupEntry = memo(function TimelineGroupEntry({
           nextGroup.item.phase === "compacted"
         ? 1
         : 0;
+  const content = (
+    <TimelineGroupView
+      {...behavior}
+      group={group}
+      foldLiveCluster={isAgentProgress(nextGroup)}
+      startupDismissed={startupDismissed}
+      trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
+      contextCompactionCount={contextCompactionCount > 0 ? contextCompactionCount : undefined}
+    />
+  );
   return (
     <GenieLoadingOptionsContext.Provider value={behavior.genieLoading}>
       <div data-og-timeline-group-anchor="" data-og-group-key={groupKey}>
         <EntranceAnimationProvider value={entranceEnabled} liveValue={liveEntranceEnabled}>
           <TimelineGroupRenderBoundary resetKeys={[group, behavior]}>
             <UserMessageDisclosureProvider value={userMessageDisclosureContext}>
-              <AnimatePresence initial={false}>
-                <motion.div
-                  key={
-                    !startupDismissed &&
-                    group.kind === "activity" &&
-                    group.items.every(
-                      (item) =>
-                        item.kind === "startup-phase" ||
-                        (item.kind === "reasoning" && !item.text.trim()),
-                    )
-                      ? "preparation"
-                      : "content"
-                  }
-                  initial={false}
-                  exit={{ opacity: 0, height: 0 }}
-                  transition={{ duration: reducedMotion ? 0 : 0.2 }}
-                >
-                  <TimelineGroupView
-                    {...behavior}
-                    group={group}
-                    foldLiveCluster={isAgentProgress(nextGroup)}
-                    startupDismissed={startupDismissed}
-                    trailingAgentText={trailingAgentTextAfterTurn(group, nextGroup)}
-                    contextCompactionCount={
-                      contextCompactionCount > 0 ? contextCompactionCount : undefined
+              {/* Item groups never switch the preparation/content key. Keep their
+                  DOM shell without mounting inert presence and motion lifecycles
+                  for every historical message in a prepend. */}
+              {group.kind === "item" ? (
+                <div>{content}</div>
+              ) : (
+                <AnimatePresence initial={false}>
+                  <motion.div
+                    key={
+                      !startupDismissed &&
+                      group.kind === "activity" &&
+                      group.items.every(
+                        (item) =>
+                          item.kind === "startup-phase" ||
+                          (item.kind === "reasoning" && !item.text.trim()),
+                      )
+                        ? "preparation"
+                        : "content"
                     }
-                  />
-                </motion.div>
-              </AnimatePresence>
+                    initial={false}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: reducedMotion ? 0 : 0.2 }}
+                  >
+                    {content}
+                  </motion.div>
+                </AnimatePresence>
+              )}
             </UserMessageDisclosureProvider>
           </TimelineGroupRenderBoundary>
         </EntranceAnimationProvider>

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -503,6 +503,7 @@ describe("timeline scroll ownership browser regression", () => {
             new Promise<{
               longTasks: number[];
               maxFrameIntervalMs: number;
+              committedRowIds: string[];
             }>((resolve) => {
               const longTasks: number[] = [];
               const frames: number[] = [];
@@ -529,6 +530,12 @@ describe("timeline scroll ownership browser regression", () => {
                 resolve({
                   longTasks,
                   maxFrameIntervalMs: Math.max(0, ...intervals),
+                  // A deferred or partially revealed prepend must not pass by
+                  // leaving its work outside the measured frame window.
+                  committedRowIds: Array.from(
+                    document.querySelectorAll("[data-timeline-row]"),
+                    (row) => row.getAttribute("data-timeline-row")!,
+                  ),
                 });
               };
               requestAnimationFrame(() => {
@@ -544,6 +551,10 @@ describe("timeline scroll ownership browser regression", () => {
       expect(after.top).toBeCloseTo(before.top ?? 0, 0);
       expect(performance.longTasks).toEqual([]);
       expect(performance.maxFrameIntervalMs).toBeLessThan(50);
+      expect(performance.committedRowIds).toEqual([
+        ...Array.from({ length: 220 }, (_, index) => `row-${900 + index}`),
+        "stream-1",
+      ]);
     } finally {
       await performancePage.close();
     }


### PR DESCRIPTION
## Summary

- Avoid mounting inert presence/motion lifecycles for ordinary timeline item groups. Retain an equivalent div, all providers, error boundaries, row components, and anchor attributes.
- Keep preparation/content transitions on activity and turn groups unchanged. Keep row-level entrance behavior and pre-paint anchor restoration unchanged.
- Strengthen the existing scheduled-prepend browser regression to require the complete ordered 220-row history plus streaming row within its measurement window. Zero long tasks and the less-than-50-ms frame budget are unchanged.

## Evidence

Two unchanged-source CI attempts reported 56/58-ms long tasks in the scheduled 100-row prepend. Bounded browser tracing attributed the work to the later synchronous React commit, including forced layout during anchor restoration, rather than the initial scheduling call. Ordinary item groups always used the same content key with initial animation disabled, so their presence/motion lifecycle added mount work without providing a transition.

The lightweight attribution run failed at the original assertion with a 51.688-ms task. With this change, the equivalent lightweight run's longest task was 34.574 ms, with no long tasks and a 33.3-ms maximum frame interval. Tracing has overhead; these samples are attribution and comparative evidence, not a statistical guarantee.

## Verification

- 94 targeted unit tests: pagination, anchor restoration, copy controls, and preparation/loading behavior.
- React package typecheck; targeted oxlint; oxfmt and diff checks.
- 44 browser regressions passed locally, including the unchanged performance budgets and strengthened mounted-row assertion.
- Three additional uninstrumented scheduled-prepend runs passed the original budgets and complete-row assertion.
- Independent source/diff review found no blocking findings.
- Desktop and mobile rendered screenshots inspected. A subsequent run with post-test screenshot capture had no long task but failed the strict frame assertion at exactly 50 ms. That failure is retained: this patch removes measured mount overhead, not a guarantee against all frame scheduling variance. No timing threshold was relaxed.

Local limitation: the compiled-CSS completed-table streaming test waits for a width greater than 778 px, but the local fallback font renders it at 769.3 px. The exact unmodified timeline source reproduces the same timeout. No source, CSS, assertion, or timeout workaround is included. The complete unchanged browser suite must pass in CI before merge.

## Summary by Sourcery

Reduce timeline prepend rendering overhead without changing animation behavior or performance budgets.

Enhancements:
- Reduce React commit overhead when prepending historical timeline item groups by avoiding unnecessary animation lifecycle mounting while preserving existing rendering behavior for animated groups.

Tests:
- Strengthen the scheduled-prepend browser regression to verify that the complete ordered history and streaming row are committed within the performance measurement window.