### PR TITLE
feat: add standalone inline MCP credential rotation

### DIFF
--- a/.changeset/standalone-inline-mcp-rotation.md
+++ b/.changeset/standalone-inline-mcp-rotation.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/core": minor
+"@opengeni/api-router": minor
+"@opengeni/sdk": minor
+---
+
+Add an authorized standalone session inline MCP credential rotation operation with durable idempotent receipts, exact destination and credential-version fencing, and atomic quiescence checks. Expose the operation through HTTP and the SDK without sending messages, scheduling work, retrying external mutations, or widening connection or attempt authority. Keep existing message-bound credential updates unchanged.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -242,6 +242,7 @@ import {
   requireAccessGrant,
   requireAccessGrantAuthorization,
   requireFreshAccessGrant,
+  rotateSessionMcpCredentialsForRequest,
   hasVerifiedOwningUserAuthorization,
   requirePermission,
   requireSessionAuthorization,
@@ -2872,6 +2873,27 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     );
   });
 
+  app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/mcp-credentials/rotate", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const authorization = await requireAccessGrantAuthorization(
+      c,
+      deps,
+      workspaceId,
+      "sessions:control",
+    );
+    const payload = await c.req.json().catch(() => null);
+    c.header("cache-control", "private, no-store");
+    return c.json(
+      await rotateSessionMcpCredentialsForRequest(
+        deps,
+        authorization,
+        c.req.param("sessionId"),
+        payload,
+        (tx) => requireFreshAccessGrant(c, { ...deps, db: tx }, workspaceId, "sessions:control"),
+      ),
+    );
+  });
+
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/queue", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     await requireAccessGrant(c, deps, workspaceId, "sessions:read");
@@ -4519,6 +4541,8 @@ export function sessionAuthorizationOperationForHttp(
   if (suffix === "/channel" && verb === "PUT") return "session.channel.write";
   if (suffix === "/variable-sets" && verb === "PUT") return "session.variable_sets.write";
   if (suffix === "/tool-policy" && verb === "PUT") return "session.tool_policy.write";
+  if (suffix === "/mcp-credentials/rotate" && verb === "POST")
+    return "session.mcp.credentials.rotate";
   if (/^\/mcp-servers\/[^/]+\/approval-policy$/.test(suffix) && verb === "PATCH") {
     return "session.mcp.approval_policy.write";
   }

--- a/apps/api/test/session-authorization.test.ts
+++ b/apps/api/test/session-authorization.test.ts
@@ -23,6 +23,7 @@ const cases: Array<[string, string, SessionAuthorizationOperation]> = [
   ["POST", "/forks", "session.fork.create"],
   ["PUT", "/channel", "session.channel.write"],
   ["PUT", "/tool-policy", "session.tool_policy.write"],
+  ["POST", "/mcp-credentials/rotate", "session.mcp.credentials.rotate"],
   ["GET", "/lineage", "session.lineage.read"],
   ["GET", "/background-commands", "session.read"],
   ["GET", "/model-context", "session.read"],

--- a/apps/api/test/session-mcp-credential-rotation.test.ts
+++ b/apps/api/test/session-mcp-credential-rotation.test.ts
@@ -1,0 +1,388 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { Hono } from "hono";
+import postgres from "postgres";
+import {
+  createApiKey,
+  createDb,
+  createSession,
+  createSessionMcpServers,
+  migrate,
+  provisionRoles,
+  revokeApiKey,
+  type DbClient,
+} from "@opengeni/db";
+import {
+  signDelegatedAccessToken,
+  type Permission,
+  type SessionAuthorizationPort,
+} from "@opengeni/contracts";
+import type { ApiRouteDeps } from "@opengeni/core";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { registerSessionRoutes } from "../src/routes/sessions";
+
+const externalAdminUrl = process.env.OPENGENI_TEST_THROWAWAY_DATABASE_ADMIN_URL?.trim();
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let available = true;
+const key = Buffer.alloc(32, 7).toString("base64");
+const permissions: Permission[] = ["sessions:read", "sessions:control", "mcp_servers:attach"];
+const delegationSecret = "rotation-test-delegation-secret";
+
+beforeAll(async () => {
+  let appUrl: string;
+  if (externalAdminUrl) {
+    await migrate(externalAdminUrl);
+    await provisionRoles(externalAdminUrl, {
+      targetSchema: "public",
+      rlsStrategy: "force",
+      appRole: "opengeni_app",
+      appPassword: "rotation_test_app",
+    });
+    admin = postgres(externalAdminUrl, { max: 4 });
+    const url = new URL(externalAdminUrl);
+    url.username = "opengeni_app";
+    url.password = "rotation_test_app";
+    appUrl = url.toString();
+  } else {
+    shared = await acquireSharedTestDatabase("api-session-mcp-credential-rotation");
+    if (!shared) {
+      if (process.env.OPENGENI_REQUIRE_REAL_DB === "1") throw new Error("PostgreSQL required");
+      available = false;
+      return;
+    }
+    admin = shared.admin;
+    appUrl = shared.appUrl;
+  }
+  client = createDb(appUrl);
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close();
+  if (shared) await shared.release();
+  else await admin?.end();
+}, 180_000);
+
+async function fixture(granted = permissions) {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('rotation HTTP test') returning id`;
+  const [workspace] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name) values (${account!.id}, 'rotation HTTP') returning id`;
+  await admin`insert into workspace_inference_controls (account_id, workspace_id)
+    values (${account!.id}, ${workspace!.id})`;
+  const token = `rotation-test-${crypto.randomUUID()}`;
+  const credential = await createApiKey(client.db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    name: "rotation test",
+    prefix: "rotation-test",
+    keyHash: createHash("sha256").update(token).digest("hex"),
+    permissions: granted,
+  });
+  const session = await createSession(client.db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    initialMessage: "",
+    resources: [],
+    tools: [{ kind: "mcp", id: "external" }],
+    metadata: {},
+    model: "test-model",
+    reasoningEffort: "low",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  await createSessionMcpServers(client.db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    sessionId: session.id,
+    servers: [
+      { id: "external", url: "https://tools.example.test/mcp", requireApproval: ["write_record"] },
+    ],
+  });
+  const request = {
+    operationKey: crypto.randomUUID(),
+    updates: [
+      {
+        id: "external",
+        expectedCredentialVersion: 1,
+        expectedServerUrl: "https://tools.example.test/mcp",
+        headers: { Authorization: "Bearer synthetic-secret-never-in-output" },
+      },
+    ],
+  };
+  const url = `/v1/workspaces/${workspace!.id}/sessions/${session.id}/mcp-credentials/rotate`;
+  return {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    session,
+    credential,
+    token,
+    request,
+    url,
+  };
+}
+
+function appWith(port?: SessionAuthorizationPort, encryptionKey = key) {
+  const app = new Hono();
+  const workflowClient = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("rotation must not access workflow scheduling");
+      },
+    },
+  );
+  registerSessionRoutes(app, {
+    settings: testSettings({
+      productAccessMode: "managed",
+      environmentsEncryptionKey: encryptionKey,
+      delegationSecret,
+    }),
+    db: client.db,
+    bus: new MemoryEventBus(),
+    workflowClient,
+    objectStorage: null,
+    managedAuth: null,
+    sessionAuthorization: port,
+    getDocumentServices: () => ({}),
+  } as unknown as ApiRouteDeps);
+  return app;
+}
+
+function send(app: Hono, f: Awaited<ReturnType<typeof fixture>>, body: unknown = f.request) {
+  return app.request(f.url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${f.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("standalone credential rotation HTTP authority", () => {
+  test("same API key rotating different sessions completes without a lock upgrade deadlock", async () => {
+    if (!available) return;
+    const f = await fixture();
+    const session = await createSession(client.db, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      initialMessage: "",
+      resources: [],
+      tools: [{ kind: "mcp", id: "external" }],
+      metadata: {},
+      model: "test-model",
+      reasoningEffort: "low",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    await createSessionMcpServers(client.db, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      sessionId: session.id,
+      servers: [{ id: "external", url: f.request.updates[0]!.expectedServerUrl }],
+    });
+    const other = { ...f, session, url: f.url.replace(f.session.id, session.id) };
+    const responses = await Promise.all([send(appWith(), f), send(appWith(), other)]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+  });
+
+  test("service receipt uses the authenticated subject, not causal service provenance", async () => {
+    if (!available) return;
+    const f = await fixture();
+    const subjectId = "host:rotation-service";
+    f.token = await signDelegatedAccessToken(delegationSecret, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      subjectId,
+      permissions,
+      principalKind: "service",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      serviceInitiator: { kind: "service", subjectId: "host:causal-scheduler" },
+    });
+    expect((await send(appWith(), f)).status).toBe(200);
+    const [receipt] = await admin`select actor_type, actor_subject_id from session_command_receipts
+      where target_session_id = ${f.session.id}`;
+    expect(receipt).toMatchObject({ actor_type: "service", actor_subject_id: subjectId });
+    expect((await send(appWith(), f)).status).toBe(200);
+  });
+
+  test("delegated human authority cannot outlive current membership regardless of subject prefix", async () => {
+    if (!available) return;
+    const f = await fixture();
+    // A signed principal kind, not a subject-name prefix, chooses human checks.
+    const subjectId = "host:delegated-human";
+    f.token = await signDelegatedAccessToken(delegationSecret, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      subjectId,
+      permissions,
+      principalKind: "human_session",
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    expect((await send(appWith(), f)).status).toBe(403);
+    await admin`insert into workspace_memberships (account_id, workspace_id, subject_id, permissions)
+      values (${f.accountId}, ${f.workspaceId}, ${subjectId}, ${admin.json(permissions)})`;
+    expect((await send(appWith(), f)).status).toBe(200);
+    await admin`delete from workspace_memberships where workspace_id = ${f.workspaceId}
+      and subject_id = ${subjectId}`;
+    expect((await send(appWith(), f)).status).toBe(403);
+    const [server] = await admin`select credential_version from session_mcp_servers
+      where session_id = ${f.session.id}`;
+    expect(server!.credential_version).toBe(2);
+  });
+
+  test("a delegated human cannot borrow the canonical cookie personal-owner exception", async () => {
+    if (!available) return;
+    const f = await fixture();
+    const subjectId = `user:${crypto.randomUUID()}`;
+    await admin`insert into organization_memberships
+      (account_id, subject_id, status, personal_workspace_id)
+      values (${f.accountId}, ${subjectId}, 'active', ${f.workspaceId})`;
+    f.token = await signDelegatedAccessToken(delegationSecret, {
+      accountId: f.accountId,
+      workspaceId: f.workspaceId,
+      subjectId,
+      permissions,
+      principalKind: "human_session",
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    expect((await send(appWith(), f)).status).toBe(403);
+    expect(
+      await admin`select id from session_command_receipts
+      where target_session_id = ${f.session.id}`,
+    ).toHaveLength(0);
+  });
+
+  test("returns one secret-safe receipt without message, event, queue, policy, or session mutation", async () => {
+    if (!available) return;
+    const f = await fixture();
+    const before = await admin`select * from sessions where id = ${f.session.id}`;
+    const app = appWith();
+    const result = await send(app, f);
+    expect(result.status).toBe(200);
+    const receipt = await result.json();
+    expect(receipt.servers).toEqual([{ id: "external", credentialVersion: 2 }]);
+    expect(JSON.stringify(receipt)).not.toContain("synthetic-secret");
+    expect(await (await send(app, f)).json()).toEqual(receipt);
+    expect(
+      await (
+        await send(app, f, {
+          ...f.request,
+          updates: [
+            {
+              ...f.request.updates[0],
+              headers: { " authorization ": f.request.updates[0]!.headers.Authorization },
+            },
+          ],
+        })
+      ).json(),
+    ).toEqual(receipt);
+    expect(await admin`select * from sessions where id = ${f.session.id}`).toEqual(before);
+    for (const table of [
+      "session_events",
+      "session_turns",
+      "session_system_updates",
+      "session_history_items",
+    ]) {
+      expect(
+        await admin`select id from ${admin(table)} where session_id = ${f.session.id}`,
+      ).toHaveLength(0);
+    }
+    const [server] =
+      await admin`select * from session_mcp_servers where session_id = ${f.session.id}`;
+    expect(server!.require_approval).toEqual(["write_record"]);
+    expect(server!.url).toBe(f.request.updates[0]!.expectedServerUrl);
+    expect(server!.connection_ref).toBeNull();
+    expect(JSON.stringify(server!.headers_encrypted)).not.toContain("synthetic-secret");
+  });
+
+  test("requires both ordinary permissions, without an attach or control bypass", async () => {
+    if (!available) return;
+    for (const granted of [["sessions:control"], ["mcp_servers:attach"]] as Permission[][]) {
+      const f = await fixture(granted);
+      expect((await send(appWith(), f)).status).toBe(403);
+    }
+  });
+
+  test("a host may allow session.control while denying this exact action", async () => {
+    if (!available) return;
+    const f = await fixture();
+    const operations: string[] = [];
+    const app = appWith({
+      authorizeSession: async ({ operation }) => {
+        operations.push(operation);
+        return operation === "session.mcp.credentials.rotate"
+          ? { allowed: false, reason: "forbidden" }
+          : { allowed: true, relatedSessionAccess: "target" };
+      },
+    });
+    expect((await send(app, f)).status).toBe(404);
+    expect(operations).toEqual(["session.mcp.credentials.rotate"]);
+    expect(
+      await admin`select id from session_command_receipts where target_session_id = ${f.session.id}`,
+    ).toHaveLength(0);
+  });
+
+  test("revocation between preflight and mutation denies and does not save a receipt", async () => {
+    if (!available) return;
+    const f = await fixture();
+    let calls = 0;
+    const app = appWith({
+      authorizeSession: async () => {
+        if (++calls === 1) await revokeApiKey(client.db, f.workspaceId, f.credential.id);
+        return { allowed: true, relatedSessionAccess: "target" };
+      },
+    });
+    expect((await send(app, f)).status).toBe(403);
+    expect(
+      await admin`select id from session_command_receipts where target_session_id = ${f.session.id}`,
+    ).toHaveLength(0);
+  });
+
+  test("replays retain live host authorization and key replacement reports explicit unavailability", async () => {
+    if (!available) return;
+    const f = await fixture();
+    expect((await send(appWith(), f)).status).toBe(200);
+    const denied = appWith({
+      authorizeSession: async () => ({ allowed: false, reason: "revoked" }),
+    });
+    expect((await send(denied, f)).status).toBe(404);
+    const changedKey = await send(appWith(undefined, Buffer.alloc(32, 9).toString("base64")), f);
+    expect(changedKey.status).toBe(503);
+    expect(await changedKey.text()).toContain("receipt_key_unavailable");
+  });
+
+  test("strict request validation and header failures never echo secret-bearing input", async () => {
+    if (!available) return;
+    const f = await fixture();
+    for (const body of [
+      { ...f.request, userMessage: "synthetic-secret-never-in-output" },
+      {
+        ...f.request,
+        updates: [
+          { ...f.request.updates[0], headers: { "synthetic-secret-never-in-output @": "value" } },
+        ],
+      },
+      {
+        ...f.request,
+        updates: [
+          {
+            ...f.request.updates[0],
+            headers: { Authorization: "synthetic-secret-never-in-output\n" },
+          },
+        ],
+      },
+    ]) {
+      const response = await send(appWith(), f, body);
+      expect(response.status).toBe(422);
+      expect(await response.text()).not.toContain("synthetic-secret-never-in-output");
+    }
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       start_period: 10s
 
   garage-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: &object-storage-client-image quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       garage:
         condition: service_healthy
@@ -128,7 +128,7 @@ services:
       retries: 20
 
   minio-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: *object-storage-client-image
     profiles: ["minio"]
     depends_on:
       minio:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1596,6 +1596,7 @@ External actors and Site viewer authority: [embedding authority internals](embed
 | First-party MCP, Codemode, or tool selection | `apps/api/src/mcp/`, `packages/codemode/`, `packages/runtime/src/` | [`mcp-surfaces.md`](mcp-surfaces.md) |
 | Compact MCP session discovery and child management | `packages/contracts/src/session-mcp-projections.ts`, `apps/api/src/mcp/session-view.ts`, `apps/api/src/mcp/server.ts`, `packages/db/src/index.ts` | [`session-monitoring-mcp.md`](session-monitoring-mcp.md) |
 | Per-session MCP or action approval | `packages/core/src/domain/sessions.ts`, `apps/worker/src/activities/agent-turn/tool-environment.ts` | [`session-mcp-servers.md`](session-mcp-servers.md) |
+| Standalone inline MCP credential rotation | `packages/core/src/application/session-mcp-credential-rotation.ts`, `packages/db/src/session-mcp-credential-rotation.ts` | [`session-mcp-servers.md`](session-mcp-servers.md#standalone-inline-credential-rotation) |
 | Capabilities, packs, or integration definitions | `packages/capabilities/`, `packages/core/src/domain/capabilities.ts` | [`capabilities.md`](capabilities.md), [`packs.md`](packs.md) |
 | Sandbox backend or provider registry | `packages/runtime/src/sandbox/providers/`, `packages/contracts/src/index.ts` | §3.9 and [`../AGENTS.md`](../AGENTS.md) Sandbox Notes |
 | Lease, snapshot, reaper, or active target | `apps/worker/src/activities/sandbox-lease.ts`, `packages/runtime/src/sandbox/routing/` | §8 and [`connected-machines.md`](connected-machines.md) |

--- a/docs/session-mcp-servers.md
+++ b/docs/session-mcp-servers.md
@@ -127,7 +127,8 @@ OpenGeni connection row. Opaque host ids are accepted; standalone connection
 lookups still use their ordinary UUID ids. A session server may use static
 headers, a connection ref, or neither.
 
-Credentials rotate through a `user.message` payload:
+Credentials can still rotate as part of an accepted `user.message` payload;
+that existing Send/Steer behavior is unchanged:
 
 ```json
 {
@@ -149,6 +150,86 @@ successful rotation replaces the encrypted header map and increments
 The connection ref is likewise immutable for the session server. To switch an
 endpoint to a different host connection, create a new session attachment rather
 than treating credential rotation as a connection-rebinding operation.
+
+### Standalone inline credential rotation
+
+An authenticated host can replace credentials without sending a message:
+
+```http
+POST /v1/workspaces/:workspaceId/sessions/:sessionId/mcp-credentials/rotate
+Content-Type: application/json
+
+{
+  "operationKey": "11111111-1111-4111-8111-111111111111",
+  "updates": [{
+    "id": "crm",
+    "expectedCredentialVersion": 1,
+    "expectedServerUrl": "https://tools.example.test/mcp",
+    "headers": { "Authorization": "Bearer synthetic-example" }
+  }]
+}
+```
+
+This strict request accepts 1–64 unique existing server IDs. Header names are
+trimmed, checked for case-insensitive duplicates, and lowercased for request
+identity; header values are not trimmed. Updates and header names are sorted
+before computing their keyed fingerprint. Each header map replaces the entire
+previous map. The URL must match the stored destination exactly. An unknown
+server, changed destination, stale version, duplicate ID, or a server with a
+`connectionRef` rejects the whole operation. This does not create, rebind, or
+change approval policy, allowed tools, connection authority, or recovery policy.
+
+Both `sessions:control` and `mcp_servers:attach` are required. Existing session
+visibility/ownership checks and the optional host callback apply, using the
+distinct `session.mcp.credentials.rotate` authorization operation. A host may
+deny rotation while allowing `session.control`. Agent-attempt credentials are
+not accepted; there is no MCP or Codemode rotation tool. Current authorization
+is revalidated in the mutation transaction, including before receipt replay.
+
+Fresh operations require no accepted/pending credential-consuming work:
+nonterminal turns, live attempts, interrupted attempts without physical
+quiescence, pending machine input, attempt-owned
+in-flight workspace admissions, and active/starting realtime prevent rotation.
+Checks and persistence use the canonical membership/tenancy/control/session
+lock order shared with admission and claim. A historical failed turn, dormant
+goal/schedule, retained historical tool/run receipt, or open viewer alone does not prevent rotation. Work admitted
+after commit uses the new credentials normally. Rotation never edits an
+accepted attempt or refreshes an already-prepared client.
+
+The stable receipt is:
+
+```json
+{
+  "operationKey": "11111111-1111-4111-8111-111111111111",
+  "sessionId": "22222222-2222-4222-8222-222222222222",
+  "servers": [{ "id": "crm", "credentialVersion": 2 }],
+  "appliedAt": "2026-01-01T00:00:00.000Z"
+}
+```
+
+The existing durable command-receipt ledger scopes the key by authenticated
+actor, account/workspace, session, and operation. An exact replay returns the
+original receipt without another write, even after later activity or rotation.
+Reusing that scoped key with different normalized input is a 409. Version,
+destination, and quiescence conflicts are also 409; malformed/brokered requests
+are 422. Existing authentication/session denial statuses remain applicable.
+
+Headers use the existing AES-GCM encryption. Receipt fingerprints use
+domain-separated HMACs, never plaintext or unkeyed hashes of credentials. No
+secret values, header names, ciphertexts, or fingerprints are returned in the
+receipt or added to session events/history. Replacing the deployment encryption
+key makes old receipt verification unavailable: replay returns explicit 503
+`credential_rotation_receipt_key_unavailable`, not a misleading payload conflict
+or a second write. There is no key ring or automatic receipt-key migration.
+Operators must account for existing encrypted credentials and receipt replay
+availability before replacing the encryption key.
+
+The SDK method is `OpenGeniClient.rotateSessionMcpCredentials`. Neither API nor
+SDK retries this mutation automatically. After an ambiguous response, reconcile
+with the same operation key and exact normalized request; do not mint a fresh
+key blindly. No user message, turn, workflow wake, retry, or implicit Resume is
+created. In particular, this operation grants no permission to replay an
+outcome-unknown external tool call or resume a failed turn.
 
 ## Connector action policy enforcement
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5748,6 +5748,47 @@ export const SessionMcpCredentialUpdateInput = z.object({
 });
 export type SessionMcpCredentialUpdateInput = z.infer<typeof SessionMcpCredentialUpdateInput>;
 
+/** Standalone credential maintenance; never admits or retries model work. */
+export const RotateSessionMcpCredentialsRequest = z
+  .object({
+    operationKey: z.string().uuid(),
+    updates: z
+      .array(
+        z
+          .object({
+            id: SessionMcpServerId,
+            expectedCredentialVersion: z.number().int().min(1).max(2_147_483_646),
+            expectedServerUrl: httpsUrl,
+            headers: z.record(z.string(), z.string()),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(64),
+  })
+  .strict();
+export type RotateSessionMcpCredentialsRequest = z.infer<typeof RotateSessionMcpCredentialsRequest>;
+
+export const RotateSessionMcpCredentialsReceipt = z
+  .object({
+    operationKey: z.string().uuid(),
+    sessionId: z.string().uuid(),
+    servers: z
+      .array(
+        z
+          .object({
+            id: SessionMcpServerId,
+            credentialVersion: z.number().int().positive(),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(64),
+    appliedAt: z.string().datetime(),
+  })
+  .strict();
+export type RotateSessionMcpCredentialsReceipt = z.infer<typeof RotateSessionMcpCredentialsReceipt>;
+
 export const SessionMcpServerMetadata = z
   .object({
     id: SessionMcpServerId,
@@ -6778,6 +6819,7 @@ export const SessionAuthorizationOperation = z.enum([
   "session.channel.write",
   "session.variable_sets.write",
   "session.mcp.approval_policy.write",
+  "session.mcp.credentials.rotate",
   "session.tool_policy.write",
   "session.goal.read",
   "session.goal.write",

--- a/packages/core/src/application/session-mcp-credential-rotation.ts
+++ b/packages/core/src/application/session-mcp-credential-rotation.ts
@@ -1,0 +1,174 @@
+import { createHmac } from "node:crypto";
+import { RotateSessionMcpCredentialsRequest, type AccessGrant } from "@opengeni/contracts";
+import {
+  encryptVariableSetValue,
+  getWorkspaceGrant,
+  subjectHasLiveWorkspaceAuthorityInScope,
+  type Database,
+} from "@opengeni/db";
+import {
+  rotateSessionMcpCredentialsAtomically,
+  SessionMcpCredentialRotationError,
+} from "@opengeni/db/session-mcp-credential-rotation";
+import { HTTPException } from "hono/http-exception";
+import type { Settings } from "@opengeni/config";
+import {
+  requirePermission,
+  requireResolvedAccessGrantAuthorization,
+  type AccessGrantAuthorization,
+} from "../access";
+import {
+  grantHasAgentAttemptAuthority,
+  requireSessionAuthorization,
+  SessionAuthorizationDeniedError,
+  SessionAuthorizationUnavailableError,
+  type SessionAuthorizationDependencies,
+} from "../session-authorization";
+import { requireVariableSetEncryption } from "../domain/environments";
+import { normalizedSessionMcpCredentialHeaders } from "../domain/sessions";
+import { externalContinuationCommitAuthorizer } from "./external-continuation";
+
+/** HMAC domains separate request identity from key availability. The key tag
+ * carries no request material and neither fingerprint is returned publicly. */
+export function sessionMcpRotationFingerprint(
+  key: Uint8Array,
+  scope: { accountId: string; workspaceId: string; sessionId: string; subjectId: string },
+  request: RotateSessionMcpCredentialsRequest,
+) {
+  return {
+    digestKeyTag: createHmac("sha256", key)
+      .update("opengeni:session-mcp-rotation:key:v1")
+      .digest("hex"),
+    requestDigest: createHmac("sha256", key)
+      .update("opengeni:session-mcp-rotation:request:v1\0")
+      .update(JSON.stringify({ ...scope, request }))
+      .digest("hex"),
+  };
+}
+
+function requireRotationGrant(grant: AccessGrant) {
+  if (grantHasAgentAttemptAuthority(grant))
+    throw new HTTPException(403, { message: "host authorization required" });
+  requirePermission(grant, "sessions:control");
+  requirePermission(grant, "mcp_servers:attach");
+}
+
+/** HTTP/SDK host boundary only. The mandatory callback re-resolves request
+ * authentication with the transaction handle, not a cached route-time grant. */
+export async function rotateSessionMcpCredentialsForRequest(
+  deps: SessionAuthorizationDependencies & { settings: Settings },
+  authorization: AccessGrantAuthorization,
+  sessionId: string,
+  raw: unknown,
+  reauthorize: (tx: Database) => Promise<AccessGrant>,
+) {
+  const grant = requireResolvedAccessGrantAuthorization(
+    authorization,
+    authorization.grant.workspaceId,
+  );
+  requireRotationGrant(grant);
+  const parsed = RotateSessionMcpCredentialsRequest.safeParse(raw);
+  if (!parsed.success)
+    throw new HTTPException(422, { message: "invalid credential rotation request" });
+  const encryptionKey = requireVariableSetEncryption(deps.settings);
+  let request: RotateSessionMcpCredentialsRequest;
+  try {
+    request = {
+      operationKey: parsed.data.operationKey,
+      updates: parsed.data.updates
+        .map((update) => ({
+          id: update.id,
+          expectedCredentialVersion: update.expectedCredentialVersion,
+          expectedServerUrl: update.expectedServerUrl,
+          headers: Object.fromEntries(
+            Object.entries(normalizedSessionMcpCredentialHeaders(update.headers))
+              .map(([name, value]) => [name.toLowerCase(), value] as const)
+              .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+          ),
+        }))
+        .sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0)),
+    };
+    if (new Set(request.updates.map((update) => update.id)).size !== request.updates.length)
+      throw new Error();
+  } catch {
+    // Header names and validation paths are caller-controlled secret channels.
+    throw new HTTPException(422, { message: "invalid credential rotation headers or server IDs" });
+  }
+  const scope = {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    sessionId,
+    subjectId: grant.subjectId,
+    actorType: grant.principalKind === "service" ? ("service" as const) : ("human" as const),
+  };
+  const externalAuthorize = externalContinuationCommitAuthorizer(authorization);
+  try {
+    return await rotateSessionMcpCredentialsAtomically(deps.db, {
+      ...scope,
+      operationKey: request.operationKey,
+      ...sessionMcpRotationFingerprint(encryptionKey, scope, request),
+      updates: request.updates.map(({ headers, ...update }) => ({
+        ...update,
+        headersEncrypted: Object.fromEntries(
+          Object.entries(headers).map(([name, value]) => [
+            name,
+            encryptVariableSetValue(encryptionKey, value),
+          ]),
+        ),
+      })),
+      authorize: async (tx) => {
+        await externalAuthorize?.(tx);
+        const fresh = await reauthorize(tx);
+        if (
+          fresh.accountId !== grant.accountId ||
+          fresh.workspaceId !== grant.workspaceId ||
+          fresh.subjectId !== grant.subjectId ||
+          fresh.principalKind !== grant.principalKind
+        )
+          throw new HTTPException(403, { message: "credential rotation authority changed" });
+        requireRotationGrant(fresh);
+        if (fresh.principalKind === "human_session" && !externalAuthorize) {
+          // Signed host grants may narrow a named human's permissions, never
+          // outlive removal or expand that human's current workspace grant.
+          const live = await getWorkspaceGrant(tx, fresh.subjectId, fresh.workspaceId);
+          if (live) {
+            requireRotationGrant(live);
+          } else if (!authorization.canonicalManagedHumanSession) {
+            throw new HTTPException(403, { message: "credential rotation authority changed" });
+          }
+          if (!(await subjectHasLiveWorkspaceAuthorityInScope(tx, scope))) {
+            throw new HTTPException(403, { message: "credential rotation authority changed" });
+          }
+        }
+        await requireSessionAuthorization({ ...deps, db: tx }, fresh, {
+          sessionId,
+          operation: "session.mcp.credentials.rotate",
+          surface: "http",
+        });
+      },
+    });
+  } catch (error) {
+    if (error instanceof HTTPException)
+      throw new HTTPException(error.status, { message: "credential rotation access denied" });
+    if (error instanceof SessionAuthorizationDeniedError)
+      throw new HTTPException(403, { message: "credential rotation access denied" });
+    if (error instanceof SessionAuthorizationUnavailableError)
+      throw new HTTPException(503, { message: "credential rotation authorization unavailable" });
+    if (error instanceof SessionMcpCredentialRotationError) {
+      const status =
+        error.code === "receipt_key_unavailable"
+          ? 503
+          : error.code === "authority_revoked"
+            ? 403
+            : error.code === "not_found"
+              ? 404
+              : error.code === "invalid_request" || error.code === "brokered_server"
+                ? 422
+                : 409;
+      throw new HTTPException(status, { message: `credential_rotation_${error.code}` });
+    }
+    // Drizzle failures can include query parameters. Never attach their cause,
+    // ciphertext, fingerprints, header names, or raw input to API telemetry.
+    throw new HTTPException(503, { message: "credential rotation unavailable" });
+  }
+}

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -434,7 +434,7 @@ export function creationInitiatorForGrant(grant: AccessGrant): FrozenCreationIni
   };
 }
 
-function normalizedSessionMcpCredentialHeaders(
+export function normalizedSessionMcpCredentialHeaders(
   headers: Record<string, string> | undefined,
 ): Record<string, string> {
   if (!headers) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export * from "./access";
 export * from "./application/external-workspace-members";
 export * from "./application/external-identity-lifecycle";
 export * from "./application/external-continuation";
+export * from "./application/session-mcp-credential-rotation";
 export * from "./application/external-link-work-admission";
 export * from "./application/connect-authority";
 export * from "./application/host-mcp-owner";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,10 @@
   "module": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
+    "./session-mcp-credential-rotation": {
+      "types": "./src/session-mcp-credential-rotation.ts",
+      "default": "./src/session-mcp-credential-rotation.ts"
+    },
     "./mcp-operations": {
       "types": "./src/mcp-operations.ts",
       "default": "./src/mcp-operations.ts"

--- a/packages/db/src/session-mcp-credential-rotation.ts
+++ b/packages/db/src/session-mcp-credential-rotation.ts
@@ -1,0 +1,249 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { RotateSessionMcpCredentialsReceipt, SessionTurnStatus } from "@opengeni/contracts";
+import { rawRows, setSubjectRlsContext, withRlsContext, type Database } from "./database";
+import { lockSessionEventWriteRows } from "./session-control";
+import * as schema from "./schema";
+
+const action = "session.mcp.credentials.rotate";
+const liveTurnStatuses = SessionTurnStatus.exclude([
+  "completed",
+  "failed",
+  "cancelled",
+  "superseded",
+  "withdrawn_for_edit",
+]).options;
+
+export class SessionMcpCredentialRotationError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_request"
+      | "not_found"
+      | "not_quiescent"
+      | "version_conflict"
+      | "destination_conflict"
+      | "brokered_server"
+      | "operation_reuse"
+      | "receipt_key_unavailable"
+      | "authority_revoked",
+  ) {
+    super(code);
+    this.name = "SessionMcpCredentialRotationError";
+  }
+}
+
+export type AtomicSessionMcpCredentialRotationInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  subjectId: string;
+  actorType: "human" | "service";
+  operationKey: string;
+  requestDigest: string;
+  digestKeyTag: string;
+  updates: Array<{
+    id: string;
+    expectedCredentialVersion: number;
+    expectedServerUrl: string;
+    headersEncrypted: Record<string, string>;
+  }>;
+  /** Trusted request authorizer, mandatory even for a committed receipt replay.
+   * Revalidate the original authenticated subject and permissions on this tx. */
+  authorize: (tx: Database) => Promise<void>;
+};
+
+/** Existing command receipts own durable idempotency; this is not a new queue
+ * command. No session/event/history/attempt/control/wake rows are mutated. */
+export async function rotateSessionMcpCredentialsAtomically(
+  db: Database,
+  input: AtomicSessionMcpCredentialRotationInput,
+): Promise<RotateSessionMcpCredentialsReceipt> {
+  if (
+    !input.updates.length ||
+    input.updates.length > 64 ||
+    new Set(input.updates.map((update) => update.id)).size !== input.updates.length ||
+    !/^[a-f0-9]{64}$/.test(input.requestDigest) ||
+    !/^[a-f0-9]{64}$/.test(input.digestKeyTag)
+  ) {
+    throw new SessionMcpCredentialRotationError("invalid_request");
+  }
+  return withRlsContext(
+    db,
+    input,
+    async (tx) => {
+      // Membership before tenancy/control/session is the canonical claim/removal
+      // order. External continuation authorization reacquires this exclusive
+      // membership fence, so taking shared first would introduce an upgrade.
+      // Do not upgrade a previously acquired shared tenancy lock.
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(
+      ${`organization-membership:${input.accountId}`}, 0))`);
+      await tx.execute(sql`select pg_advisory_xact_lock_shared(hashtextextended(
+      ${`session-tenancy:${input.workspaceId}`}, 0))`);
+      await setSubjectRlsContext(tx, input.subjectId);
+      const [target] = await tx
+        .select({ id: schema.sessions.id })
+        .from(schema.sessions)
+        .where(
+          and(
+            eq(schema.sessions.accountId, input.accountId),
+            eq(schema.sessions.workspaceId, input.workspaceId),
+            eq(schema.sessions.id, input.sessionId),
+          ),
+        );
+      if (!target) throw new SessionMcpCredentialRotationError("not_found");
+      const locks = await lockSessionEventWriteRows(tx, {
+        workspaceId: input.workspaceId,
+        controlLock: "share",
+        sessionIds: [input.sessionId],
+      });
+      const session = locks.sessions[0];
+      if (!session || session.accountId !== input.accountId) {
+        throw new SessionMcpCredentialRotationError("not_found");
+      }
+      // Hold a current API key through commit. The ordinary access resolver's
+      // last-used write alone does not recheck a revocation racing its first read.
+      // Take UPDATE directly because fresh resolution writes lastUsedAt.
+      if (input.subjectId.startsWith("api_key:")) {
+        const keyId = input.subjectId.slice("api_key:".length);
+        const [key] = await tx
+          .select({ id: schema.apiKeys.id, permissions: schema.apiKeys.permissions })
+          .from(schema.apiKeys)
+          .where(
+            and(
+              eq(schema.apiKeys.id, keyId),
+              eq(schema.apiKeys.accountId, input.accountId),
+              sql`(${schema.apiKeys.workspaceId} is null or ${schema.apiKeys.workspaceId} = ${input.workspaceId}::uuid)`,
+              sql`${schema.apiKeys.revokedAt} is null`,
+              sql`(${schema.apiKeys.expiresAt} is null or ${schema.apiKeys.expiresAt} > clock_timestamp())`,
+            ),
+          )
+          .for("update");
+        if (
+          !key ||
+          (!key.permissions.includes("workspace:admin") &&
+            (!key.permissions.includes("sessions:control") ||
+              !key.permissions.includes("mcp_servers:attach")))
+        )
+          throw new SessionMcpCredentialRotationError("authority_revoked");
+      }
+      await input.authorize(tx);
+      const [prior] = await tx
+        .select()
+        .from(schema.sessionCommandReceipts)
+        .where(
+          and(
+            eq(schema.sessionCommandReceipts.accountId, input.accountId),
+            eq(schema.sessionCommandReceipts.workspaceId, input.workspaceId),
+            eq(schema.sessionCommandReceipts.targetSessionId, input.sessionId),
+            eq(schema.sessionCommandReceipts.actorType, input.actorType),
+            eq(schema.sessionCommandReceipts.actorSubjectId, input.subjectId),
+            eq(schema.sessionCommandReceipts.action, action),
+            eq(schema.sessionCommandReceipts.operationKey, input.operationKey),
+          ),
+        );
+      if (prior) {
+        if (prior.result.digestKeyTag !== input.digestKeyTag)
+          throw new SessionMcpCredentialRotationError("receipt_key_unavailable");
+        if (prior.canonicalRequestHash !== input.requestDigest)
+          throw new SessionMcpCredentialRotationError("operation_reuse");
+        return RotateSessionMcpCredentialsReceipt.parse(prior.result.receipt);
+      }
+      // Session lock serializes admission, claim, realtime start, interruption
+      // settlement, and attempt-owned provider admission. Dormant goals/schedules
+      // and unrelated viewers are deliberately not credential consumers.
+      // Retained run snapshots and tool receipts need a live turn/attempt to
+      // consume credentials; their historical presence alone is not activity.
+      const [busy] = await rawRows<{ present: boolean }>(
+        tx,
+        sql`select (
+      exists(select 1 from session_turns where workspace_id = ${input.workspaceId}::uuid
+        and session_id = ${input.sessionId}::uuid and status in (${sql.join(
+          liveTurnStatuses.map((status) => sql`${status}`),
+          sql`, `,
+        )}))
+      or exists(select 1 from session_turn_attempts a where a.workspace_id = ${input.workspaceId}::uuid
+        and a.session_id = ${input.sessionId}::uuid and (a.state <> 'closed' or
+          (a.quiesced_at is null and exists(select 1 from session_attempt_interruptions i
+            where i.workspace_id = a.workspace_id and i.attempt_id = a.id))))
+      or exists(select 1 from session_system_updates where workspace_id = ${input.workspaceId}::uuid
+        and session_id = ${input.sessionId}::uuid and state = 'pending')
+      or exists(select 1 from sandbox_workspace_mutation_admissions where workspace_id = ${input.workspaceId}::uuid
+        and session_id = ${input.sessionId}::uuid and attempt_id is not null and settled_at is null)
+      or exists(select 1 from session_realtime_modes where workspace_id = ${input.workspaceId}::uuid
+        and session_id = ${input.sessionId}::uuid and state = 'active')
+      or exists(select 1 from session_realtime_connections where workspace_id = ${input.workspaceId}::uuid
+        and session_id = ${input.sessionId}::uuid and state not in ('failed', 'closed'))
+    ) as present`,
+      );
+      if (!busy || busy.present) throw new SessionMcpCredentialRotationError("not_quiescent");
+      const rows = await tx
+        .select()
+        .from(schema.sessionMcpServers)
+        .where(
+          and(
+            eq(schema.sessionMcpServers.workspaceId, input.workspaceId),
+            eq(schema.sessionMcpServers.sessionId, input.sessionId),
+            inArray(
+              schema.sessionMcpServers.serverId,
+              input.updates.map((update) => update.id),
+            ),
+          ),
+        )
+        .orderBy(schema.sessionMcpServers.serverId)
+        .for("update");
+      for (const update of input.updates) {
+        const row = rows.find((server) => server.serverId === update.id);
+        if (!row || row.accountId !== input.accountId)
+          throw new SessionMcpCredentialRotationError("not_found");
+        if (row.connectionRef) throw new SessionMcpCredentialRotationError("brokered_server");
+        if (row.url !== update.expectedServerUrl)
+          throw new SessionMcpCredentialRotationError("destination_conflict");
+        if (
+          !Number.isInteger(update.expectedCredentialVersion) ||
+          update.expectedCredentialVersion < 1 ||
+          update.expectedCredentialVersion >= 2_147_483_647 ||
+          row.credentialVersion !== update.expectedCredentialVersion
+        )
+          throw new SessionMcpCredentialRotationError("version_conflict");
+      }
+      const receipt: RotateSessionMcpCredentialsReceipt = {
+        operationKey: input.operationKey,
+        sessionId: input.sessionId,
+        appliedAt: new Date().toISOString(),
+        servers: input.updates.map((update) => ({
+          id: update.id,
+          credentialVersion: update.expectedCredentialVersion + 1,
+        })),
+      };
+      for (const update of input.updates) {
+        await tx
+          .update(schema.sessionMcpServers)
+          .set({
+            headersEncrypted: update.headersEncrypted,
+            credentialVersion: update.expectedCredentialVersion + 1,
+            updatedAt: new Date(receipt.appliedAt),
+          })
+          .where(
+            and(
+              eq(schema.sessionMcpServers.workspaceId, input.workspaceId),
+              eq(schema.sessionMcpServers.sessionId, input.sessionId),
+              eq(schema.sessionMcpServers.serverId, update.id),
+            ),
+          );
+      }
+      await tx.insert(schema.sessionCommandReceipts).values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        actorType: input.actorType,
+        actorSubjectId: input.subjectId,
+        action,
+        targetSessionId: input.sessionId,
+        operationKey: input.operationKey,
+        canonicalRequestHash: input.requestDigest,
+        result: { digestKeyTag: input.digestKeyTag, receipt },
+      });
+      return receipt;
+    },
+    undefined,
+    "none",
+  );
+}

--- a/packages/db/test/session-mcp-credential-rotation.test.ts
+++ b/packages/db/test/session-mcp-credential-rotation.test.ts
@@ -1,0 +1,478 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import * as database from "../src/index";
+import type { Database, DbClient } from "../src/index";
+import {
+  rotateSessionMcpCredentialsAtomically,
+  type AtomicSessionMcpCredentialRotationInput as RotationInput,
+} from "../src/session-mcp-credential-rotation";
+
+const externalAdminUrl = process.env.OPENGENI_TEST_THROWAWAY_DATABASE_ADMIN_URL?.trim();
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let first: DbClient;
+let second: DbClient;
+let available = true;
+const encryptionKey = new Uint8Array(32).fill(7);
+const serverUrl = "https://tools.example.test/mcp";
+
+async function rotate(db: Database, input: RotationInput): Promise<unknown> {
+  return rotateSessionMcpCredentialsAtomically(db, input);
+}
+
+beforeAll(async () => {
+  let appUrl: string;
+  if (externalAdminUrl) {
+    await database.migrate(externalAdminUrl);
+    await database.provisionRoles(externalAdminUrl, {
+      targetSchema: "public",
+      rlsStrategy: "force",
+      appRole: "opengeni_app",
+      appPassword: "rotation_test_app",
+    });
+    admin = postgres(externalAdminUrl, { max: 4 });
+    const url = new URL(externalAdminUrl);
+    url.username = "opengeni_app";
+    url.password = "rotation_test_app";
+    appUrl = url.toString();
+  } else {
+    shared = await acquireSharedTestDatabase("session-mcp-credential-rotation");
+    if (!shared) {
+      if (process.env.OPENGENI_REQUIRE_REAL_DB === "1") throw new Error("PostgreSQL required");
+      available = false;
+      return;
+    }
+    admin = shared.admin;
+    appUrl = shared.appUrl;
+  }
+  first = database.createDb(appUrl);
+  second = database.createDb(appUrl);
+}, 180_000);
+
+afterAll(async () => {
+  await Promise.all([first?.close(), second?.close()]);
+  if (shared) await shared.release();
+  else await admin?.end();
+}, 180_000);
+
+async function fixture(): Promise<RotationInput> {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('credential rotation test') returning id`;
+  const [workspace] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name) values (${account!.id}, 'rotation') returning id`;
+  await admin`insert into workspace_inference_controls (account_id, workspace_id)
+    values (${account!.id}, ${workspace!.id})`;
+  const session = await database.createSession(first.db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    initialMessage: "",
+    resources: [],
+    tools: [{ kind: "mcp", id: "external" }],
+    metadata: {},
+    model: "test-model",
+    reasoningEffort: "low",
+    latencyMode: "standard",
+    sandboxBackend: "none",
+  });
+  await database.createSessionMcpServers(first.db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    sessionId: session.id,
+    servers: [
+      {
+        id: "external",
+        url: serverUrl,
+        headersEncrypted: {
+          authorization: database.encryptVariableSetValue(encryptionKey, "Bearer original"),
+        },
+      },
+    ],
+  });
+  return {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    sessionId: session.id,
+    subjectId: "test-rotation-host",
+    actorType: "human" as const,
+    operationKey: crypto.randomUUID(),
+    requestDigest: "a".repeat(64),
+    digestKeyTag: "b".repeat(64),
+    updates: [
+      {
+        id: "external",
+        expectedCredentialVersion: 1,
+        expectedServerUrl: serverUrl,
+        headersEncrypted: {
+          authorization: database.encryptVariableSetValue(encryptionKey, "Bearer replacement"),
+        },
+      },
+    ],
+    authorize: async () => {},
+  };
+}
+
+async function state(input: RotationInput) {
+  const [row] = await admin`
+    select credential_version, headers_encrypted from session_mcp_servers
+    where workspace_id = ${input.workspaceId} and session_id = ${input.sessionId}`;
+  return row!;
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitForBlockedBackend(pid: number) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const [row] = await admin`select pid from pg_stat_activity
+      where datname = current_database() and usename = 'opengeni_app'
+      and state = 'active' and wait_event_type = 'Lock'
+      and ${pid} = any(pg_blocking_pids(pid)) limit 1`;
+    if (row) return;
+    await Bun.sleep(10);
+  }
+  throw new Error("expected a real PostgreSQL lock wait");
+}
+
+describe("atomic standalone credential rotation (real PostgreSQL)", () => {
+  test("exact replay retains the original receipt and performs no second write", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const receipt = await rotate(first.db, input);
+    expect(await rotate(second.db, input)).toEqual(receipt);
+    expect((await state(input)).credential_version).toBe(2);
+    const facts = await admin`select * from session_command_receipts
+      where target_session_id = ${input.sessionId}`;
+    expect(facts).toHaveLength(1);
+    expect(JSON.stringify(facts)).not.toContain("Bearer replacement");
+    const turns = await admin`select id from session_turns where session_id = ${input.sessionId}`;
+    expect(turns).toHaveLength(0);
+  });
+
+  test("revalidates authority before an exact replay", async () => {
+    if (!available) return;
+    const input = await fixture();
+    await rotate(first.db, input);
+    await expect(
+      rotate(second.db, {
+        ...input,
+        authorize: async () => {
+          throw new Error("revoked");
+        },
+      }),
+    ).rejects.toThrow("revoked");
+    expect((await state(input)).credential_version).toBe(2);
+  });
+
+  test("concurrent exact replay has one durable write and identical receipts", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const [one, two] = await Promise.all([rotate(first.db, input), rotate(second.db, input)]);
+    expect(one).toEqual(two);
+    expect((await state(input)).credential_version).toBe(2);
+    expect(
+      await admin`select id from session_command_receipts where target_session_id = ${input.sessionId}`,
+    ).toHaveLength(1);
+  });
+
+  test("historical failure alone permits rotation but a closed unquiesced interruption does not", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const start = await database.initializeSessionStartAtomically(first.db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    const attemptId = crypto.randomUUID();
+    const claim = await database.claimSessionWorkForAttempt(first.db, input.workspaceId, {
+      sessionId: input.sessionId,
+      workflowId: start.temporalWorkflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    if (claim.action !== "claimed") throw new Error("claim required");
+    await database.applySessionTurnSettlement(first.db, input.workspaceId, {
+      sessionId: input.sessionId,
+      turnId: claim.turn.id,
+      triggerEventId: claim.turn.triggerEventId,
+      attemptId,
+      turnStatus: "failed",
+      sessionStatus: "failed",
+      activeTurnId: null,
+      events: [],
+    });
+    // Settled turns retain provider snapshots and recorded tool results. These
+    // receipts do not themselves own a live credential-consuming attempt.
+    await admin`insert into agent_run_states
+      (account_id, workspace_id, session_id, turn_id, state_version, serialized_run_state)
+      values (${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${claim.turn.id}, 1, '{}')`;
+    await admin`insert into session_pending_tool_calls
+      (account_id, workspace_id, session_id, turn_id, execution_generation, attempt_id,
+       call_id, call_type, call_item_ordered, result_recorded_at)
+      values (${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${claim.turn.id},
+        1, ${attemptId}, 'historical-call', 'function_call', '{}', now())`;
+    await rotate(second.db, input);
+    const [receipt] = await admin<
+      { id: string }[]
+    >`select id from session_command_receipts where target_session_id = ${input.sessionId}`;
+    await admin`insert into session_attempt_interruptions
+      (account_id, workspace_id, session_id, operation_id, attempt_id, kind, control_revision, state)
+      values (${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${receipt!.id},
+        ${attemptId}, 'steer', 1, 'settled')`;
+    await admin`update session_turn_attempts set quiesced_at = null where id = ${attemptId}`;
+    const fresh = {
+      ...input,
+      operationKey: crypto.randomUUID(),
+      updates: [
+        {
+          ...input.updates[0]!,
+          expectedCredentialVersion: 2,
+        },
+      ],
+    };
+    await expect(rotate(second.db, fresh)).rejects.toThrow("not_quiescent");
+    await admin`update session_turn_attempts set quiesced_at = now() where id = ${attemptId}`;
+    await rotate(second.db, fresh);
+    expect((await state(input)).credential_version).toBe(3);
+  });
+
+  test("concurrent fresh operations with the same expected version have one winner", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const results = await Promise.allSettled([
+      rotate(first.db, input),
+      rotate(second.db, { ...input, operationKey: crypto.randomUUID() }),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect((await state(input)).credential_version).toBe(2);
+  });
+
+  test("stale version, changed destination, and unknown IDs do not partially update", async () => {
+    if (!available) return;
+    for (const invalid of [
+      { expectedCredentialVersion: 2 },
+      { expectedServerUrl: "https://other.example.test/mcp" },
+      { id: "unknown" },
+    ]) {
+      const input = await fixture();
+      await expect(
+        rotate(first.db, { ...input, updates: [{ ...input.updates[0]!, ...invalid }] }),
+      ).rejects.toThrow();
+      expect((await state(input)).credential_version).toBe(1);
+    }
+  });
+
+  test("unknown server in a batch rolls back every server and the receipt", async () => {
+    if (!available) return;
+    const input = await fixture();
+    await expect(
+      rotate(first.db, {
+        ...input,
+        updates: [
+          input.updates[0]!,
+          {
+            ...input.updates[0]!,
+            id: "unknown",
+          },
+        ],
+      }),
+    ).rejects.toThrow("not_found");
+    expect((await state(input)).credential_version).toBe(1);
+    expect(
+      await admin`select id from session_command_receipts where target_session_id = ${input.sessionId}`,
+    ).toHaveLength(0);
+  });
+
+  test("brokered rows and changed payload reuse are rejected without replacing credentials", async () => {
+    if (!available) return;
+    const input = await fixture();
+    await rotate(first.db, input);
+    await expect(rotate(second.db, { ...input, requestDigest: "d".repeat(64) })).rejects.toThrow(
+      "operation_reuse",
+    );
+    await admin`update session_mcp_servers set connection_ref = '{"providerDomain":"example.test","kind":"oauth2"}'::jsonb
+      where session_id = ${input.sessionId}`;
+    await expect(
+      rotate(first.db, {
+        ...input,
+        operationKey: crypto.randomUUID(),
+        updates: [{ ...input.updates[0]!, expectedCredentialVersion: 2 }],
+      }),
+    ).rejects.toThrow("brokered_server");
+    expect((await state(input)).credential_version).toBe(2);
+  });
+
+  test("a wrong tenant or session cannot use another session's receipt", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const other = await fixture();
+    await rotate(first.db, input);
+    await expect(rotate(second.db, { ...input, workspaceId: other.workspaceId })).rejects.toThrow(
+      "not_found",
+    );
+    await expect(rotate(second.db, { ...input, sessionId: other.sessionId })).rejects.toThrow(
+      "not_found",
+    );
+    expect((await state(input)).credential_version).toBe(2);
+    expect((await state(other)).credential_version).toBe(1);
+  });
+
+  test("rotation serializes concurrent prompt admission before any new claim", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const entered = deferred<number>();
+    const release = deferred();
+    const rotation = rotate(first.db, {
+      ...input,
+      authorize: async (tx) => {
+        const rows = await tx.execute<{ pid: number }>(sql`select pg_backend_pid() as pid`);
+        entered.resolve(rows[0]!.pid);
+        await release.promise;
+      },
+    });
+    const pid = await entered.promise;
+    const admission = database.initializeSessionStartAtomically(second.db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    try {
+      await waitForBlockedBackend(pid);
+    } finally {
+      release.resolve();
+    }
+    await rotation;
+    const start = await admission;
+    expect(start.turn).toBeTruthy();
+    const attemptId = crypto.randomUUID();
+    const claim = await database.claimSessionWorkForAttempt(second.db, input.workspaceId, {
+      sessionId: input.sessionId,
+      workflowId: start.temporalWorkflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    expect(claim.action).toBe("claimed");
+    const servers = await database.listSessionMcpServersForRun(
+      second.db,
+      input.workspaceId,
+      input.sessionId,
+      attemptId,
+      encryptionKey,
+    );
+    expect(servers[0]!.credentialVersion).toBe(2);
+    expect(servers[0]!.headers.authorization).toBe("Bearer replacement");
+  });
+
+  test("a concurrent claim wins serialization and rotation cannot alter its prepared credentials", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const start = await database.initializeSessionStartAtomically(first.db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    const entered = deferred<number>();
+    const release = deferred();
+    const attemptId = crypto.randomUUID();
+    const claim = database.withSessionActivityRlsContext(
+      first.db,
+      input,
+      async (tx) => {
+        const result = await database.claimSessionWorkForAttempt(tx, input.workspaceId, {
+          sessionId: input.sessionId,
+          workflowId: start.temporalWorkflowId,
+          workflowRunId: crypto.randomUUID(),
+          attemptId,
+          dispatchId: crypto.randomUUID(),
+          trigger: { kind: "next" },
+        });
+        const rows = await tx.execute<{ pid: number }>(sql`select pg_backend_pid() as pid`);
+        entered.resolve(rows[0]!.pid);
+        await release.promise;
+        return result;
+      },
+      undefined,
+      "shared",
+      true,
+    );
+    const pid = await entered.promise;
+    const rotation = rotate(second.db, input).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    try {
+      await waitForBlockedBackend(pid);
+    } finally {
+      release.resolve();
+    }
+    expect((await claim).action).toBe("claimed");
+    expect(await rotation).toMatchObject({ message: "not_quiescent" });
+    const servers = await database.listSessionMcpServersForRun(
+      first.db,
+      input.workspaceId,
+      input.sessionId,
+      attemptId,
+      encryptionKey,
+    );
+    expect(servers[0]!.credentialVersion).toBe(1);
+    expect(servers[0]!.headers.authorization).toBe("Bearer original");
+  });
+
+  test("key replacement is unavailable, not payload conflict or second write", async () => {
+    if (!available) return;
+    const input = await fixture();
+    await rotate(first.db, input);
+    await expect(rotate(second.db, { ...input, digestKeyTag: "c".repeat(64) })).rejects.toThrow(
+      "receipt_key_unavailable",
+    );
+    expect((await state(input)).credential_version).toBe(2);
+  });
+
+  test("queued and claimed work block fresh rotation, while a receipt still replays", async () => {
+    if (!available) return;
+    const input = await fixture();
+    const receipt = await rotate(first.db, input);
+    const start = await database.initializeSessionStartAtomically(first.db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    expect(await rotate(second.db, input)).toEqual(receipt);
+    const fresh = {
+      ...input,
+      operationKey: crypto.randomUUID(),
+      updates: [{ ...input.updates[0]!, expectedCredentialVersion: 2 }],
+    };
+    await expect(rotate(second.db, fresh)).rejects.toThrow("not_quiescent");
+    const claim = await database.claimSessionWorkForAttempt(first.db, input.workspaceId, {
+      sessionId: input.sessionId,
+      workflowId: start.temporalWorkflowId,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    expect(claim.action).toBe("claimed");
+    await expect(rotate(second.db, fresh)).rejects.toThrow("not_quiescent");
+    expect((await state(input)).credential_version).toBe(2);
+  });
+});

--- a/packages/db/tsup.config.ts
+++ b/packages/db/tsup.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     "session-tenancy": "src/session-tenancy.ts",
     "session-background-commands": "src/session-background-commands.ts",
     "session-command-output": "src/session-command-output.ts",
+    "session-mcp-credential-rotation": "src/session-mcp-credential-rotation.ts",
     "retained-provider-commands": "src/retained-provider-commands.ts",
     "session-event-slices": "src/session-event-slices.ts",
     "mcp-operations": "src/mcp-operations.ts",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -819,6 +819,32 @@ await client.sendApprovalDecision(workspaceId, sessionId, { approvalId, decision
 
 ## Session tool policy and native web search
 
+For standalone credential maintenance, use the dedicated operation rather than
+sending a message:
+
+```ts
+const request = {
+  operationKey: crypto.randomUUID(),
+  updates: [{
+    id: "crm",
+    expectedCredentialVersion: 1,
+    expectedServerUrl: "https://tools.example.test/mcp",
+    headers: { Authorization: `Bearer ${replacementToken}` },
+  }],
+};
+const receipt = await client.rotateSessionMcpCredentials(workspaceId, sessionId, request);
+```
+
+Only exact existing inline servers without `connectionRef` are eligible. Both
+session control and MCP attach permissions, live session authorization, expected
+versions, and a quiescent credential-consumer boundary are required. This never
+sends a message, starts work, retries a failed turn, or refreshes an active
+client. Reconcile an ambiguous response with the same request/key; the SDK does
+not retry mutations automatically. Exact authorized replay returns the original
+receipt without a second write. Old receipt verification fails explicitly with
+503 if the deployment encryption key has been replaced. See the full
+[rotation contract](../../docs/session-mcp-servers.md#standalone-inline-credential-rotation).
+
 Omitting `tools` when creating a top-level session selects the current
 workspace-default capability policy, including the built-in `files` server.
 Passing `tools`, including `[]`, is an intentional fixed narrowing and can

--- a/packages/sdk/src/embedding-client.ts
+++ b/packages/sdk/src/embedding-client.ts
@@ -12,6 +12,21 @@ import type {
 
 /** Public product embedding administration, kept out of the native browser client. */
 export class OpenGeniEmbeddingClient extends OpenGeniArtifactClient {
+  /** Rotate existing inline credentials only while no credential-consuming work
+   * is pending or active. Reuse the operation key and exact request to reconcile
+   * a lost response. This operation never schedules or retries model work. */
+  async rotateSessionMcpCredentials(
+    workspaceId: string,
+    sessionId: string,
+    request: import("./types").RotateSessionMcpCredentialsRequest,
+  ): Promise<import("./types").RotateSessionMcpCredentialsReceipt> {
+    return this.requestJson(
+      "POST",
+      `/v1/workspaces/${workspaceId}/sessions/${sessionId}/mcp-credentials/rotate`,
+      request,
+    );
+  }
+
   /** Server-side organization-key client scoped to one host-authenticated user.
    * Does not mutate this client, provision workspace membership, or link native
    * identities. The API verifies key and membership authority on each request. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -955,6 +955,8 @@ export type {
   SessionSummary,
   LineageNode,
   SessionMcpCredentialUpdateInput,
+  RotateSessionMcpCredentialsRequest,
+  RotateSessionMcpCredentialsReceipt,
   SessionMcpApprovalPolicy,
   SessionMcpServerInput,
   SessionMcpServerMetadata,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -646,6 +646,23 @@ export type SessionMcpCredentialUpdateInput = {
   headers: Record<string, string>;
 };
 
+export type RotateSessionMcpCredentialsRequest = {
+  operationKey: string;
+  updates: Array<{
+    id: string;
+    expectedCredentialVersion: number;
+    expectedServerUrl: string;
+    headers: Record<string, string>;
+  }>;
+};
+
+export type RotateSessionMcpCredentialsReceipt = {
+  operationKey: string;
+  sessionId: string;
+  servers: Array<{ id: string; credentialVersion: number }>;
+  appliedAt: string;
+};
+
 export type SessionMcpApprovalPolicy = boolean | string[];
 
 export type SessionMcpServerMetadata = {

--- a/packages/sdk/test/session-mcp-credential-rotation.test.ts
+++ b/packages/sdk/test/session-mcp-credential-rotation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { OpenGeniClient } from "../src/index";
+
+const workspaceId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const sessionId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const request = {
+  operationKey: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  updates: [
+    {
+      id: "external",
+      expectedCredentialVersion: 1,
+      expectedServerUrl: "https://tools.example.test/mcp",
+      headers: { Authorization: "Bearer synthetic-rotation-secret" },
+    },
+  ],
+};
+
+describe("standalone session MCP credential rotation", () => {
+  test("uses the dedicated operation without sending a message or enqueueing work", async () => {
+    const calls: Request[] = [];
+    const receipt = {
+      operationKey: request.operationKey,
+      sessionId,
+      servers: [{ id: "external", credentialVersion: 2 }],
+      appliedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      apiKey: "synthetic-api-key",
+      fetch: (async (url, init) => {
+        calls.push(new Request(url, init));
+        return Response.json(receipt);
+      }) as typeof fetch,
+    });
+    expect(await client.rotateSessionMcpCredentials(workspaceId, sessionId, request)).toEqual(
+      receipt,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url).toBe(
+      `https://api.example.test/v1/workspaces/${workspaceId}/sessions/${sessionId}/mcp-credentials/rotate`,
+    );
+    expect(await calls[0]!.json()).toEqual(request);
+    expect(JSON.stringify(receipt)).not.toContain("synthetic-rotation-secret");
+  });
+
+  test("does not automatically retry an ambiguous mutation transport failure", async () => {
+    let calls = 0;
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      apiKey: "synthetic-api-key",
+      fetch: (async () => {
+        calls += 1;
+        throw new Error("connection lost");
+      }) as unknown as typeof fetch,
+    });
+    await expect(
+      client.rotateSessionMcpCredentials(workspaceId, sessionId, request),
+    ).rejects.toThrow();
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/testing/src/object-storage-fixture.ts
+++ b/packages/testing/src/object-storage-fixture.ts
@@ -10,7 +10,11 @@ export const GARAGE_FIXTURE_S3_PROVIDER = "Other";
 export const GARAGE_FIXTURE_SANDBOX_ENDPOINT = "http://garage:3900";
 export const GARAGE_FIXTURE_IMAGE =
   "dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690";
-export const GARAGE_FIXTURE_MC_IMAGE = "minio/mc:RELEASE.2025-08-13T08-35-41Z";
+// The release publisher pushes the same build to Docker Hub and Quay:
+// https://github.com/minio/mc/blob/7394ce0dd2a80935aded936b09fa12cbb3cb8096/docker-buildx.sh#L25-L32
+// Pin the multi-platform index, not an architecture-specific child manifest.
+export const GARAGE_FIXTURE_MC_IMAGE =
+  "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727";
 
 export const MINIO_FIXTURE_ACCESS_KEY_ID = "minioadmin";
 export const MINIO_FIXTURE_SECRET_ACCESS_KEY = "minioadmin";

--- a/packages/testing/test/object-storage-fixture.test.ts
+++ b/packages/testing/test/object-storage-fixture.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { GARAGE_FIXTURE_MC_IMAGE } from "../src/object-storage-fixture";
+
+test("object-storage bootstrap clients share the official immutable release image", async () => {
+  const compose = Bun.YAML.parse(
+    await readFile(new URL("../../../docker-compose.yml", import.meta.url), "utf8"),
+  ) as {
+    services: Record<string, { image: string; entrypoint?: string[]; command?: string }>;
+  };
+  expect(GARAGE_FIXTURE_MC_IMAGE).toBe(
+    "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727",
+  );
+  for (const service of ["garage-init", "minio-init"]) {
+    expect(compose.services[service]!.image).toBe(GARAGE_FIXTURE_MC_IMAGE);
+    expect(compose.services[service]!.entrypoint).toEqual(["/bin/sh", "-c"]);
+  }
+  expect(compose.services["garage-init"]!.command).toContain(
+    "mc cors set local/opengeni-files /cors.xml",
+  );
+  expect(compose.services["minio-init"]!.command).toContain(
+    "mc mb --ignore-existing local/opengeni-files",
+  );
+  expect(compose.services.garage!.image).toStartWith("dxflrs/garage:");
+  expect(compose.services.minio!.image).toStartWith("minio/minio:");
+});

--- a/scripts/db-package-contract.test.ts
+++ b/scripts/db-package-contract.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import config from "../packages/db/tsup.config";
+import { rewriteEntryPointsToDist } from "./rewrite-entry-points";
+
+test("every public DB source subpath has a matching runtime build entry", async () => {
+  const directory = join(import.meta.dir, "../packages/db");
+  const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+  const resolved = typeof config === "function" ? await config({}) : config;
+  const configs = Array.isArray(resolved) ? resolved : [resolved];
+  const entries = Object.assign({}, ...configs.map((item) => item.entry));
+  const published = structuredClone(manifest);
+  rewriteEntryPointsToDist(published);
+
+  for (const [subpath, value] of Object.entries(manifest.exports)) {
+    const source = value as { types?: string; import?: string; default?: string };
+    const runtime = source.import ?? source.default;
+    if (!runtime?.startsWith("./src/") || !runtime.endsWith(".ts")) continue;
+    const name = runtime.slice("./src/".length, -".ts".length);
+    expect(entries[name], `${subpath} runtime build entry`).toBe(runtime.slice(2));
+    expect(existsSync(join(directory, runtime))).toBe(true);
+    const emittedRuntime = published.exports[subpath].import ?? published.exports[subpath].default;
+    expect(emittedRuntime).toBe(`./dist/${name}.js`);
+    expect(published.exports[subpath].types).toBe(`./dist/${name}.d.ts`);
+    // Unit shards need no dist. Repeat after the canonical package build to
+    // verify the actual shipped runtime and declaration artifacts as well.
+    if (process.env.OPENGENI_VERIFY_BUILT_EMBEDDING_PACKAGES === "1") {
+      expect(existsSync(join(directory, emittedRuntime)), subpath).toBe(true);
+      expect(existsSync(join(directory, published.exports[subpath].types)), subpath).toBe(true);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Add a host-authorized standalone API and root SDK operation for rotating existing inline MCP credentials without submitting a message, scheduling work, resuming attempts, or retrying mutations.

- Require current session authorization plus control and MCP attach permissions, including on receipt replay.
- Bind each atomic encrypted update to the exact destination and expected credential version; reject brokered references and active credential-consuming work.
- Reuse durable command receipts with keyed request fingerprints; exact replay performs no second write.
- Serialize against admission and claiming using existing lock order. Historical execution snapshots do not block idle-session repair.

## Verification

- Red regressions before implementation and before correcting historical-state overblocking.
- 25 real-PostgreSQL, HTTP and SDK tests passed (94 assertions), independently rerun on Bun 1.4.0.
- 1,286 broader tests passed; contracts, DB, core, SDK and API typechecks passed.
- Formatting, lint and diff checks passed.

## Limits

No automatic recovery authority, failed-turn retry, new migration, or deployment changes. Existing message-bound rotation is unchanged. Replacing the encryption key makes old receipt replay explicitly unavailable; no keyring or receipt migration is introduced.

## Summary by Sourcery

Expose standalone, idempotent inline MCP credential rotation with strict authorization, atomic safety checks, and HTTP/SDK access.

New Features:
- Add an authorized standalone API and SDK operation for rotating existing inline MCP credentials without sending messages or scheduling work.

Bug Fixes:
- Prevent duplicate credential writes through durable, authorization-aware receipt replay and reject stale, mismatched, brokered, or active-use rotations.

Enhancements:
- Enforce atomic destination/version fencing, quiescence checks, secret-safe request fingerprints, and explicit encryption-key replay failures.
- Document the standalone rotation contract and expose its request and receipt types across contracts, core, API, and SDK.

Build:
- Add the database rotation entry point and validate public database subpaths against runtime build entries.

Deployment:
- Pin object-storage bootstrap clients to an immutable Quay image digest.

Documentation:
- Document standalone inline MCP credential rotation, authorization requirements, quiescence behavior, idempotent replay, and key replacement limitations.
- Update architecture references and SDK usage guidance.

Tests:
- Add real-PostgreSQL, HTTP, SDK, authorization, concurrency, replay, validation, quiescence, and object-storage fixture coverage.