### PR TITLE
feat(react): localize user message disclosure labels

### DIFF
--- a/.changeset/localized-user-message-disclosure.md
+++ b/.changeset/localized-user-message-disclosure.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Allow hosts to localize user-message disclosure actions through direct component props and the default timeline composition. Each label falls back independently to English, while message expansion, accessible controls, and scroll anchoring retain their existing behavior.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -688,6 +688,15 @@ intentional changes should regenerate those snapshots and review the diff.
 - `UserMessageBody` — the shared lossless rendered-height disclosure for
   already-sent user text. Use it inside a custom `renderMessageText` user branch
   so attachments and voice identity remain outside the clipped Markdown region.
+  Pass `disclosureLabels={{ showMore: "Afficher davantage", showLess: "Réduire" }}`
+  to localize a direct instance. For the default timeline, pass the same object
+  as `MessageTimeline.userMessageDisclosureLabels` or
+  `SessionConversation.userMessageDisclosureLabels`; custom `UserMessageBody`
+  renderers inside that timeline inherit these labels too. Each direct label
+  overrides its timeline label independently, then falls back to `Show more`
+  or `Show less`. Changing labels does not reset a message's expanded state.
+  `UserMessageDisclosureLabels` is exported from both `@opengeni/react` and
+  `@opengeni/react/session-ui`.
 - `SessionStatus` / `StatusDot` — status badges; live states breathe.
 - `FleetTile` — one session in a fleet grid: title, status, model, recency.
 - `ModelPicker` — a compact model dropdown for a composer slot, grouping the

--- a/packages/react/demo/user-message-test-harness.tsx
+++ b/packages/react/demo/user-message-test-harness.tsx
@@ -8,6 +8,7 @@ import {
   UserMessageBody,
   type TimelineItem,
   type UserMessageItem,
+  type UserMessageDisclosureLabels,
 } from "@opengeni/react";
 import "./styles.css";
 
@@ -15,6 +16,7 @@ type UserMessageHarness = {
   prepend: () => void;
   stream: () => void;
   scroller: () => HTMLElement;
+  setDisclosureLabels: (labels: UserMessageDisclosureLabels) => void;
 };
 
 declare global {
@@ -118,6 +120,8 @@ function HiddenShadowActionFixture() {
 }
 
 function Harness() {
+  const [disclosureLabels, setDisclosureLabels] = useState<UserMessageDisclosureLabels>();
+  const defaultRenderer = new URLSearchParams(window.location.search).has("defaultRenderer");
   const [streamed, setStreamed] = useState(false);
   const [prepended, setPrepended] = useState(false);
   const items = useMemo(
@@ -147,6 +151,7 @@ function Harness() {
       prepend: () => flushSync(() => setPrepended(true)),
       stream: () => flushSync(() => setStreamed(true)),
       scroller,
+      setDisclosureLabels: (labels) => flushSync(() => setDisclosureLabels(labels)),
     };
     return () => {
       delete window.userMessageHarness;
@@ -229,7 +234,8 @@ function Harness() {
           className="min-h-0 flex-1 overflow-hidden rounded-og-lg border border-og-border bg-og-surface-1"
           items={items}
           hasOlder
-          renderMessageText={renderMessageText}
+          renderMessageText={defaultRenderer ? undefined : renderMessageText}
+          userMessageDisclosureLabels={disclosureLabels}
         />
       </section>
     </main>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -62,6 +62,7 @@ import {
   UserMessageBody,
   UserMessageDisclosureProvider,
   type UserMessageDisclosureContextValue,
+  type UserMessageDisclosureLabels,
 } from "./user-message-body";
 import {
   createTipFollowState,
@@ -128,6 +129,8 @@ const TimelineAnnotationSelection = lazy(() => import("./timeline-annotation-sel
 const TimelineAnnotationMarkers = lazy(() => import("./timeline-annotation-markers"));
 
 export type MessageTimelineProps = {
+  /** Localized user-message disclosure actions, including custom UserMessageBody renderers. */
+  userMessageDisclosureLabels?: UserMessageDisclosureLabels | undefined;
   /** Raw session events (projected internally) … */
   events?: SessionEvent[] | undefined;
   /** … or pre-projected items (e.g. from `useSessionEvents().timeline`). */
@@ -404,6 +407,7 @@ function cssEscapeAttribute(value: string): string {
  * with a "jump to latest" affordance when the reader scrolls back.
  */
 export function MessageTimeline({
+  userMessageDisclosureLabels,
   events,
   items,
   status: _status,
@@ -919,8 +923,16 @@ export function MessageTimeline({
     () => ({
       expandedByMessageId: userMessageDisclosureMemoryRef.current,
       beginChange: beginUserMessageDisclosureChange,
+      labels: {
+        showMore: userMessageDisclosureLabels?.showMore,
+        showLess: userMessageDisclosureLabels?.showLess,
+      },
     }),
-    [beginUserMessageDisclosureChange],
+    [
+      beginUserMessageDisclosureChange,
+      userMessageDisclosureLabels?.showMore,
+      userMessageDisclosureLabels?.showLess,
+    ],
   );
   const timelineGroupEntryContext = useMemo<TimelineGroupEntryContext>(
     () => ({

--- a/packages/react/src/components/session-conversation.tsx
+++ b/packages/react/src/components/session-conversation.tsx
@@ -11,11 +11,14 @@ import { ChatComposer, type ChatComposerProps } from "./chat-composer";
 import { QueueSurface } from "./queue-surface";
 import { HumanInputSurface, type HumanInputSurfaceProps } from "./human-input-surface";
 import { MessageTimeline } from "./message-timeline";
+import type { UserMessageDisclosureLabels } from "./user-message-body";
 import { conversationTimeline } from "../conversation-timeline";
 import { cn } from "../lib/cn";
 
 export type SessionConversationProps = ClientOverride & {
   sessionId: string;
+  /** Localized actions for already-sent user-message disclosure. */
+  userMessageDisclosureLabels?: UserMessageDisclosureLabels | undefined;
   loadSkillReview?: HumanInputSurfaceProps["loadSkillReview"];
   className?: string;
   /** Defaults to filling the host. The host owns available height. */
@@ -32,6 +35,7 @@ export function SessionConversation(props: SessionConversationProps) {
 
 function Conversation({
   sessionId,
+  userMessageDisclosureLabels,
   loadSkillReview,
   client,
   workspaceId,
@@ -71,6 +75,7 @@ function Conversation({
     >
       {error && <p role="alert">{error.message}</p>}
       <MessageTimeline
+        userMessageDisclosureLabels={userMessageDisclosureLabels}
         className="min-h-0 flex-1"
         items={conversationTimeline(feed.timeline, queue, composer)}
         status={status}

--- a/packages/react/src/components/user-message-body.tsx
+++ b/packages/react/src/components/user-message-body.tsx
@@ -190,7 +190,15 @@ function observeSharedResize(element: Element, callback: () => void): (() => voi
   };
 }
 
+export type UserMessageDisclosureLabels = {
+  /** Collapsed disclosure action. Defaults to "Show more". */
+  showMore?: string | undefined;
+  /** Expanded disclosure action. Defaults to "Show less". */
+  showLess?: string | undefined;
+};
+
 export type UserMessageDisclosureContextValue = {
+  labels?: UserMessageDisclosureLabels | undefined;
   expandedByMessageId: Map<string, boolean>;
   beginChange: (
     messageBody: HTMLElement,
@@ -235,6 +243,8 @@ export type UserMessageBodyProps = {
   text: string;
   children: ReactNode;
   className?: string | undefined;
+  /** Per-field overrides for timeline labels, then the English defaults. */
+  disclosureLabels?: UserMessageDisclosureLabels | undefined;
 };
 
 /**
@@ -247,7 +257,13 @@ export type UserMessageBodyProps = {
  * remembers expansion per durable message id and preserves the reader's scroll
  * anchor when height changes.
  */
-export function UserMessageBody({ messageId, text, children, className }: UserMessageBodyProps) {
+export function UserMessageBody({
+  messageId,
+  text,
+  children,
+  className,
+  disclosureLabels,
+}: UserMessageBodyProps) {
   const disclosure = useContext(UserMessageDisclosureContext);
   const [expanded, setExpanded] = useState(
     () => disclosure?.expandedByMessageId.get(messageId) ?? false,
@@ -454,7 +470,9 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
         className="mt-1.5 inline-flex min-h-7 items-center rounded-og-sm px-1.5 text-og-xs font-medium text-og-fg-muted outline-hidden transition-colors hover:bg-og-surface-3/60 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:min-h-11"
         onClick={(event) => toggle(event.currentTarget)}
       >
-        {expanded ? "Show less" : "Show more"}
+        {expanded
+          ? (disclosureLabels?.showLess ?? disclosure?.labels?.showLess ?? "Show less")
+          : (disclosureLabels?.showMore ?? disclosure?.labels?.showMore ?? "Show more")}
       </button>
     </div>
   );

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -511,7 +511,10 @@ export { GeneratedVideoPlayer } from "./components/generated-video-player";
 export type { GeneratedVideoPlayerProps } from "./components/generated-video-player";
 export type { MessageTimelineProps } from "./components/message-timeline";
 export { UserMessageBody, userMessageLikelyNeedsDisclosure } from "./components/user-message-body";
-export type { UserMessageBodyProps } from "./components/user-message-body";
+export type {
+  UserMessageBodyProps,
+  UserMessageDisclosureLabels,
+} from "./components/user-message-body";
 export {
   Markdown,
   sandboxFileLocationFromHref,

--- a/packages/react/src/session-ui.ts
+++ b/packages/react/src/session-ui.ts
@@ -16,7 +16,10 @@ export type { MessageTimelineProps } from "./components/message-timeline";
 export { createOlderHistoryLoadReceipt } from "./older-history";
 export type { OlderHistoryLoader, OlderHistoryLoadReceipt } from "./older-history";
 export { UserMessageBody, userMessageLikelyNeedsDisclosure } from "./components/user-message-body";
-export type { UserMessageBodyProps } from "./components/user-message-body";
+export type {
+  UserMessageBodyProps,
+  UserMessageDisclosureLabels,
+} from "./components/user-message-body";
 export { BUILT_IN_TURN_SUMMARY_FACET_IDS } from "./timeline/turn-summary";
 export type {
   BuiltInTurnSummaryFacetId,

--- a/packages/react/test/session-conversation.test.tsx
+++ b/packages/react/test/session-conversation.test.tsx
@@ -74,6 +74,18 @@ test("complete conversation loads queue and provides queue actions beside compos
     pendingInputAttachment: null,
   };
   const client = fakeClient({
+    listEvents: async () =>
+      [
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          sessionId: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          sequence: 1,
+          type: "user.message",
+          occurredAt: "2026-09-07T00:00:00Z",
+          payload: { text: "A complete long message. ".repeat(80) },
+        },
+      ] as never,
     getSession: async () =>
       ({
         id: SESSION_ID,
@@ -101,10 +113,28 @@ test("complete conversation loads queue and provides queue actions beside compos
     },
   });
   const view = await renderComponent(
-    <SessionConversation sessionId={SESSION_ID} client={client} workspaceId={WORKSPACE_ID} />,
+    <SessionConversation
+      sessionId={SESSION_ID}
+      client={client}
+      workspaceId={WORKSPACE_ID}
+      userMessageDisclosureLabels={{ showMore: "Afficher davantage", showLess: "Réduire" }}
+    />,
   );
   try {
     await flush(100);
+    const disclosure = view.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    expect(disclosure.textContent).toBe("Afficher davantage");
+    await actRun(() => disclosure.click());
+    expect(disclosure.textContent).toBe("Réduire");
+    await view.rerender(
+      <SessionConversation sessionId={SESSION_ID} client={client} workspaceId={WORKSPACE_ID} />,
+    );
+    expect(disclosure.textContent).toBe("Show less");
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    await actRun(() => disclosure.click());
+    expect(disclosure.textContent).toBe("Show more");
     expect(streams).toBe(1);
     expect(view.container.querySelector("textarea")).not.toBeNull();
     const surface = view.container.querySelector("[data-og-conversation]");

--- a/packages/react/test/user-message-body.test.tsx
+++ b/packages/react/test/user-message-body.test.tsx
@@ -6,7 +6,9 @@ import {
   UserMessageBody,
   type TimelineItem,
   type UserMessageItem,
+  type UserMessageDisclosureLabels,
 } from "../src";
+import type { UserMessageDisclosureLabels as SessionUiDisclosureLabels } from "../src/session-ui";
 import { actRun, flush, registerDom, renderComponent } from "./render-hook";
 
 registerDom();
@@ -78,6 +80,78 @@ function elementRect(top: number, bottom: number, left = 0, right = 240): DOMRec
 }
 
 describe("UserMessageBody", () => {
+  test("localizes direct disclosure labels with per-field English defaults", async () => {
+    const text = longMarkdown();
+    const labels: UserMessageDisclosureLabels = { showMore: "Afficher davantage" };
+    const sessionUiLabels: SessionUiDisclosureLabels = labels;
+    const r = await renderComponent(
+      <UserMessageBody messageId="localized-direct" text={text} disclosureLabels={sessionUiLabels}>
+        <Markdown>{text}</Markdown>
+      </UserMessageBody>,
+    );
+    const button = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    expect(button.textContent).toBe("Afficher davantage");
+    await actRun(() => button.click());
+    expect(button.textContent).toBe("Show less");
+    await r.unmount();
+  });
+
+  test("updates default timeline labels without resetting expansion or control identity", async () => {
+    const items = [user("localized-timeline", longMarkdown())];
+    const r = await renderComponent(
+      <MessageTimeline
+        items={items}
+        userMessageDisclosureLabels={{ showMore: "Afficher davantage", showLess: "Réduire" }}
+      />,
+    );
+    const button = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    expect(button.textContent).toBe("Afficher davantage");
+    const controls = button.getAttribute("aria-controls");
+    await actRun(() => button.click());
+    expect(button.textContent).toBe("Réduire");
+    await r.rerender(
+      <MessageTimeline
+        items={items}
+        userMessageDisclosureLabels={{ showMore: "Mehr anzeigen", showLess: "Weniger anzeigen" }}
+      />,
+    );
+    expect(button.textContent).toBe("Weniger anzeigen");
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(button.getAttribute("aria-controls")).toBe(controls);
+    await actRun(() => button.click());
+    expect(button.textContent).toBe("Mehr anzeigen");
+    await r.unmount();
+  });
+
+  test("direct overrides retain unspecified timeline context labels", async () => {
+    const r = await renderComponent(
+      <MessageTimeline
+        items={[user("localized-custom", longMarkdown())]}
+        userMessageDisclosureLabels={{ showMore: "Context more", showLess: "Context less" }}
+        renderMessageText={(text, item) => (
+          <UserMessageBody
+            messageId={item.id}
+            text={text}
+            disclosureLabels={{ showMore: "Direct more" }}
+          >
+            <Markdown>{text}</Markdown>
+          </UserMessageBody>
+        )}
+      />,
+    );
+    const button = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    expect(button.textContent).toBe("Direct more");
+    await actRun(() => button.click());
+    expect(button.textContent).toBe("Context less");
+    await r.unmount();
+  });
+
   test("shares one observer and one resize listener across every message", async () => {
     let observerCount = 0;
     globalThis.ResizeObserver = class {

--- a/test/e2e/user-message-disclosure.browser.e2e.ts
+++ b/test/e2e/user-message-disclosure.browser.e2e.ts
@@ -49,6 +49,61 @@ describe("long sent user-message browser acceptance", () => {
     { name: "mobile", width: 390, height: 844 },
     { name: "desktop", width: 1440, height: 960 },
   ] as const) {
+    for (const defaultRenderer of [false, true]) {
+      test(`localizes ${defaultRenderer ? "default" : "custom"} disclosure without resetting state on ${viewport.name}`, async () => {
+        const page = await openHarness(browser, baseUrl, viewport, defaultRenderer);
+        try {
+          await page.evaluate(() =>
+            window.userMessageHarness!.setDisclosureLabels({
+              showMore: "Afficher le message dans son intégralité",
+              showLess: "Réduire le message",
+            }),
+          );
+          const body = page.locator('[data-og-message-id="long-user-message"]');
+          const button = body.getByRole("button", {
+            name: "Afficher le message dans son intégralité",
+            exact: true,
+          });
+          await button.scrollIntoViewIfNeeded();
+          await button.focus();
+          const controls = await button.getAttribute("aria-controls");
+          if (evidenceDir)
+            await page.screenshot({
+              path: `${evidenceDir}/localized-${defaultRenderer ? "default" : "custom"}-${viewport.name}-collapsed.png`,
+            });
+          await button.press("Enter");
+          const expanded = body.getByRole("button", { name: "Réduire le message", exact: true });
+          expect(await expanded.getAttribute("aria-expanded")).toBe("true");
+          await page.evaluate(() =>
+            window.userMessageHarness!.setDisclosureLabels({
+              showMore: "Mehr anzeigen",
+              showLess: "Weniger anzeigen",
+            }),
+          );
+          const translated = body.getByRole("button", { name: "Weniger anzeigen", exact: true });
+          expect(await translated.getAttribute("aria-expanded")).toBe("true");
+          expect(await translated.getAttribute("aria-controls")).toBe(controls);
+          expect(await translated.evaluate((node) => node === document.activeElement)).toBe(true);
+          await translated.scrollIntoViewIfNeeded();
+          if (evidenceDir)
+            await page.screenshot({
+              path: `${evidenceDir}/localized-${defaultRenderer ? "default" : "custom"}-${viewport.name}-expanded.png`,
+            });
+          await translated.press("Space");
+          expect(
+            await body
+              .getByRole("button", { name: "Mehr anzeigen", exact: true })
+              .getAttribute("aria-expanded"),
+          ).toBe("false");
+          expect(
+            await page.evaluate(() => document.documentElement.scrollWidth - innerWidth),
+          ).toBeLessThanOrEqual(1);
+        } finally {
+          await page.context().close();
+        }
+      });
+    }
+
     test(`is lossless, bounded, keyboard accessible, and viewport-safe on ${viewport.name}`, async () => {
       const page = await openHarness(browser, baseUrl, viewport);
       try {
@@ -437,6 +492,7 @@ async function openHarness(
   browser: Browser,
   baseUrl: string,
   viewport: { width: number; height: number },
+  defaultRenderer = false,
 ): Promise<Page> {
   const context = await browser.newContext({
     viewport,
@@ -444,7 +500,9 @@ async function openHarness(
     isMobile: viewport.width <= 390,
   });
   const page = await context.newPage();
-  await page.goto(`${baseUrl}/user-message-test.html`);
+  await page.goto(
+    `${baseUrl}/user-message-test.html${defaultRenderer ? "?defaultRenderer=1" : ""}`,
+  );
   await page.waitForFunction(() => window.userMessageHarness !== undefined);
   await page.locator('[data-og-message-id="long-user-message"]').waitFor({ timeout: 15_000 });
   return page;


### PR DESCRIPTION
## Summary

Add optional string labels for user-message disclosure with unchanged English defaults:

- UserMessageBody.disclosureLabels for direct overrides.
- MessageTimeline.userMessageDisclosureLabels for default and custom renderers.
- SessionConversation.userMessageDisclosureLabels for the full conversation composition.

Each field resolves independently from direct override to timeline context to English default. Label changes preserve expansion memory, control identity, scroll anchoring and keyboard behavior. No CSS or unrelated labels change. Public types, documentation and a changeset are included.

## Verification

- Red/green regressions for direct, context, default timeline and real conversation composition.
- 1,798 React tests and eight desktop/mobile browser tests passed.
- Independent focused rerun: 13 tests, 96 assertions passed.
- Desktop/mobile screenshots independently inspected; localized long labels, focus, Enter/Space and accessible controls verified.
- React typecheck, package build, emitted declarations, formatting and lint passed.

No deployment changes.

## Summary by Sourcery

Enable hosts to localize user-message disclosure actions across direct, timeline, and full conversation compositions while retaining English fallbacks and existing interaction behavior.

New Features:
- Add independently overridable localized labels for user-message disclosure actions, with direct component, timeline, and session conversation configuration.
- Export the user-message disclosure label type through the main and session UI React APIs.

Enhancements:
- Preserve message expansion state, accessible control identity, focus, keyboard behavior, and scroll anchoring when disclosure labels change.

Documentation:
- Document direct and composed timeline localization options and fallback behavior for user-message disclosure labels.

Tests:
- Add component, timeline, conversation, and desktop/mobile browser coverage for localization, fallback resolution, accessibility, and state preservation.

Chores:
- Add a React package changeset for localized user-message disclosure actions.