### PR TITLE
fix: prevent macOS capture leaks and unblock desktop discovery

### DIFF
--- a/.changeset/desktop-observation-discovery.md
+++ b/.changeset/desktop-observation-discovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Show discovered desktop targets immediately so slow or failed semantic inspection cannot block the live view or switching windows and screens.

--- a/agent/crates/opengeni-agent-macos-ffi/src/ffi/ax.rs
+++ b/agent/crates/opengeni-agent-macos-ffi/src/ffi/ax.rs
@@ -292,7 +292,9 @@ impl MacAxControllerImpl {
         let worker_target = target.clone();
         let join = thread::Builder::new()
             .name(format!("opengeni-ax-{process_id}"))
-            .spawn(move || ax_worker_main(&worker_target, &receiver, &ready))
+            .spawn(move || {
+                crate::with_autorelease_pool(|| ax_worker_main(&worker_target, &receiver, &ready));
+            })
             .map_err(|error| MacFfiError::Ffi(format!("spawn AX worker: {error}")))?;
         match ready_receiver.recv_timeout(Duration::from_secs(3)) {
             Ok(Ok(())) => {
@@ -379,29 +381,37 @@ fn ax_worker_main(
     let mut last_liveness_poll = Instant::now();
 
     loop {
-        state.pump_notifications();
-        match commands.recv_timeout(AX_WORKER_POLL) {
-            Ok(AxWorkerCommand::Snapshot { target, response }) => {
-                state.pump_notifications();
-                let _ = response.send(state.snapshot(target));
+        let keep_running = crate::with_autorelease_pool(|| {
+            state.pump_notifications();
+            match commands.recv_timeout(AX_WORKER_POLL) {
+                Ok(AxWorkerCommand::Snapshot { target, response }) => {
+                    state.pump_notifications();
+                    let _ = response.send(state.snapshot(target));
+                }
+                Ok(AxWorkerCommand::Perform {
+                    target,
+                    selector,
+                    action,
+                    response,
+                }) => {
+                    state.pump_notifications();
+                    let _ = response.send(state.perform(&target, &selector, &action));
+                }
+                Ok(AxWorkerCommand::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return false
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
             }
-            Ok(AxWorkerCommand::Perform {
-                target,
-                selector,
-                action,
-                response,
-            }) => {
-                state.pump_notifications();
-                let _ = response.send(state.perform(&target, &selector, &action));
+            if last_liveness_poll.elapsed() >= AX_WORKER_LIVENESS_POLL {
+                if validate_running_application(worker_target).is_err() {
+                    return false;
+                }
+                last_liveness_poll = Instant::now();
             }
-            Ok(AxWorkerCommand::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
-        }
-        if last_liveness_poll.elapsed() >= AX_WORKER_LIVENESS_POLL {
-            if validate_running_application(worker_target).is_err() {
-                break;
-            }
-            last_liveness_poll = Instant::now();
+            true
+        });
+        if !keep_running {
+            break;
         }
     }
     state.invalidate_all();

--- a/agent/crates/opengeni-agent-macos-ffi/src/ffi/stream.rs
+++ b/agent/crates/opengeni-agent-macos-ffi/src/ffi/stream.rs
@@ -5,6 +5,7 @@
 //! publishes only the newest tightly-packed RGBA frame into a bounded slot.
 //! Consumers therefore cannot build an unbounded decode/copy queue.
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -118,13 +119,15 @@ define_class!(
             sample_buffer: &CMSampleBuffer,
             output_type: SCStreamOutputType,
         ) {
-            if output_type == SCStreamOutputType::Screen {
-                match sample_to_rgba(sample_buffer) {
-                    Ok(Some(frame)) => self.ivars().slot.publish(Ok(frame)),
-                    Ok(None) => {}
-                    Err(error) => self.ivars().slot.fail(error),
+            crate::with_autorelease_pool(|| {
+                if output_type == SCStreamOutputType::Screen {
+                    match sample_to_rgba(sample_buffer) {
+                        Ok(Some(frame)) => self.ivars().slot.publish(Ok(frame)),
+                        Ok(None) => {}
+                        Err(error) => self.ivars().slot.fail(error),
+                    }
                 }
-            }
+            });
         }
     }
 
@@ -132,9 +135,11 @@ define_class!(
     unsafe impl SCStreamDelegate for CaptureOutput {
         #[unsafe(method(stream:didStopWithError:))]
         fn did_stop(&self, _stream: &SCStream, error: &NSError) {
-            self.ivars()
-                .slot
-                .fail(format!("ScreenCaptureKit stream stopped: {error}"));
+            crate::with_autorelease_pool(|| {
+                self.ivars()
+                    .slot
+                    .fail(format!("ScreenCaptureKit stream stopped: {error}"));
+            });
         }
     }
 );
@@ -150,13 +155,85 @@ impl CaptureOutput {
 struct StreamRuntime {
     stream: Retained<SCStream>,
     output: Retained<CaptureOutput>,
-    _queue: DispatchRetained<DispatchQueue>,
+    queue: DispatchRetained<DispatchQueue>,
+    start_requested: bool,
+    start_completion: Arc<StartCompletion>,
+}
+
+/// The second event owns teardown: completion after abandonment, or normal
+/// abandonment after completion. Stopping a still-pending start is insufficient
+/// because the OS may start producing frames after that stop returned an error.
+#[derive(Default)]
+struct StartCompletion(AtomicU8);
+
+impl StartCompletion {
+    fn complete(&self) -> bool {
+        self.0.fetch_or(1, Ordering::AcqRel) & 2 != 0
+    }
+
+    fn abandon(&self) -> bool {
+        self.0.fetch_or(2, Ordering::AcqRel) & 1 != 0
+    }
+}
+
+impl Drop for StreamRuntime {
+    fn drop(&mut self) {
+        // Keep the native resources in the completion block until a pending
+        // start finishes. That callback then owns the final stop and detach.
+        if self.start_requested && !self.start_completion.abandon() {
+            return;
+        }
+        if self.start_requested {
+            let (stopped_tx, stopped_rx) = mpsc::channel();
+            let stopped = block2::RcBlock::new(move |error: *mut NSError| {
+                let _ = stopped_tx.send(error_message(error));
+            });
+            // SAFETY: only this owner calls start/stop after construction.
+            unsafe {
+                self.stream
+                    .stopCaptureWithCompletionHandler(Some(&*stopped));
+            }
+            let _ = stopped_rx.recv_timeout(STOP_TIMEOUT);
+        }
+        let output: &ProtocolObject<dyn SCStreamOutput> = ProtocolObject::from_ref(&*self.output);
+        // SAFETY: remove the exact output registered during construction. If
+        // discovery completed after its receiver expired, capture never started.
+        let _ = unsafe {
+            self.stream
+                .removeStreamOutput_type_error(output, SCStreamOutputType::Screen)
+        };
+    }
+}
+
+fn stop_abandoned_start(
+    stream: &Retained<SCStream>,
+    output: Retained<CaptureOutput>,
+    queue: DispatchRetained<DispatchQueue>,
+) {
+    let stopped_stream = stream.clone();
+    let stopped = block2::RcBlock::new(move |_error: *mut NSError| {
+        crate::with_autorelease_pool(|| {
+            let _keep_queue_alive = &queue;
+            let output: &ProtocolObject<dyn SCStreamOutput> = ProtocolObject::from_ref(&*output);
+            // SAFETY: the worker relinquished this exact stream while startup
+            // was pending; only this late-completion path now owns teardown.
+            let _ = unsafe {
+                stopped_stream.removeStreamOutput_type_error(output, SCStreamOutputType::Screen)
+            };
+        });
+    });
+    // Do not block ScreenCaptureKit's completion queue waiting on itself.
+    // The copied stop block retains the stream, output and queue until stopped.
+    unsafe {
+        stream.stopCaptureWithCompletionHandler(Some(&*stopped));
+    }
 }
 
 /// ARC-backed ScreenCaptureKit objects are created on its discovery callback
 /// and transferred exactly once to the dedicated owner thread. No stream method
-/// is called before that transfer; every later start/stop/remove call happens on
-/// the owner thread. Output callbacks touch only the synchronized `FrameSlot`.
+/// is called before that transfer. If the owner abandons a pending start, the
+/// completion callback retains the resources and takes exclusive teardown
+/// ownership. Output callbacks touch only the synchronized `FrameSlot`.
 struct OwnedRuntime(StreamRuntime);
 
 // SAFETY: see `OwnedRuntime`'s ownership invariant above. This is the only
@@ -199,7 +276,11 @@ impl CaptureStream {
         let (stop_tx, stop_rx) = mpsc::channel();
         let worker = thread::Builder::new()
             .name("opengeni-sck-stream".to_string())
-            .spawn(move || run_stream(source, max_size, &worker_slot, &ready_tx, &stop_rx))
+            .spawn(move || {
+                crate::with_autorelease_pool(|| {
+                    run_stream(source, max_size, &worker_slot, &ready_tx, &stop_rx);
+                });
+            })
             .map_err(|error| MacFfiError::Ffi(format!("start capture worker: {error}")))?;
 
         match ready_rx.recv_timeout(DISCOVERY_TIMEOUT) {
@@ -279,7 +360,7 @@ fn run_stream(
     ready: &mpsc::Sender<Result<(), String>>,
     stop: &mpsc::Receiver<()>,
 ) {
-    let runtime = match discover_runtime(source, max_size, Arc::clone(slot)) {
+    let mut runtime = match discover_runtime(source, max_size, Arc::clone(slot)) {
         Ok(runtime) => runtime.0,
         Err(error) => {
             let _ = ready.send(Err(error));
@@ -289,11 +370,21 @@ fn run_stream(
     };
 
     let (started_tx, started_rx) = mpsc::channel();
+    let start_completion = Arc::clone(&runtime.start_completion);
+    let late_stream = runtime.stream.clone();
+    let late_output = runtime.output.clone();
+    let late_queue = runtime.queue.clone();
     let started = block2::RcBlock::new(move |error: *mut NSError| {
+        if start_completion.complete() {
+            crate::with_autorelease_pool(|| {
+                stop_abandoned_start(&late_stream, late_output.clone(), late_queue.clone());
+            });
+        }
         let _ = started_tx.send(error_message(error));
     });
     // SAFETY: runtime owns the stream for this thread and the copied block stays
     // alive until ScreenCaptureKit invokes it.
+    runtime.start_requested = true;
     unsafe {
         runtime
             .stream
@@ -316,25 +407,7 @@ fn run_stream(
     }
 
     let _ = stop.recv();
-    let (stopped_tx, stopped_rx) = mpsc::channel();
-    let stopped = block2::RcBlock::new(move |error: *mut NSError| {
-        let _ = stopped_tx.send(error_message(error));
-    });
-    // SAFETY: serialized owner-thread shutdown; the callback is bounded below.
-    unsafe {
-        runtime
-            .stream
-            .stopCaptureWithCompletionHandler(Some(&*stopped));
-    }
-    let _ = stopped_rx.recv_timeout(STOP_TIMEOUT);
-    let output: &ProtocolObject<dyn SCStreamOutput> = ProtocolObject::from_ref(&*runtime.output);
-    // SAFETY: the exact output registered during construction is removed after
-    // capture has stopped; failure only means SCK already detached it.
-    let _ = unsafe {
-        runtime
-            .stream
-            .removeStreamOutput_type_error(output, SCStreamOutputType::Screen)
-    };
+    drop(runtime);
     slot.stop();
 }
 
@@ -504,7 +577,9 @@ fn build_runtime(
     Ok(StreamRuntime {
         stream,
         output,
-        _queue: queue,
+        queue,
+        start_requested: false,
+        start_completion: Arc::default(),
     })
 }
 
@@ -576,5 +651,57 @@ fn classify_start_error(error: String) -> MacFfiError {
         MacFfiError::TargetStale(error)
     } else {
         MacFfiError::Ffi(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StartCompletion;
+    use std::sync::{Arc, Barrier};
+
+    #[test]
+    fn completed_start_is_stopped_by_its_owner() {
+        let completion = StartCompletion::default();
+        assert!(
+            !completion.complete(),
+            "a live owner still needs the stream"
+        );
+        assert!(
+            completion.abandon(),
+            "owner must stop before detaching output"
+        );
+    }
+
+    #[test]
+    fn timed_out_start_is_stopped_only_after_late_completion() {
+        let completion = StartCompletion::default();
+        assert!(
+            !completion.abandon(),
+            "cannot cancel a pending OS start with stop"
+        );
+        // Both success and error callbacks finish the outstanding OS operation;
+        // only then can the abandoned stream be stopped and its output detached.
+        assert!(
+            completion.complete(),
+            "late callback must own final cleanup"
+        );
+    }
+
+    #[test]
+    fn start_completion_racing_timeout_has_exactly_one_cleanup_owner() {
+        for _ in 0..100 {
+            let completion = Arc::new(StartCompletion::default());
+            let gate = Arc::new(Barrier::new(2));
+            let callback_completion = Arc::clone(&completion);
+            let callback_gate = Arc::clone(&gate);
+            let callback = std::thread::spawn(move || {
+                callback_gate.wait();
+                callback_completion.complete()
+            });
+            gate.wait();
+            let owner_stops = completion.abandon();
+            let callback_stops = callback.join().expect("start callback");
+            assert_ne!(owner_stops, callback_stops);
+        }
     }
 }

--- a/agent/crates/opengeni-agent-macos-ffi/src/lib.rs
+++ b/agent/crates/opengeni-agent-macos-ffi/src/lib.rs
@@ -38,6 +38,16 @@
 #[allow(unsafe_code)]
 mod ffi;
 
+/// Runs one synchronous native operation with a thread-local Cocoa pool.
+///
+/// Rust worker threads do not have AppKit's event-loop pools. Drain temporary
+/// Objective-C objects before returning; retained handles may outlive the pool.
+/// Call this inside each worker operation, never around an async future.
+#[cfg(target_os = "macos")]
+pub fn with_autorelease_pool<T>(operation: impl FnOnce() -> T) -> T {
+    objc2::rc::autoreleasepool(|_| operation())
+}
+
 /// A probed display: an opaque id plus its **pixel** dimensions (the size a
 /// captured frame will be, so a viewer canvas matches 1:1).
 #[derive(Debug, Clone, PartialEq)]
@@ -352,7 +362,7 @@ impl MacAxController {
     pub fn snapshot(&self, target: &MacTargetInfo) -> Result<MacAxSnapshot, MacFfiError> {
         #[cfg(target_os = "macos")]
         {
-            self.inner.snapshot(target)
+            with_autorelease_pool(|| self.inner.snapshot(target))
         }
         #[cfg(not(target_os = "macos"))]
         {
@@ -378,7 +388,7 @@ impl MacAxController {
     ) -> Result<(), MacFfiError> {
         #[cfg(target_os = "macos")]
         {
-            self.inner.perform_action(target, selector, action)
+            with_autorelease_pool(|| self.inner.perform_action(target, selector, action))
         }
         #[cfg(not(target_os = "macos"))]
         {
@@ -544,7 +554,7 @@ pub enum MacFfiError {
 pub fn probe_display() -> Option<DisplayInfo> {
     #[cfg(target_os = "macos")]
     {
-        ffi::probe_display()
+        with_autorelease_pool(ffi::probe_display)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -561,7 +571,7 @@ pub fn probe_display() -> Option<DisplayInfo> {
 pub fn list_displays() -> Result<Vec<DisplayInfo>, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::list_displays()
+        with_autorelease_pool(ffi::list_displays)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -580,7 +590,7 @@ pub fn list_displays() -> Result<Vec<DisplayInfo>, MacFfiError> {
 pub fn capture_rgba() -> Result<RgbaFrame, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::capture_rgba()
+        with_autorelease_pool(ffi::capture_rgba)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -602,7 +612,7 @@ pub fn capture_display_rgba(display_id: &str) -> Result<RgbaFrame, MacFfiError> 
         let display_id = display_id.parse::<u32>().map_err(|_| {
             MacFfiError::Invalid("macOS display id is not a CGDirectDisplayID".to_string())
         })?;
-        ffi::capture_display_rgba(display_id)
+        with_autorelease_pool(|| ffi::capture_display_rgba(display_id))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -629,7 +639,9 @@ pub fn capture_display_rgba_sized(
         let display_id = display_id.parse::<u32>().map_err(|_| {
             MacFfiError::Invalid("macOS display id is not a CGDirectDisplayID".to_string())
         })?;
-        ffi::capture_display_rgba_sized(display_id, Some((max_width, max_height)))
+        with_autorelease_pool(|| {
+            ffi::capture_display_rgba_sized(display_id, Some((max_width, max_height)))
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -655,7 +667,7 @@ pub fn start_display_frame_stream(
         let display_id = display_id.parse::<u32>().map_err(|_| {
             MacFfiError::Invalid("macOS display id is not a CGDirectDisplayID".to_string())
         })?;
-        if !ffi::screen_capture_granted() {
+        if !with_autorelease_pool(ffi::screen_capture_granted) {
             return Err(MacFfiError::PermissionDenied(
                 "Screen Recording permission is required for live display capture".to_string(),
             ));
@@ -682,7 +694,7 @@ pub fn start_display_frame_stream(
 pub fn list_targets() -> Result<Vec<MacTargetInfo>, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::list_targets()
+        with_autorelease_pool(ffi::list_targets)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -704,7 +716,7 @@ pub fn capture_window_rgba(
 ) -> Result<MacWindowFrame, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::capture_window_rgba(window_id, expected_process_id)
+        with_autorelease_pool(|| ffi::capture_window_rgba(window_id, expected_process_id))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -728,11 +740,13 @@ pub fn capture_window_rgba_sized(
 ) -> Result<MacWindowFrame, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::capture_window_rgba_sized(
-            window_id,
-            expected_process_id,
-            Some((max_width, max_height)),
-        )
+        with_autorelease_pool(|| {
+            ffi::capture_window_rgba_sized(
+                window_id,
+                expected_process_id,
+                Some((max_width, max_height)),
+            )
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -756,7 +770,7 @@ pub fn start_window_frame_stream(
 ) -> Result<MacFrameStream, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        if !ffi::screen_capture_granted() {
+        if !with_autorelease_pool(ffi::screen_capture_granted) {
             return Err(MacFfiError::PermissionDenied(
                 "Screen Recording permission is required for live window capture".to_string(),
             ));
@@ -786,7 +800,7 @@ pub fn start_window_frame_stream(
 pub fn focus_target(target: &MacTargetInfo) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::focus_target(target)
+        with_autorelease_pool(|| ffi::focus_target(target))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -806,7 +820,7 @@ pub fn focus_target(target: &MacTargetInfo) -> Result<(), MacFfiError> {
 pub fn launch_application(application_id: &str) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::launch_application(application_id)
+        with_autorelease_pool(|| ffi::launch_application(application_id))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -840,7 +854,7 @@ pub fn run_background_application(
         let bundle = application_bundle.to_str().ok_or_else(|| {
             MacFfiError::Invalid("application bundle path is not valid UTF-8".to_string())
         })?;
-        ffi::run_background_application(bundle, arguments, pid_file)
+        with_autorelease_pool(|| ffi::run_background_application(bundle, arguments, pid_file))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -862,7 +876,7 @@ pub fn run_background_application(
 pub fn inject(input: &InputEvent) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::inject(input)
+        with_autorelease_pool(|| ffi::inject(input))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -883,7 +897,7 @@ pub fn inject(input: &InputEvent) -> Result<(), MacFfiError> {
 pub fn inject_batch(inputs: &[InputEvent]) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::inject_batch(inputs)
+        with_autorelease_pool(|| ffi::inject_batch(inputs))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -909,7 +923,9 @@ pub fn inject_display_batch(
 ) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::inject_display_batch(display, frame_width, frame_height, inputs)
+        with_autorelease_pool(|| {
+            ffi::inject_display_batch(display, frame_width, frame_height, inputs)
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -935,7 +951,9 @@ pub fn inject_window(
 ) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::inject_window(input, logical_bounds, frame_width, frame_height)
+        with_autorelease_pool(|| {
+            ffi::inject_window(input, logical_bounds, frame_width, frame_height)
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -960,7 +978,9 @@ pub fn inject_window_batch(
 ) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::inject_window_batch(inputs, logical_bounds, frame_width, frame_height)
+        with_autorelease_pool(|| {
+            ffi::inject_window_batch(inputs, logical_bounds, frame_width, frame_height)
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -987,7 +1007,9 @@ pub fn focus_and_inject_window(
 ) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::focus_and_inject_window(target, expected_bounds, frame_width, frame_height, inputs)
+        with_autorelease_pool(|| {
+            ffi::focus_and_inject_window(target, expected_bounds, frame_width, frame_height, inputs)
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1011,7 +1033,7 @@ pub fn focus_and_inject_target(
 ) -> Result<(), MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::focus_and_inject_target(target, inputs)
+        with_autorelease_pool(|| ffi::focus_and_inject_target(target, inputs))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1028,7 +1050,7 @@ pub fn focus_and_inject_target(
 pub fn screen_capture_granted() -> bool {
     #[cfg(target_os = "macos")]
     {
-        ffi::screen_capture_granted()
+        with_autorelease_pool(ffi::screen_capture_granted)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1042,7 +1064,7 @@ pub fn screen_capture_granted() -> bool {
 pub fn accessibility_trusted() -> bool {
     #[cfg(target_os = "macos")]
     {
-        ffi::accessibility_trusted()
+        with_autorelease_pool(ffi::accessibility_trusted)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1056,7 +1078,7 @@ pub fn accessibility_trusted() -> bool {
 pub fn input_monitoring_granted() -> bool {
     #[cfg(target_os = "macos")]
     {
-        ffi::input_monitoring_granted()
+        with_autorelease_pool(ffi::input_monitoring_granted)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1076,7 +1098,7 @@ pub fn input_monitoring_granted() -> bool {
 pub fn machine_locked() -> Result<bool, MacFfiError> {
     #[cfg(target_os = "macos")]
     {
-        ffi::machine_locked()
+        with_autorelease_pool(ffi::machine_locked)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1092,6 +1114,6 @@ pub fn machine_locked() -> Result<bool, MacFfiError> {
 pub fn request_grants() {
     #[cfg(target_os = "macos")]
     {
-        ffi::request_grants();
+        with_autorelease_pool(ffi::request_grants);
     }
 }

--- a/agent/crates/opengeni-computer-native/src/clipboard.rs
+++ b/agent/crates/opengeni-computer-native/src/clipboard.rs
@@ -7,6 +7,14 @@ use crate::{
     NativeClipboardAction,
 };
 
+#[cfg(target_os = "macos")]
+use opengeni_agent_macos_ffi::with_autorelease_pool;
+
+#[cfg(not(target_os = "macos"))]
+fn with_autorelease_pool<T>(operation: impl FnOnce() -> T) -> T {
+    operation()
+}
+
 const MAX_CLIPBOARD_BYTES: usize = 1024 * 1024;
 
 /// Long-lived text clipboard handle for one native helper/graphical seat.
@@ -21,7 +29,7 @@ pub(crate) struct NativeClipboardController {
 
 impl NativeClipboardController {
     pub(crate) fn open() -> NativeAdapterResult<Self> {
-        let clipboard = Clipboard::new().map_err(map_read_error)?;
+        let clipboard = with_autorelease_pool(Clipboard::new).map_err(map_read_error)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(clipboard)),
         })
@@ -30,21 +38,23 @@ impl NativeClipboardController {
     pub(crate) async fn read(&self) -> NativeAdapterResult<NativeClipboard> {
         let inner = Arc::clone(&self.inner);
         tokio::task::spawn_blocking(move || {
-            let mut clipboard = inner.lock().map_err(|_| poisoned())?;
-            match clipboard.get_text() {
-                Ok(text) => {
-                    let (text, truncated) = bounded_text(text);
-                    Ok(NativeClipboard {
-                        text: Some(text),
-                        truncated,
-                    })
+            with_autorelease_pool(|| {
+                let mut clipboard = inner.lock().map_err(|_| poisoned())?;
+                match clipboard.get_text() {
+                    Ok(text) => {
+                        let (text, truncated) = bounded_text(text);
+                        Ok(NativeClipboard {
+                            text: Some(text),
+                            truncated,
+                        })
+                    }
+                    Err(ClipboardError::ContentNotAvailable) => Ok(NativeClipboard {
+                        text: None,
+                        truncated: false,
+                    }),
+                    Err(error) => Err(map_read_error(error)),
                 }
-                Err(ClipboardError::ContentNotAvailable) => Ok(NativeClipboard {
-                    text: None,
-                    truncated: false,
-                }),
-                Err(error) => Err(map_read_error(error)),
-            }
+            })
         })
         .await
         .map_err(|error| {
@@ -91,11 +101,13 @@ impl NativeClipboardController {
         }
         let inner = Arc::clone(&self.inner);
         tokio::task::spawn_blocking(move || {
-            inner
-                .lock()
-                .map_err(|_| poisoned())?
-                .set_text(text)
-                .map_err(map_mutation_error)
+            with_autorelease_pool(|| {
+                inner
+                    .lock()
+                    .map_err(|_| poisoned())?
+                    .set_text(text)
+                    .map_err(map_mutation_error)
+            })
         })
         .await
         .map_err(|error| {
@@ -108,11 +120,13 @@ impl NativeClipboardController {
     async fn clear(&self) -> NativeAdapterResult<()> {
         let inner = Arc::clone(&self.inner);
         tokio::task::spawn_blocking(move || {
-            inner
-                .lock()
-                .map_err(|_| poisoned())?
-                .clear()
-                .map_err(map_mutation_error)
+            with_autorelease_pool(|| {
+                inner
+                    .lock()
+                    .map_err(|_| poisoned())?
+                    .clear()
+                    .map_err(map_mutation_error)
+            })
         })
         .await
         .map_err(|error| {

--- a/agent/crates/opengeni-computer-native/tests/macos_autorelease.rs
+++ b/agent/crates/opengeni-computer-native/tests/macos_autorelease.rs
@@ -1,0 +1,83 @@
+//! Exercise the actual helper's Rust threads, not the test harness's Cocoa pool.
+
+#![cfg(target_os = "macos")]
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt as _;
+use tokio::process::Command;
+
+#[tokio::test]
+#[ignore = "requires an unlocked local macOS GUI session"]
+async fn native_discovery_drains_cocoa_temporaries() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_opengeni-computer-native"))
+        .env("OBJC_DEBUG_MISSING_POOLS", "YES")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("start native helper with Cocoa lifetime diagnostics");
+    let mut input = child.stdin.take().expect("helper input");
+    // Discovery is read-only and also works without Screen Recording grants:
+    // the helper then enumerates applications through AppKit alone.
+    for (request_id, method) in ["capabilities", "targets", "targets"].iter().enumerate() {
+        let request = serde_json::to_vec(&serde_json::json!({
+            "protocolVersion": 2,
+            "requestId": request_id.to_string(),
+            "method": method,
+        }))
+        .expect("encode native request");
+        input
+            .write_all(
+                &u32::try_from(request.len())
+                    .expect("bounded request")
+                    .to_be_bytes(),
+            )
+            .await
+            .expect("write frame length");
+        input.write_all(&request).await.expect("write request");
+    }
+    drop(input);
+    let output = tokio::time::timeout(Duration::from_secs(45), child.wait_with_output())
+        .await
+        .expect("native helper must drain requests and exit")
+        .expect("wait for helper");
+    let diagnostics = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "native helper failed: {diagnostics}"
+    );
+    assert!(
+        !diagnostics.contains("MISSING POOLS"),
+        "native operations leaked autoreleased Cocoa objects: {diagnostics}"
+    );
+    let mut bytes = output.stdout.as_slice();
+    let mut response_ids = Vec::new();
+    while !bytes.is_empty() {
+        let size = u32::from_be_bytes(bytes[..4].try_into().expect("response header")) as usize;
+        let response: serde_json::Value =
+            serde_json::from_slice(&bytes[4..4 + size]).expect("response JSON");
+        assert_eq!(
+            response["status"], "ok",
+            "native request failed: {:?}",
+            response["error"]
+        );
+        response_ids.push(
+            response["requestId"]
+                .as_str()
+                .expect("request id")
+                .to_owned(),
+        );
+        if response["requestId"] != "0" {
+            assert!(
+                response["result"].is_array(),
+                "discovery must return targets"
+            );
+        }
+        bytes = &bytes[4 + size..];
+    }
+    response_ids.sort();
+    assert_eq!(response_ids, ["0", "1", "2"]);
+}

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -46,6 +46,7 @@ function fakeSelfhostedSession(port: number) {
 // process are unaffected (only WS is intercepted).
 const realDb = await import("@opengeni/db");
 const realGetSandbox = realDb.getSandbox;
+const realGetSessionAuthorityEpoch = realDb.getSessionAuthorityEpoch;
 mock.module("@opengeni/db", () => ({
   ...realDb,
   getSandbox: async (db: never, workspaceId: string, sandboxId: string) => {
@@ -73,17 +74,7 @@ mock.module("@opengeni/db", () => ({
     input: { accountId: string; workspaceId: string; sessionId: string },
   ) => {
     if (input.workspaceId === WS) return 1;
-    // KNOWN BUG, pre-existing and not fixed here: this fallback is
-    // SELF-RECURSIVE. `mock.module` replaces the live `@opengeni/db` namespace,
-    // and `realDb` is that same namespace object — so unlike `realGetSandbox`
-    // above (captured BEFORE the mock, which is the correct pattern), this
-    // resolves to the mock and recurses for any workspace other than WS. It is a
-    // cause of failures in the shared-process sandbox/desktop suites. Those
-    // failures are NOT a personal-workspace authority defect: the 0281 mint
-    // already handles the personal-workspace pointer (see
-    // `sandbox-desktop-stream.test.ts`). Fix by capturing the real function into
-    // a local before `mock.module`, as `realGetSandbox` does.
-    return realDb.getSessionAuthorityEpoch(db, input);
+    return realGetSessionAuthorityEpoch(db, input);
   },
 }));
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1278,6 +1278,10 @@ its durable `ComputerSession` binding before forwarding the exact bytes, and the
 SDK retains its independent verification. The browser extension is an attachment
 client, not an authorization service.
 
+Native macOS operations drain thread-local Cocoa pools; capture owners stop
+pending starts during teardown. Desktop discovery publishes independently of
+semantic observation so stalled inspection does not block target selection.
+
 New capability negotiation advertises only `manual` and `on-verify` recording.
 Historical `ComputerUse`, `on-turn`, and `computer_screenshot` contract shapes
 remain parseable for old events, SDK clients, and retained evidence, but they do

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -99,6 +99,15 @@ ScreenCaptureKit/CGEvent desktop feature as the release build. This is the suppo
 an agent binary next to arbitrary helpers can create a protocol-skewed runtime
 that production installation and managed updates deliberately forbid.
 
+The macOS native bridge drains Cocoa autorelease pools around synchronous calls
+and each Accessibility worker iteration. Stream ownership includes stopping a
+requested capture even when startup times out; dropping a timed-out request does
+not cancel the OS operation. The desktop viewer publishes discovered targets
+before awaiting semantic observation so a stalled app cannot prevent switching
+to another window or screen. `macos_autorelease` exercises the actual helper with
+Objective-C missing-pool diagnostics enabled; run this ignored test explicitly
+in an unlocked local GUI session.
+
 The Chrome Native Messaging bridge accepts two exact extension origins: the
 development manifest key (`imdmcebcclhibdfolbokjbiibpcnpbel`) and the Chrome Web
 Store item (`phpmmcbeelfkcinjfbbggegjdcdmnnch`). Both the installed native-host

--- a/packages/react/demo/loading-ideas.tsx
+++ b/packages/react/demo/loading-ideas.tsx
@@ -106,7 +106,10 @@ function App() {
                 </span>
                 <span className="command">
                   {Array.from(text).map((char, n) => (
-                    <span key={n} style={{ "--letter": n } as React.CSSProperties}>
+                    <span
+                      key={text.slice(0, n + 1)}
+                      style={{ "--letter": n } as React.CSSProperties}
+                    >
                       {char}
                     </span>
                   ))}

--- a/packages/react/demo/rolling-steps.tsx
+++ b/packages/react/demo/rolling-steps.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { MessageTimeline } from "../src/components/message-timeline";
-import type { ToolCallItem } from "../src/timeline/types";
+import { MessageTimeline, type ToolCallItem } from "@opengeni/react";
 import "./styles.css";
 const commands = [
   "rg --files src",

--- a/packages/react/src/hooks/use-computer-session.ts
+++ b/packages/react/src/hooks/use-computer-session.ts
@@ -117,6 +117,33 @@ export function useComputerSession(options: UseComputerSessionOptions): UseCompu
       if (!mountedRef.current || requestRef.current.id !== id) return;
       const targets = sortComputerTargets(targetResponse.targets);
       const selected = chooseTarget(targets, selectedTargetIdRef.current, session.platform);
+      // Discovery is useful independently of semantic observation. Publish it
+      // now so a slow/unresponsive application cannot block the frame stream
+      // or prevent the person from choosing a different window or screen.
+      const previous = observationRef.current.observation;
+      const retainedObservation =
+        selected &&
+        previous?.target.id === selected.id &&
+        previous.target.controllerGeneration === selected.controllerGeneration &&
+        previous.target.targetGeneration === selected.targetGeneration
+          ? previous
+          : null;
+      selectedTargetIdRef.current = selected?.id ?? null;
+      targetsRef.current = { computerSessionId, targets };
+      observationRef.current = { computerSessionId, observation: retainedObservation };
+      setState((current) =>
+        current.computerSessionId === computerSessionId
+          ? {
+              ...current,
+              session,
+              targets,
+              selectedTargetId: selected?.id ?? null,
+              observation: retainedObservation,
+              loading: false,
+              error: null,
+            }
+          : current,
+      );
       const observation = selected
         ? await client.observeComputerTarget(workspaceId, computerSessionId, selected.id, {
             signal: controller.signal,
@@ -303,7 +330,15 @@ export function useComputerSession(options: UseComputerSessionOptions): UseCompu
         ? (targetsRef.current.targets.find((candidate) => candidate.id === frame.targetId) ??
           (currentObservation?.target.id === frame.targetId ? currentObservation.target : null))
         : null;
-      const target = frameTarget ?? focusTarget ?? currentObservation?.target ?? null;
+      const inputTarget =
+        (action.type === "keyboard" || action.type === "clipboard") &&
+        targetsRef.current.computerSessionId === computerSessionId
+          ? targetsRef.current.targets.find(
+              (candidate) => candidate.id === selectedTargetIdRef.current,
+            )
+          : null;
+      const target =
+        frameTarget ?? focusTarget ?? currentObservation?.target ?? inputTarget ?? null;
       if (!target) throw new Error("The desktop target is not ready for input.");
       if (frame && frame.targetId !== selectedTargetIdRef.current) {
         throw new Error("The displayed desktop frame is no longer selected.");

--- a/packages/react/src/timeline/platform-activity-row.tsx
+++ b/packages/react/src/timeline/platform-activity-row.tsx
@@ -10,7 +10,6 @@ export default function PlatformActivityRow({
   t: displayName,
   b: BotIcon,
   m: Markdown,
-  r: truncate,
   j,
   s,
 }: {

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -336,6 +336,80 @@ describe("ComputerSession React resources", () => {
     await hook.unmount();
   });
 
+  test.each(["pending", "failed"])(
+    "allows switching targets while the initial observation is %s",
+    async (initialState) => {
+      const windowTarget = target();
+      const screenTarget = target("screen-1", "screen");
+      const inputRequests: unknown[] = [];
+      let settleInitial!: (value: ComputerObservation) => void;
+      const initial = new Promise<ComputerObservation>((resolve) => {
+        settleInitial = resolve;
+      });
+      const client = fakeClient({
+        getComputerSession: async () => ({ ...computerSession(), platform: "macos" }),
+        listComputerTargets: async () => ({
+          computerSessionId: COMPUTER_SESSION_ID,
+          controllerGeneration: "controller-1",
+          targets: [windowTarget, screenTarget],
+        }),
+        observeComputerTarget: async (_workspaceId, _computerSessionId, targetId) => {
+          if (targetId === screenTarget.id) return observation(screenTarget);
+          if (initialState === "failed") throw new Error("Observation timed out");
+          return await initial;
+        },
+        actInComputer: async (_workspaceId, _computerSessionId, request) => {
+          inputRequests.push(request);
+          return { ...receipt(observation(windowTarget), request.operationId), observation: null };
+        },
+      });
+      const hook = await renderHook(
+        () =>
+          useComputerSession({
+            client,
+            workspaceId: WORKSPACE_ID,
+            computerSessionId: COMPUTER_SESSION_ID,
+            pollIntervalMs: 60_000,
+          }),
+        undefined,
+      );
+      try {
+        await flush(20);
+        expect(hook.result.current.targets).toHaveLength(2);
+        expect(hook.result.current.selectedTarget?.id).toBe(windowTarget.id);
+        expect(hook.result.current.observation).toBeNull();
+        await actRun(async () => {
+          await hook.result.current.act({ type: "keyboard", action: "type", value: "hello" });
+          await hook.result.current.act({ type: "clipboard", operation: "paste" });
+        });
+        expect(inputRequests).toHaveLength(2);
+        for (const request of inputRequests) {
+          expect(request).toMatchObject({
+            targetId: windowTarget.id,
+            expectedTargetGeneration: windowTarget.targetGeneration,
+            expectedObservationId: null,
+            expectedFrameId: null,
+          });
+        }
+        await actRun(async () => {
+          await hook.result.current.selectTarget(screenTarget.id);
+        });
+        expect(hook.result.current.selectedTarget?.id).toBe(screenTarget.id);
+        expect(hook.result.current.observation?.target.id).toBe(screenTarget.id);
+        await actRun(async () => {
+          settleInitial(observation(windowTarget));
+        });
+        await flush(5);
+        expect(hook.result.current.selectedTarget?.id).toBe(screenTarget.id);
+        expect(hook.result.current.observation?.target.id).toBe(screenTarget.id);
+        expect(hook.result.current.error).toBeNull();
+      } finally {
+        settleInitial(observation(windowTarget));
+        await hook.unmount();
+      }
+    },
+  );
+
   test("keeps target selection local and fences semantic and pixel actions exactly", async () => {
     const windowTarget = target();
     const screenTarget = target("screen-1", "screen");

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -438,7 +438,8 @@ const budgets = {
   // stylesheet to 32,221 gzip bytes. Keep the next whole-KiB envelope.
   // Main 52ff56a94 is already 33,660 gzip bytes; the scroll-control gutter
   // adds 14. Preserve the measured whole-KiB envelope and 1-KiB headroom.
-  cssGzip: wholeKibEnvelope(33_674),
+  // Base 7135113e5 already measures 34,868 gzip bytes on macOS and Linux.
+  cssGzip: wholeKibEnvelope(34_868),
 } as const;
 
 // The canonical sensitive-preview policy measures 626,021 gzip bytes across
@@ -509,6 +510,10 @@ const effectiveBudgets = {
     // Retain the established 1.5 KiB variance allowance (643 KiB total).
     // Initial, raw, file-count, per-file, lazy, and CSS caps stay unchanged.
     wholeKibEnvelope(656_741, 1.5 * kib),
+    // Base 7135113e5 measures 659,490; desktop changes measure 659,492 on
+    // macOS and 659,488 in Linux CI. Keep the existing minimum 1-KiB
+    // headroom policy and round the envelope to whole KiB.
+    wholeKibEnvelope(659_492),
   ),
   directSessionFiles: Math.max(
     budgets.directSessionFiles,

--- a/scripts/web-bundle-budget-policy.test.ts
+++ b/scripts/web-bundle-budget-policy.test.ts
@@ -72,7 +72,7 @@ describe("web bundle budget policy", () => {
       "directSessionFiles: 31",
       "lazyChunkRaw: 800 * kib",
       "lazyChunkGzip: 240 * kib",
-      "cssGzip: wholeKibEnvelope(33_674)",
+      "cssGzip: wholeKibEnvelope(34_868)",
     ])
       expect(source).toContain(limit);
   });


### PR DESCRIPTION
Mac desktop helpers invoked Cocoa on Rust threads without autorelease pools, allowing temporary objects to accumulate. Capture startup also had error/timeout paths that could leave an asynchronous stream running. Drain pools per native operation and Accessibility iteration, and give normal shutdown or late startup completion exclusive ownership of stopping and detaching the stream.

Desktop discovery previously waited for semantic inspection before publishing any targets. Publish discovery immediately so a stalled app does not block the live stream or selecting another target. Preserve observation/generation fencing and allow raw keyboard/clipboard input against the selected discovered target.

Validation:
- Independent review completed; no outstanding findings.
- macOS strict clippy and 23 native unit tests pass; startup completion/abandonment ordering and racing ownership are covered.
- 25 React interaction tests pass, including pending/failed initial inspection, target switching, stale completion, and input.
- Actual helper probe with Objective-C diagnostics: 201 missing-pool warnings before, zero after. The GUI regression requires an unlocked Mac and is explicitly ignored in headless CI.
- Full `bun run check` was run: typechecks/public hygiene passed; unrelated failures include a pre-existing private demo import, unavailable local sandbox image, and a recursive API test mock. Remaining build stages are checked separately.

The first CI run confirmed baseline admission defects on the unchanged base. A separate small correction commit repairs public demo imports, unused/index-key lint findings, and the self-recursive test mock. It also aligns the existing whole-KiB budget policy to independently reproduced base measurements: direct-session gzip 659,490 bytes before / 659,492 after on macOS, 659,488 in Linux CI; CSS 34,868 bytes in both. Existing minimum headroom is preserved; unrelated budgets are unchanged. The 22 affected tests, 25 budget-policy tests, full lint, and production web build pass after these corrections.

## Summary by Sourcery

Prevent macOS native resource leaks and capture-stream races while making desktop discovery immediately usable despite delayed semantic inspection.

New Features:
- Publish discovered desktop targets before semantic observation completes, allowing live viewing, target switching, and keyboard or clipboard input during slow or failed inspection.

Bug Fixes:
- Prevent macOS Cocoa autoreleased objects from accumulating across native worker operations and Accessibility iterations.
- Ensure capture streams are stopped and detached exactly once across normal shutdown, startup failure, timeout, and late startup completion paths.

Enhancements:
- Preserve target selection, observation generation fencing, and stale completion handling while discovery and observation proceed independently.

Build:
- Align web bundle budget envelopes with independently reproduced base measurements while preserving existing headroom.

Documentation:
- Document macOS autorelease-pool handling, capture startup ownership, and non-blocking desktop discovery behavior.

Tests:
- Add coverage for capture startup ownership races and native macOS missing-autorelease-pool diagnostics.
- Add React interaction coverage for switching targets and sending input while initial observation is pending or failed.

Chores:
- Correct public demo imports, lint findings, and a self-recursive API test mock.