### PR TITLE
fix(react): restore desktop reconnect after an established stream fails

### DIFF
--- a/.changeset/desktop-retained-frame-reconnect.md
+++ b/.changeset/desktop-retained-frame-reconnect.md
@@ -2,4 +2,4 @@
 "@opengeni/react": patch
 ---
 
-Show desktop connection errors and Reconnect after an established stream fails, and let Refresh desktops retry a failed stream.
+Show desktop connection errors and Reconnect after an established stream fails or socket retries are exhausted, and let Refresh desktops retry a failed stream.

--- a/.changeset/desktop-retained-frame-reconnect.md
+++ b/.changeset/desktop-retained-frame-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Show desktop connection errors and Reconnect after an established stream fails, and let Refresh desktops retry a failed stream.

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -112,6 +112,11 @@ On macOS, runner restart waits for the previous launchd label to disappear befor
 accepting a replacement. A matching program path on a retiring job is not proof
 that the replacement started.
 
+If a desktop producer ends after delivering frames, the viewer exposes its
+connection error and Reconnect action instead of leaving the last image over
+them. Refresh desktops also retries a failed stream; terminal placement changes
+still require the existing replacement-session recovery path.
+
 The Chrome Native Messaging bridge accepts two exact extension origins: the
 development manifest key (`imdmcebcclhibdfolbokjbiibpcnpbel`) and the Chrome Web
 Store item (`phpmmcbeelfkcinjfbbggegjdcdmnnch`). Both the installed native-host

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -114,8 +114,9 @@ that the replacement started.
 
 If a desktop producer ends after delivering frames, the viewer exposes its
 connection error and Reconnect action instead of leaving the last image over
-them. Refresh desktops also retries a failed stream; terminal placement changes
-still require the existing replacement-session recovery path.
+them. Exhausted socket retries become an explicit connection error. Refresh
+desktops also retries a failed stream; terminal placement changes still require
+the existing replacement-session recovery path.
 
 The Chrome Native Messaging bridge accepts two exact extension origins: the
 development manifest key (`imdmcebcclhibdfolbokjbiibpcnpbel`) and the Chrome Web

--- a/packages/react/src/components/computer-viewer.tsx
+++ b/packages/react/src/components/computer-viewer.tsx
@@ -567,7 +567,12 @@ export function ComputerViewer({
           if (relevant[0]) selectComputerSession({ sessionId: relevant[0].id, pinned: false });
         }}
         onCreate={hideGenericCreate ? undefined : createComputer}
-        onRefresh={() => void Promise.all([refreshRegistry(), refreshComputer()])}
+        onRefresh={() => {
+          if (frames.state === "error" && !generationLossSelected && !generationLossFrames) {
+            frames.reconnect();
+          }
+          void Promise.all([refreshRegistry(), refreshComputer()]);
+        }}
       />
       <InteractionInterventionBanner
         interventions={selectedInterventions}
@@ -1031,8 +1036,11 @@ function ComputerViewport(props: {
   actionRef.current = props.onAction;
   readClipboardRef.current = props.onReadClipboard;
   errorRef.current = props.onError;
+  const streamFailed = props.connectionState === "error";
   const rawInputEnabled =
-    !props.backgroundActions || props.target?.kind === "screen" || props.target?.focused === true;
+    !streamFailed &&
+    !props.machineLocked &&
+    (!props.backgroundActions || props.target?.kind === "screen" || props.target?.focused === true);
 
   const paintQueuedFrames = useCallback(() => {
     if (decodingFrameRef.current) return;
@@ -1346,7 +1354,7 @@ function ComputerViewport(props: {
     if (inputRef.current) inputRef.current.value = "";
   };
 
-  const showCanvas = props.frame !== null && !props.machineLocked;
+  const showCanvas = props.frame !== null && !props.machineLocked && !streamFailed;
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
       <canvas

--- a/packages/react/src/hooks/use-computer-frame-stream.ts
+++ b/packages/react/src/hooks/use-computer-frame-stream.ts
@@ -159,9 +159,19 @@ export function useComputerFrameStream(
       pendingFrame = null;
     };
 
+    const clearRecoveryTimers = () => {
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (expiryTimer) clearTimeout(expiryTimer);
+      reconnectTimer = null;
+      expiryTimer = null;
+    };
+
     const scheduleReconnect = () => {
       if (disposed || reconnectTimer) return;
-      if (failures >= MAX_AUTOMATIC_RECONNECTS_WITHOUT_A_FRAME) return;
+      if (failures >= MAX_AUTOMATIC_RECONNECTS_WITHOUT_A_FRAME) {
+        clearRecoveryTimers();
+        return;
+      }
       const delay = Math.min(5_000, 250 * 2 ** Math.min(failures, 5));
       failures += 1;
       setResult((current) => ({ ...current, state: "reconnecting" }));
@@ -177,6 +187,7 @@ export function useComputerFrameStream(
       setResult((current) => ({ ...current, state: "error", error }));
       clearSocket();
       if (reconnectAutomatically) scheduleReconnect();
+      else clearRecoveryTimers();
     };
 
     const onOpen = (source: ComputerFrameWebSocket) => {
@@ -295,8 +306,7 @@ export function useComputerFrameStream(
 
     const onClose = (source: ComputerFrameWebSocket) => {
       if (disposed || source !== socket) return;
-      clearSocket();
-      scheduleReconnect();
+      fail(new Error("Desktop view lost connection."));
     };
 
     const connectSocket = () => {
@@ -406,8 +416,7 @@ export function useComputerFrameStream(
       disposed = true;
       pendingFrame = null;
       attachmentAbort.abort();
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      if (expiryTimer) clearTimeout(expiryTimer);
+      clearRecoveryTimers();
       clearSocket(true);
     };
   }, [client, enabled, nonce, options.computerSessionId, options.targetId, workspaceId]);

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { StreamFrame, StreamOpen, StreamOpenAck } from "@opengeni/agent-proto";
+import { StreamClose, StreamFrame, StreamOpen, StreamOpenAck } from "@opengeni/agent-proto";
 import { OpenGeniApiError } from "@opengeni/sdk";
 import type {
   ComputerActionReceipt,
@@ -1109,6 +1109,103 @@ describe("ComputerViewer", () => {
     expect(rendered.container.textContent).toContain("Reconnect");
     await rendered.unmount();
   });
+
+  for (const recovery of ["Reconnect", "Refresh desktops"]) {
+    test(`recovers an ended desktop producer through ${recovery} after a visible frame`, async () => {
+      const current = computerSession();
+      const currentTarget = target();
+      const sockets: FakeComputerSocket[] = [];
+      let attachmentCalls = 0;
+      const client = fakeClient({
+        listComputerSessions: async () => ({ revision: 1, sessions: [current] }),
+        getComputerSession: async () => current,
+        listComputerTargets: async () => ({
+          computerSessionId: current.id,
+          controllerGeneration: "controller-1",
+          targets: [currentTarget],
+        }),
+        observeComputerTarget: async () => observation(currentTarget),
+        attachComputerSession: async () => {
+          attachmentCalls += 1;
+          return relayAttachment(currentTarget.id);
+        },
+      });
+      const rendered = await renderComponent(
+        <ComputerViewer
+          client={client}
+          workspaceId={WORKSPACE_ID}
+          sessionId={SESSION_ID}
+          webSocketFactory={(url, protocols) => {
+            const socket = new FakeComputerSocket(url, protocols);
+            sockets.push(socket);
+            return socket as unknown as ComputerFrameWebSocket;
+          }}
+        />,
+      );
+      try {
+        await flush(40);
+        const showFrame = async (socket: FakeComputerSocket) => {
+          await dispatch(socket, "open");
+          await dispatch(socket, "message", {
+            data: relayMessage(
+              2,
+              StreamOpenAck.encode({ accepted: true, error: undefined, resumeFromSeq: "0" }).finish(),
+            ),
+          });
+          await dispatch(socket, "message", {
+            data: relayMessage(
+              3,
+              StreamFrame.encode({
+                channelId: "computer-channel-1",
+                seq: "1",
+                data: frameMessage(currentTarget.id, 1),
+                producedAtMs: String(Date.now()),
+              }).finish(),
+            ),
+          });
+          await flush(10);
+        };
+        const canvas = rendered.container.querySelector("canvas")!;
+        const keyboard = rendered.container.querySelector<HTMLTextAreaElement>(
+          "textarea[aria-label='Desktop keyboard input']",
+        )!;
+        await showFrame(sockets[0]!);
+        expect(canvas.classList.contains("invisible")).toBe(false);
+        expect(keyboard.disabled).toBe(false);
+
+        await dispatch(sockets[0]!, "message", {
+          data: relayMessage(
+            4,
+            StreamClose.encode({
+              channelId: "computer-channel-1",
+              reason: 0,
+              message: "producer ended",
+            }).finish(),
+          ),
+        });
+        await flush(10);
+        expect(rendered.container.textContent).toContain("Live view disconnected");
+        expect(canvas.classList.contains("invisible")).toBe(true);
+        expect(keyboard.disabled).toBe(true);
+        expect(attachmentCalls).toBe(1);
+
+        const retry = [...rendered.container.querySelectorAll("button")].find(
+          (button) =>
+            button.textContent?.trim() === recovery || button.getAttribute("aria-label") === recovery,
+        );
+        expect(retry).toBeDefined();
+        await actRun(() => retry!.click());
+        await flush(40);
+        expect(attachmentCalls).toBe(2);
+        await showFrame(sockets[1]!);
+        expect(canvas.classList.contains("invisible")).toBe(false);
+        expect(keyboard.disabled).toBe(false);
+        expect(rendered.container.textContent).not.toContain("Live view disconnected");
+      } finally {
+        await rendered.unmount();
+      }
+    });
+  }
 
   test("pins an exact ComputerSession requested by Browser navigation", async () => {
     const current = computerSession();

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -602,6 +602,46 @@ describe("ComputerSession frame stream", () => {
     await hook.unmount();
   });
 
+  test("exposes an error after sockets exhaust the bounded reconnect attempts", async () => {
+    const sockets: FakeComputerSocket[] = [];
+    const client = fakeClient({
+      attachComputerSession: async () => ({
+        ...relayAttachment("window-1"),
+        expiresAt: new Date(Date.now() + 2_000).toISOString(),
+      }),
+    });
+    const hook = await renderHook(
+      () =>
+        useComputerFrameStream({
+          client,
+          workspaceId: WORKSPACE_ID,
+          computerSessionId: COMPUTER_SESSION_ID,
+          targetId: "window-1",
+          webSocketFactory: (url, protocols) => {
+            const socket = new FakeComputerSocket(url, protocols);
+            sockets.push(socket);
+            return socket as unknown as ComputerFrameWebSocket;
+          },
+        }),
+      undefined,
+    );
+    try {
+      await flush(10);
+      for (const [index, delay] of [300, 550, 10].entries()) {
+        await dispatch(sockets[index]!, "open");
+        await dispatch(sockets[index]!, "close");
+        await flush(delay);
+      }
+      expect(sockets).toHaveLength(3);
+      expect(hook.result.current.state).toBe("error");
+      expect(hook.result.current.error?.message).toBe("Desktop view lost connection.");
+      await flush(550);
+      expect(sockets).toHaveLength(3);
+    } finally {
+      await hook.unmount();
+    }
+  });
+
   test("uses the distinct Computer relay stream kind", async () => {
     let socket: FakeComputerSocket | null = null;
     const client = fakeClient({
@@ -1127,7 +1167,10 @@ describe("ComputerViewer", () => {
         observeComputerTarget: async () => observation(currentTarget),
         attachComputerSession: async () => {
           attachmentCalls += 1;
-          return relayAttachment(currentTarget.id);
+          return {
+            ...relayAttachment(currentTarget.id),
+            expiresAt: new Date(Date.now() + 2_000).toISOString(),
+          };
         },
       });
       const rendered = await renderComponent(
@@ -1149,7 +1192,11 @@ describe("ComputerViewer", () => {
           await dispatch(socket, "message", {
             data: relayMessage(
               2,
-              StreamOpenAck.encode({ accepted: true, error: undefined, resumeFromSeq: "0" }).finish(),
+              StreamOpenAck.encode({
+                accepted: true,
+                error: undefined,
+                resumeFromSeq: "0",
+              }).finish(),
             ),
           });
           await dispatch(socket, "message", {
@@ -1187,11 +1234,15 @@ describe("ComputerViewer", () => {
         expect(rendered.container.textContent).toContain("Live view disconnected");
         expect(canvas.classList.contains("invisible")).toBe(true);
         expect(keyboard.disabled).toBe(true);
+        // The old grant renewal must not revive a terminal producer behind
+        // the error panel without either recovery action below.
+        await flush(1_100);
         expect(attachmentCalls).toBe(1);
 
         const retry = [...rendered.container.querySelectorAll("button")].find(
           (button) =>
-            button.textContent?.trim() === recovery || button.getAttribute("aria-label") === recovery,
+            button.textContent?.trim() === recovery ||
+            button.getAttribute("aria-label") === recovery,
         );
         expect(retry).toBeDefined();
         await actRun(() => retry!.click());


### PR DESCRIPTION
After an established desktop stream ended, its retained image hid the error panel and Reconnect action. Refresh desktops only reloaded discovery. Socket retries could also exhaust while leaving Connecting visible, and the old grant-renewal timer silently restarted terminal streams.

The viewer now exposes errors, disables raw input against the stale image, and lets Reconnect or Refresh desktops request a fresh stream. Exhausted retries leave an explicit error and cancel pending renewal/retry timers. Existing placement-generation fencing and retry limits remain intact.

Validation: independent review completed. All 28 computer-interaction tests pass, covering decoded frame → terminal close → both recovery paths, exhausted sockets, and no implicit renewal beyond grant expiry. Both retained-frame regressions fail against the prior viewer. React typecheck, package build, formatting, repository lint and documentation guards pass.

## Summary by Sourcery

Restore reliable desktop stream recovery by surfacing terminal failures, preventing stale-stream interaction, and requiring an explicit recovery action.

New Features:
- Allow Reconnect and Refresh desktops to recover a desktop stream after an established producer failure.

Bug Fixes:
- Expose desktop connection errors instead of allowing a retained frame to obscure the error panel and recovery action.
- Prevent exhausted socket retries and terminal stream failures from leaving stale Connecting state or silently renewing the stream.
- Disable raw desktop input while the displayed stream is disconnected.

Enhancements:
- Preserve existing retry limits and placement-generation fencing while centralizing cleanup of pending recovery timers.

Documentation:
- Document desktop stream error visibility, retry behavior, and recovery through Reconnect or Refresh desktops.

Tests:
- Add coverage for exhausted socket retries and recovery after a visible frame through both supported recovery actions.