### PR TITLE
fix(browserd): reacquire retiring capture source on renewal

### DIFF
--- a/.changeset/desktop-source-renewal.md
+++ b/.changeset/desktop-source-renewal.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/browserd": patch
+---
+
+Reacquire the live capture source when a viewer renews while its previous subscription is retiring, preventing renewal from attaching to a stopped source.

--- a/packages/browserd/src/computer-driver.ts
+++ b/packages/browserd/src/computer-driver.ts
@@ -214,6 +214,7 @@ export class NativeComputerDriver implements ComputerInteractionDriver {
     let group = this.frameStreams.get(targetId);
     while (group?.stopping) {
       await group.done;
+      this.assertOpen();
       group = this.frameStreams.get(targetId);
     }
     if (!group) {
@@ -231,7 +232,9 @@ export class NativeComputerDriver implements ComputerInteractionDriver {
     let profile = group.profiles.get(key);
     if (profile?.stopped) {
       await profile.done;
-      profile = group.profiles.get(key);
+      // Retiring the last profile can also retire its group. Reacquire both
+      // from the registry so renewal cannot attach to a detached/stopping source.
+      return this.subscribeFrames(targetId, options);
     }
     let created = false;
     if (!profile) {

--- a/packages/browserd/test/computer-driver.test.ts
+++ b/packages/browserd/test/computer-driver.test.ts
@@ -14,6 +14,28 @@ const computerSessionId = "11111111-1111-4111-8111-111111111111";
 const controllerGeneration = "controller-1";
 
 describe("NativeComputerDriver", () => {
+  test("renews a subscription while the last viewer is retiring", async () => {
+    const transport = new FixtureNativeTransport();
+    const driver = new NativeComputerDriver({
+      computerSessionId,
+      controllerGeneration,
+      client: transport,
+    });
+    try {
+      const first = await driver.subscribeFrames("window-1");
+      await first[Symbol.asyncIterator]().next();
+      await first.close();
+      const renewed = await driver.subscribeFrames("window-1");
+      await expect(renewed[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+        done: false,
+        value: { frameId: "frame-2" },
+      });
+      await renewed.close();
+    } finally {
+      await driver.close();
+    }
+  });
+
   test("projects native targets, observations, causal actions, and latest-wins frames", async () => {
     const transport = new FixtureNativeTransport();
     const driver = new NativeComputerDriver({


### PR DESCRIPTION
A viewer renewing immediately after its last subscription closes can wait for that profile to finish, then attach to the same capture group after it has begun stopping. The replacement stream fails instead of resuming.

Reacquire the current group and profile after retirement, and recheck driver closure after awaiting group teardown. Adds a regression that fails on the previous implementation and passes with this change.

Validation: browserd suite 127 passed, 16 skipped; browserd typecheck passed; independent review found no actionable issues.
