### PR TITLE
fix(react): reset frame sequence fence on desktop renewal

### DIFF
--- a/.changeset/desktop-renewal-sequences.md
+++ b/.changeset/desktop-renewal-sequences.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Accept restarted frame sequences after a fresh desktop attachment so automatic renewal does not freeze the last image. Preserve frame ordering within a stream and reject detached sockets.

--- a/packages/react/src/hooks/use-computer-frame-stream.ts
+++ b/packages/react/src/hooks/use-computer-frame-stream.ts
@@ -376,6 +376,9 @@ export function useComputerFrameStream(
           throw new Error("desktop attachment does not match the requested resource");
         }
         controllerGeneration = attachment.controllerGeneration;
+        // A fresh attachment owns a new producer whose sequence can restart.
+        // Transport reconnects reuse the attachment and retain their sequence fence.
+        latestRef.current = { key: "", sequence: -1 };
         activeAttachment = attachment;
         activeStream = attachment.stream;
         attachmentExpiresAt = Date.parse(attachment.expiresAt);

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -602,6 +602,49 @@ describe("ComputerSession frame stream", () => {
     await hook.unmount();
   });
 
+  test("accepts restarted frame sequences after attachment renewal", async () => {
+    const sockets: FakeComputerSocket[] = [];
+    let attaches = 0;
+    const client = fakeClient({
+      attachComputerSession: async () => ({
+        ...attachment("window-1"),
+        expiresAt: new Date(Date.now() + (++attaches === 1 ? 2_000 : 120_000)).toISOString(),
+      }),
+    });
+    const hook = await renderHook(
+      () =>
+        useComputerFrameStream({
+          client,
+          workspaceId: WORKSPACE_ID,
+          computerSessionId: COMPUTER_SESSION_ID,
+          targetId: "window-1",
+          webSocketFactory: (url, protocols) => {
+            const socket = new FakeComputerSocket(url, protocols);
+            sockets.push(socket);
+            return socket as unknown as ComputerFrameWebSocket;
+          },
+        }),
+      undefined,
+    );
+    try {
+      await dispatch(sockets[0]!, "open");
+      await dispatch(sockets[0]!, "message", { data: frameMessage("window-1", 100).buffer });
+      await flush(10);
+      expect(hook.result.current.frame?.sequence).toBe(100);
+      await flush(1_100);
+      expect(sockets).toHaveLength(2);
+      await dispatch(sockets[1]!, "open");
+      await dispatch(sockets[1]!, "message", { data: frameMessage("window-1", 2).buffer });
+      await dispatch(sockets[1]!, "message", { data: frameMessage("window-1", 1).buffer });
+      await dispatch(sockets[0]!, "message", { data: frameMessage("window-1", 101).buffer });
+      await flush(10);
+      expect(hook.result.current.state).toBe("live");
+      expect(hook.result.current.frame?.sequence).toBe(2);
+    } finally {
+      await hook.unmount();
+    }
+  });
+
   test("exposes an error after sockets exhaust the bounded reconnect attempts", async () => {
     const sockets: FakeComputerSocket[] = [];
     const client = fakeClient({


### PR DESCRIPTION
Desktop attachment renewal creates a fresh producer whose frame sequence can restart at 1. The viewer retained the previous producer's high-water mark and silently discarded valid new frames, freezing the last image after renewal.

Reset the sequence fence after validating a fresh attachment. Ordinary transport reconnects retain their ordering fence, and detached socket frames remain rejected.

Validation: the regression retained sequence 100 on the baseline instead of accepting the renewed sequence 2; all 29 computer-interaction tests pass with the fix.

React typecheck passed. Independent review found no actionable issues.
