### PR TITLE
fix(oauth): accept Microsoft offline access via refresh tokens

### DIFF
--- a/.changeset/microsoft-offline-access.md
+++ b/.changeset/microsoft-offline-access.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+---
+
+Accept Microsoft's token responses that omit offline_access from access-token scopes. Require a refresh token as proof of offline access, preserve that capability after refresh, and continue rejecting missing resource permissions.

--- a/apps/api/src/integrations/provider-oauth.ts
+++ b/apps/api/src/integrations/provider-oauth.ts
@@ -375,7 +375,7 @@ export async function completeApiIntegrationProviderOAuth(
     if (!providerScopesInclude(definition, token.scopes, state.authorizeScopes)) {
       throw new ProviderOAuthCallbackError("scope_not_granted");
     }
-    const grantedScopes = token.scopes.length > 0 ? token.scopes : state.authorizeScopes;
+    let grantedScopes = token.scopes.length > 0 ? token.scopes : state.authorizeScopes;
     const identity = await verifyProviderIdentity(deps, definition, token);
     if (
       state.expectedProviderPrincipalId &&
@@ -414,6 +414,11 @@ export async function completeApiIntegrationProviderOAuth(
     }
     if (!refreshToken) {
       throw new ProviderOAuthCallbackError("refresh_token_missing");
+    }
+    // Microsoft omits offline_access from access-token scopes. The new or
+    // previously verified refresh token proves this capability instead.
+    if (definition.provider.id === "microsoft") {
+      grantedScopes = uniqueStrings([...grantedScopes, "offline_access"]);
     }
     const credentialEncrypted = encryptEnvironmentValue(
       key,
@@ -926,7 +931,11 @@ function providerScopesInclude(
     return value;
   };
   const granted = new Set(effective.map(normalize));
-  return definition.authentication.scopes.every((scope) => granted.has(normalize(scope)));
+  return definition.authentication.scopes.every(
+    (scope) =>
+      (definition.provider.id === "microsoft" && normalize(scope) === "offline_access") ||
+      granted.has(normalize(scope)),
+  );
 }
 
 function providerOAuthReturnUrl(

--- a/apps/api/test/api-integration-provider-oauth.test.ts
+++ b/apps/api/test/api-integration-provider-oauth.test.ts
@@ -820,7 +820,9 @@ describe("API Integration provider OAuth", () => {
     const workspace = await freshWorkspace();
     const fixture = providerFixture();
     fixture.microsoftPlans.push({
-      scopes: [...MICROSOFT_OUTLOOK_MAIL_INTEGRATION_DEFINITION.authentication.scopes],
+      scopes: MICROSOFT_OUTLOOK_MAIL_INTEGRATION_DEFINITION.authentication.scopes.filter(
+        (scope) => scope !== "offline_access",
+      ),
       refreshToken: "microsoft-refresh-token",
     });
     const firstStart = await start(fixture, workspace, {
@@ -842,16 +844,18 @@ describe("API Integration provider OAuth", () => {
         ...MICROSOFT_OUTLOOK_CALENDAR_INTEGRATION_DEFINITION.authentication.scopes,
       ]),
     ];
-    fixture.microsoftPlans.push({ scopes: unionScopes });
+    fixture.microsoftPlans.push({
+      scopes: unionScopes.filter((scope) => scope !== "offline_access"),
+    });
     const reconnect = await start(fixture, workspace, {
       definitionId: MICROSOFT_OUTLOOK_CALENDAR_INTEGRATION_DEFINITION.id,
       connectionId: firstConnection.id,
       ownership: "workspace",
     });
     expect(reconnect.response.status).toBe(200);
-    expect(new URL(reconnect.authorizationUrl).searchParams.get("scope")?.split(" ")).toEqual(
-      unionScopes,
-    );
+    expect(
+      new URL(reconnect.authorizationUrl).searchParams.get("scope")?.split(" ").sort(),
+    ).toEqual([...unionScopes].sort());
     const reconnectState = new URL(reconnect.authorizationUrl).searchParams.get("state")!;
     const reconnectCallback = await callback(fixture, reconnectState);
     expect(
@@ -862,7 +866,7 @@ describe("API Integration provider OAuth", () => {
     )[0]!;
     expect(reconnected.id).toBe(firstConnection.id);
     expect(reconnected.version).toBe(firstConnection.version + 1);
-    expect(reconnected.grantedScopes).toEqual(unionScopes);
+    expect([...reconnected.grantedScopes].sort()).toEqual([...unionScopes].sort());
     expect(reconnected.metadata.authorizedDefinitionIds).toEqual(
       [
         MICROSOFT_OUTLOOK_CALENDAR_INTEGRATION_DEFINITION.id,
@@ -903,6 +907,34 @@ describe("API Integration provider OAuth", () => {
       await listConnectionsMetadata(client.db, workspace.workspaceId, workspace.subjectId)
     )[0]!;
     expect(unchanged.version).toBe(reconnected.version);
+  }, 60_000);
+
+  test("Microsoft still requires mail permissions and a refresh token", async () => {
+    if (!available) return;
+    for (const missing of ["Mail.Send", "refresh_token"]) {
+      const workspace = await freshWorkspace();
+      const fixture = providerFixture();
+      fixture.microsoftPlans.push({
+        scopes: MICROSOFT_OUTLOOK_MAIL_INTEGRATION_DEFINITION.authentication.scopes.filter(
+          (scope) => scope !== "offline_access" && scope !== missing,
+        ),
+        ...(missing === "refresh_token" ? {} : { refreshToken: "must-not-persist" }),
+      });
+      const started = await start(fixture, workspace, {
+        definitionId: MICROSOFT_OUTLOOK_MAIL_INTEGRATION_DEFINITION.id,
+        ownership: "workspace",
+      });
+      const result = await callback(
+        fixture,
+        new URL(started.authorizationUrl).searchParams.get("state")!,
+      );
+      expect(new URL(result.headers.get("location")!).searchParams.get("reason")).toBe(
+        missing === "refresh_token" ? "refresh_token_missing" : "scope_not_granted",
+      );
+      expect(
+        await listConnectionsMetadata(client.db, workspace.workspaceId, workspace.subjectId),
+      ).toEqual([]);
+    }
   }, 60_000);
 
   test("converges concurrent same-principal callbacks and rejects insufficient provider grants", async () => {

--- a/packages/db/src/connection-token-resolver.ts
+++ b/packages/db/src/connection-token-resolver.ts
@@ -1548,6 +1548,15 @@ export async function refreshOAuthConnectionCredential(
   const expiresAt = expiresAtFromTokenResponse(payload, cred.expiresAt);
   const scopeText = stringValue(payload.scope);
   const returnedScopes = scopeText?.split(/[\s,]+/).filter(Boolean) ?? [];
+  // A successful Microsoft refresh proves offline access, although Microsoft
+  // reports only access-token permissions in the response's scope field.
+  if (
+    scopeText &&
+    ref.providerDomain.toLowerCase() === "graph.microsoft.com" &&
+    !returnedScopes.some((scope) => scope.toLowerCase() === "offline_access")
+  ) {
+    returnedScopes.push("offline_access");
+  }
   const refreshTokenExpiresIn =
     typeof payload.refresh_token_expires_in === "number"
       ? payload.refresh_token_expires_in
@@ -1574,7 +1583,14 @@ export async function refreshOAuthConnectionCredential(
       "Bearer",
     ...(expiresAt ? { expires_at: expiresAt.toISOString() } : {}),
     ...(resource ? { resource } : {}),
-    ...(scopeText ? { scope: scopeText } : {}),
+    ...(scopeText
+      ? {
+          scope:
+            ref.providerDomain.toLowerCase() === "graph.microsoft.com"
+              ? returnedScopes.join(" ")
+              : scopeText,
+        }
+      : {}),
     ...(refreshTokenExpiresAt ? { refresh_token_expires_at: refreshTokenExpiresAt } : {}),
     ...(clientSecret && !personalGitHub
       ? { client_secret: clientSecret, token_endpoint_auth_method: authMethod }

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -2178,6 +2178,37 @@ describe("buildConnectionTokenResolver", () => {
     }
   });
 
+  test("Microsoft refresh preserves offline access without restoring missing API scopes", async () => {
+    const refreshed = await refreshOAuthConnectionCredential(
+      brokerCredential({
+        kind: "oauth2",
+        credential: {
+          access_token: "AC",
+          refresh_token: "RF",
+          token_endpoint: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+          client_id: "microsoft-client",
+          scope: "offline_access User.Read Mail.Send",
+        },
+      }),
+      { providerDomain: "graph.microsoft.com", kind: "oauth2" },
+      settings,
+      {
+        fetchImpl: (async () =>
+          Response.json({
+            access_token: "AC2",
+            scope: "User.Read",
+            expires_in: 3600,
+          })) as typeof fetch,
+        dnsLookup: async () => [{ address: "93.184.216.34", family: 4 }],
+      },
+    );
+    expect(refreshed.grantedScopes).toEqual(["User.Read", "offline_access"]);
+    expect(refreshed.credential).toMatchObject({
+      refresh_token: "RF",
+      scope: "User.Read offline_access",
+    });
+  });
+
   test("provider credentials may request a JSON OAuth refresh body", async () => {
     const originalFetch = globalThis.fetch;
     let capturedBody: Record<string, unknown> | null = null;


### PR DESCRIPTION
Microsoft Outlook authorization succeeds at the provider but OpenGeni rejects the callback with `scope_not_granted`: Microsoft omits `offline_access` from the access-token scope list.

Treat a new or previously verified refresh token as proof of Microsoft offline access. Continue requiring every resource permission, and preserve offline access when refreshing tokens without restoring missing resource scopes.

Validation: 65 focused API OAuth and connection broker tests pass; API typecheck passes; independent review found no blocking issues. Regression coverage includes first connection, reconnect without a replacement refresh token, missing Mail.Send, missing refresh token, and refresh responses with reduced resource permissions.

## Summary by Sourcery

Handle Microsoft's refresh-token-based offline access while retaining strict validation of required resource permissions.

Bug Fixes:
- Accept Microsoft OAuth callbacks when offline_access is omitted from access-token scopes while continuing to require resource permissions and a refresh token.
- Preserve Microsoft offline-access capability across token refreshes without reintroducing resource scopes missing from the refresh response.

Tests:
- Add regression coverage for Microsoft initial authorization, reconnects, missing resource permissions, missing refresh tokens, and reduced-scope refresh responses.