### PR TITLE
test(db): infer the Microsoft refresh mock transport type

### DIFF
--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -2193,12 +2193,12 @@ describe("buildConnectionTokenResolver", () => {
       { providerDomain: "graph.microsoft.com", kind: "oauth2" },
       settings,
       {
-        fetchImpl: (async () =>
+        fetchImpl: async () =>
           Response.json({
             access_token: "AC2",
             scope: "User.Read",
             expires_in: 3600,
-          })) as typeof fetch,
+          }),
         dnsLookup: async () => [{ address: "93.184.216.34", family: 4 }],
       },
     );


### PR DESCRIPTION
The Microsoft refresh regression test cast a zero-argument function to Bun fetch, whose type also requires preconnect. Infer the existing FetchLike parameter type instead. Database package typechecking and all 55 connection tests pass; runtime behavior unchanged.

## Summary by Sourcery

Correct the Microsoft refresh mock transport typing in the database connection tests.

Enhancements:
- Update the Microsoft refresh regression test to infer the existing fetch implementation type without an incompatible cast.

Tests:
- Improve type safety in the Microsoft refresh connection test while preserving its runtime behavior.