### PR TITLE
fix(react): complete native goal loading and composer contracts

### DIFF
--- a/.changeset/native-react-session-contracts.md
+++ b/.changeset/native-react-session-contracts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Load authoritative goals on mount when reusing a shared event feed. Add optional native loading messages for accessible status, slow waits, and details controls, preserving English defaults. Expose SessionChrome's successful queue-checkout composer focus handoff.

--- a/docs/design/genie-loading.md
+++ b/docs/design/genie-loading.md
@@ -32,6 +32,32 @@ Hosts can customize the SDK without editing its source:
 Orb states use the `thinking-orbs` component's typed options. Omitted settings
 keep the defaults; an empty phrase list also falls back to the defaults.
 
+To brand or localize the native visual, supply `genieLoading.phrases` and
+`genieLoading.messages`. Every message is optional and defaults to the existing
+English copy:
+
+```tsx
+<MessageTimeline
+  events={events}
+  genieLoading={{
+    phrases: ["Preparing…"],
+    messages: {
+      status: "Preparing your task.",
+      slowStatus: "Preparing your task. Taking longer than usual.",
+      slowText: "A little longer than usual…",
+      showDetails: "Show details",
+      hideDetails: "Hide details",
+    },
+  }}
+/>
+```
+
+`status` and `slowStatus` are the stable screen-reader announcements; phrase
+rotation stays decorative. The slow text appears after 30 seconds, while the
+details button appears after 15 seconds (or whenever details are open). Message
+overrides preserve native timing, accessibility, and details behavior. Empty
+phrase arrays retain the default phrase list.
+
 For an entirely different visual, supply `genieLoading.render`:
 
 ```tsx

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -495,6 +495,18 @@ same-origin `/demo-api` proxy and the exact published SDK/React entrypoints.
 
 ## Composer customization (`@opengeni/react/composer`)
 
+`SessionChrome` accepts `onComposerFocus` for queue editing. Connect it to
+`controller.focusInput` from `useChatComposerController`, or focus a custom
+input through its ref. Chrome calls it after a successful checkout and
+`composer.applyDraft`, including confirmed draft replacement; failed checkout
+and pending/cancelled replacement do not request focus. The host retains
+ownership of the input and no DOM selector or global focus event is needed.
+
+When sharing `useSessionEvents().events` with `useGoal`, the hook still fetches
+the authoritative goal on mount and target changes, even when the supplied log
+already contains goal events. The shared log drives subsequent invalidations
+without opening another event stream. A 404 remains a normal goal-less state.
+
 Use `ChatComposer` for the standard layout and its `controlsStart`, `header`,
 and `messages` props for small additions. For a different layout, import the
 headless controller and compound primitives as a namespace. The controller is

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -100,6 +100,11 @@ export type SessionChromeProps = {
   queue: UseTurnQueueResult;
   /** Needed for queue edit → composer checkout. Omit with `readOnly`. */
   composer?: ComposerState | undefined;
+  /** Focus the composer after a successful queue checkout has applied its draft.
+   * Connect to the composer controller's `focusInput`, or a custom input ref.
+   * Never called for failed checkout or while replacement awaits confirmation.
+   */
+  onComposerFocus?: (() => void) | undefined;
   goal?: UseGoalResult | null | undefined;
   /** Expanded agents body (host supplies tree / list). */
   agentsPanel?: ReactNode;
@@ -431,6 +436,7 @@ export function SessionChrome({
   sessionStatus,
   queue,
   composer,
+  onComposerFocus,
   goal,
   agentsPanel,
   commandsPanel,
@@ -802,7 +808,10 @@ export function SessionChrome({
                     expectedDraftRevision: composer.draftRevision,
                     replaceDraft: true,
                   });
-                  if (checkedOut) composer.applyDraft(checkedOut);
+                  if (checkedOut) {
+                    composer.applyDraft(checkedOut);
+                    onComposerFocus?.();
+                  }
                 })();
               }
             : undefined
@@ -819,7 +828,10 @@ export function SessionChrome({
                         expectedDraftRevision: composer.draftRevision,
                         replaceDraft: false,
                       });
-                      if (checkedOut) composer.applyDraft(checkedOut);
+                      if (checkedOut) {
+                        composer.applyDraft(checkedOut);
+                        onComposerFocus?.();
+                      }
                     })();
                   },
                 );

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -138,7 +138,9 @@ export function useGoal(
       return;
     }
     if (sharedFeed) {
-      setLoading(false);
+      // A shared log supplies invalidations, not the authoritative goal snapshot.
+      setLoading(true);
+      void load();
       return () => {
         retireLoads();
       };

--- a/packages/react/src/timeline/genie-loading.tsx
+++ b/packages/react/src/timeline/genie-loading.tsx
@@ -12,6 +12,14 @@ export type GenieLoadingOptions = {
   /** Replace the visual while preserving SDK loading visibility and transitions. */
   render?: (props: GenieLoadingRenderProps) => ReactNode;
   phrases?: readonly string[];
+  /** Native copy overrides. Omitted messages retain the default English copy. */
+  messages?: {
+    status?: string;
+    slowStatus?: string;
+    slowText?: string;
+    showDetails?: string;
+    hideDetails?: string;
+  };
   /** Public adapter options; the renderer dependency's declarations stay private. */
   orb?: {
     state?:
@@ -90,10 +98,14 @@ export function GenieLoading({
       </div>
       <div className="og-genie-copy">
         <span className="sr-only" role="status">
-          {slow ? "Preparing your task. Taking longer than usual." : "Preparing your task."}
+          {slow
+            ? (options?.messages?.slowStatus ?? "Preparing your task. Taking longer than usual.")
+            : (options?.messages?.status ?? "Preparing your task.")}
         </span>
         <span key={slow ? "slow" : phrase} className="og-genie-phrase" aria-hidden="true">
-          {slow ? "A little longer than usual…" : phrases[phrase % phrases.length]}
+          {slow
+            ? (options?.messages?.slowText ?? "A little longer than usual…")
+            : phrases[phrase % phrases.length]}
         </span>
         {showDetails || detailsOpen ? (
           <button
@@ -102,7 +114,9 @@ export function GenieLoading({
             aria-expanded={detailsOpen}
             onClick={onShowDetails}
           >
-            {detailsOpen ? "Hide details" : "Behind the magic"}
+            {detailsOpen
+              ? (options?.messages?.hideDetails ?? "Hide details")
+              : (options?.messages?.showDetails ?? "Behind the magic")}
             <span aria-hidden="true"> ↗</span>
           </button>
         ) : null}

--- a/packages/react/test/genie-loading.test.tsx
+++ b/packages/react/test/genie-loading.test.tsx
@@ -1,12 +1,52 @@
 import { afterEach, expect, test } from "bun:test";
 import { act } from "react";
 import { ActivityRail } from "../src/timeline/activity-rail";
+import { GenieLoading, GenieLoadingOptionsContext } from "../src/timeline/genie-loading";
 import { MessageTimeline } from "../src/components/message-timeline";
 import { StartupTimings } from "../src/timeline/startup-timings";
 import { setStartupDetails } from "../src/timeline/startup-preference";
 import type { StartupPhaseItem } from "../src/timeline/types";
 import { registerDom, renderComponent, flush } from "./render-hook";
 registerDom();
+const messages = {
+  status: "Préparation en cours",
+  slowStatus: "La préparation prend plus de temps",
+  slowText: "Encore un instant…",
+  showDetails: "Afficher les détails",
+  hideDetails: "Masquer les détails",
+};
+const options = { phrases: ["Préparation…"], messages };
+test("native messages localize normal, slow, and expanded states without replacing rendering", async () => {
+  for (const age of [0, 16_000, 31_000]) {
+    for (const detailsOpen of [false, true]) {
+      let clicks = 0;
+      const r = await renderComponent(
+        <GenieLoadingOptionsContext.Provider value={options}>
+          <GenieLoading
+            startedAt={new Date(Date.now() - age).toISOString()}
+            detailsOpen={detailsOpen}
+            onShowDetails={() => clicks++}
+          />
+        </GenieLoadingOptionsContext.Provider>,
+      );
+      expect(r.container.querySelector('[role="status"]')?.textContent).toBe(
+        age >= 30_000 ? messages.slowStatus : messages.status,
+      );
+      expect(r.container.querySelector(".og-genie-phrase")?.textContent).toBe(
+        age >= 30_000 ? messages.slowText : "Préparation…",
+      );
+      const button = r.container.querySelector("button");
+      if (age >= 15_000 || detailsOpen) {
+        expect(button?.textContent).toContain(
+          detailsOpen ? messages.hideDetails : messages.showDetails,
+        );
+        await act(async () => button!.click());
+        expect(clicks).toBe(1);
+      } else expect(button).toBeNull();
+      await r.unmount();
+    }
+  }
+});
 afterEach(() => setStartupDetails(false));
 function phase(overrides: Partial<StartupPhaseItem> = {}): StartupPhaseItem {
   return {

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1420,29 +1420,39 @@ describe("useGoal", () => {
     await hook.unmount();
   });
 
-  test("shared empty event logs do not probe the goal endpoint", async () => {
-    let reads = 0;
-    const client = fakeClient({
-      getGoal: async () => {
-        reads += 1;
-        return fakeGoal();
-      },
-    });
-    const hook = await renderHook(
-      () =>
-        useGoal(SESSION_ID, {
-          client,
-          workspaceId: WORKSPACE_ID,
-          events: noEvents,
-        }),
-      undefined,
-    );
-    await flush();
-    expect(reads).toBe(0);
-    expect(hook.result.current.goal).toBeNull();
-    expect(hook.result.current.loading).toBe(false);
-    await hook.unmount();
-  });
+  test.each([{ events: [] }, { events: [makeEvent(1, "goal.set")] }])(
+    "shared event logs load authoritative goals on mount: %j",
+    async ({ events: initialEvents }) => {
+      const events = [...initialEvents];
+      let reads = 0;
+      let streams = 0;
+      const client = fakeClient({
+        streamEvents: () => {
+          streams += 1;
+          throw new Error("Shared feeds must not open a second stream");
+        },
+        getGoal: async () => {
+          reads += 1;
+          return fakeGoal();
+        },
+      });
+      const hook = await renderHook(
+        () =>
+          useGoal(SESSION_ID, {
+            client,
+            workspaceId: WORKSPACE_ID,
+            events,
+          }),
+        undefined,
+      );
+      await flush();
+      expect(reads).toBe(1);
+      expect(streams).toBe(0);
+      expect(hook.result.current.goal).not.toBeNull();
+      expect(hook.result.current.loading).toBe(false);
+      await hook.unmount();
+    },
+  );
 
   test("pause and resume PATCH the goal and update local state", async () => {
     const calls: { status: string; rationale?: string | undefined }[] = [];
@@ -1526,7 +1536,7 @@ describe("useGoal", () => {
       undefined,
     );
     await flush();
-    // Populate the goal (shared-feed skips the initial auto-load).
+    // Explicit refresh remains supported alongside the initial snapshot.
     await flushing(async () => {
       await hook.result.current.refresh();
     });
@@ -1554,10 +1564,10 @@ describe("useGoal", () => {
       [] as SessionEvent[],
     );
     await flush();
-    expect(reads).toBe(0);
+    expect(reads).toBe(1);
     await hook.rerender([makeEvent(1, "goal.paused")]);
     await flush(250);
-    expect(reads).toBe(1);
+    expect(reads).toBe(2);
     expect(hook.result.current.isPaused).toBe(true);
     await hook.unmount();
   });
@@ -1585,7 +1595,7 @@ describe("useGoal", () => {
       [] as SessionEvent[],
     );
     await flush();
-    expect(reads).toBe(0);
+    expect(reads).toBe(1);
 
     await hook.rerender([
       makeEvent(1, "agent.message.delta"),
@@ -1596,7 +1606,7 @@ describe("useGoal", () => {
     ]);
     await flush(250);
 
-    expect(reads).toBe(1);
+    expect(reads).toBe(2);
     expect(hook.result.current.goal?.continuation?.state).toBe("scheduled");
     await hook.unmount();
   });
@@ -1626,10 +1636,11 @@ describe("useGoal", () => {
     await flush();
 
     const pendingRefresh = hook.result.current.refresh();
-    expect(reads).toEqual([SESSION_ID]);
+    expect(reads).toEqual([SESSION_ID, SESSION_ID]);
+    const resolvePrevious = resolveGoal!;
     await hook.rerender(otherSessionId);
     await flushing(async () => {
-      resolveGoal!(fakeGoal({ text: "stale goal from the previous session" }));
+      resolvePrevious(fakeGoal({ text: "stale goal from the previous session" }));
       await pendingRefresh;
     });
 

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -746,95 +746,126 @@ describe("SessionChrome", () => {
     expect(mounted.container.querySelector('[data-og-session-chrome-panel="steering"]')).toBeNull();
   });
 
-  test("expands queue and reveals hover actions wired to queue APIs", async () => {
-    const calls: string[] = [];
-    const appliedDrafts: Array<NonNullable<ComposerState["draft"]>> = [];
-    const checkedOut: NonNullable<ComposerState["draft"]> = {
-      revision: 3,
-      text: "first queued prompt",
-      resources: [],
-      model: "model-x",
-      reasoningEffort: "medium",
-      latencyMode: "standard",
-      sourceTurnId: "11111111-1111-4111-8111-111111111111",
-      sourceTurnVersion: 1,
-      updatedAt: new Date().toISOString(),
-    };
-    const q = queue({
-      removeTurn: async (turnId) => {
-        calls.push(`remove:${turnId}`);
-        return true;
-      },
-      steerTurn: async (turnId) => {
-        calls.push(`steer:${turnId}`);
-        return true;
-      },
-      moveTurn: async (turnId, before) => {
-        calls.push(`move:${turnId}:${before ?? "null"}`);
-        return true;
-      },
-      editTurn: async (turnId) => {
-        calls.push(`edit:${turnId}`);
-        return checkedOut;
-      },
-    });
-    mounted = await renderComponent(
-      <SessionChrome
-        queue={q}
-        composer={composer({
-          applyDraft: (draft) => appliedDrafts.push(draft),
-        })}
-      />,
-    );
+  test.each([
+    { replace: false, succeeds: true },
+    { replace: true, succeeds: true },
+    { replace: false, succeeds: false },
+    { replace: true, succeeds: false },
+  ])(
+    "queue actions hand focus back only after successful checkout: %j",
+    async ({ replace, succeeds }) => {
+      const calls: string[] = [];
+      const appliedDrafts: Array<NonNullable<ComposerState["draft"]>> = [];
+      const checkedOut: NonNullable<ComposerState["draft"]> = {
+        revision: 3,
+        text: "first queued prompt",
+        resources: [],
+        model: "model-x",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sourceTurnId: "11111111-1111-4111-8111-111111111111",
+        sourceTurnVersion: 1,
+        updatedAt: new Date().toISOString(),
+      };
+      const q = queue({
+        removeTurn: async (turnId) => {
+          calls.push(`remove:${turnId}`);
+          return true;
+        },
+        steerTurn: async (turnId) => {
+          calls.push(`steer:${turnId}`);
+          return true;
+        },
+        moveTurn: async (turnId, before) => {
+          calls.push(`move:${turnId}:${before ?? "null"}`);
+          return true;
+        },
+        editTurn: async (turnId) => {
+          calls.push(`edit:${turnId}`);
+          return succeeds ? checkedOut : null;
+        },
+      });
+      mounted = await renderComponent(
+        <SessionChrome
+          queue={q}
+          composer={composer({
+            hasDraftContent: () => replace,
+            applyDraft: (draft) => {
+              appliedDrafts.push(draft);
+              calls.push("apply-draft");
+            },
+          })}
+          onComposerFocus={() => calls.push("focus-composer")}
+        />,
+      );
 
-    const queueChip = mounted.container.querySelector<HTMLButtonElement>(
-      '[data-og-session-chrome-signal="queue"]',
-    );
-    expect(queueChip).not.toBeNull();
-    expect(
-      mounted.container.querySelector('[data-og-session-chrome-panel="queue"]'),
-    ).not.toBeNull();
-    expect(mounted.container.querySelector('[data-og-session-chrome-open="true"]')).not.toBeNull();
+      const queueChip = mounted.container.querySelector<HTMLButtonElement>(
+        '[data-og-session-chrome-signal="queue"]',
+      );
+      expect(queueChip).not.toBeNull();
+      expect(
+        mounted.container.querySelector('[data-og-session-chrome-panel="queue"]'),
+      ).not.toBeNull();
+      expect(
+        mounted.container.querySelector('[data-og-session-chrome-open="true"]'),
+      ).not.toBeNull();
 
-    const remove = mounted.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Remove queued prompt 1"]',
-    );
-    const steer = mounted.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Steer queued prompt 1"]',
-    );
-    const edit = mounted.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Edit queued prompt 1"]',
-    );
-    const moveDown = mounted.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Move queued prompt 1 down"]',
-    );
-    expect(remove).not.toBeNull();
-    expect(steer).not.toBeNull();
-    expect(edit).not.toBeNull();
-    expect(moveDown).not.toBeNull();
-    expect(steer?.disabled).toBe(true);
+      const remove = mounted.container.querySelector<HTMLButtonElement>(
+        '[aria-label="Remove queued prompt 1"]',
+      );
+      const steer = mounted.container.querySelector<HTMLButtonElement>(
+        '[aria-label="Steer queued prompt 1"]',
+      );
+      const edit = mounted.container.querySelector<HTMLButtonElement>(
+        '[aria-label="Edit queued prompt 1"]',
+      );
+      const moveDown = mounted.container.querySelector<HTMLButtonElement>(
+        '[aria-label="Move queued prompt 1 down"]',
+      );
+      expect(remove).not.toBeNull();
+      expect(steer).not.toBeNull();
+      expect(edit).not.toBeNull();
+      expect(moveDown).not.toBeNull();
+      expect(steer?.disabled).toBe(true);
 
-    // The optimistic→authoritative row handoff must settle before pointer
-    // actions become available; otherwise a press can be lost on DOM replace.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 260));
-    });
-    expect(steer?.disabled).toBe(false);
+      // The optimistic→authoritative row handoff must settle before pointer
+      // actions become available; otherwise a press can be lost on DOM replace.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 260));
+      });
+      expect(steer?.disabled).toBe(false);
 
-    await act(async () => {
-      steer?.click();
-      remove?.click();
-      edit?.click();
-      moveDown?.click();
-    });
-    expect(calls).toContain("steer:11111111-1111-4111-8111-111111111111");
-    expect(calls).toContain("remove:11111111-1111-4111-8111-111111111111");
-    expect(calls).toContain("edit:11111111-1111-4111-8111-111111111111");
-    expect(appliedDrafts).toEqual([checkedOut]);
-    expect(
-      calls.some((entry) => entry.startsWith("move:11111111-1111-4111-8111-111111111111:")),
-    ).toBe(true);
-  });
+      await act(async () => {
+        steer?.click();
+        remove?.click();
+        edit?.click();
+        moveDown?.click();
+      });
+      if (replace) {
+        expect(calls).not.toContain("focus-composer");
+        expect(calls).not.toContain("apply-draft");
+        const keep = Array.from(mounted.container.querySelectorAll("button")).find(
+          (button) => button.textContent === "Keep current draft",
+        );
+        await act(async () => keep!.click());
+        expect(calls).not.toContain("focus-composer");
+        await act(async () => edit!.click());
+        const confirm = Array.from(mounted.container.querySelectorAll("button")).find(
+          (button) => button.textContent === "Replace and edit",
+        );
+        await act(async () => confirm!.click());
+      }
+      expect(calls).toContain("steer:11111111-1111-4111-8111-111111111111");
+      expect(calls).toContain("remove:11111111-1111-4111-8111-111111111111");
+      expect(calls).toContain("edit:11111111-1111-4111-8111-111111111111");
+      expect(appliedDrafts).toEqual(succeeds ? [checkedOut] : []);
+      if (succeeds) expect(calls.slice(-2)).toEqual(["apply-draft", "focus-composer"]);
+      else expect(calls).not.toContain("focus-composer");
+      expect(
+        calls.some((entry) => entry.startsWith("move:11111111-1111-4111-8111-111111111111:")),
+      ).toBe(true);
+    },
+  );
 
   test("explains pending child receipts and opens only their typed source", async () => {
     const childId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";


### PR DESCRIPTION
## Summary

- Fetch the authoritative goal on mount when `useGoal` reuses a shared event feed, including already-loaded history, without opening another stream.
- Add optional `GenieLoadingOptions.messages` for normal/slow accessible status, slow visible text, and show/hide details labels. Existing English defaults and native rendering remain unchanged.
- Add `SessionChrome.onComposerFocus`, called after successful queue checkout applies its draft, for direct wiring to the native composer controller's `focusInput()` or a custom input ref.
- Document the public contracts and include a React minor changeset; no runtime or embedding application changes.

## Verification

- CI run `34697331565` succeeded on exact head `c5c38cfb2b30e20b2bef31043f7ea5c1b37bbc09`: 38 jobs passed, 10 skipped. PR is mergeable with a clean merge state. GitHub reports no separately required check contexts.
- `bun test packages/react/test`: 1,830 passed, 0 failed across 119 files.
- Targeted hook/loading/chrome/declaration tests: 195 passed, 0 failed.
- React package TypeScript check passed.
- Targeted oxlint: 0 warnings/errors; `git diff --check` passed.
- Chromium rendered interaction check at 1280×900 and 390×844: native localized loading/status/details, slow state, authoritative goal display, and successful queue-edit focus through the native composer controller; no horizontal overflow.
- Regression coverage includes empty/preloaded shared logs, live invalidations, stale session reads, successful/failed checkout, confirmed replacement, and cancelled replacement.

Responsible agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/af754b5e-70c3-4941-ba45-084c7d6c7023