### PR TITLE
fix(web): settle visibility before hydrating new-session drafts

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -688,11 +688,12 @@ describe("web API auth helpers", () => {
     }
   });
 
-  test("drains finite JSON before exposing it and releases the native source lock", async () => {
+  test("fully consumes finite JSON before exposing detached bytes", async () => {
     const originalFetch = globalThis.fetch;
     const observed: { signal?: AbortSignal | null } = {};
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
     let source!: ReadableStream<Uint8Array>;
+    let nativeResponse!: Response;
     globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
       observed.signal = init?.signal ?? null;
       source = new ReadableStream<Uint8Array>({
@@ -700,9 +701,10 @@ describe("web API auth helpers", () => {
           bodyController = controller;
         },
       });
-      return new Response(source, {
+      nativeResponse = new Response(source, {
         headers: { "content-type": "application/json" },
       });
+      return nativeResponse;
     }) as unknown as typeof fetch;
 
     try {
@@ -722,7 +724,7 @@ describe("web API auth helpers", () => {
       bodyController.close();
       const response = await pending;
       expect(observed.signal?.aborted).toBe(false);
-      expect(source.locked).toBe(false);
+      expect(nativeResponse.bodyUsed).toBe(true);
       await expect(response.json()).resolves.toEqual({ ok: true });
     } finally {
       configureManagedActorEpoch(null);
@@ -868,38 +870,49 @@ describe("web API auth helpers", () => {
     }
   });
 
-  test("aborts a finite JSON drain when the accepted actor changes", async () => {
-    const originalFetch = globalThis.fetch;
-    const observed: { signal?: AbortSignal | null } = {};
-    let source!: ReadableStream<Uint8Array>;
-    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
-      observed.signal = init?.signal ?? null;
-      source = new ReadableStream<Uint8Array>({
-        start(controller) {
-          init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), {
-            once: true,
-          });
-          controller.enqueue(new TextEncoder().encode('{"partial":'));
-        },
-      });
-      return new Response(source, {
-        headers: { "content-type": "application/json" },
-      });
-    }) as unknown as typeof fetch;
+  test.each(["actor", "caller", "document"] as const)(
+    "aborts a partial finite JSON drain on %s retirement",
+    async (retirement) => {
+      const originalFetch = globalThis.fetch;
+      const observed: { signal?: AbortSignal | null } = {};
+      const caller = new AbortController();
+      let source!: ReadableStream<Uint8Array>;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        observed.signal = init?.signal ?? null;
+        source = new ReadableStream<Uint8Array>({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), {
+              once: true,
+            });
+            controller.enqueue(new TextEncoder().encode('{"partial":'));
+          },
+        });
+        return new Response(source, {
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
 
-    try {
-      configureManagedActorEpoch("14");
-      const pending = managedActorFetch("https://api.example.test/v1/workspaces");
-      await Promise.resolve();
-      configureManagedActorEpoch("15");
-      expect(observed.signal?.aborted).toBe(true);
-      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-      expect(source.locked).toBe(false);
-    } finally {
-      configureManagedActorEpoch(null);
-      globalThis.fetch = originalFetch;
-    }
-  });
+      try {
+        configureManagedActorEpoch("14");
+        const pending = managedActorFetch("https://api.example.test/v1/workspaces", {
+          method: "PUT",
+          signal: caller.signal,
+        });
+        await Promise.resolve();
+        expect(managedActorMutationBusySnapshot()).toBe(true);
+        if (retirement === "actor") configureManagedActorEpoch("15");
+        else if (retirement === "caller")
+          caller.abort(new DOMException("caller stopped", "AbortError"));
+        else handleManagedActorPageHide(false);
+        expect(observed.signal?.aborted).toBe(true);
+        await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+        expect(managedActorMutationBusySnapshot()).toBe(false);
+      } finally {
+        configureManagedActorEpoch(null);
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
 
   test("keeps detached JSON actor-bound and retargets caller aborts after the native drain", async () => {
     const originalFetch = globalThis.fetch;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -361,7 +361,13 @@ export async function managedActorFetch(
     const finiteSseBatch = finiteSseBatchKind(response, boundedHttp1Sse);
     const detachedResponse = isFiniteJsonResponse(response) || finiteSseBatch !== null;
     if (detachedResponse) {
-      const bytes = await readFiniteResponseBytes(response);
+      // Let the native Body consumer own finite JSON through transport
+      // completion. Manually releasing its reader at decoded EOF can make
+      // Chromium report ERR_ABORTED even after every JSON byte was delivered.
+      // Keep the existing explicit reader lifecycle for bounded SSE batches.
+      const bytes = isFiniteJsonResponse(response)
+        ? await response.arrayBuffer()
+        : await readFiniteResponseBytes(response);
       if (responseIsStale()) {
         throw new DOMException(
           "Ignored a response from the previous browser account",

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -832,9 +832,12 @@ function SessionsIndexRouteContent({
     onApplyRemote: applyRemoteDraft,
     restoreReadyFiles: attachments.restoreReadyFiles,
     hydrateResources,
-    // Tool policy needs the MCP catalog. GitHub is optional: an unreadied
-    // catalog must not keep the create composer disabled / unsendable.
-    resourceHydrationReady: context.workspaceMcpCatalogReady,
+    // Establish the passive baseline only after effective visibility settles.
+    // Otherwise a late Personal-workspace capability response turns hydration
+    // into an autosave, racing navigation and sibling drafts without a user edit.
+    // Failed capability reads settle to the existing unavailable fallback too.
+    // GitHub remains optional and must not keep the composer unsendable.
+    resourceHydrationReady: context.workspaceMcpCatalogReady && tenancyCapabilities !== null,
   });
   const busy = context.busy || submitting;
   const privateCreateUnavailable =

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -4113,6 +4113,40 @@ describe("provider-neutral browser account acceptance", () => {
     }
   });
 
+  test("repeated finite review reads finish without native transport cancellation", async () => {
+    const reviewAccount = await createActualUser({
+      displayName: "Review Reader",
+      email: `review-reader-${RUN_ID}@example.test`,
+      organizationName: "Review Reader Organization",
+    });
+    const browser = await launchAccountBrowser(requestedEngine as EngineName);
+    try {
+      const page = await browser.newPage();
+      const problems = observeBrowser(page);
+      setBrowserPhase(problems, "primary-set-sign-in");
+      await signIn(page, reviewAccount);
+      await waitForFiniteReadQuiescence(problems);
+      setBrowserPhase(problems, "stable-finite-review-reads");
+      // Exercise repeated real SDK reads in a stable document. Each iteration
+      // must reach a native terminal before another poll; no routing, fetch
+      // replacement, navigation, or cancellation exemption is involved.
+      for (let i = 0; i < 100; i++) {
+        const pending = page.waitForResponse((response) =>
+          response.url().endsWith("/knowledge/entries/search"),
+        );
+        await page.evaluate(() =>
+          window.dispatchEvent(new Event("opengeni:knowledge-review-updated")),
+        );
+        const response = await pending;
+        expect(response.status()).toBe(200);
+        await waitForFiniteReadQuiescence(problems);
+      }
+      await expectNoBrowserProblems(problems);
+    } finally {
+      await browser.close();
+    }
+  }, 180_000);
+
   test("real users add, race, switch, re-authenticate, deep-link, and revoke without stale tenant state", async () => {
     if (!owned) throw new Error("database fixture unavailable");
     const engine = requestedEngine as EngineName;

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -4376,6 +4376,11 @@ describe("provider-neutral browser account acceptance", () => {
 
       setBrowserPhase(pageProblems, "cross-slot-deep-link");
       const draftRequestStart = draftRequests.length;
+      const targetDraftPath = `/v1/workspaces/${alpha.workspaceId}/new-session-draft`;
+      const targetDraftRequests = () =>
+        draftRequests
+          .slice(draftRequestStart)
+          .filter(({ pathname }) => pathname === targetDraftPath);
       const capabilityUrl = `**/v1/workspaces/${alpha.workspaceId}/session-tenancy/capabilities`;
       let releaseCapabilities!: () => void;
       const capabilitiesReleased = new Promise<void>((resolve) => {
@@ -4398,11 +4403,10 @@ describe("provider-neutral browser account acceptance", () => {
         // Hydrating early would acknowledge a temporary workspace-visible value,
         // then autosave the passive Personal projection as a user edit.
         await page.waitForTimeout(600);
-        expect(draftRequests.slice(draftRequestStart)).toEqual([]);
+        expect(targetDraftRequests()).toEqual([]);
         const hydrated = page.waitForResponse(
           (response) =>
-            new URL(response.url()).pathname ===
-              `/v1/workspaces/${alpha.workspaceId}/new-session-draft` &&
+            new URL(response.url()).pathname === targetDraftPath &&
             response.request().method() === "GET" &&
             response.status() === 200,
         );
@@ -4414,9 +4418,7 @@ describe("provider-neutral browser account acceptance", () => {
       }
       await waitForFiniteReadQuiescence(pageProblems);
       await page.waitForTimeout(600);
-      expect(
-        draftRequests.slice(draftRequestStart).filter(({ method }) => method !== "GET"),
-      ).toEqual([]);
+      expect(targetDraftRequests().filter(({ method }) => method !== "GET")).toEqual([]);
       await page.goto(`${publicOrigin}/sessions/${beta.sessionId}`, {
         waitUntil: "domcontentloaded",
       });

--- a/test/e2e/browser-accounts-acceptance.e2e.ts
+++ b/test/e2e/browser-accounts-acceptance.e2e.ts
@@ -4127,6 +4127,13 @@ describe("provider-neutral browser account acceptance", () => {
     const secondTab = await context.newPage();
     const otherPage = await otherBrowserSet.newPage();
     const pageProblems = observeBrowser(page);
+    const draftRequests: Array<{ method: string; pathname: string }> = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (pathname.endsWith("/new-session-draft")) {
+        draftRequests.push({ method: request.method(), pathname });
+      }
+    });
     const secondTabProblems = observeBrowser(secondTab);
     const otherProblems = observeBrowser(otherPage);
 
@@ -4368,8 +4375,48 @@ describe("provider-neutral browser account acceptance", () => {
       expect(secondTab.url()).not.toContain(alpha.workspaceId);
 
       setBrowserPhase(pageProblems, "cross-slot-deep-link");
-      await selectAccount(page, beta, alpha);
+      const draftRequestStart = draftRequests.length;
+      const capabilityUrl = `**/v1/workspaces/${alpha.workspaceId}/session-tenancy/capabilities`;
+      let releaseCapabilities!: () => void;
+      const capabilitiesReleased = new Promise<void>((resolve) => {
+        releaseCapabilities = resolve;
+      });
+      let capabilitiesIntercepted!: () => void;
+      const capabilitiesPending = new Promise<void>((resolve) => {
+        capabilitiesIntercepted = resolve;
+      });
+      const holdCapabilities = async (route: Route) => {
+        capabilitiesIntercepted();
+        await capabilitiesReleased;
+        await route.continue();
+      };
+      await page.route(capabilityUrl, holdCapabilities);
+      try {
+        await selectAccount(page, beta, alpha);
+        await capabilitiesPending;
+        // Deliberately outlast the autosave debounce while visibility is unknown.
+        // Hydrating early would acknowledge a temporary workspace-visible value,
+        // then autosave the passive Personal projection as a user edit.
+        await page.waitForTimeout(600);
+        expect(draftRequests.slice(draftRequestStart)).toEqual([]);
+        const hydrated = page.waitForResponse(
+          (response) =>
+            new URL(response.url()).pathname ===
+              `/v1/workspaces/${alpha.workspaceId}/new-session-draft` &&
+            response.request().method() === "GET" &&
+            response.status() === 200,
+        );
+        releaseCapabilities();
+        await hydrated;
+      } finally {
+        releaseCapabilities();
+        await page.unroute(capabilityUrl, holdCapabilities);
+      }
       await waitForFiniteReadQuiescence(pageProblems);
+      await page.waitForTimeout(600);
+      expect(
+        draftRequests.slice(draftRequestStart).filter(({ method }) => method !== "GET"),
+      ).toEqual([]);
       await page.goto(`${publicOrigin}/sessions/${beta.sessionId}`, {
         waitUntil: "domcontentloaded",
       });


### PR DESCRIPTION
## Summary

- Wait for the new-session visibility capability decision before establishing the passive draft hydration baseline.
- Prevent a late Personal-workspace capability response from autosaving an otherwise untouched draft and racing document navigation or a sibling draft.
- Preserve explicit flushes, revision conflict checks, and the strict browser failure ledger. No mutation cancellation exemption or automatic retry is added.
- Use the native whole-body consumer for finite JSON so decoded EOF does not end ownership through manual reader release. Preserve live and bounded SSE behavior unchanged.

## Evidence and validation

- Main `50ac8374a781c0324b2481d83728320afdce0dce`, CI run `34698897461`, accounts job `103567141901`: Firefox reported one `NS_BINDING_ABORTED` draft PUT during `cross-slot-deep-link` (4 pass, 1 fail, 300 assertions).
- A synthetic local trace exposed the unwanted read-only write: an empty revision-zero draft was saved solely to project `options.visibility` to `private` after capability resolution. A passing ordinary journey therefore does not establish absence of this race.
- Added a deterministic cross-slot regression that holds the capability response beyond the autosave debounce, requires draft hydration to wait, then requires no passive write after hydration. Against the old implementation it fails on the premature draft GET (4 pass, 1 fail, 255 assertions).
- Targeted draft hook, create-request, and route hydration tests: **71 pass, 0 fail, 283 assertions**.
- Focused lint and diff whitespace checks: passed.
- Corrected the regression to observe only the target workspace while its capability response is held; departing-workspace reads remain covered by the unchanged strict global ledger. Verified the corrected regression red without the readiness gate (4 pass, 1 fail, 255 assertions) and green with it: **Firefox 5 pass, 0 fail, 305 assertions**.
- `bun run check`: public hygiene and partial typechecking (including web) passed; the process was interrupted by SIGTERM before completion. This full local check is not claimed green. Upstream CI and independent review remain required.
- The exact prior head's CI `34701644093` passed Firefox and WebKit but failed Chromium job `103574509868` on read-only knowledge search. This is separate from the original Firefox draft mutation.
- Isolated stable-document evidence: the original manual drain produced 26 native `ERR_ABORTED` terminals in 100 managed review reads despite all JSON bodies parsing and no abort signal. Twenty ordinary fetch/JSON reads in that same browser completed cleanly. A native whole-body comparison completed 100 managed and 20 ordinary reads without failures.
- Added an uninstrumented repeated-read browser regression with no fetch replacement, routing, navigation, or ledger exemption. It fails on the original implementation (106 assertions) and passes with native JSON consumption. The regression owns a separate synthetic account. Full local Chromium accounts on `1547b254e`: **6 pass, 0 fail, 456 assertions**.
- Finite JSON unit tests now verify consumption, partial-write rejection on actor/caller/document retirement, and mutation-busy cleanup instead of asserting an internal source-lock implementation detail. Existing detached-body late-actor and bounded/live SSE tests remain in force.
- Combined API/draft/create-request/hydration tests: **111 pass, 0 fail, 439 assertions**. Web typecheck and focused lint passed.
- Exact revised-head CI `34704549553` on `1547b254ed882bf41d58d243eef72c429b119e42`: **success**, including all three accounts browsers, source/type contracts, unit shards, real-service/recovery tests, impacted E2E, package/bundle contracts and deployment-artifact checks. Independent exact-head review remains required before merge.

Responsible agent session: https://jorgebot.tail0c8161.ts.net/workspaces/3006d92d-b27c-4f40-8762-2e3613806d74/sessions/93d7aa7e-f27b-4191-a1fd-f2763861705f